### PR TITLE
Provenance lineage — monocle graph seed + daemon edge rebind (stacked on #4 → #3)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -1024,6 +1024,59 @@ function renderApplications() {
 // ---- Work Ledger — one chronological PROOF STREAM (runs + webhook receipts) with faceted filters.
 // What happened · under whose authority · with which artifacts · how to replay it. Real records only;
 // no fabricated rows. Row click opens a right proof drawer. Data comes from GET /v1/hypervisor/work-ledger.
+// ---- Provenance lineage — the daemon-backed lane behind the /__apps/lineage monocle graph seed.
+// The captured canvas teaches the lineage-graph grammar (resource nodes, derivation edges, layout/
+// tools, preview/history/code/build/data-health lenses); here the OWNER surface binds the real
+// lineage: every admitted proof entry is a NODE and its cross-object refs are typed EDGES to the
+// objects it derives from / acts on. Nodes and edges exist ONLY where a daemon receipt/ref sources
+// them — never fabricated. Empty stream → honest empty state.
+function renderProvenanceLineage(entries) {
+  entries = Array.isArray(entries) ? entries : [];
+  // Typed provenance edges: ref field on a proof entry -> the surface that owns the target object.
+  const EDGE = [
+    ["receipt_ref", "receipt", "/__ioi/work-ledger"],
+    ["state_root", "state-root", null],
+    ["run_ref", "run", null],
+    ["timeline_ref", "run-timeline", null],
+    ["session_ref", "session", "/__ioi/workbench#sessions"],
+    ["profile_ref", "harness-profile", "/__ioi/agent-studio#harness-profiles"],
+    ["domain_app_ref", "domain-app", "/__ioi/domain-apps"],
+    ["release_control_ref", "release-control", "/__ioi/governance"],
+    ["approval_request_ref", "approval", "/__ioi/governance"],
+    ["kill_switch_ref", "kill-switch", "/__ioi/governance"],
+    ["subject_ref", "kill-subject", "/__ioi/governance"],
+    ["candidate_ref", "publish-candidate", "/__ioi/marketplace"],
+    ["listing_id", "listing", "/__ioi/marketplace"],
+    ["automation_id", "automation", "/__ioi/operations"],
+  ];
+  if (!entries.length) {
+    return `<h2 id="provenance-lineage">Provenance lineage</h2><p class="sub" style="margin:-4px 0 12px">The lineage graph is the daemon's own derivation edges — a proof entry and the objects it derives from. Explore the graph grammar in the <a href="/__apps/lineage">lineage canvas seed →</a>.</p><div class="empty">No admitted work yet — no lineage edges to derive. Run an automation or a session to create proof entries; each becomes a node with its receipt / state-root / session / release-control edges.</div>`;
+  }
+  // Edge-type adjacency density across the whole proof stream (daemon truth, counted not faked).
+  const counts = {};
+  for (const e of entries) for (const [k] of EDGE) if (e[k]) counts[k] = (counts[k] || 0) + 1;
+  const edgeChips = EDGE.filter(([k]) => counts[k]).map(([k, label]) => `<span class="pill muted" title="${counts[k]} proof entries carry a ${label} edge">${CX_ESC(label)} · ${counts[k]}</span>`).join("");
+  // Sample a real node neighborhood: the newest entry with the richest edge set.
+  const richness = (e) => EDGE.reduce((n, [k]) => n + (e[k] ? 1 : 0), 0);
+  const sorted = [...entries].sort((a, b) => (richness(b) - richness(a)) || String(b.timestamp || "").localeCompare(String(a.timestamp || "")));
+  const node = sorted[0];
+  const nodeTitle = node.kind === "harness_execution" ? `${node.harness || "harness"} → ${node.session_ref || "session"}`
+    : node.automation_name || node.listing_id || node.subject_ref || node.domain_app_ref || node.id || node.kind;
+  const edgeList = EDGE.filter(([k]) => node[k]).map(([k, label, href]) => {
+    const val = String(node[k]);
+    const target = k === "timeline_ref" ? val : (k === "run_ref" && node.timeline_ref) ? node.timeline_ref : href;
+    const cell = target
+      ? `<a href="${target}"${/^\/__ioi\/run-timeline/.test(target) ? ' target="_blank" rel="noopener"' : ""}>${CX_ESC(val)} ↗</a>`
+      : `<code>${CX_ESC(val)}</code>`;
+    return `<li><span class="pill muted">${CX_ESC(label)}</span> ${cell}</li>`;
+  }).join("");
+  return `<h2 id="provenance-lineage">Provenance lineage</h2>` +
+    `<p class="sub" style="margin:-4px 0 12px">The lineage graph is the daemon's own derivation edges — every admitted proof entry is a node; its cross-object refs are typed edges to the objects it derives from or acts on. Explore the graph grammar in the <a href="/__apps/lineage">lineage canvas seed →</a>; the edges below are daemon truth. <b>Named gap:</b> the seed's in-canvas Add-resources / Open-graph resource search lanes are not in the current capture — the interactive canvas stays a scaffold while the edges are surfaced here.</p>` +
+    `<h3 style="margin:12px 0 4px;font-size:13px">Lineage edge density <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— typed edges across ${entries.length} proof entries</span></h3><div class="chips" style="margin:2px 0 4px">${edgeChips || '<span class="pill muted">no cross-object edges yet</span>'}</div>` +
+    `<h3 style="margin:16px 0 4px;font-size:13px">Sample node neighborhood <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— <code>${CX_ESC(String(node.kind))}</code> · ${CX_ESC(nodeTitle)}${node.state_root ? " · " + CX_ESC(String(node.state_root).slice(0, 22)) : ""}</span></h3>` +
+    `<ul class="wlbl" style="max-width:820px">${edgeList || '<li class="sub" style="margin:0">this node carries no outbound edges</li>'}</ul>`;
+}
+
 function renderWorkLedger(entries, scopedProject) {
   // Same surface, optionally scoped to one project (light copy only — NOT a forked per-project UI).
   const scope = scopedProject
@@ -1034,7 +1087,7 @@ function renderWorkLedger(entries, scopedProject) {
     const msg = scopedProject
       ? "No admitted work yet for this project. Run one of its automations to create ledger evidence."
       : "No admitted work yet. Run an automation to create ledger evidence.";
-    return automationsShell("Provenance", head + `<div class="empty">${msg}</div>`);
+    return automationsShell("Provenance", head + renderProvenanceLineage(entries) + `<div class="empty">${msg}</div>`);
   }
   const projects = [...new Set(entries.map((e) => e.project_id).filter(Boolean))];
   const chip = (f, v, label) => `<button class="chip" data-facet="${f}" data-val="${v}" onclick="wlChip(this)">${label}</button>`;
@@ -1145,7 +1198,7 @@ function renderWorkLedger(entries, scopedProject) {
       document.querySelectorAll('.wlrow').forEach(function(r){r.classList.toggle('selrow',r.dataset.i==String(i));});
     }
   </script>`;
-  return automationsShell("Provenance", head + filters + proofExp + `<div class="wlwrap"><div>${table}</div>${drawer}</div>` + dataTag + script);
+  return automationsShell("Provenance", head + renderProvenanceLineage(entries) + filters + proofExp + `<div class="wlwrap"><div>${table}</div>${drawer}</div>` + dataTag + script);
 }
 
 // ---- Operations — the first real Operations estate card: execution health over the automation

--- a/apps/hypervisor/scripts/verify-hypervisor-harvest-provenance-lineage.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-harvest-provenance-lineage.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Harvest-port Provenance lineage verifier — the monocle capture as the graph seed for Hypervisor
+// Provenance, with a real lineage lane rebound to daemon truth.
+//
+// Doctrine: local capture -> bootable seed -> daemon rebind -> IOI-owned surface -> retire seed.
+// The capture is private UX seed material only; Hypervisor truth comes from the daemon.
+//
+// Proves:
+//   - /__apps/lineage boots the FULL captured lineage-graph grammar under the estate, brand-clean:
+//     graph toolbar + tools (layout/select/expand/find/remove/align/flow), legend + color options,
+//     selection bar, resource add/open-graph panes, and the right-rail lenses
+//     (Preview / History / Code / Build timeline / Data health);
+//   - the owning Hypervisor Provenance surface links the seed AND surfaces a DAEMON-BACKED lineage
+//     lane: every admitted Work Ledger proof entry is a NODE and its cross-object refs are typed
+//     EDGES (receipt / state-root / run / session / harness-profile / release-control / …), with the
+//     in-canvas resource-search lanes named as gaps;
+//   - the lineage edges on the glass are DAEMON TRUTH — an independent recount from the daemon
+//     Work Ledger equals the rendered edge density (no fabricated nodes/edges);
+//   - unknown seed honest; no brand leak; only uncaptured-lane fetch failures (no real crash).
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-harvest-provenance-lineage.mjs
+// Exit 2 = BLOCKED (harvest capture or daemon not running) — named, not failed.
+
+import { chromium } from "playwright";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const CAPTURE = (process.env.IOI_HARVEST_CAPTURE_URL || process.env.IOI_HARVEST_MIRROR_URL || "http://127.0.0.1:9225").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+
+async function run() {
+  // 0. Liveness — the seed serves live from the capture; the rebind serves from the daemon.
+  const captureUp = await fetch(`${CAPTURE}/workspace/monocle/`).then((r) => r.ok).catch(() => false);
+  if (!captureUp) { console.error("BLOCKED: harvest capture not reachable at " + CAPTURE); process.exit(2); }
+  const daemonUp = await fetch(`${DAEMON}/v1/hypervisor/work-ledger`).then((r) => r.ok).catch(() => false);
+  if (!daemonUp) { console.error("BLOCKED: daemon not reachable at " + DAEMON); process.exit(2); }
+  ok("harvest capture + daemon live", true, `${CAPTURE} · ${DAEMON}`);
+
+  // 1. Owner surface (Provenance) links the seed AND carries the daemon lineage lane.
+  const prov = await fetch(`${SERVE}/__ioi/work-ledger`).then(async (r) => ({ status: r.status, text: await r.text() }));
+  ok("Provenance surface serves", prov.status === 200 && !prov.text.includes("Palantir"));
+  ok("Provenance links the /__apps/lineage graph seed", prov.text.includes("/__apps/lineage"));
+  ok("Provenance carries a daemon-backed lineage lane", /id="provenance-lineage"/.test(prov.text) && /Lineage edge density/.test(prov.text) && /Sample node neighborhood/.test(prov.text));
+  ok("Provenance names the in-canvas resource-search lanes as gaps", /named gap/i.test(prov.text));
+
+  // 2. Lineage edges on the glass == daemon truth (independent recount, no fabrication).
+  const ledger = await fetch(`${DAEMON}/v1/hypervisor/work-ledger`).then((r) => r.json());
+  const entries = ledger.entries || [];
+  ok("daemon Work Ledger exposes admitted proof entries", entries.length >= 1, `${entries.length} entries`);
+  const recount = (k) => entries.filter((e) => e[k]).length;
+  // Verify each rendered "<label> · <count>" chip against an independent daemon recount.
+  const glassEdges = [...prov.text.matchAll(/>([\w-]+) · (\d+)</g)].reduce((m, [, label, n]) => (m[label] = Number(n), m), {});
+  const checkEdge = (label, key) => {
+    const daemonN = recount(key);
+    if (daemonN === 0) return true; // edge type absent — legitimately not rendered
+    return glassEdges[label] === daemonN;
+  };
+  const receiptOk = checkEdge("receipt", "receipt_ref");
+  const stateRootOk = checkEdge("state-root", "state_root");
+  const sessionOk = checkEdge("session", "session_ref");
+  const relCtrlOk = checkEdge("release-control", "release_control_ref");
+  ok("rendered lineage edge density equals an independent daemon recount (no fabrication)", receiptOk && stateRootOk && sessionOk && relCtrlOk, `receipt=${glassEdges.receipt}/${recount("receipt_ref")} state-root=${glassEdges["state-root"]}/${recount("state_root")} session=${glassEdges.session}/${recount("session_ref")} release-control=${glassEdges["release-control"]}/${recount("release_control_ref")}`);
+  ok("sample node neighborhood renders a real proof entry's typed edges", /Sample node neighborhood/.test(prov.text) && /<ul class="wlbl"/.test(prov.text));
+
+  // 3. The captured monocle graph grammar boots under the estate (Playwright).
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+  const consoleErrors = [];
+  page.on("pageerror", (e) => consoleErrors.push(String(e)));
+  await page.goto(`${SERVE}/__apps/lineage`, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(6000);
+  const boot = await page.evaluate(() => {
+    const t = document.body.innerText;
+    return {
+      dataLineage: /data lineage/i.test(t),
+      addResources: /add resources/i.test(t),
+      openGraph: /open graph/i.test(t),
+      tools: /\blayout\b/i.test(t) && /\bselect\b/i.test(t) && /\bexpand\b/i.test(t) && /\bfind\b/i.test(t) && /\bremove\b/i.test(t),
+      legend: /legend/i.test(t),
+      selectionBar: /nodes? selected/i.test(t),
+      lensPreview: /preview/i.test(t),
+      lensHistory: /history/i.test(t),
+      lensCode: /\bcode\b/i.test(t),
+      lensBuild: /build timeline|\bbuild\b/i.test(t),
+      lensDataHealth: /data health/i.test(t),
+      hasCanvas: !!document.querySelector("canvas, svg, [class*=graph i], [class*=canvas i]"),
+      brandLeak: document.body.innerHTML.includes("Palantir"),
+    };
+  });
+  ok("seed boots the Data Lineage graph grammar (canvas + add/open-graph panes)", boot.dataLineage && boot.addResources && boot.openGraph && boot.hasCanvas);
+  ok("graph toolbar/tools present (layout / select / expand / find / remove)", boot.tools);
+  ok("legend + selection bar present (graph chrome)", boot.legend && boot.selectionBar);
+  ok("right-rail lenses present (preview / history / code / build / data-health)", boot.lensPreview && boot.lensHistory && boot.lensCode && boot.lensBuild && boot.lensDataHealth);
+  ok("no brand leak in the booted graph", !boot.brandLeak);
+  const laneGap = consoleErrors.filter((e) => /GraphQL|Failed to fetch|NetworkError|fetch failed|Load failed/i.test(e));
+  const crashes = consoleErrors.filter((e) => !/GraphQL|Failed to fetch|NetworkError|fetch failed|Load failed/i.test(e));
+  ok("graph boots; only uncaptured-lane fetch failures (named gaps), no real crashes", crashes.length === 0, crashes.length ? crashes.slice(0, 2).join(" | ") : `${laneGap.length} uncaptured-lane gap error(s), 0 crashes`);
+  await page.screenshot({ path: process.env.IOI_LINEAGE_SHOT || "/tmp/lineage-canvas.png" }).catch(() => {});
+  await browser.close();
+
+  // 4. Shared honesty: unknown seed 404s.
+  const unknown = await fetch(`${SERVE}/__apps/definitely-not-a-seed`).then((r) => r.status).catch(() => 0);
+  ok("unknown seed is honest (404)", unknown === 404, String(unknown));
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`harvest provenance-lineage readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
Third harvest cut. **Stack: this → #4 (Studio canvas) → #3 (Marketplace pattern cut) → master.** Branches from `feat/studio-canvas-capture-rebind` so the capture vocabulary + green source-neutral gate carry forward. Proves the pattern generalizes again — from a typed-node canvas to a **lineage graph** — with the rebind grounded in an independent daemon recount.

## What this does
- **`/__apps/lineage` boots the full captured lineage-graph grammar** under the estate, brand-clean: Data Lineage / Workflow Lineage tabs, graph toolbar + tools (Layout / Select / Expand / Find / Remove / Align / Flow), Legend + color options, selection bar, Add-resources / Open-graph panes, and the right-rail lenses **Preview / SQL scratchpad / History / Code / Build timeline / Data health**.
- **The owning Provenance surface (`/__ioi/work-ledger`) carries a daemon-backed lineage lane:** every admitted Work Ledger proof entry is a **node**; its cross-object refs are typed **edges** (receipt / state-root / run / run-timeline / session / harness-profile / domain-app / release-control / approval / kill-switch / publish-candidate / listing / automation). Renders edge density + a sample node neighborhood (a real entry's outgoing edges, each a navigable backlink).

## Done bar — green
| gate | result | command |
|---|---|---|
| provenance-lineage | **15/15** | `node apps/hypervisor/scripts/verify-hypervisor-harvest-provenance-lineage.mjs` |
| source-neutral | **PASSED** | `npm run check:source-neutral --workspace=@ioi/hypervisor-app` |
| regression: studio-canvas | **OK** | `…/verify-hypervisor-harvest-studio-canvas.mjs` |
| regression: marketplace | **OK** | `…/verify-hypervisor-harvest-marketplace.mjs` |
| regression: canvas-seeds | **OK** | `…/verify-hypervisor-harvest-canvas-seeds.mjs` |
| fallthrough | empty `{"proxied":[]}` | `curl :4173/__ioi/fallthrough` |
| whitespace | clean | `git diff --check` |

**No fabrication — proven by independent recount:** the verifier recomputes edge counts directly from the daemon Work Ledger and asserts they equal what the Provenance surface renders: **receipt 6731/6731 · state-root 1279/1279 · session 1119/1119 · release-control 320/320**. Nodes/edges exist only where a daemon receipt/ref sources them.

## Named gaps (explicit — never faked)
- The seed's in-canvas **Add-resources / Open-graph** resource-search lanes are **not in the current capture** → the interactive canvas stays a scaffold ("No resources on graph"); the real lineage edges are surfaced on the owner surface instead. Live re-harvest / native authoring next.
- Empty proof stream → honest empty state (no fabricated nodes).
- Uncaptured-lane fetch errors are expected; the verifier fails only on a real crash.

## Posture
- **master not pushed.** Feature branch pushed for review, stacked on #4.
- Doctrine: `local capture → bootable seed → daemon rebind → IOI-owned surface → retire seed`. Harvest the mature graph grammar, prove it under IOI routes, rebind to daemon truth — not cloning Palantir as product.

Scope held: Provenance lineage-graph rebind only — no Vertex / Pipeline Builder / Workshop / native authoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)