### PR TITLE
Studio system canvas — solution-design capture seed + daemon composition-pattern rebind

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2157,6 +2157,33 @@ function renderLaunchPolicies(policies, profiles) {
   return `<h2 id="launch-policies">Launch policies</h2><p class="sub" style="margin:-4px 0 12px">Saved IOI Agent strategy presets — the daemon planner composes a policy with live registry facts, authority, privacy posture, budget, and failure policy at launch. Seeded defaults are protected; clone to customize.</p>${policies.length ? cards : `<div class="empty">No launch policies yet.</div>`}${form}`;
 }
 
+// ---- System designs (Studio) — the daemon-backed lane behind the /__apps/designer solution-design
+// canvas seed. The captured canvas teaches the composition grammar (typed concept/component/resource
+// nodes, save/actions/open, AIP critique, load-from-lineage); here the OWNER surface binds the parts
+// that are real daemon truth: the composition-pattern reference library (the daemon's own canonical
+// system shapes) and saved system designs (ODK surface descriptors). Every fact is daemon state or a
+// named gap — no fabricated nodes/imports.
+function renderStudioSystemDesigns(sd) {
+  sd = sd || {};
+  const patterns = Array.isArray(sd.compositionPatterns) ? sd.compositionPatterns : [];
+  const designs = Array.isArray(sd.surfaceDescriptors) ? sd.surfaceDescriptors : [];
+  const prettyPattern = (p) => String(p || "").replace(/_/g, " ");
+  const patternLib = patterns.length
+    ? `<div class="chips" style="margin:2px 0 4px">${patterns.map((p) => `<span class="pill muted" title="daemon composition pattern">${CX_ESC(prettyPattern(p))}</span>`).join("")}</div>`
+    : `<div class="empty">The daemon exposes no composition patterns.</div>`;
+  const designRows = designs.length
+    ? `<table><thead><tr><th>System design</th><th>Pattern</th><th>Ref</th></tr></thead><tbody>${designs.map((d) => `<tr>
+        <td><b>${CX_ESC(d.name || d.title || d.id || "—")}</b></td>
+        <td><span class="pill muted">${CX_ESC(prettyPattern(d.composition_pattern || d.pattern || "—"))}</span></td>
+        <td><code style="font-size:11px">${CX_ESC(d.ref || d.surface_descriptor_ref || d.id || "")}</code></td>
+      </tr>`).join("")}</tbody></table>`
+    : `<div class="empty">No saved system designs yet. Compose one in the <a href="/__apps/designer">system canvas seed →</a>; the daemon persists an admitted design as an ODK surface descriptor. (The seed's in-canvas Open / Save / reference-library / load-from-lineage lanes are <b>named gaps</b> in the current capture — authored natively or live re-harvested next, never faked.)</div>`;
+  return `<h2 id="system-designs">System designs</h2>` +
+    `<p class="sub" style="margin:-4px 0 12px">The Studio composition plane — a system design composes typed <b>concept / component / resource</b> nodes into an IOI system shape. Compose in the <a href="/__apps/designer">canvas seed →</a>; the reference library and saved designs below are daemon truth.</p>` +
+    `<h3 style="margin:14px 0 4px;font-size:13px">Composition pattern library <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the ${patterns.length} canonical system shapes the daemon recognizes (the reference examples a design starts from)</span></h3>${patternLib}` +
+    `<h3 style="margin:16px 0 4px;font-size:13px">Saved system designs <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— admitted ODK surface descriptors</span></h3>${designRows}`;
+}
+
 function renderAgentStudio(agents, profiles, routes, providers, conversations, runs, selId, q, modelRoutes, launchPolicies, intel) {
   const enc = encodeURIComponent;
   agents = Array.isArray(agents) ? agents : [];
@@ -2175,7 +2202,7 @@ function renderAgentStudio(agents, profiles, routes, providers, conversations, r
   const styles = `<style>.wrap{max-width:1180px}.asgrid{display:grid;grid-template-columns:248px 1fr;gap:20px;align-items:start}.aslist{position:sticky;top:16px;max-height:82vh;overflow:auto;display:flex;flex-direction:column;gap:6px}.asrow{display:block;padding:10px 12px;border:1px solid #24262d;border-radius:10px;background:#15171c;text-decoration:none;color:inherit}.asrow:hover{border-color:#3a82f6}.asrow.sel{border-color:#3a82f6;box-shadow:0 0 0 1px #3a82f6 inset}.asrow .nm{font-weight:600;color:#fff;font-size:12.5px}.asrow .ml{color:#878a93;font-size:11.5px;margin-top:2px;word-break:break-all}.asearch{width:100%;box-sizing:border-box;padding:9px 12px;border-radius:9px;border:1px solid #2a2c33;background:#0e0f13;color:#e6e7ea;font:inherit;margin-bottom:10px}</style>`;
   if (!agents.length) {
     // Registry truth still renders without agents — routes exist independently of the agent estate.
-    return automationsShell("Studio", styles + head + `<div class="empty">No agents yet. An agent is created when you start a session or run an automation — once one exists it will appear here with its model route, runtime posture, and activity.</div>` + renderModelRouteRegistry(modelRoutes) + renderLaunchPolicies(launchPolicies, profiles));
+    return automationsShell("Studio", styles + head + renderStudioSystemDesigns((intel || {}).systemDesigns) + `<div class="empty">No agents yet. An agent is created when you start a session or run an automation — once one exists it will appear here with its model route, runtime posture, and activity.</div>` + renderModelRouteRegistry(modelRoutes) + renderLaunchPolicies(launchPolicies, profiles));
   }
   // Selected agent (query ?agent=, else first of the filtered list).
   const sel = filtered.find((a) => a.id === selId) || filtered[0] || agents[0];
@@ -2339,7 +2366,7 @@ function renderAgentStudio(agents, profiles, routes, providers, conversations, r
   </script>`;
   const right = `<div><div class="row" style="margin-bottom:2px"><h2 style="margin:0">${CX_ESC(agentShort(a.id))}</h2><span class="pill ${(a.status || "") === "active" ? "ok" : "muted"}">${CX_ESC(a.status || "—")}</span></div>${tabBar}${panels}${tabScript}</div>`;
   const body = `<div class="row" style="justify-content:space-between"><span class="sub" style="margin:0">${agents.length} agent${agents.length === 1 ? "" : "s"} · ${activeCount} active${qn ? ` · ${filtered.length} matching “${CX_ESC(q)}”` : ""}</span></div><div class="asgrid">${left}${right}</div>`;
-  return automationsShell("Studio", styles + head + body);
+  return automationsShell("Studio", styles + head + renderStudioSystemDesigns((intel || {}).systemDesigns) + body);
 }
 
 // ---- Foundry — a CONTROLLED BUILDER over the daemon Foundry object plane (estate surface #4).
@@ -5688,7 +5715,7 @@ const server = http.createServer((req, res) => {
       const selId = sp.get("agent") || "";
       const q = sp.get("q") || "";
       const J = (p) => fetch(`${DAEMON}${p}`).then((x) => x.json()).catch(() => ({}));
-      const [ag, pr, ro, pv, cv, tr, mr, lp, me, sk, af, cn, cl, mp, mprj, rq, om, imp, rcl, coh] = await Promise.all([
+      const [ag, pr, ro, pv, cv, tr, mr, lp, me, sk, af, cn, cl, mp, mprj, rq, om, imp, rcl, coh, odkov, odksd] = await Promise.all([
         J("/v1/agents"),
         J("/v1/hypervisor/agent-runner-profiles"),
         J("/v1/model-mount/routes"),
@@ -5709,6 +5736,8 @@ const server = http.createServer((req, res) => {
         J("/v1/hypervisor/intelligence/improvement-proposals"),
         J("/v1/hypervisor/governance/release-controls"),
         J("/v1/hypervisor/governance/cohorts"),
+        J("/v1/hypervisor/odk/overview"),
+        J("/v1/hypervisor/odk/surface-descriptors"),
       ]);
       // Decorate rollout-bound learned variants with their control's cohort names + mode so
       // the policy card can say WHO the rollout applies to.
@@ -5733,7 +5762,7 @@ const server = http.createServer((req, res) => {
         q,
         mr.routes || [],
         lp.policies || [],
-        { entries: me.entries || [], skills: sk.skills || [], affinities: af.affinities || [], connectors: cn.connectors || [], leases: cl.leases || [], proposals: mp.proposals || [], projections: (mprj.projections || []).slice(0, 20), review: (rq.items || []).slice(0, 20), mining: (om.candidates || []).slice(0, 10), improvements: (imp.proposals || []).slice(0, 15) },
+        { entries: me.entries || [], skills: sk.skills || [], affinities: af.affinities || [], connectors: cn.connectors || [], leases: cl.leases || [], proposals: mp.proposals || [], projections: (mprj.projections || []).slice(0, 20), review: (rq.items || []).slice(0, 20), mining: (om.candidates || []).slice(0, 10), improvements: (imp.proposals || []).slice(0, 15), systemDesigns: { compositionPatterns: (odkov || {}).composition_patterns || [], surfaceDescriptors: (odksd || {}).surface_descriptors || (odksd || {}).descriptors || [] } },
       ));
       return;
     }

--- a/apps/hypervisor/scripts/verify-hypervisor-harvest-studio-canvas.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-harvest-studio-canvas.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Harvest-port Studio canvas verifier — the solution-design capture as the pattern seed for
+// Hypervisor Studio's typed system canvas.
+//
+// Doctrine: local capture -> bootable seed -> daemon rebind -> IOI-owned surface -> retire seed.
+// The capture is private UX seed material only; Hypervisor truth comes from the daemon.
+//
+// Proves:
+//   - the /__apps/designer seed boots under the estate, brand-clean, with the FULL captured
+//     composition grammar (typed concept/component/resource palette, canvas surface, save/actions/
+//     open affordances, AIP critique, welcome + create options);
+//   - the owning Hypervisor Studio surface links the seed AND surfaces a DAEMON-BACKED System
+//     designs lane: the composition-pattern reference library (daemon truth, verbatim) + saved
+//     system designs (ODK surface descriptors), with the in-canvas open/save/reference/load-lineage
+//     lanes named as gaps (uncaptured) — never faked;
+//   - the reference library on the glass equals the daemon's composition patterns (no fabrication);
+//   - an unknown seed is honest; the offline capture names the outage; no brand leak.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-harvest-studio-canvas.mjs
+// Exit 2 = BLOCKED (harvest capture or daemon not running) — named, not failed.
+
+import { chromium } from "playwright";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const CAPTURE = (process.env.IOI_HARVEST_CAPTURE_URL || process.env.IOI_HARVEST_MIRROR_URL || "http://127.0.0.1:9225").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+
+async function run() {
+  // 0. Liveness — the seed serves live from the capture; the rebind serves from the daemon.
+  const captureUp = await fetch(`${CAPTURE}/workspace/solution-design/`).then((r) => r.ok).catch(() => false);
+  if (!captureUp) { console.error("BLOCKED: harvest capture not reachable at " + CAPTURE); process.exit(2); }
+  const daemonUp = await fetch(`${DAEMON}/v1/hypervisor/odk/overview`).then((r) => r.ok).catch(() => false);
+  if (!daemonUp) { console.error("BLOCKED: daemon not reachable at " + DAEMON); process.exit(2); }
+  ok("harvest capture + daemon live", true, `${CAPTURE} · ${DAEMON}`);
+
+  // 1. Owner surface (Hypervisor Studio) links the seed AND carries the daemon System designs lane.
+  const studio = await fetch(`${SERVE}/__ioi/agent-studio`).then(async (r) => ({ status: r.status, text: await r.text() }));
+  ok("Studio surface serves", studio.status === 200 && !studio.text.includes("Palantir"));
+  ok("Studio links the /__apps/designer canvas seed", studio.text.includes("/__apps/designer"));
+  ok("Studio carries a daemon-backed System designs lane", /id="system-designs"/.test(studio.text) && /Composition pattern library/.test(studio.text));
+  ok("Studio names the in-canvas lanes as gaps (no faked open/save/import)", /named gaps/i.test(studio.text));
+
+  // 2. Reference library on the glass == the daemon's composition patterns (verbatim, no fabrication).
+  const ov = await fetch(`${DAEMON}/v1/hypervisor/odk/overview`).then((r) => r.json());
+  const patterns = ov.composition_patterns || [];
+  ok("daemon exposes composition patterns", patterns.length >= 5, `${patterns.length} patterns`);
+  const pretty = (p) => String(p).replace(/_/g, " ");
+  const allOnGlass = patterns.every((p) => studio.text.includes(pretty(p)));
+  ok("every daemon composition pattern renders on the Studio glass", allOnGlass, patterns.map(pretty).join(", "));
+  // Honesty: saved designs = daemon surface descriptors (empty renders the honest compose prompt).
+  const sd = await fetch(`${DAEMON}/v1/hypervisor/odk/surface-descriptors`).then((r) => r.json());
+  const descriptors = sd.surface_descriptors || sd.descriptors || [];
+  if (descriptors.length === 0) {
+    ok("empty saved-designs state is honest (compose prompt, not a fabricated list)", /No saved system designs yet/.test(studio.text));
+  } else {
+    ok("saved system designs render from daemon surface descriptors", descriptors.every((d) => studio.text.includes(d.name || d.id || "")));
+  }
+
+  // 3. The captured canvas grammar boots under the estate (Playwright).
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+  const consoleErrors = [];
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+  await page.goto(`${SERVE}/__apps/designer`, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(6000);
+  const boot = await page.evaluate(() => {
+    const t = document.body.innerText;
+    return {
+      solutionDesigner: /Solution Designer|solution design/i.test(t),
+      concept: /\bconcept\b/i.test(t),
+      component: /\bcomponent\b/i.test(t),
+      resource: /\bresource\b/i.test(t),
+      save: /\bsave\b/i.test(t),
+      actions: /\bactions\b/i.test(t),
+      openDiagram: /open diagram/i.test(t),
+      critic: /AIP CRITIC|AIP Critic/i.test(t),
+      referenceExample: /reference example/i.test(t),
+      loadFromLineage: /load from data lineage/i.test(t.replace(/\s+/g, " ")),
+      hasCanvas: !!document.querySelector("canvas, [class*=canvas i], [class*=editor i]"),
+      brandLeak: document.body.innerHTML.includes("Palantir"),
+    };
+  });
+  ok("seed boots to the Solution Designer canvas", boot.solutionDesigner && boot.hasCanvas);
+  ok("typed node palette present (concept / component / resource)", boot.concept && boot.component && boot.resource);
+  ok("canvas controls present (save / actions / open diagram)", boot.save && boot.actions && boot.openDiagram);
+  ok("AI critique affordance present (captured grammar)", boot.critic);
+  ok("create affordances present (reference example + load-from-lineage)", boot.referenceExample && boot.loadFromLineage);
+  ok("no brand leak in the booted canvas", !boot.brandLeak);
+  // A harvest seed's UNCAPTURED data lanes fail by design (that is the gap the rebind fills);
+  // the canvas grammar must still boot. Pass when the only page errors are those uncaptured-lane
+  // fetch/GraphQL failures — fail on any genuine crash (the honest bar for an adopting seed).
+  const laneGapErrors = consoleErrors.filter((e) => /GraphQL|Failed to fetch|NetworkError|fetch failed|Load failed/i.test(e));
+  const realCrashes = consoleErrors.filter((e) => !/GraphQL|Failed to fetch|NetworkError|fetch failed|Load failed/i.test(e));
+  ok("canvas boots; only uncaptured-lane fetch failures (named gaps), no real crashes", realCrashes.length === 0, realCrashes.length ? realCrashes.slice(0, 2).join(" | ") : `${laneGapErrors.length} uncaptured-lane gap error(s), 0 crashes`);
+  await page.screenshot({ path: process.env.IOI_STUDIO_SHOT || "/tmp/studio-canvas.png" }).catch(() => {});
+  await browser.close();
+
+  // 4. Shared honesty: unknown seed 404s; offline capture names the outage.
+  const unknown = await fetch(`${SERVE}/__apps/definitely-not-a-seed`).then((r) => r.status).catch(() => 0);
+  ok("unknown seed is honest (404)", unknown === 404, String(unknown));
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`harvest studio-canvas readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
Second harvest cut, stacked on #3 (branches from `feat/marketplace-rebind` so the capture vocabulary + green source-neutral gate carry forward). Follows the Marketplace pattern-cut shape.

## What this does
- **`/__apps/designer` boots the full captured composition grammar** under the estate, brand-clean: typed **CONCEPT / COMPONENT / RESOURCE** node palette, canvas surface, Save / Actions / Open diagram, AIP critique, and the create affordances ("Start planning" honestly **Unavailable**, reference example, Load from Data Lineage). The captured canvas teaches the app-suite's core composition grammar — private UX seed material, not product truth.
- **The owning Studio surface (`/__ioi/agent-studio`) carries a daemon-backed "System designs" lane**: the composition-pattern reference library rendered verbatim from the daemon's **11 canonical system shapes** (`/v1/hypervisor/odk/overview` `composition_patterns`), plus saved system designs from ODK surface descriptors (honest compose-prompt empty state).
- **In-canvas Open / Save / reference-library / load-from-lineage lanes are NAMED GAPS** in the current capture — authored natively or live re-harvested next, never faked.

## Done bar — green
- `verify-hypervisor-harvest-studio-canvas.mjs` **16/16** (seed boots the grammar; owner links seed + daemon lane; every daemon pattern on the glass; only uncaptured-lane fetch failures = named gaps, no real crashes; unknown seed honest; no brand leak).
- `check:source-neutral` PASSES (capture vocabulary); canvas-seeds + marketplace regressions green; `/__ioi/fallthrough` empty; `git diff --check` clean.

## Posture
- master not pushed. Branch pushed for review, stacked on #3.
- Doctrine: `local capture → bootable seed → daemon rebind → IOI-owned surface → retire seed`. We harvest the mature canvas grammar, prove it under IOI routes, and rebind it to IOI truth — not cloning Palantir as product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)