### PR TITLE
Ontology manager contract — promote the ODK DomainOntology plane in place (stacked on #10)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2643,10 +2643,15 @@ async function odkPickers() {
 }
 // ---- payload builders (form -> daemon JSON), shared by create + patch.
 function odkOntologyPayload(p) {
-  const csv = (k) => (p.get(k) || "").split(",").map((s) => s.trim()).filter(Boolean);
+  // The typed CanonicalObjectModel is authored as JSON; a parse failure is marked so the daemon
+  // rejects it with a clean error (never silently dropped to an empty model).
+  const raw = (p.get("canonical_object_model") || "").trim();
+  let com;
+  if (!raw) com = { value_types: [], object_types: [], link_types: [], action_types: [] };
+  else { try { com = JSON.parse(raw); } catch { com = { __json_parse_error: true }; } }
   return {
     domain: (p.get("domain") || "").trim(), version: (p.get("version") || "0.1.0").trim(), description: (p.get("description") || "").trim(),
-    canonical_object_model: { objects: csv("com_objects"), actions: csv("com_actions"), events: csv("com_events"), states: csv("com_states"), roles: csv("com_roles") },
+    canonical_object_model: com,
   };
 }
 function odkRecipePayload(p) {
@@ -2683,17 +2688,23 @@ function odkDetailActions(family, id) {
 }
 // ---- forms
 function renderOdkOntologyForm(existing) {
-  const ex = existing || {}; const isEdit = !!existing; const com = ex.canonical_object_model || {};
+  const ex = existing || {}; const isEdit = !!existing;
+  const com = ex.canonical_object_model || { value_types: [], object_types: [], link_types: [], action_types: [] };
+  const comJson = JSON.stringify(com, null, 2);
   const action = isEdit ? `/__ioi/odk/ontologies/${encodeURIComponent(ex.id)}/patch` : `/__ioi/odk/ontologies`;
+  const shape = `value_types: [{ id, name, base, enum_values? }]   base ∈ string integer double boolean timestamp date enum markdown geo_point attachment
+object_types: [{ id, name, title_property?, properties:[{ id, name, value_type, required? }] }]   value_type → a base or a declared value_type id
+link_types: [{ id, name, from, to, cardinality }]   from/to → object_type ids · cardinality ∈ one_to_one one_to_many many_to_many
+action_types: [{ id, name, kind, applies_to? }]   kind ∈ create_object modify_object delete_object function
+Type ids match ^[a-z][a-z0-9_]*$. Health is "ready" only with ≥1 typed object (properties + title) and ≥1 link or action.`;
   const inner = `<p><a href="/__ioi/odk">← ODK</a></p><h1>${isEdit ? "Edit" : "New"} Domain Ontology</h1>
-    <p class="sub">The semantic root. Draft-only; nothing is generated or executed.</p>
+    <p class="sub">The typed semantic root — validated fail-closed by the daemon. Draft-only; nothing is generated or executed.</p>
     <form method="post" action="${action}">
       <div class="two">${odkField("Domain", "domain", ex.domain, "lending")}${odkField("Version", "version", ex.version || "0.1.0")}</div>
       ${odkArea("Description", "description", ex.description)}
-      <h2>Canonical object model <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— comma-separated</span></h2>
-      <div class="two">${odkCsvField("Objects", "com_objects", com.objects, "Loan, Borrower")}${odkCsvField("Actions", "com_actions", com.actions, "approve, fund")}</div>
-      <div class="two">${odkCsvField("Events", "com_events", com.events, "Funded")}${odkCsvField("States", "com_states", com.states, "draft, funded")}</div>
-      ${odkCsvField("Roles", "com_roles", com.roles, "officer")}
+      <h2>Canonical object model <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— typed JSON</span></h2>
+      <details style="margin:0 0 8px"><summary class="sub" style="cursor:pointer">Shape — value / object / link / action types</summary><pre class="sub" style="white-space:pre-wrap;margin:6px 0 0">${CX_ESC(shape)}</pre></details>
+      <div class="field"><label>canonical_object_model (JSON)</label><textarea name="canonical_object_model" rows="16" style="font-family:ui-monospace,monospace;font-size:12px">${CX_ESC(comJson)}</textarea></div>
       <div class="row"><button class="act" type="submit">${isEdit ? "Save draft" : "Create draft ontology"}</button> <a class="act ghost" href="/__ioi/odk">Cancel</a></div>
     </form>`;
   return automationsShell(`${isEdit ? "Edit" : "New"} Domain Ontology`, inner);
@@ -2786,19 +2797,70 @@ function odkProofCitations(rec, lists) {
     ${cits.length ? `<table><thead><tr><th>Kind</th><th>Status</th><th>When</th><th>Proof</th></tr></thead><tbody>${rows}</tbody></table><p class="sub" style="margin:6px 0 0">${cits.length} citation${cits.length === 1 ? "" : "s"} · <a href="/__ioi/work-ledger">Provenance →</a></p>`
       : `<div class="empty">No proof-stream citations yet — receipts cite this ref when governed work touches it.</div>`}</div>`;
 }
+// ---- Ontology-manager rendering. The typed CanonicalObjectModel is daemon-validated authority;
+// health is honest (draft/incomplete allowed); the plane owns NO object instances, so no explorer
+// rows are ever shown — the schema/explorer captures stay secondary reference grammars.
+function ontologyHealthPill(h) {
+  const st = (h && h.status) || "empty";
+  const cls = st === "ready" ? "ok" : st === "empty" ? "muted" : "warn";
+  return `<span class="pill ${cls}">${CX_ESC(st)}</span>`;
+}
+function renderOntologyHealth(h) {
+  h = h || {}; const c = h.counts || {};
+  const counts = `${c.object_types || 0} obj · ${c.value_types || 0} val · ${c.link_types || 0} link · ${c.action_types || 0} act`;
+  const gaps = (h.gaps && h.gaps.length)
+    ? `<ul style="margin:6px 0 0;padding-left:18px">${h.gaps.map((g) => `<li class="sub" style="margin:0">${CX_ESC(g)}</li>`).join("")}</ul>`
+    : `<div class="sub" style="margin:6px 0 0">No gaps — the required semantic pieces are present.</div>`;
+  const instances = h.object_instances == null ? 0 : h.object_instances;
+  return `<div style="border:1px solid #24262d;border-radius:10px;padding:12px 14px;margin:0 0 14px;background:#15171c">
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap"><b>Readiness</b> ${ontologyHealthPill(h)} <span class="sub" style="margin:0">${CX_ESC(counts)}</span></div>
+    ${gaps}
+    <div class="sub" style="margin:8px 0 0"><b>${CX_ESC(String(instances))}</b> object instances — ${CX_ESC(h.object_data_note || "schema only; no object-instance plane is bound.")}</div>
+  </div>`;
+}
+function renderOntologyModel(com) {
+  com = com || {}; const esc = CX_ESC; const idc = (x) => `<code>${esc(x || "")}</code>`;
+  const arr = (k) => (Array.isArray(com[k]) ? com[k] : []);
+  const vts = arr("value_types"), ots = arr("object_types"), lts = arr("link_types"), ats = arr("action_types");
+  const valueTable = vts.length
+    ? `<table><thead><tr><th>Value type</th><th>Base</th><th>Enum</th></tr></thead><tbody>${vts.map((v) => `<tr><td>${esc(v.name || v.id)} ${idc(v.id)}</td><td><span class="pill muted">${esc(v.base || "string")}</span></td><td>${(v.enum_values && v.enum_values.length) ? v.enum_values.map((e) => `<span class="pill muted">${esc(e)}</span>`).join(" ") : "—"}</td></tr>`).join("")}</tbody></table>`
+    : `<div class="empty">No value types.</div>`;
+  const objBlocks = ots.length ? ots.map((o) => {
+    const props = Array.isArray(o.properties) ? o.properties : [];
+    const ptable = props.length
+      ? `<table><thead><tr><th>Property</th><th>Value type</th><th>Required</th></tr></thead><tbody>${props.map((p) => `<tr><td>${esc(p.name || p.id)} ${idc(p.id)}${o.title_property === p.id ? ` <span class="pill ok">title</span>` : ""}</td><td><code>${esc(p.value_type || "")}</code></td><td>${p.required ? "yes" : "—"}</td></tr>`).join("")}</tbody></table>`
+      : `<div class="empty">No properties.</div>`;
+    return `<div style="border:1px solid #24262d;border-radius:10px;padding:10px 12px;margin:0 0 10px;background:#15171c"><div style="font-weight:600;margin-bottom:4px">${esc(o.name || o.id)} ${idc(o.id)}</div>${ptable}</div>`;
+  }).join("") : `<div class="empty">No object types — the model is an empty draft.</div>`;
+  const linkTable = lts.length
+    ? `<table><thead><tr><th>Link</th><th>From → To</th><th>Cardinality</th></tr></thead><tbody>${lts.map((l) => `<tr><td>${esc(l.name || l.id)} ${idc(l.id)}</td><td><code>${esc(l.from || "")}</code> → <code>${esc(l.to || "")}</code></td><td><span class="pill muted">${esc(l.cardinality || "")}</span></td></tr>`).join("")}</tbody></table>`
+    : `<div class="empty">No link types.</div>`;
+  const actTable = ats.length
+    ? `<table><thead><tr><th>Action / function</th><th>Kind</th><th>Applies to</th></tr></thead><tbody>${ats.map((a) => `<tr><td>${esc(a.name || a.id)} ${idc(a.id)}</td><td><span class="pill muted">${esc(a.kind || "")}</span></td><td>${a.applies_to ? `<code>${esc(a.applies_to)}</code>` : "—"}</td></tr>`).join("")}</tbody></table>`
+    : `<div class="empty">No action / function types.</div>`;
+  return `<h2>Value types (${vts.length})</h2>${valueTable}<h2>Object types (${ots.length})</h2>${objBlocks}<h2>Link types (${lts.length})</h2>${linkTable}<h2>Actions &amp; functions (${ats.length})</h2>${actTable}`;
+}
 function renderOdkOntologyDetail(o, lists) {
-  const chips = (arr) => (arr && arr.length) ? arr.map((x) => `<span class="pill muted">${CX_ESC(x)}</span>`).join(" ") : "—";
   const com = o.canonical_object_model || {};
+  // Legacy (pre-hardening) untyped string arrays are shown as clearly-labeled, non-authoritative names.
+  const legacyChips = (arr) => arr.map((x) => `<span class="pill muted">${CX_ESC(typeof x === "string" ? x : (x.name || x.id || ""))}</span>`).join(" ");
+  const legacy = [["objects", com.objects], ["actions", com.actions], ["events", com.events], ["states", com.states], ["roles", com.roles]]
+    .filter(([, v]) => Array.isArray(v) && v.length && v.every((x) => typeof x === "string"));
+  const legacyBlock = legacy.length
+    ? `<h2>Legacy names <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— untyped, pre-hardening; not part of the validated model</span></h2><dl class="grid">${legacy.map(([k, v]) => `<dt>${CX_ESC(k)}</dt><dd>${legacyChips(v)}</dd>`).join("")}</dl>`
+    : "";
   const grid = `<dl class="grid">
     <dt>Id</dt><dd><code>${CX_ESC(o.id)}</code></dd><dt>Ref</dt><dd><code>${CX_ESC(o.ref)}</code></dd>
     <dt>Domain · version</dt><dd>${CX_ESC(o.domain)} · ${CX_ESC(o.version || "")}</dd>
-    <dt>Status</dt><dd><span class="pill warn">${CX_ESC(o.status || "draft")}</span></dd>
+    <dt>Status · revision</dt><dd><span class="pill warn">${CX_ESC(o.status || "draft")}</span> <span class="pill muted">rev ${CX_ESC(String(o.revision || 1))}</span></dd>
     <dt>Description</dt><dd>${CX_ESC(o.description || "—")}</dd>
-    <dt>Objects</dt><dd>${chips(com.objects)}</dd><dt>Actions</dt><dd>${chips(com.actions)}</dd>
-    <dt>Events</dt><dd>${chips(com.events)}</dd><dt>States</dt><dd>${chips(com.states)}</dd><dt>Roles</dt><dd>${chips(com.roles)}</dd>
     <dt>Created · updated</dt><dd>${CX_ESC(o.created_at || "")}<br><span class="sub" style="margin:0">${CX_ESC(o.updated_at || "")}</span></dd>
   </dl>`;
-  return automationsShell(o.domain || "Domain Ontology", `<p><a href="/__ioi/odk">← ODK</a></p><h1>${CX_ESC(o.domain || o.id)}</h1><p class="sub">DomainOntology · draft.</p>${odkDetailActions("ontologies", o.id)}${grid}${odkReferencedBy(o, lists, "ontologies")}${odkProofCitations(o, lists)}`);
+  const hist = (o.history && o.history.length)
+    ? `<h2>History (${o.history.length})</h2><dl class="grid">${o.history.slice().reverse().map((e) => `<dt>rev ${CX_ESC(String(e.revision || ""))} · ${CX_ESC(e.op || "")}</dt><dd>${CX_ESC(e.summary || "")}<br><span class="sub" style="margin:0">${CX_ESC(e.at || "")}${e.receipt_ref ? ` · <code>${CX_ESC(e.receipt_ref)}</code>` : ""}</span></dd>`).join("")}</dl>`
+    : "";
+  const explorerNote = `<p class="sub" style="margin:14px 0 0"><b>Object explorer:</b> no rows — this ontology binds no object-instance plane (schema only). The <a href="/__apps/explorer">Object explorer capture ↗</a> is a secondary reference grammar, not a rebound surface.</p>`;
+  return automationsShell(o.domain || "Domain Ontology", `<p><a href="/__ioi/odk">← ODK</a></p><h1>${CX_ESC(o.domain || o.id)}</h1><p class="sub">DomainOntology · draft · the typed semantic world-model (daemon-validated).</p>${odkDetailActions("ontologies", o.id)}${renderOntologyHealth(o.health)}${grid}${renderOntologyModel(com)}${legacyBlock}${hist}${explorerNote}${odkReferencedBy(o, lists, "ontologies")}${odkProofCitations(o, lists)}`);
 }
 function renderOdkRecipeDetail(r, lists) {
   const refrow = (label, arr) => `<dt>${label}</dt><dd>${(arr && arr.length) ? arr.map((x) => odkRefLink(x)).join(" ") : "—"}</dd>`;
@@ -2884,10 +2946,34 @@ function renderDataSourcesSection(dataSources) {
     table;
 }
 
+// The daemon ontology manager is authority: each row carries the typed-model counts, honest health,
+// and revision. NO object/explorer rows are shown (schema only — no object-instance plane is bound);
+// the schema/explorer captures are secondary reference grammars.
+function renderOntologySection(ontologies) {
+  ontologies = Array.isArray(ontologies) ? ontologies : [];
+  const rows = ontologies.map((o) => {
+    const h = o.health || {}; const c = h.counts || {};
+    const model = `${c.object_types || 0} obj · ${c.value_types || 0} val · ${c.link_types || 0} link · ${c.action_types || 0} act`;
+    const gaps = (h.gaps && h.gaps.length) ? ` <span class="sub" style="margin:0" title="${CX_ESC(h.gaps.join("; "))}">${h.gaps.length} gap${h.gaps.length === 1 ? "" : "s"}</span>` : "";
+    return `<tr>
+      <td><a href="/__ioi/odk/ontologies/${encodeURIComponent(o.id)}"><b>${CX_ESC(o.domain || o.id)}</b></a><div class="meta" style="color:#878a93;font-size:11.5px;margin-top:2px"><code>${CX_ESC(o.ref || "")}</code> · v${CX_ESC(o.version || "0.1.0")}</div></td>
+      <td>${CX_ESC(model)}</td>
+      <td>${ontologyHealthPill(h)}${gaps}</td>
+      <td><span class="pill muted">rev ${CX_ESC(String(o.revision || 1))}</span></td>
+    </tr>`;
+  }).join("");
+  const table = ontologies.length
+    ? `<table><thead><tr><th>Domain</th><th>Object model</th><th>Health</th><th>Revision</th></tr></thead><tbody>${rows}</tbody></table>`
+    : `<div class="empty">No ontologies yet. Create one — a typed CanonicalObjectModel (value / object / link / action types), validated fail-closed by the daemon. Health is honest: <code>ready</code> only when the required semantic pieces exist.</div>`;
+  return `<h2 id="domain-ontologies" style="display:flex;justify-content:space-between;align-items:center">Domain Ontologies <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the daemon ontology manager (${ontologies.length}) · authority</span> <a class="act" href="/__ioi/odk/ontologies/new">+ New ontology</a></h2>`
+    + `<p class="sub" style="margin:-4px 0 10px">The typed world-model is <b>daemon truth</b> — object / link / action / value types validated fail-closed, every revision receipted. Health is honest (draft/incomplete allowed; <code>ready</code> only when required pieces exist). <b>No object / explorer rows are shown</b> — schema only; a real ontology-bound object plane is not built. The <a href="/__apps/schema">Schema workbench capture ↗</a> and <a href="/__apps/explorer">Object explorer capture ↗</a> are secondary reference grammars, not rebound surfaces.</p>`
+    + table;
+}
+
 function renderOdkLanding(ov, lists) {
   const o = ov || {}; const sub = o.substrate || {};
   const note = o.status_note || "ODK foundation: drafts only. No transformation runs, no generated UI artifacts, no Domain App creation.";
-  const head = `<h1>Ontology</h1><p class="sub">The semantic world-model systems act on — author draft ontologies, value types, surface descriptors, and manifests over real substrate (planes scaffolded by the ODK developer kit). The <a href="#data-planes">Data planes</a> (recipes, sources) share this surface until their dedicated surface lands. Nothing here transforms data or generates a running app. <a href="/__apps/schema">Schema workbench seed (adopting) →</a> · <a href="/__apps/explorer">Object explorer seed (adopting) →</a></p>`;
+  const head = `<h1>Ontology</h1><p class="sub">The semantic world-model systems act on — a typed, daemon-validated CanonicalObjectModel (object / link / action / value types) plus surface descriptors and manifests over real substrate (planes scaffolded by the ODK developer kit). The <a href="#data-planes">Data planes</a> (recipes, sources) share this surface until their dedicated surface lands. Nothing here transforms data or generates a running app; the object model is a validated schema, not object data.</p>`;
   const banner = `<div class="chips"><span class="pill warn">draft-only</span> <span class="sub" style="margin:0">${CX_ESC(note)}</span></div>`;
   const stat = (label, val) => `<div style="flex:1;min-width:104px;padding:12px 14px;border:1px solid #24262d;border-radius:10px;background:#15171c"><div style="font-size:22px;font-weight:700;color:#fff">${CX_ESC(String(val == null ? "—" : val))}</div><div style="color:#878a93;font-size:12px;margin-top:2px">${CX_ESC(label)}</div></div>`;
   const stats = `<h2>Substrate</h2><div class="row" style="gap:10px;align-items:stretch">${stat("Env classes", sub.environment_classes)}${stat("Foundry specs", sub.foundry_specs)}${stat("Foundry plans", sub.foundry_run_plans)}${stat("Ledger", sub.work_ledger_entries)}${stat("Connectors", sub.connectors)}</div>`;
@@ -2895,7 +2981,7 @@ function renderOdkLanding(ov, lists) {
   const outkinds = `<div class="chips"><span class="chiplabel">Recipe output kinds</span>${(o.recipe_output_kinds || []).map((k) => `<span class="pill muted">${CX_ESC(k)}</span>`).join("")}</div>`;
   const section = (title, family, items, nameKey, newLabel) => `<h2 style="display:flex;justify-content:space-between;align-items:center">${title} (${items.length}) <a class="act" href="/__ioi/odk/${family}/new">+ ${newLabel}</a></h2>${items.length ? items.map((x) => odkCard(family, x, nameKey)).join("") : `<div class="empty">None yet.</div>`}`;
   return automationsShell("Ontology", head + banner + stats + patterns + outkinds
-    + section("Domain Ontologies", "ontologies", lists.ontologies, "domain", "New ontology")
+    + renderOntologySection(lists.ontologies)
     + `<div id="data-planes">` + renderDataSourcesSection(lists.data_sources || []) + section("Data Recipes", "data-recipes", lists.data_recipes, "name", "New recipe") + `</div>`
     + section("Surface Descriptors", "surface-descriptors", lists.surface_descriptors, "name", "New descriptor")
     + section("ODK Manifests", "manifests", lists.manifests, "name", "New manifest"));

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-manager.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-manager.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Ontology-manager contract done-bar — the ODK DomainOntology plane PROMOTED IN PLACE into a sharper
+// schema-workbench contract (NOT a second plane). Data supplies declared source truth; Ontology is
+// the semantic spine that recipes, domain apps, marketplace packs, evals and generated surfaces bind
+// into — so its typed model is load-bearing and validated fail-closed.
+//
+// Asserts:
+//   - No parallel ontology truth: /v1/hypervisor/odk/domain-ontologies is authority; the top-level
+//     /v1/hypervisor/ontologies is only a GET alias over the same handler (no POST plane beside it).
+//   - A typed CanonicalObjectModel (value/object/link/action types) validates and projects `ready`
+//     health with object_instances 0; create is revision 1 + receipted + a history entry.
+//   - Fail-closed on malformed models: missing domain, invalid type id, duplicate name, unresolved
+//     link end, unresolved property value_type, bad cardinality, bad action kind, enum w/o values.
+//   - Health is honest: an object with no relations/actions is `incomplete`; a legacy string-array
+//     model (the pre-hardening shape) is tolerated as `empty` (no regression to older builders).
+//   - PATCH bumps revision + appends history + writes a receipt; a malformed PATCH is rejected and
+//     does NOT bump the revision.
+//   - The Data/Ontology owner surface renders the manager as authority (typed counts + health) and
+//     keeps NO object/explorer rows — the schema/explorer captures stay secondary references.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-ontology-manager.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+// A well-formed model: typed object (property → base + declared value type), a relation, an action.
+const readyModel = () => ({
+  value_types: [{ id: "money", name: "Money", base: "double" }],
+  object_types: [
+    { id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "title", name: "Title", value_type: "string" },
+      { id: "amount", name: "Amount", value_type: "money" },
+    ] },
+    { id: "borrower", name: "Borrower", title_property: "name", properties: [{ id: "name", name: "Name", value_type: "string" }] },
+  ],
+  link_types: [{ id: "held_by", name: "Held by", from: "loan", to: "borrower", cardinality: "one_to_many" }],
+  action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }],
+});
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon not reachable at " + DAEMON); process.exit(2); }
+  const made = [];
+
+  // 0. No parallel plane — the alias is GET-only over ODK; there is no POST truth beside it.
+  const aliasGet = await jd("GET", "/v1/hypervisor/ontologies");
+  ok("top-level /ontologies is a GET alias over ODK (list shape)", aliasGet.status === 200 && Array.isArray(aliasGet.j.ontologies), "alias ok");
+  const aliasPost = await fetch(`${DAEMON}/v1/hypervisor/ontologies`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" }).then((r) => r.status).catch(() => 0);
+  ok("no parallel write plane beside ODK (alias POST not allowed)", aliasPost === 404 || aliasPost === 405, `POST -> ${aliasPost}`);
+
+  // 1. Typed create → ready, revision 1, receipted, history.
+  const created = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "verify-ontology-mgr", canonical_object_model: readyModel() });
+  const rec = created.j.ontology;
+  if (rec?.id) made.push(rec.id);
+  ok("typed ontology creates (201)", created.status === 201 && !!rec?.ref, rec?.ref);
+  ok("readiness health projects `ready` (required pieces present)", rec?.health?.status === "ready", rec?.health?.status);
+  ok("no object instances (schema only — explorer boundary)", rec?.health?.object_instances === 0);
+  ok("create is revision 1 + receipted + a history entry", rec?.revision === 1 && (rec?.receipt_refs || []).length >= 1 && (rec?.history || []).length >= 1, `rev ${rec?.revision}`);
+  ok("receipt ref is an ontology receipt", String((rec?.receipt_refs || [])[0] || "").startsWith("agentgres://odk-ontology-receipt/"));
+
+  // 2. Health + history projection routes (projections over ODK).
+  const health = await jd("GET", `/v1/hypervisor/odk/domain-ontologies/${rec.id}/health`);
+  ok("/:id/health projects readiness", health.status === 200 && health.j.health?.status === "ready" && health.j.revision === 1);
+  const hist = await jd("GET", `/v1/hypervisor/odk/domain-ontologies/${rec.id}/history`);
+  ok("/:id/history returns history + receipts", hist.status === 200 && (hist.j.history || []).length >= 1 && (hist.j.receipts || []).length >= 1);
+
+  // 3. Fail-closed lanes — each rejected with its specific code.
+  const reject = async (label, body, code) => {
+    const r = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", body);
+    ok(`fail-closed: ${label}`, r.status === 400 && r.j.error?.code === code, r.j.error?.code || `status ${r.status}`);
+    if (r.j?.ontology?.id) made.push(r.j.ontology.id); // safety: never leak an accidental create
+  };
+  await reject("missing domain", { canonical_object_model: {} }, "odk_domain_required");
+  await reject("invalid type id", { domain: "x", canonical_object_model: { object_types: [{ id: "Loan!", name: "Loan" }] } }, "ontology_type_id_invalid");
+  await reject("duplicate object name", { domain: "x", canonical_object_model: { object_types: [
+    { id: "a", name: "Loan", title_property: "t", properties: [{ id: "t", name: "T", value_type: "string" }] },
+    { id: "b", name: "loan", title_property: "t", properties: [{ id: "t", name: "T", value_type: "string" }] },
+  ] } }, "ontology_duplicate_name");
+  await reject("unresolved link end", { domain: "x", canonical_object_model: { object_types: [{ id: "loan", name: "Loan" }], link_types: [{ id: "l", name: "L", from: "loan", to: "ghost", cardinality: "one_to_one" }] } }, "ontology_ref_unresolved");
+  await reject("unresolved property value_type", { domain: "x", canonical_object_model: { object_types: [{ id: "loan", name: "Loan", properties: [{ id: "amt", name: "Amt", value_type: "currency" }] }] } }, "ontology_ref_unresolved");
+  await reject("bad cardinality", { domain: "x", canonical_object_model: { object_types: [{ id: "a", name: "A" }, { id: "b", name: "B" }], link_types: [{ id: "l", name: "L", from: "a", to: "b", cardinality: "lots" }] } }, "ontology_cardinality_invalid");
+  await reject("bad action kind", { domain: "x", canonical_object_model: { object_types: [{ id: "a", name: "A" }], action_types: [{ id: "x", name: "X", kind: "teleport", applies_to: "a" }] } }, "ontology_action_kind_invalid");
+  await reject("enum value type without values", { domain: "x", canonical_object_model: { value_types: [{ id: "grade", name: "Grade", base: "enum" }] } }, "ontology_enum_values_required");
+  await reject("malformed model JSON (parse sentinel)", { domain: "x", canonical_object_model: { __json_parse_error: true } }, "ontology_object_model_json_invalid");
+
+  // 4. Honest health — incomplete + legacy back-compat.
+  const inc = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "verify-incomplete", canonical_object_model: { object_types: [{ id: "loan", name: "Loan", title_property: "t", properties: [{ id: "t", name: "T", value_type: "string" }] }] } });
+  if (inc.j?.ontology?.id) made.push(inc.j.ontology.id);
+  ok("object with no relations/actions is `incomplete` (honest)", inc.j.ontology?.health?.status === "incomplete" && (inc.j.ontology?.health?.gaps || []).some((g) => /relations or behaviors/.test(g)));
+  const legacy = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "verify-legacy", canonical_object_model: { objects: ["Loan", "Borrower"], actions: ["approve"], states: ["draft"], roles: [], events: [] } });
+  if (legacy.j?.ontology?.id) made.push(legacy.j.ontology.id);
+  ok("legacy string-array model still creates (no regression to older builders)", legacy.status === 201 && legacy.j.ontology?.health?.status === "empty", legacy.j.ontology?.health?.status);
+
+  // 5. PATCH — revision bump + history + receipt; a bad patch is rejected without a bump.
+  const p1 = await jd("PATCH", `/v1/hypervisor/odk/domain-ontologies/${rec.id}`, { description: "now underwritten" });
+  ok("valid patch bumps revision + appends history + receipt", p1.j.ontology?.revision === 2 && (p1.j.ontology?.history || []).length === 2 && (p1.j.ontology?.receipt_refs || []).length === 2, `rev ${p1.j.ontology?.revision}`);
+  const p2 = await jd("PATCH", `/v1/hypervisor/odk/domain-ontologies/${rec.id}`, { canonical_object_model: { object_types: [{ id: "BAD ID", name: "x" }] } });
+  ok("malformed patch is rejected (ok:false + code)", p2.j.ok === false && p2.j.error?.code === "ontology_type_id_invalid", p2.j.error?.code);
+  const afterBad = await jd("GET", `/v1/hypervisor/odk/domain-ontologies/${rec.id}/health`);
+  ok("rejected patch does NOT bump the revision", afterBad.j.revision === 2, `rev ${afterBad.j.revision}`);
+
+  // 6. Overview projections — model vocab + honest health rollup (over ODK, not a 2nd plane).
+  const ov = await jd("GET", "/v1/hypervisor/odk/overview");
+  ok("overview publishes the object-model vocab", (ov.j.object_model_vocab?.base_value_types || []).length >= 5 && (ov.j.object_model_vocab?.link_cardinalities || []).length === 3 && (ov.j.object_model_vocab?.action_kinds || []).length === 4);
+  ok("overview publishes an honest health rollup", ov.j.ontology_health && typeof ov.j.ontology_health.ready === "number" && typeof ov.j.ontology_health.incomplete === "number" && typeof ov.j.ontology_health.empty === "number");
+
+  // 7. Owner surface — renders the manager as authority; explorer stays secondary.
+  const page = await fetch(`${SERVE}/__ioi/odk`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+  ok("Data/Ontology surface serves brand-clean", page.status === 200 && !/\bPalantir\b/.test(page.text));
+  ok("surface frames the ontology manager as authority", /daemon ontology manager/.test(page.text));
+  ok("surface renders the real ontology (authority row)", page.text.includes("verify-ontology-mgr"));
+  ok("surface shows honest health (a `ready` pill)", /pill ok">ready/.test(page.text));
+  ok("surface shows NO object/explorer rows (schema-only boundary named)", /No object \/ explorer rows are shown/.test(page.text));
+  ok("schema + explorer captures kept secondary (linked references)", page.text.includes("/__apps/explorer") && page.text.includes("/__apps/schema"));
+
+  // Cleanup.
+  for (const id of made) await jd("DELETE", `/v1/hypervisor/odk/domain-ontologies/${id}`);
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`ontology-manager readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -1091,6 +1091,14 @@ async fn async_main() -> anyhow::Result<()> {
                 .delete(odk_routes::handle_odk_ontology_delete),
         )
         .route(
+            "/v1/hypervisor/odk/domain-ontologies/:id/health",
+            get(odk_routes::handle_odk_ontology_health),
+        )
+        .route(
+            "/v1/hypervisor/odk/domain-ontologies/:id/history",
+            get(odk_routes::handle_odk_ontology_history),
+        )
+        .route(
             "/v1/hypervisor/odk/data-recipes",
             get(odk_routes::handle_odk_recipe_list).post(odk_routes::handle_odk_recipe_create),
         )

--- a/crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs
@@ -57,6 +57,29 @@ const RECIPE_OUTPUT_KINDS: &[&str] = &[
     "training_material",
 ];
 
+// ---- Ontology-manager contract vocabulary. The DomainOntology carries a typed CanonicalObjectModel
+// (value types, object types with typed properties, relation/link types, action/function
+// declarations). These enums are the schema-workbench semantics validated fail-closed at write time.
+/// Base value types a declared value_type may specialize (an `enum` base must carry `enum_values`).
+const BASE_VALUE_TYPES: &[&str] = &[
+    "string",
+    "integer",
+    "double",
+    "boolean",
+    "timestamp",
+    "date",
+    "enum",
+    "markdown",
+    "geo_point",
+    "attachment",
+];
+/// Relation cardinalities a link_type may declare.
+const LINK_CARDINALITIES: &[&str] = &["one_to_one", "one_to_many", "many_to_many"];
+/// Action/function kinds an action_type may declare (non-`function` kinds require an object target).
+const ACTION_KINDS: &[&str] = &["create_object", "modify_object", "delete_object", "function"];
+/// Receipts for ontology create/patch land here (history is also embedded on the record).
+const KIND_ONT_RECEIPT: &str = "odk-ontology-receipts";
+
 fn safe(seg: &str) -> String {
     seg.replace(
         |c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_',
@@ -226,6 +249,19 @@ fn json_del(data_dir: &str, kind: &str, id: &str) -> Json<Value> {
     let removed = remove_record(data_dir, kind, id);
     Json(json!({ "ok": removed, "removed": removed, "id": id }))
 }
+/// Count ontologies whose readiness health matches `status` (records without health read as `empty`).
+fn ont_health_count(ontologies: &[Value], status: &str) -> usize {
+    ontologies
+        .iter()
+        .filter(|o| {
+            o.get("health")
+                .and_then(|h| h.get("status"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("empty")
+                == status
+        })
+        .count()
+}
 
 // =================================== OVERVIEW ====================================================
 
@@ -279,11 +315,292 @@ pub(crate) async fn handle_odk_overview(State(st): State<Arc<DaemonState>>) -> J
         },
         "composition_patterns": COMPOSITION_PATTERNS,
         "recipe_output_kinds": RECIPE_OUTPUT_KINDS,
+        // Ontology-manager contract projections (over ODK — not a second plane).
+        "object_model_vocab": {
+            "base_value_types": BASE_VALUE_TYPES,
+            "link_cardinalities": LINK_CARDINALITIES,
+            "action_kinds": ACTION_KINDS
+        },
+        "ontology_health": {
+            "ready": ont_health_count(&ontologies, "ready"),
+            "incomplete": ont_health_count(&ontologies, "incomplete"),
+            "empty": ont_health_count(&ontologies, "empty")
+        },
         "recent_ontologies": recents(&ontologies, "domain"),
         "recent_data_recipes": recents(&recipes, "name"),
         "recent_manifests": recents(&manifests, "name"),
         "recent_surface_descriptors": recents(&descriptors, "name")
     }))
+}
+
+// ============================ ONTOLOGY-MANAGER CONTRACT =========================================
+//
+// The DomainOntology is the semantic spine the rest of the estate leans on, so its typed model is
+// validated fail-closed. A CanonicalObjectModel is the four typed collections:
+//   value_types   [{ id, name, base, enum_values? }]
+//   object_types  [{ id, name, title_property?, properties:[{ id, name, value_type, required? }] }]
+//   link_types    [{ id, name, from, to, cardinality }]     (from/to resolve to object_type ids)
+//   action_types  [{ id, name, kind, applies_to? }]         (applies_to resolves to an object_type)
+// A `value_type` on a property resolves to a base type OR a declared value_type id. Type ids match
+// `^[a-z][a-z0-9_]*$`. Legacy string-array keys (objects/actions/events/states/roles) are TOLERATED
+// for back-compat but are not a typed model — they count as `empty` health, never validated as types.
+// The plane owns NO object instances: `object_instances` is always 0 and explorer rows require a
+// real ontology-bound object plane (not built here).
+
+type VErr = (String, String);
+fn verr(code: &str, msg: String) -> VErr {
+    (code.to_string(), msg)
+}
+/// Type ids are lowercase-first, then `[a-z0-9_]` — a stable machine identifier (no crate regex dep).
+fn valid_type_id(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+/// A COM collection: absent/null → empty; present must be an array (else a fail-closed error).
+fn com_arr<'a>(com: &'a Value, key: &str) -> Result<Vec<&'a Value>, VErr> {
+    match com.get(key) {
+        None | Some(Value::Null) => Ok(vec![]),
+        Some(Value::Array(a)) => Ok(a.iter().collect()),
+        Some(_) => Err(verr(
+            "ontology_collection_invalid",
+            format!("`{key}` must be an array of typed entries"),
+        )),
+    }
+}
+fn entry_id(e: &Value) -> &str {
+    e.get("id").and_then(|v| v.as_str()).unwrap_or("")
+}
+fn entry_name(e: &Value) -> String {
+    e.get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+/// Validate ids (shape + uniqueness) and names (present + unique, case-insensitive) for a collection.
+fn check_ids_and_names(entries: &[&Value], label: &str) -> Result<Vec<String>, VErr> {
+    let mut ids: Vec<String> = Vec::new();
+    let mut names_lc: Vec<String> = Vec::new();
+    for e in entries {
+        let id = entry_id(e);
+        if !valid_type_id(id) {
+            return Err(verr(
+                "ontology_type_id_invalid",
+                format!("{label} id '{id}' is invalid — must match ^[a-z][a-z0-9_]*$"),
+            ));
+        }
+        if ids.iter().any(|x| x == id) {
+            return Err(verr(
+                "ontology_duplicate_id",
+                format!("duplicate {label} id '{id}'"),
+            ));
+        }
+        let name = entry_name(e);
+        if name.trim().is_empty() {
+            return Err(verr(
+                "ontology_name_required",
+                format!("{label} '{id}' requires a name"),
+            ));
+        }
+        let nl = name.to_lowercase();
+        if names_lc.iter().any(|x| *x == nl) {
+            return Err(verr(
+                "ontology_duplicate_name",
+                format!("duplicate {label} name '{name}'"),
+            ));
+        }
+        ids.push(id.to_string());
+        names_lc.push(nl);
+    }
+    Ok(ids)
+}
+
+/// Validate a CanonicalObjectModel fail-closed and project its readiness health. Returns the health
+/// object on success (draft/incomplete are allowed — status is honest), or a typed error to reject.
+fn validate_object_model(com: &Value) -> Result<Value, VErr> {
+    // A serve-form JSON textarea that failed to parse marks itself so the author sees a clean error.
+    if com.get("__json_parse_error").is_some() {
+        return Err(verr(
+            "ontology_object_model_json_invalid",
+            "canonical_object_model must be valid JSON".into(),
+        ));
+    }
+    let value_types = com_arr(com, "value_types")?;
+    let object_types = com_arr(com, "object_types")?;
+    let link_types = com_arr(com, "link_types")?;
+    let action_types = com_arr(com, "action_types")?;
+
+    let value_ids = check_ids_and_names(&value_types, "value_type")?;
+    let object_ids = check_ids_and_names(&object_types, "object_type")?;
+    let _link_ids = check_ids_and_names(&link_types, "link_type")?;
+    let _action_ids = check_ids_and_names(&action_types, "action_type")?;
+
+    // Value types: base must be known; an `enum` base must enumerate its values.
+    for vt in &value_types {
+        let base = vt.get("base").and_then(|v| v.as_str()).unwrap_or("string");
+        if !BASE_VALUE_TYPES.contains(&base) {
+            return Err(verr(
+                "ontology_value_base_invalid",
+                format!("value_type '{}' base '{base}' is not a known base type", entry_id(vt)),
+            ));
+        }
+        if base == "enum"
+            && !vt
+                .get("enum_values")
+                .and_then(|v| v.as_array())
+                .map(|a| !a.is_empty())
+                .unwrap_or(false)
+        {
+            return Err(verr(
+                "ontology_enum_values_required",
+                format!("enum value_type '{}' must declare non-empty enum_values", entry_id(vt)),
+            ));
+        }
+    }
+    let resolves_value = |vt: &str| BASE_VALUE_TYPES.contains(&vt) || value_ids.iter().any(|x| x == vt);
+
+    // Object types: typed properties resolve to a value type; title_property resolves to a property.
+    let mut gaps: Vec<String> = Vec::new();
+    for obj in &object_types {
+        let oid = entry_id(obj);
+        let oname = entry_name(obj);
+        let disp = if oname.is_empty() { oid.to_string() } else { oname };
+        let props = com_arr(obj, "properties")?;
+        let prop_ids = check_ids_and_names(&props, &format!("property (object '{oid}')"))?;
+        for p in &props {
+            let pvt = p.get("value_type").and_then(|v| v.as_str()).unwrap_or("");
+            if pvt.is_empty() {
+                return Err(verr(
+                    "ontology_property_value_type_required",
+                    format!("property '{}' on object '{oid}' requires a value_type", entry_id(p)),
+                ));
+            }
+            if !resolves_value(pvt) {
+                return Err(verr(
+                    "ontology_ref_unresolved",
+                    format!("property '{}' on object '{oid}' references unknown value_type '{pvt}'", entry_id(p)),
+                ));
+            }
+        }
+        match obj
+            .get("title_property")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            Some(tp) if !prop_ids.iter().any(|x| x == tp) => {
+                return Err(verr(
+                    "ontology_ref_unresolved",
+                    format!("object '{oid}' title_property '{tp}' is not one of its properties"),
+                ));
+            }
+            Some(_) => {}
+            None => gaps.push(format!("object '{disp}' has no title_property")),
+        }
+        if prop_ids.is_empty() {
+            gaps.push(format!("object '{disp}' has no properties"));
+        }
+    }
+
+    // Link types: cardinality is enumerated; both ends resolve to declared object types.
+    for lk in &link_types {
+        let lid = entry_id(lk);
+        let card = lk.get("cardinality").and_then(|v| v.as_str()).unwrap_or("");
+        if !LINK_CARDINALITIES.contains(&card) {
+            return Err(verr(
+                "ontology_cardinality_invalid",
+                format!("link_type '{lid}' cardinality '{card}' must be one of {LINK_CARDINALITIES:?}"),
+            ));
+        }
+        for end in ["from", "to"] {
+            let t = lk.get(end).and_then(|v| v.as_str()).unwrap_or("");
+            if !object_ids.iter().any(|x| x == t) {
+                return Err(verr(
+                    "ontology_ref_unresolved",
+                    format!("link_type '{lid}' {end} '{t}' does not resolve to a declared object_type"),
+                ));
+            }
+        }
+    }
+
+    // Action/function types: kind is enumerated; object-mutating kinds must target an object type.
+    for ac in &action_types {
+        let aid = entry_id(ac);
+        let kind = ac.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+        if !ACTION_KINDS.contains(&kind) {
+            return Err(verr(
+                "ontology_action_kind_invalid",
+                format!("action_type '{aid}' kind '{kind}' must be one of {ACTION_KINDS:?}"),
+            ));
+        }
+        let applies_to = ac.get("applies_to").and_then(|v| v.as_str()).unwrap_or("");
+        if !applies_to.is_empty() && !object_ids.iter().any(|x| x == applies_to) {
+            return Err(verr(
+                "ontology_ref_unresolved",
+                format!("action_type '{aid}' applies_to '{applies_to}' does not resolve to a declared object_type"),
+            ));
+        }
+        if kind != "function" && applies_to.is_empty() {
+            return Err(verr(
+                "ontology_action_target_required",
+                format!("action_type '{aid}' of kind '{kind}' requires an applies_to object_type"),
+            ));
+        }
+    }
+
+    // Readiness projection — honest: draft/incomplete allowed, `ready` only when the required
+    // semantic pieces exist (≥1 typed object with properties + a title, and ≥1 relation or action).
+    let (n_obj, n_link, n_act) = (object_types.len(), link_types.len(), action_types.len());
+    let status = if n_obj == 0 {
+        gaps.insert(0, "no object_types declared — the model is an empty draft".into());
+        "empty"
+    } else {
+        if n_link == 0 && n_act == 0 {
+            gaps.push("no link_types or action_types — the model declares no relations or behaviors".into());
+        }
+        if gaps.is_empty() {
+            "ready"
+        } else {
+            "incomplete"
+        }
+    };
+    let legacy = |k: &str| com.get(k).and_then(|v| v.as_array()).map(|a| a.len()).unwrap_or(0);
+    let legacy_untyped =
+        legacy("objects") + legacy("actions") + legacy("events") + legacy("states") + legacy("roles");
+
+    Ok(json!({
+        "status": status,
+        "counts": {
+            "value_types": value_types.len(),
+            "object_types": n_obj,
+            "link_types": n_link,
+            "action_types": n_act
+        },
+        "gaps": gaps,
+        "object_instances": 0,
+        "object_data_note": "schema only — no object-instance/projection plane is bound; explorer rows require a real ontology-bound object plane (not built here)",
+        "legacy_untyped_names": legacy_untyped
+    }))
+}
+
+/// Write an ontology receipt and return the full receipt record (its ref is embedded in history).
+fn ontology_receipt(data_dir: &str, ontology_ref: &str, op: &str, summary: &str) -> Value {
+    let id = format!("ontr_{:x}", nanos());
+    let receipt_ref = format!("agentgres://odk-ontology-receipt/{id}");
+    let rec = json!({
+        "schema_version": "ioi.hypervisor.odk.ontology-receipt.v1",
+        "receipt_id": id,
+        "receipt_ref": receipt_ref,
+        "ontology_ref": ontology_ref,
+        "op": op,
+        "outcome": "ok",
+        "summary": summary,
+        "at": iso_now()
+    });
+    let _ = persist_record(data_dir, KIND_ONT_RECEIPT, &id, &rec);
+    rec
 }
 
 // ================================ DOMAIN ONTOLOGY ================================================
@@ -300,8 +617,9 @@ pub(crate) async fn handle_odk_ontology_list(
     Json(json!({ "ok": true, "ontologies": items }))
 }
 
-/// POST /v1/hypervisor/odk/domain-ontologies — create a DomainOntology DRAFT. The semantic root:
-/// it embeds the CanonicalObjectModel (objects/actions/events/states/roles), kept lightweight.
+/// POST /v1/hypervisor/odk/domain-ontologies — create a DomainOntology DRAFT. The semantic root: it
+/// embeds a typed CanonicalObjectModel (value/object/link/action types), validated fail-closed, and
+/// carries revision 1 + a create receipt + a readiness health projection.
 pub(crate) async fn handle_odk_ontology_create(
     State(st): State<Arc<DaemonState>>,
     Json(body): Json<Value>,
@@ -317,23 +635,34 @@ pub(crate) async fn handle_odk_ontology_create(
             "A DomainOntology must declare a non-empty domain.",
         );
     };
+    let com = body.get("canonical_object_model").cloned().unwrap_or_else(|| {
+        json!({ "value_types": [], "object_types": [], "link_types": [], "action_types": [] })
+    });
+    let health = match validate_object_model(&com) {
+        Ok(h) => h,
+        Err((code, msg)) => return bad(&code, &msg),
+    };
     let id = format!("ont_{:x}", nanos());
     let now = iso_now();
-    let com = body.get("canonical_object_model").cloned().unwrap_or_else(|| {
-        json!({ "objects": [], "actions": [], "events": [], "states": [], "roles": [] })
-    });
+    let oref = format!("ontology://{id}");
+    let receipt = ontology_receipt(&st.data_dir, &oref, "created", "DomainOntology draft created");
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
     let record = json!({
         "schema_version": "ioi.hypervisor.odk.domain-ontology.v1",
         "object": "ioi.hypervisor.odk.domain_ontology",
         "id": id,
-        "ref": format!("ontology://{id}"),
+        "ref": oref,
         "domain": domain,
         "version": body.get("version").and_then(|v| v.as_str()).unwrap_or("0.1.0"),
         "description": body.get("description").and_then(|v| v.as_str()).unwrap_or(""),
         "status": "draft",
-        // CanonicalObjectModel embedded (draft, lightweight — not a separate lifecycle table yet).
+        // Typed CanonicalObjectModel embedded + validated; health is the readiness projection.
         "canonical_object_model": com,
-        "created_at": now,
+        "health": health,
+        "revision": 1,
+        "receipt_refs": [receipt_ref.clone()],
+        "history": [ { "revision": 1, "op": "created", "at": now.clone(), "summary": "DomainOntology draft created", "receipt_ref": receipt_ref } ],
+        "created_at": now.clone(),
         "updated_at": now
     });
     let _ = persist_record(&st.data_dir, KIND_ONT, &id, &record);
@@ -347,6 +676,8 @@ pub(crate) async fn handle_odk_ontology_get(
     json_get(&st.data_dir, KIND_ONT, "ontology", &id)
 }
 
+/// PATCH — fail-closed on a malformed model (revision is NOT bumped on rejection); on success bumps
+/// the revision, recomputes health, appends a history entry, and writes a patch receipt.
 pub(crate) async fn handle_odk_ontology_patch(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
@@ -355,12 +686,46 @@ pub(crate) async fn handle_odk_ontology_patch(
     let Some(mut o) = load(&st.data_dir, KIND_ONT, &id) else {
         return Json(json!({ "ok": false, "reason": "ontology not found" }));
     };
+    // Validate a replacement model BEFORE mutating anything — a bad patch changes nothing.
+    if let Some(new_com) = body.get("canonical_object_model") {
+        if let Err((code, msg)) = validate_object_model(new_com) {
+            return Json(json!({ "ok": false, "error": { "code": code, "message": msg } }));
+        }
+    }
+    let mut changed: Vec<&str> = Vec::new();
     for key in ["domain", "version", "description", "canonical_object_model"] {
         if let Some(v) = body.get(key) {
             o[key] = v.clone();
+            changed.push(key);
         }
     }
-    o["updated_at"] = json!(iso_now());
+    // Recompute health from the resulting model (guaranteed valid — it was checked above or unchanged).
+    let com = o.get("canonical_object_model").cloned().unwrap_or_else(|| json!({}));
+    if let Ok(health) = validate_object_model(&com) {
+        o["health"] = health;
+    }
+    let rev = o.get("revision").and_then(|v| v.as_u64()).unwrap_or(1) + 1;
+    o["revision"] = json!(rev);
+    let now = iso_now();
+    o["updated_at"] = json!(now.clone());
+    let summary = format!(
+        "patched: {}",
+        if changed.is_empty() { "no-op".to_string() } else { changed.join(", ") }
+    );
+    let oref = o.get("ref").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let receipt = ontology_receipt(&st.data_dir, &oref, "patched", &summary);
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    // Append a bounded history entry + carry the receipt ref.
+    let mut hist = o.get("history").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    hist.push(json!({ "revision": rev, "op": "patched", "at": now, "summary": summary, "receipt_ref": receipt_ref.clone() }));
+    let len = hist.len();
+    if len > 20 {
+        hist = hist[len - 20..].to_vec();
+    }
+    o["history"] = json!(hist);
+    let mut refs = o.get("receipt_refs").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    refs.push(receipt_ref);
+    o["receipt_refs"] = json!(refs);
     let _ = persist_record(&st.data_dir, KIND_ONT, &id, &o);
     Json(json!({ "ok": true, "ontology": o }))
 }
@@ -370,6 +735,60 @@ pub(crate) async fn handle_odk_ontology_delete(
     AxumPath(id): AxumPath<String>,
 ) -> Json<Value> {
     json_del(&st.data_dir, KIND_ONT, &id)
+}
+
+/// GET /v1/hypervisor/odk/domain-ontologies/:id/health — the readiness projection (over ODK).
+pub(crate) async fn handle_odk_ontology_health(
+    State(st): State<Arc<DaemonState>>,
+    AxumPath(id): AxumPath<String>,
+) -> (StatusCode, Json<Value>) {
+    match load(&st.data_dir, KIND_ONT, &id) {
+        Some(o) => (
+            StatusCode::OK,
+            Json(json!({
+                "ok": true,
+                "ontology_ref": o.get("ref").cloned().unwrap_or(Value::Null),
+                "revision": o.get("revision").cloned().unwrap_or(json!(1)),
+                "health": o.get("health").cloned().unwrap_or_else(|| json!({ "status": "empty" }))
+            })),
+        ),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "ok": false, "reason": "ontology not found" })),
+        ),
+    }
+}
+
+/// GET /v1/hypervisor/odk/domain-ontologies/:id/history — embedded history + persisted receipts.
+pub(crate) async fn handle_odk_ontology_history(
+    State(st): State<Arc<DaemonState>>,
+    AxumPath(id): AxumPath<String>,
+) -> (StatusCode, Json<Value>) {
+    let Some(o) = load(&st.data_dir, KIND_ONT, &id) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "ok": false, "reason": "ontology not found" })),
+        );
+    };
+    let oref = o.get("ref").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let mut receipts = read_record_dir(&st.data_dir, KIND_ONT_RECEIPT);
+    receipts.retain(|r| r.get("ontology_ref").and_then(|v| v.as_str()) == Some(oref.as_str()));
+    receipts.sort_by(|a, b| {
+        b.get("at")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .cmp(a.get("at").and_then(|v| v.as_str()).unwrap_or(""))
+    });
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "ontology_ref": oref,
+            "revision": o.get("revision").cloned().unwrap_or(json!(1)),
+            "history": o.get("history").cloned().unwrap_or_else(|| json!([])),
+            "receipts": receipts
+        })),
+    )
 }
 
 // =================================== DATA RECIPE ================================================
@@ -875,5 +1294,114 @@ mod odk_tests {
         assert!(RECIPE_OUTPUT_KINDS.contains(&"ontology_objects"));
         assert!(RECIPE_OUTPUT_KINDS.contains(&"training_material"));
         assert!(!RECIPE_OUTPUT_KINDS.contains(&"magic"));
+    }
+
+    // ---- Ontology-manager contract validation.
+
+    #[test]
+    fn type_id_shape_is_enforced() {
+        assert!(valid_type_id("loan"));
+        assert!(valid_type_id("loan_v2"));
+        assert!(!valid_type_id("Loan")); // uppercase-first
+        assert!(!valid_type_id("2loan")); // digit-first
+        assert!(!valid_type_id("loan type")); // space
+        assert!(!valid_type_id("")); // empty
+    }
+
+    /// A well-formed model with a typed object (property → base value_type), a relation and an action.
+    fn ready_model() -> Value {
+        json!({
+            "value_types": [{ "id": "money", "name": "Money", "base": "double" }],
+            "object_types": [
+                { "id": "loan", "name": "Loan", "title_property": "title",
+                  "properties": [
+                    { "id": "title", "name": "Title", "value_type": "string" },
+                    { "id": "amount", "name": "Amount", "value_type": "money" }
+                  ] },
+                { "id": "borrower", "name": "Borrower", "title_property": "name",
+                  "properties": [ { "id": "name", "name": "Name", "value_type": "string" } ] }
+            ],
+            "link_types": [{ "id": "held_by", "name": "Held by", "from": "loan", "to": "borrower", "cardinality": "one_to_many" }],
+            "action_types": [{ "id": "approve", "name": "Approve", "kind": "modify_object", "applies_to": "loan" }]
+        })
+    }
+
+    #[test]
+    fn ready_model_projects_ready_health() {
+        let h = validate_object_model(&ready_model()).expect("valid");
+        assert_eq!(h["status"], "ready");
+        assert_eq!(h["counts"]["object_types"], 2);
+        assert_eq!(h["object_instances"], 0);
+        assert_eq!(h["gaps"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn empty_model_is_allowed_but_empty_health() {
+        let h = validate_object_model(&json!({})).expect("empty is allowed as a draft");
+        assert_eq!(h["status"], "empty");
+    }
+
+    #[test]
+    fn legacy_string_array_model_is_tolerated_as_empty() {
+        // Back-compat: the pre-hardening shape (string arrays) must still validate (health empty).
+        let legacy = json!({ "objects": ["Loan", "Borrower"], "actions": ["approve"], "states": ["draft"], "roles": [], "events": [] });
+        let h = validate_object_model(&legacy).expect("legacy shape must not be rejected");
+        assert_eq!(h["status"], "empty");
+        assert_eq!(h["legacy_untyped_names"], 4);
+    }
+
+    #[test]
+    fn object_without_relation_or_action_is_incomplete() {
+        let m = json!({
+            "object_types": [{ "id": "loan", "name": "Loan", "title_property": "title",
+                "properties": [{ "id": "title", "name": "Title", "value_type": "string" }] }]
+        });
+        let h = validate_object_model(&m).expect("valid but incomplete");
+        assert_eq!(h["status"], "incomplete");
+        assert!(h["gaps"].as_array().unwrap().iter().any(|g| g.as_str().unwrap().contains("relations or behaviors")));
+    }
+
+    #[test]
+    fn invalid_type_id_is_rejected() {
+        let mut m = ready_model();
+        m["object_types"][0]["id"] = json!("Loan Type!");
+        assert_eq!(validate_object_model(&m).unwrap_err().0, "ontology_type_id_invalid");
+    }
+
+    #[test]
+    fn duplicate_object_name_is_rejected() {
+        let mut m = ready_model();
+        m["object_types"][1]["name"] = json!("loan"); // dup of "Loan" (case-insensitive)
+        assert_eq!(validate_object_model(&m).unwrap_err().0, "ontology_duplicate_name");
+    }
+
+    #[test]
+    fn unresolved_link_end_is_rejected() {
+        let mut m = ready_model();
+        m["link_types"][0]["to"] = json!("nonexistent");
+        assert_eq!(validate_object_model(&m).unwrap_err().0, "ontology_ref_unresolved");
+    }
+
+    #[test]
+    fn unresolved_property_value_type_is_rejected() {
+        let mut m = ready_model();
+        m["object_types"][0]["properties"][1]["value_type"] = json!("currency"); // not a base nor declared
+        assert_eq!(validate_object_model(&m).unwrap_err().0, "ontology_ref_unresolved");
+    }
+
+    #[test]
+    fn bad_cardinality_and_action_kind_are_rejected() {
+        let mut m = ready_model();
+        m["link_types"][0]["cardinality"] = json!("some_to_many");
+        assert_eq!(validate_object_model(&m).unwrap_err().0, "ontology_cardinality_invalid");
+        let mut m2 = ready_model();
+        m2["action_types"][0]["kind"] = json!("teleport");
+        assert_eq!(validate_object_model(&m2).unwrap_err().0, "ontology_action_kind_invalid");
+    }
+
+    #[test]
+    fn enum_value_type_requires_values() {
+        let m = json!({ "value_types": [{ "id": "grade", "name": "Grade", "base": "enum" }] });
+        assert_eq!(validate_object_model(&m).unwrap_err().0, "ontology_enum_values_required");
     }
 }


### PR DESCRIPTION
**Stack: this → #10 (data-source) → #9 → #8 → … → master.** The steer was: *take Ontology next, but don't create a second ontology plane beside ODK — promote the existing ODK `DomainOntology` plane into a sharper ontology-manager contract.* That's exactly this cut. Data now supplies declared source truth; Ontology is the semantic spine that Data Recipes, Domain Apps, Marketplace ontology packs, evals and generated surfaces all bind into — so this adds **load-bearing structure**, not breadth.

## No parallel plane
`/v1/hypervisor/odk/domain-ontologies` stays authority. The top-level `/v1/hypervisor/ontologies` is only a **GET alias** over the same handler (POST → **405**; no write truth beside ODK). ✔ acceptance bar.

## Typed CanonicalObjectModel — validated fail-closed
The DomainOntology now carries a typed model:
| collection | shape | resolves |
|---|---|---|
| `value_types` | `{ id, name, base, enum_values? }` | base ∈ 10 known bases; `enum` needs values |
| `object_types` | `{ id, name, title_property?, properties:[{ id, name, value_type, required? }] }` | property `value_type` → base or a declared value_type id |
| `link_types` | `{ id, name, from, to, cardinality }` | from/to → declared object_type ids |
| `action_types` | `{ id, name, kind, applies_to? }` | object-mutating kinds require a target |

Every rejection is a **typed code**: `odk_domain_required`, `ontology_type_id_invalid` (`^[a-z][a-z0-9_]*$`), `ontology_duplicate_id`/`_name`, `ontology_ref_unresolved` (link end · property value_type · title · applies_to), `ontology_cardinality_invalid`, `ontology_action_kind_invalid`, `ontology_enum_values_required`, `ontology_object_model_json_invalid`.

**Back-compat:** legacy string-array models (`objects/actions/…`) are tolerated as `empty` health — the pre-hardening builders create unchanged.

## Honest health, receipts, history
- **Health is honest:** draft/incomplete allowed; `ready` **only** when the required semantic pieces exist (≥1 typed object with properties + a title, and ≥1 relation or action). Gaps are named.
- **No object data:** the plane owns no instances — `object_instances` is always **0**; explorer rows require a real ontology-bound object plane (not built). Stated plainly on the surface.
- **Every create/patch** bumps a `revision`, appends a bounded `history` entry, and writes a **receipt**. A malformed patch is rejected **without** bumping the revision.
- New `GET /:id/health` and `/:id/history` projections (over ODK); `overview` publishes the object-model vocab + a `{ready,incomplete,empty}` rollup.

## Surface
`/__ioi/odk` renders the manager as **authority** — a typed-model table (counts · honest health pill · revision), a readiness panel, and typed value/object/link/action tables on the detail. It states plainly **no object/explorer rows are shown**; the schema/explorer captures stay **secondary reference grammars**. Authoring posts the typed model as JSON (a parse failure is rejected cleanly).

## Done bar — green
| gate | result |
|---|---|
| ontology-manager | **31/31** · `verify-hypervisor-ontology-manager.mjs` |
| cargo test -p ioi-node | **75/75** (+11 ontology unit tests) |
| source-neutral | **PASSED** |
| named regressions | data-source **17/17** · automations-owner **12/12** · model-catalog **11/11** · harvest-queue-seeds **45/45** |
| legacy ODK builders (back-compat) | governed-lifecycle **39/39** · p2-builder **20/20** · p3-round2 **13/13** |
| surface-parity reverse-lineage · fallthrough empty · git diff --check | hold / clean |

- **master not pushed.** Feature branch, stacked on #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)