### PR TITLE
Automations owner-surface — daemon-authority shape (stacked on #8)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -536,19 +536,24 @@ function automationProjectName(a, projectsById) {
 function renderAutomationsList(automations, projectId, projectsById) {
   const filtName = projectId ? automationProjectName({ project_ref: projectId }, projectsById) : "";
   const newHref = `/__ioi/automations/new${projectId ? `?project=${encodeURIComponent(projectId)}` : ""}`;
-  const head = `<h1>Automations</h1>
-    <p class="sub">Project-scoped durable work — each automation hangs off a project, runs on the daemon over a real environment, and records a tamper-evident transcript. ${projectId ? `Filtered to <b>${CX_ESC(filtName)}</b> · <a href="/__ioi/automations">show all</a>` : "Showing all projects."}</p>
-    <div class="row"><a class="act" href="${newHref}">+ New automation</a><a class="act ghost" href="/__apps/monitors">Monitor wizard seed (adopting) →</a></div>`;
+  // Owner-surface contract: Automations owns DURABLE ORCHESTRATION — the daemon automation records
+  // below are the truth (real specs, triggers, steps, projects), authoritative and countable. The
+  // captured object-monitoring wizard is a SECONDARY reference grammar (a linked walkthrough for the
+  // condition→effect authoring UX), explicitly NOT daemon truth — no captured row is presented here.
+  const head = `<h1 id="automations-owner">Automations</h1>
+    <p class="sub">Durable orchestration — each automation is a daemon-owned spec that hangs off a project, runs over a real environment, and records a tamper-evident transcript. The <b>${automations.length}</b> record${automations.length === 1 ? "" : "s"} below ${projectId ? `(filtered to <b>${CX_ESC(filtName)}</b> · <a href="/__ioi/automations">show all</a>)` : "across all projects"} are daemon truth. <span class="sub">The <a href="/__apps/monitors">monitor-wizard capture ↗</a> is a secondary reference grammar for authoring condition→effect monitors — a linked walkthrough, not a rebound surface; its example rows are never shown here as daemon automations.</span></p>
+    <div class="row"><a class="act" href="${newHref}">+ New automation</a><a class="act ghost" href="/__apps/monitors">Monitor-wizard capture (reference) →</a></div>`;
   if (!automations.length) {
-    return automationsShell("Automations", head + `<div class="empty">No automations yet${projectId ? " for this project" : ""} — create one to get started.</div>`);
+    return automationsShell("Automations", head + `<div class="empty">No daemon automations yet${projectId ? " for this project" : ""} — create one to get started. (The monitor-wizard capture stays a reference; it never fabricates automations here.)</div>`);
   }
   const cards = automations.map((a) => {
     const enabled = a.enabled !== false;
     const steps = Array.isArray(a.steps) ? a.steps.length : 0;
     const model = a.model || "default model";
-    return `<a class="card" href="/__ioi/automations/${encodeURIComponent(a.automation_id)}"><div class="main">
-      <div class="name">${CX_ESC(a.name || a.automation_id)}<span class="pill ${enabled ? "ok" : "muted"}">${enabled ? "enabled" : "disabled"}</span><span class="pill muted">${CX_ESC(a.trigger_kind || "manual")}</span></div>
-      <div class="meta">${CX_ESC(automationProjectName(a, projectsById))} · ${CX_ESC(String(model))} · ${steps} step${steps === 1 ? "" : "s"}</div>
+    const trigger = (a.trigger && (a.trigger.kind || a.trigger.trigger_kind)) || a.trigger_kind || "manual";
+    return `<a class="card automation-card" href="/__ioi/automations/${encodeURIComponent(a.automation_id)}"><div class="main">
+      <div class="name">${CX_ESC(a.name || a.automation_id)}<span class="pill ${enabled ? "ok" : "muted"}">${enabled ? "enabled" : "disabled"}</span><span class="pill muted">${CX_ESC(trigger)}</span></div>
+      <div class="meta">${CX_ESC(automationProjectName(a, projectsById))} · ${CX_ESC(String(model))} · ${steps} step${steps === 1 ? "" : "s"} · <code style="font-size:10.5px">${CX_ESC(a.automation_id)}</code></div>
       </div><span class="act ghost">Open →</span></a>`;
   }).join("");
   return automationsShell("Automations", head + cards);

--- a/apps/hypervisor/scripts/verify-hypervisor-harvest-automations-owner.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-harvest-automations-owner.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Automations owner-surface verifier — the THIRD harvest shape: owner-surface daemon authority.
+//
+// When a captured seed makes no single reboundable data lane (a canvas/wizard grammar), the daemon
+// truth lives on the IOI-OWNED surface and the seed stays a linked, SECONDARY reference. This
+// verifies that contract for Automations (canon: Automations owns durable orchestration):
+//   - the /__ioi/automations surface renders the estate's REAL daemon automations (count + names
+//     match an independent daemon read — no fabrication);
+//   - the object-monitoring capture seed is present but visibly SECONDARY (a linked reference/
+//     walkthrough, never a rebound surface);
+//   - NO captured walkthrough row is presented as a daemon automation (the seed's example content
+//     never leaks into the owner surface as truth);
+//   - trigger/steps render from daemon truth; the surface is brand-clean.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-harvest-automations-owner.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+const esc = (s) => String(s).replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+
+async function run() {
+  const dmUp = await fetch(`${DAEMON}/v1/hypervisor/automations`).then((r) => r.ok).catch(() => false);
+  if (!dmUp) { console.error("BLOCKED: daemon not reachable at " + DAEMON); process.exit(2); }
+
+  // Independent daemon read — the truth the surface must equal.
+  const auto = await fetch(`${DAEMON}/v1/hypervisor/automations`).then((r) => r.json());
+  const automations = auto.automations || [];
+  ok("daemon exposes durable automations", automations.length >= 1, `${automations.length} automations`);
+  const names = automations.map((a) => a.name || a.automation_id).filter(Boolean);
+  const ids = automations.map((a) => a.automation_id);
+
+  const page = await fetch(`${SERVE}/__ioi/automations`).then(async (r) => ({ status: r.status, text: await r.text() }));
+  ok("Automations owner surface serves, brand-clean", page.status === 200 && !/\bPalantir\b/.test(page.text));
+
+  // 1. Owner section renders the REAL daemon automations (count + names + ids).
+  ok("surface states the real daemon automation count", new RegExp(`<b>${automations.length}</b> record`).test(page.text), String(automations.length));
+  const renderedNames = names.filter((n) => page.text.includes(esc(n)));
+  ok("every daemon automation name renders on the surface (no omission)", renderedNames.length === names.length, `${renderedNames.length}/${names.length}`);
+  const renderedIds = ids.filter((id) => page.text.includes(id));
+  ok("daemon automation ids render (traceable to real records, not fabricated)", renderedIds.length === ids.length, `${renderedIds.length}/${ids.length}`);
+  const cardCount = (page.text.match(/class="card automation-card"/g) || []).length;
+  ok("card count equals the daemon automation count (no phantom rows)", cardCount === automations.length, `${cardCount} cards vs ${automations.length}`);
+
+  // 2. The capture seed is present but SECONDARY (linked reference, not a rebound surface).
+  ok("monitor-wizard capture is linked", page.text.includes("/__apps/monitors"));
+  ok("capture seed framed as a SECONDARY reference (not daemon truth)", /reference|walkthrough|secondary/i.test(page.text) && /not a rebound surface|never (shown|fabricates)|never a rebound/i.test(page.text));
+
+  // 3. NO captured walkthrough content is presented as a daemon automation. The object-monitoring /
+  //    aip-assist captures render "… Walkthrough" rows; none may appear on the owner surface.
+  ok("no captured walkthrough row is presented as a daemon automation", !/Walkthrough<\/|AIP Chatbot with transcribed/i.test(page.text));
+  ok("no aip-assist walkthrough creator leaks onto the surface", !page.text.includes("aip-assist"));
+
+  // 4. Trigger/steps render from daemon truth (the card meta reflects the real spec).
+  const a0 = automations[0];
+  const trig0 = (a0.trigger && (a0.trigger.kind || a0.trigger.trigger_kind)) || a0.trigger_kind || "manual";
+  ok("card renders the daemon trigger kind", page.text.includes(`>${esc(trig0)}<`), trig0);
+  ok("card renders daemon step counts", /\d+ step/.test(page.text));
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`harvest automations-owner readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });


### PR DESCRIPTION
**Stack: this → #8 (model-catalog) → #7 → #6 → #5 → #4 → #3 → master.** The **third harvest shape**, formalized — and the one that completes the program's decision rule.

## The three shapes (now all proven)
1. **Lane rebind** — a seed with a populated captured envelope + a 1:1 daemon plane, rendered from one lane → answer the lane with daemon truth (marketplace #3, model-catalog #8).
2. **Owner-surface daemon authority** — a canvas/wizard seed with no single reboundable lane → the daemon truth lives on the IOI-owned surface; the seed stays a linked, secondary reference (Studio #4, Provenance #5, **Automations here**).
3. **Daemon-plane-first** — the truth is empty → build the daemon contract before any UI (backlog: data-sources, ontologies).

The machinery attempt (reverted, unshipped) is what forced shape #3: a seed that renders captured data from a lane you can't isolate must not be called "covered."

## What this does
Canon: **Automations owns durable orchestration.** `/__ioi/automations` now states this and renders the estate's **25 real daemon automations** as the authority — real spec cards (name, enabled, daemon trigger kind [fixed to read `trigger.kind`], project, step count, real `automation_id`). The object-monitoring capture is reframed from "adopting seed" to a clearly **secondary "monitor-wizard capture (reference)"** — a linked walkthrough, explicitly not daemon truth; its example rows are never presented here as automations.

## Done bar — green
| gate | result |
|---|---|
| automations-owner | **12/12** · `verify-hypervisor-harvest-automations-owner.mjs` |
| source-neutral | **PASSED** |
| regressions: model-catalog / marketplace / provenance-lineage | **OK** |
| fallthrough empty · git diff --check | clean |

**No fabrication / no leak (enforced):** independent daemon read → count + every name + every id render; card count == daemon count (no phantom rows); NO captured walkthrough row or `aip-assist` creator appears as daemon truth.

## Posture
- **master not pushed.** Feature branch, stacked on #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)