### PR TITLE
Data-source daemon plane — daemon-plane-first shape (stacked on #9)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2863,6 +2863,27 @@ function odkCard(family, rec, nameKey) {
     : (rec.ref ? CX_ESC(rec.ref) : "");
   return `<a class="card" href="/__ioi/odk/${family}/${e(rec.id)}"><div class="main"><div class="name">${CX_ESC(rec[nameKey] || rec.name || rec.id)} <span class="pill warn">${CX_ESC(rec.status || "draft")}</span></div><div class="meta">${sub}</div></div><span class="act ghost">Open →</span></a>`;
 }
+// Data sources — the DAEMON-PLANE-FIRST shape: a real daemon data-source registry is the authority
+// (built as a contract before any UI promise); the capture seeds are secondary references. A
+// registration is a validated, receipted DECLARATION — ingestion is explicitly NOT wired (named
+// gap), never faked.
+function renderDataSourcesSection(dataSources) {
+  dataSources = Array.isArray(dataSources) ? dataSources : [];
+  const rows = dataSources.map((d) => `<tr>
+    <td><b>${CX_ESC(d.name || d.source_id || "—")}</b><div class="meta" style="color:#878a93;font-size:11.5px;margin-top:2px"><code>${CX_ESC(d.source_ref || "")}</code></div></td>
+    <td><span class="pill muted">${CX_ESC(d.kind || "—")}</span></td>
+    <td>${d.endpoint ? `<code style="font-size:11px">${CX_ESC(d.endpoint)}</code>` : "<span class=\"sub\" style=\"margin:0\">local</span>"}</td>
+    <td><span class="pill muted">${CX_ESC(d.credential_posture || "—")}</span></td>
+    <td><span class="pill ${(d.lifecycle || {}).status === "declared" ? "muted" : "ok"}">${CX_ESC((d.lifecycle || {}).status || "declared")}</span> <span class="pill warn" title="ingestion is not wired — declaration only">not ingesting</span></td>
+  </tr>`).join("");
+  const table = dataSources.length
+    ? `<table><thead><tr><th>Source</th><th>Kind</th><th>Endpoint</th><th>Credential</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`
+    : `<div class="empty">No data sources declared yet. Register one against the daemon <code>POST /v1/hypervisor/data-sources</code> — a validated, receipted declaration (credentials by posture only; ingestion is a named gap, never faked here).</div>`;
+  return `<h2 id="data-sources">Data sources <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the daemon data-source registry (${dataSources.length}) · authority</span></h2>` +
+    `<p class="sub" style="margin:-4px 0 10px">Declared external sources are <b>daemon truth</b> — a fail-closed, receipted registry (credentials by posture only). Ingestion is <b>not wired</b> (a named gap requiring a future authority crossing), never faked. The <a href="/__apps/sources">Data Connection capture ↗</a> and <a href="/__apps/ingest">pipeline capture ↗</a> are secondary reference grammars, not rebound surfaces.</p>` +
+    table;
+}
+
 function renderOdkLanding(ov, lists) {
   const o = ov || {}; const sub = o.substrate || {};
   const note = o.status_note || "ODK foundation: drafts only. No transformation runs, no generated UI artifacts, no Domain App creation.";
@@ -2875,7 +2896,7 @@ function renderOdkLanding(ov, lists) {
   const section = (title, family, items, nameKey, newLabel) => `<h2 style="display:flex;justify-content:space-between;align-items:center">${title} (${items.length}) <a class="act" href="/__ioi/odk/${family}/new">+ ${newLabel}</a></h2>${items.length ? items.map((x) => odkCard(family, x, nameKey)).join("") : `<div class="empty">None yet.</div>`}`;
   return automationsShell("Ontology", head + banner + stats + patterns + outkinds
     + section("Domain Ontologies", "ontologies", lists.ontologies, "domain", "New ontology")
-    + `<div id="data-planes"><p class="sub" style="margin:0 0 8px"><a href="/__apps/ingest">Source-first pipeline seed (adopting) →</a> · <a href="/__apps/sources">Data Connection seed (adopting) →</a></p>` + section("Data Recipes", "data-recipes", lists.data_recipes, "name", "New recipe") + `</div>`
+    + `<div id="data-planes">` + renderDataSourcesSection(lists.data_sources || []) + section("Data Recipes", "data-recipes", lists.data_recipes, "name", "New recipe") + `</div>`
     + section("Surface Descriptors", "surface-descriptors", lists.surface_descriptors, "name", "New descriptor")
     + section("ODK Manifests", "manifests", lists.manifests, "name", "New manifest"));
 }
@@ -6419,12 +6440,13 @@ const server = http.createServer((req, res) => {
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
     if (pathname === "/__ioi/odk" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
-      const [ov, o, r, d, m] = await Promise.all([
+      const [ov, o, r, d, m, ds] = await Promise.all([
         J("/v1/hypervisor/odk/overview"),
         J("/v1/hypervisor/odk/domain-ontologies"),
         J("/v1/hypervisor/odk/data-recipes"),
         J("/v1/hypervisor/odk/surface-descriptors"),
         J("/v1/hypervisor/odk/manifests"),
+        J("/v1/hypervisor/data-sources"),
       ]);
       res.writeHead(200, HTMLH);
       res.end(renderOdkLanding(ov, {
@@ -6432,6 +6454,7 @@ const server = http.createServer((req, res) => {
         data_recipes: r.data_recipes || [],
         surface_descriptors: d.surface_descriptors || [],
         manifests: m.manifests || [],
+        data_sources: ds.data_sources || [],
       }));
       return;
     }

--- a/apps/hypervisor/scripts/verify-hypervisor-data-source-plane.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-data-source-plane.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Data-source daemon plane done-bar — the DAEMON-PLANE-FIRST shape (contract before any UI promise).
+//
+// The Data surface's source catalog had no daemon truth (empty capture envelope, no plane). Per the
+// decision rule, the truth is built as a daemon CONTRACT first: a fail-closed, receipted DRAFT
+// registry of declared external data sources — admission-only, ingestion explicitly not wired.
+//
+// Asserts: the plane serves; registration is FAIL-CLOSED (plaintext secret rejected, unknown kind
+// rejected, network kind requires an endpoint, credential posture validated); a valid registration
+// persists as a `declared`, receipted record that is honestly NOT wired for ingestion; the record
+// reads back; the overview names its governance gaps; and the Data owner surface renders the plane
+// as authority with the sources seed kept secondary.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-data-source-plane.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/data-sources`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon data-source plane not reachable at " + DAEMON); process.exit(2); }
+
+  // 1. Plane serves + overview names its draft-nature gaps.
+  const list0 = await jd("GET", "/v1/hypervisor/data-sources");
+  ok("data-source plane serves a registry list", list0.status === 200 && Array.isArray(list0.j.data_sources), `${(list0.j.data_sources || []).length} sources`);
+  const ov = await jd("GET", "/v1/hypervisor/data-sources/overview");
+  ok("overview schema + known kinds + governance gaps", ov.j.schema_version === "ioi.hypervisor.data-sources-overview.v1" && (ov.j.known_kinds || []).length >= 5 && (ov.j.governance_gaps || []).length >= 1);
+  ok("overview names that ingestion is NOT wired (draft honesty)", JSON.stringify(ov.j.governance_gaps || []).match(/not wired|declaration only|nothing here connects/i) !== null);
+
+  // 2. Registration is FAIL-CLOSED.
+  const secret = await jd("POST", "/v1/hypervisor/data-sources", { name: "x", kind: "postgres", endpoint: "postgres://h", password: "hunter2" });
+  ok("plaintext secret rejected outright", secret.status === 400 && secret.j.error?.code === "data_source_plaintext_secret_rejected", secret.j.error?.code);
+  const badKind = await jd("POST", "/v1/hypervisor/data-sources", { name: "x", kind: "bogus" });
+  ok("unknown kind rejected fail-closed", badKind.status === 400 && badKind.j.error?.code === "data_source_kind_invalid", badKind.j.error?.code);
+  const noEndpoint = await jd("POST", "/v1/hypervisor/data-sources", { name: "x", kind: "postgres" });
+  ok("network kind without an endpoint rejected", noEndpoint.status === 400 && noEndpoint.j.error?.code === "data_source_endpoint_required", noEndpoint.j.error?.code);
+  const noName = await jd("POST", "/v1/hypervisor/data-sources", { kind: "local_folder" });
+  ok("registration without a name rejected", noName.status === 400 && noName.j.error?.code === "data_source_name_required", noName.j.error?.code);
+  const badCred = await jd("POST", "/v1/hypervisor/data-sources", { name: "x", kind: "local_folder", credential_posture: "just_paste_the_key" });
+  ok("invalid credential posture rejected (postures only, never a secret)", badCred.status === 400 && badCred.j.error?.code === "data_source_credential_posture_invalid", badCred.j.error?.code);
+
+  // 3. Valid registration = declared, receipted, honestly NOT wired.
+  const marker = `Verify Source ${Date.now().toString(36)}`;
+  const created = await jd("POST", "/v1/hypervisor/data-sources", { name: marker, kind: "rest_api", endpoint: "https://api.example.invalid/v1", credential_posture: "wallet_credential_lease" });
+  const rec = created.j.data_source;
+  ok("valid registration persists a declared record", created.status === 201 && rec?.schema_version === "ioi.hypervisor.data-source.v1" && rec?.lifecycle?.status === "declared", rec?.source_id);
+  ok("registration is receipted", (rec?.receipt_refs || []).length >= 1 && String(rec.receipt_refs[0]).startsWith("agentgres://data-source-receipt/"));
+  ok("registration is honestly NOT wired for ingestion (named gap, no fake runtime)", rec?.ingestion?.wired === false);
+  ok("no plaintext credential stored (posture only)", rec?.credential_posture === "wallet_credential_lease" && !JSON.stringify(rec).match(/hunter2|password|api_key/i));
+  const got = await jd("GET", `/v1/hypervisor/data-sources/${rec.source_id}`);
+  ok("record reads back by id", got.status === 200 && got.j.data_source?.name === marker);
+  const listN = await jd("GET", "/v1/hypervisor/data-sources");
+  ok("registered source appears in the list", (listN.j.data_sources || []).some((d) => d.source_id === rec.source_id));
+
+  // 4. Data owner surface renders the plane as authority, sources seed secondary.
+  const page = await fetch(`${SERVE}/__ioi/odk`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+  ok("Data/Ontology surface serves brand-clean", page.status === 200 && !/\bPalantir\b/.test(page.text));
+  ok("owner surface renders the data-source plane as authority (the registered source)", page.text.includes(marker) || /Data sources/i.test(page.text), "surface reflects the plane");
+  ok("sources capture seed kept secondary (linked reference)", page.text.includes("/__apps/sources"));
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`data-source plane readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -86,6 +86,8 @@ mod lifecycle_routes;
 mod marketplace_routes;
 #[path = "hypervisor_daemon_routes/microvm.rs"]
 mod microvm;
+#[path = "hypervisor_daemon_routes/data_source_routes.rs"]
+mod data_source_routes;
 #[path = "hypervisor_daemon_routes/harness_routes.rs"]
 mod harness_routes;
 #[path = "hypervisor_daemon_routes/model_routes.rs"]
@@ -1584,6 +1586,19 @@ async fn async_main() -> anyhow::Result<()> {
             "/v1/hypervisor/harness-profiles/:id/session-bindings",
             post(harness_routes::handle_harness_profile_bind_session)
                 .get(harness_routes::handle_harness_profile_bindings_list),
+        )
+        .route(
+            "/v1/hypervisor/data-sources",
+            get(data_source_routes::handle_data_sources_list)
+                .post(data_source_routes::handle_data_source_create),
+        )
+        .route(
+            "/v1/hypervisor/data-sources/overview",
+            get(data_source_routes::handle_data_sources_overview),
+        )
+        .route(
+            "/v1/hypervisor/data-sources/:id",
+            get(data_source_routes::handle_data_source_get),
         )
         .route(
             "/v1/hypervisor/placement/resolve",

--- a/crates/node/src/bin/hypervisor_daemon_routes/data_source_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/data_source_routes.rs
@@ -1,0 +1,251 @@
+//! Data-source REGISTRY — daemon-owned truth for declared external data sources. A DRAFT plane
+//! (contract-first, per the estate doctrine): a registration is a validated, receipted DECLARATION
+//! of an external source the estate may later ingest from. It is admission-only — nothing here
+//! connects, extracts, or moves data; effectful ingestion is a NAMED GAP that requires a future
+//! wallet/authority crossing bound to admitted substrate.
+//!
+//! Doctrine enforced here:
+//! - Registration is FAIL-CLOSED: the source kind must be a known kind, a network kind must carry an
+//!   endpoint, and a credential is NEVER accepted as a plaintext secret — only a declared
+//!   credential posture (the secret stays in the daemon's own credential planes, referenced by
+//!   posture). A plaintext `secret`/`password`/`api_key` in the body is rejected outright.
+//! - Every registration writes a receipt; the record is honest about its lifecycle (`declared`) and
+//!   names that ingestion is not wired.
+//! - Records persist under `data-source-registry` (a fresh plane; no existing family is touched).
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+
+use super::{iso_now, persist_record, read_record_dir, DaemonState};
+
+const SOURCE_SCHEMA: &str = "ioi.hypervisor.data-source.v1";
+const RECEIPT_SCHEMA: &str = "ioi.hypervisor.data-source-receipt.v1";
+const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.data-sources-overview.v1";
+pub(crate) const RECORD_DIR: &str = "data-source-registry";
+const RECEIPT_DIR: &str = "data-source-registry-receipts";
+
+/// Known source kinds. `network` kinds require an endpoint; `local` kinds (file/object drop) do not.
+const SOURCE_KINDS: &[(&str, bool)] = &[
+    ("postgres", true),
+    ("mysql", true),
+    ("rest_api", true),
+    ("graphql_api", true),
+    ("s3", true),
+    ("object_store", true),
+    ("http_feed", true),
+    ("kafka", true),
+    ("file_drop", false),
+    ("local_folder", false),
+];
+/// Declared credential postures (the secret itself never enters this plane).
+const CREDENTIAL_POSTURES: &[&str] = &[
+    "no_credentials_required",
+    "wallet_credential_lease",
+    "provider_vault_token",
+    "customer_boundary",
+];
+/// Body keys that would be a plaintext secret — rejected outright (no secret ever enters the plane).
+const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
+
+fn nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+fn s(v: &Value, k: &str, d: &str) -> String {
+    v.get(k).and_then(|x| x.as_str()).unwrap_or(d).to_string()
+}
+fn opt_s(v: &Value, k: &str) -> Option<String> {
+    v.get(k)
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|x| !x.is_empty())
+        .map(str::to_string)
+}
+
+fn kind_requires_endpoint(kind: &str) -> Option<bool> {
+    SOURCE_KINDS
+        .iter()
+        .find(|(k, _)| *k == kind)
+        .map(|(_, net)| *net)
+}
+
+fn load_source(data_dir: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, RECORD_DIR)
+        .into_iter()
+        .find(|r| r.get("source_id").and_then(|v| v.as_str()) == Some(id))
+}
+
+fn source_receipt(data_dir: &str, source_ref: &str, op: &str, outcome: &str) -> String {
+    let id = format!("dsr_{:x}", nanos());
+    let receipt_ref = format!("agentgres://data-source-receipt/{id}");
+    let _ = persist_record(
+        data_dir,
+        RECEIPT_DIR,
+        &id,
+        &json!({
+            "schema_version": RECEIPT_SCHEMA, "receipt_id": id, "receipt_ref": receipt_ref,
+            "source_ref": source_ref, "op": op, "outcome": outcome, "at": iso_now()
+        }),
+    );
+    receipt_ref
+}
+
+fn sorted_sources(data_dir: &str) -> Vec<Value> {
+    let mut sources = read_record_dir(data_dir, RECORD_DIR);
+    sources.sort_by(|a, b| s(b, "created_at", "").cmp(&s(a, "created_at", "")));
+    sources
+}
+
+/// GET /v1/hypervisor/data-sources — the declared data-source registry (newest first).
+pub(crate) async fn handle_data_sources_list(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    Json(json!({
+        "schema_version": SOURCE_SCHEMA,
+        "data_sources": sorted_sources(&st.data_dir),
+        "runtimeTruthSource": "daemon-runtime"
+    }))
+}
+
+/// GET /v1/hypervisor/data-sources/overview — posture + counts + governance gaps (named honestly).
+pub(crate) async fn handle_data_sources_overview(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let sources = read_record_dir(&st.data_dir, RECORD_DIR);
+    let by_kind = |kind: &str| sources.iter().filter(|r| s(r, "kind", "") == kind).count();
+    let kinds: Value = SOURCE_KINDS
+        .iter()
+        .filter(|(k, _)| by_kind(k) > 0)
+        .map(|(k, _)| json!({ "kind": k, "count": by_kind(k) }))
+        .collect();
+    Json(json!({
+        "schema_version": OVERVIEW_SCHEMA,
+        "data_sources": sources.len(),
+        "kinds": kinds,
+        "known_kinds": SOURCE_KINDS.iter().map(|(k, _)| *k).collect::<Vec<_>>(),
+        "credential_postures": CREDENTIAL_POSTURES,
+        "governance_gaps": [
+            "this is a DRAFT registry — a registration is a validated declaration only; nothing here connects, extracts, or moves data",
+            "ingestion/extraction is not wired: an effectful pull requires a future wallet/authority crossing bound to admitted substrate (named, not built)",
+            "credentials never enter this plane — only a declared credential posture is stored; the secret lives in the daemon credential planes and is referenced by posture"
+        ],
+        "runtimeTruthSource": "daemon-runtime"
+    }))
+}
+
+/// GET /v1/hypervisor/data-sources/:id — one declared source.
+pub(crate) async fn handle_data_source_get(
+    State(st): State<Arc<DaemonState>>,
+    AxumPath(id): AxumPath<String>,
+) -> (StatusCode, Json<Value>) {
+    match load_source(&st.data_dir, &id) {
+        Some(record) => (StatusCode::OK, Json(json!({ "data_source": record }))),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": { "code": "not_found", "data_source": id } })),
+        ),
+    }
+}
+
+/// POST /v1/hypervisor/data-sources — register a declared source. FAIL-CLOSED: known kind, name
+/// required, endpoint required for network kinds, valid credential posture, and NO plaintext secret.
+pub(crate) async fn handle_data_source_create(
+    State(st): State<Arc<DaemonState>>,
+    Json(body): Json<Value>,
+) -> (StatusCode, Json<Value>) {
+    let err = |code: &str, msg: &str| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": { "code": code, "message": msg } })),
+        )
+    };
+    // Reject plaintext secrets outright — the plane never accepts a raw credential.
+    if let Some(obj) = body.as_object() {
+        if PLAINTEXT_SECRET_KEYS
+            .iter()
+            .any(|k| obj.contains_key(*k) && !obj[*k].is_null())
+        {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": {
+                    "code": "data_source_plaintext_secret_rejected",
+                    "message": "Plaintext credentials are never accepted. Declare credential_posture; the secret stays in the daemon credential planes."
+                } })),
+            );
+        }
+    }
+    let name = match opt_s(&body, "name") {
+        Some(n) => n,
+        None => return err("data_source_name_required", "A data source requires a name."),
+    };
+    let kind = s(&body, "kind", "");
+    let requires_endpoint = match kind_requires_endpoint(&kind) {
+        Some(v) => v,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": {
+                    "code": "data_source_kind_invalid",
+                    "message": "Unknown data source kind.",
+                    "known_kinds": SOURCE_KINDS.iter().map(|(k, _)| *k).collect::<Vec<_>>()
+                } })),
+            );
+        }
+    };
+    let endpoint = opt_s(&body, "endpoint");
+    if requires_endpoint && endpoint.is_none() {
+        return err(
+            "data_source_endpoint_required",
+            "A network data source kind requires an endpoint.",
+        );
+    }
+    let credential_posture = s(&body, "credential_posture", "no_credentials_required");
+    if !CREDENTIAL_POSTURES.contains(&credential_posture.as_str()) {
+        return err(
+            "data_source_credential_posture_invalid",
+            "credential_posture must be a declared posture (never a plaintext secret).",
+        );
+    }
+    let source_id = format!("ds_{:x}", nanos());
+    let source_ref = format!("data-source:{source_id}");
+    let receipt = source_receipt(&st.data_dir, &source_ref, "registered", "ok");
+    let record = json!({
+        "schema_version": SOURCE_SCHEMA,
+        "source_id": source_id,
+        "source_ref": source_ref,
+        "name": name,
+        "kind": kind,
+        "endpoint": endpoint,
+        "credential_posture": credential_posture,
+        "credential_binding": opt_s(&body, "credential_lease_ref").map(|r| json!({ "kind": "lease_ref", "credential_lease_ref": r })).unwrap_or(Value::Null),
+        "project_ref": opt_s(&body, "project_ref"),
+        "lifecycle": { "status": "declared" },
+        "ingestion": { "wired": false, "note": "declaration only — extraction requires a future authority crossing (named gap)" },
+        "receipt_refs": [receipt],
+        "created_at": iso_now(),
+        "updated_at": iso_now(),
+        "runtimeTruthSource": "daemon-runtime"
+    });
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &source_id, &record);
+    (StatusCode::CREATED, Json(json!({ "data_source": record })))
+}
+
+#[cfg(test)]
+mod data_source_tests {
+    use super::*;
+
+    #[test]
+    fn network_kind_requires_endpoint() {
+        assert_eq!(kind_requires_endpoint("postgres"), Some(true));
+        assert_eq!(kind_requires_endpoint("local_folder"), Some(false));
+        assert_eq!(kind_requires_endpoint("nonsense"), None);
+    }
+
+    #[test]
+    fn plaintext_secret_keys_are_named() {
+        assert!(PLAINTEXT_SECRET_KEYS.contains(&"password"));
+        assert!(PLAINTEXT_SECRET_KEYS.contains(&"api_key"));
+    }
+}


### PR DESCRIPTION
**Stack: this → #9 (automations-owner) → #8 → #7 → #6 → #5 → #4 → #3 → master.** The **daemon-plane-first** shape, opened deliberately per the steer: *start with a daemon contract, not a UI promise.*

## Why this shape
The Data source catalog had **no daemon plane** and an **empty capture envelope** (`extracts/source` → `{}`) — so neither a lane rebind nor an owner-surface read was possible. Per the decision rule, the truth is built as a daemon **contract** first.

## What this does
New daemon plane `/v1/hypervisor/data-sources` (`data_source_routes.rs`) — a **draft** registry of declared external sources (list / overview / get / register):
- **Fail-closed registration:** known kind (10; network kinds require an endpoint), name required, credential posture validated, and a **plaintext secret in the body is rejected outright** — the plane never accepts a raw credential; only a declared `credential_posture` is stored (the secret stays in the daemon credential planes).
- Every registration is **receipted** and honestly `declared` + `ingestion.wired: false` — extraction is a **named gap** requiring a future authority crossing; nothing here connects, extracts, or moves data.

**Only after** the truth exists, the Data owner surface (`/__ioi/odk`) renders the plane as **authority** (a real Data-sources table) and reframes the data-connection / pipeline captures as **secondary reference grammars**. No UI promised ahead of truth.

## Done bar — green
| gate | result |
|---|---|
| data-source plane | **17/17** · `verify-hypervisor-data-source-plane.mjs` |
| cargo test -p ioi-node | **64/64** (+ 2 new unit tests) |
| source-neutral | **PASSED** |
| regressions: automations-owner / model-catalog / canvas-seeds | **OK** |
| fallthrough empty · git diff --check | clean |

## The program is now a complete decision rule (four shapes)
1. **Lane rebind** — populated envelope + 1:1 daemon plane + single lane (marketplace #3, model-catalog #8).
2. **Owner-surface authority** — no single lane (Studio #4, Provenance #5, Automations #9).
3. **Capture-completeness inventory** — the map + fidelity oracle (#6, #7).
4. **Daemon-plane-first** — the truth is empty → build the contract (this PR).

- **master not pushed.** Feature branch, stacked on #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)