### PR TITLE
ODK ConnectorMapping — the first inert authority-crossing brick (stacked on #12)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2955,10 +2955,10 @@ function renderDataSourcesSection(dataSources) {
 // authority (receipts, policy gates, substrate readiness, conformance, source-neutrality) is threaded
 // SIDEWAYS into that familiar IA rather than replacing it.
 
-// The authority contracts still to cross before object data / explorer / actions become live. Named,
-// not built — this is the honest boundary the whole surface is careful about.
+// The authority-crossing LADDER. ConnectorMapping (rung 1) is now a real inert daemon contract;
+// the rest remain named-but-missing. Each rung must exist before the next is allowed to do anything —
+// this is the honest boundary the whole surface is careful about.
 const OM_MISSING_CONTRACTS = [
-  ["ConnectorMapping", "bind declared data-source fields → canonical object properties", "data-backed object types"],
   ["PolicyBoundDataView", "who/what may read · transform · distill · train · evaluate · export · publish · route", "governed reads over object data"],
   ["TransformationRun + receipts", "auditable mapping runs recorded before any projection exists", "object projections you can trust"],
   ["OntologyProjection", "the explicit model → explorer / search / runtime bridge", "Object Explorer rows & saved object sets"],
@@ -2966,9 +2966,24 @@ const OM_MISSING_CONTRACTS = [
 function omBoundaryNote(text) {
   return `<div style="border:1px dashed #3a3d46;border-radius:10px;padding:10px 12px;margin:0 0 12px;background:#141519;color:#9a9da6;font-size:12.5px">${text}</div>`;
 }
-function omMissingContracts() {
-  const rows = OM_MISSING_CONTRACTS.map(([name, what, unlocks]) => `<tr><td><code>${CX_ESC(name)}</code></td><td>${CX_ESC(what)}</td><td class="sub" style="margin:0">unlocks ${CX_ESC(unlocks)}</td></tr>`).join("");
-  return `<table><thead><tr><th>Missing contract</th><th>What it declares</th><th>What it unlocks</th></tr></thead><tbody>${rows}</tbody></table>`;
+function omContractLadder(nMappings) {
+  const declared = `<tr><td><code>ConnectorMapping</code> <span class="pill ok">declared</span></td><td>declared source fields → typed object properties</td><td class="sub" style="margin:0">${nMappings} mapping${nMappings === 1 ? "" : "s"} · inert (no extraction)</td></tr>`;
+  const missing = OM_MISSING_CONTRACTS.map(([name, what, unlocks]) => `<tr><td><code>${CX_ESC(name)}</code> <span class="pill muted">missing</span></td><td>${CX_ESC(what)}</td><td class="sub" style="margin:0">unlocks ${CX_ESC(unlocks)}</td></tr>`).join("");
+  return `<table><thead><tr><th>Contract</th><th>What it declares</th><th>Status / unlocks</th></tr></thead><tbody>${declared}${missing}</tbody></table>`;
+}
+// Connector mappings bound to the selected ontology — daemon truth (declared, inert).
+function omConnectorMappings(mappings) {
+  mappings = Array.isArray(mappings) ? mappings : [];
+  if (!mappings.length) return `<div class="empty">No connector mappings bound to this ontology. A mapping declares how a data source's fields would bind to this object model — validated fail-closed, receipted, and <b>inert</b> (no extraction).</div>`;
+  const pill = (h) => { const st = (h && h.status) || "incomplete"; return `<span class="pill ${st === "ready" ? "ok" : "warn"}">${CX_ESC(st)}</span>`; };
+  const rows = mappings.map((m) => `<tr>
+    <td><b>${CX_ESC(m.name || m.id)}</b><div class="meta" style="color:#878a93;font-size:11.5px;margin-top:2px"><code>${CX_ESC(m.ref || "")}</code></div></td>
+    <td><code>${CX_ESC(m.data_source_ref || m.data_source_id || "—")}</code></td>
+    <td><code>${CX_ESC(m.object_type_id || "—")}</code></td>
+    <td>${(m.field_mappings || []).length + 2} field${((m.field_mappings || []).length + 2) === 1 ? "" : "s"}</td>
+    <td>${pill(m.health)} <span class="pill warn" title="inert — no extraction">not extracting</span></td>
+  </tr>`).join("");
+  return `<table><thead><tr><th>Mapping</th><th>Data source</th><th>Object type</th><th>Fields</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 function omUnavailablePane(title, why, contract) {
   return `<h2 id="pane-${title.toLowerCase().replace(/[^a-z]+/g, "-")}">${CX_ESC(title)} <span class="pill muted">unavailable</span></h2>`
@@ -3063,23 +3078,27 @@ function renderOntologyManager(ov, lists, selectedId) {
         <dt>Authority crossing</dt><dd><span class="pill warn">not crossed</span> <span class="sub" style="margin:0">no ingestion / transform / writeback — object data stays empty until the contracts below exist</span></dd>
       </dl>`;
 
-  // ---- Resources (recipes / descriptors / manifests bound to this ontology) + Data plane.
+  // ---- Resources (recipes / descriptors / manifests / connector mappings bound to this ontology)
+  //      + Data plane.
   const boundRef = selected ? selected.ref : "__none__";
   const recs = (lists.data_recipes || []).filter((r) => r.ontology_ref === boundRef);
   const descs = (lists.surface_descriptors || []).filter((d) => d.ontology_ref === boundRef);
   const mans = (lists.manifests || []).filter((m) => (m.ontology_refs || []).includes(boundRef));
+  const maps = (lists.connector_mappings || []).filter((m) => m.ontology_ref === boundRef);
   const resourceSection = (title, family, items, nameKey, newLabel) => `<h3 style="display:flex;justify-content:space-between;align-items:center;margin:12px 0 6px">${title} (${items.length}) <a class="act ghost" href="/__ioi/odk/${family}/new">+ ${newLabel}</a></h3>${items.length ? items.map((x) => odkCard(family, x, nameKey)).join("") : `<div class="empty">None bound to this ontology.</div>`}`;
   const resourcesPane = `<h2 id="pane-resources">Resources <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— bound to ${selected ? CX_ESC(selected.domain) : "—"}</span></h2>`
+    + `<h3 style="margin:12px 0 6px">Connector mappings (${maps.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— source fields → object properties · daemon truth · inert</span></h3>${omConnectorMappings(maps)}`
     + resourceSection("Data recipes", "data-recipes", recs, "name", "New recipe")
     + resourceSection("Surface descriptors", "surface-descriptors", descs, "name", "New descriptor")
     + resourceSection("ODK manifests", "manifests", mans, "name", "New manifest");
 
   const dataPane = `<div id="pane-data">${renderDataSourcesSection(lists.data_sources || [])}</div>`;
 
-  // ---- Object data / Explorer: the honest unavailable lane + the missing-contract ladder.
+  // ---- Object data / Explorer: the honest unavailable lane + the authority-crossing ladder
+  //      (ConnectorMapping now declared/inert; the rest still missing).
   const explorerPane = `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill muted">unavailable</span></h2>`
     + omBoundaryNote(`This ontology binds <b>no object-instance plane</b>, so there are <b>no rows to explore</b> — the reference Object Explorer is a search surface over real objects; ours stays empty until the authority crossing below is made. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`)
-    + `<h3 style="margin:12px 0 6px">Missing authority contracts</h3>` + omMissingContracts();
+    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder</h3>` + omContractLadder(maps.length);
 
   const counts = { "object-types": ots.length, "properties": propCount, "link-types": lts.length, "action-types": nonFuncActs.length, "value-types": vts.length, "groups": 0, "interfaces": 0, "functions": funcs.length };
   const panes = objectTypesPane + propertiesPane + linkPane + actionPane + valuePane
@@ -6632,13 +6651,14 @@ const server = http.createServer((req, res) => {
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
     if (pathname === "/__ioi/odk" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
-      const [ov, o, r, d, m, ds] = await Promise.all([
+      const [ov, o, r, d, m, ds, cm] = await Promise.all([
         J("/v1/hypervisor/odk/overview"),
         J("/v1/hypervisor/odk/domain-ontologies"),
         J("/v1/hypervisor/odk/data-recipes"),
         J("/v1/hypervisor/odk/surface-descriptors"),
         J("/v1/hypervisor/odk/manifests"),
         J("/v1/hypervisor/data-sources"),
+        J("/v1/hypervisor/odk/connector-mappings"),
       ]);
       const selectedOntology = new URL(req.url, "http://x").searchParams.get("ontology") || "";
       res.writeHead(200, HTMLH);
@@ -6648,6 +6668,7 @@ const server = http.createServer((req, res) => {
         surface_descriptors: d.surface_descriptors || [],
         manifests: m.manifests || [],
         data_sources: ds.data_sources || [],
+        connector_mappings: cm.connector_mappings || [],
       }, selectedOntology));
       return;
     }

--- a/apps/hypervisor/scripts/verify-hypervisor-connector-mapping.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-connector-mapping.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// ConnectorMapping done-bar — the FIRST inert authority-crossing brick.
+//
+// A ConnectorMapping DECLARES how a registered data source's fields would bind to a typed ontology
+// object's properties. It is validated, receipted, and INERT: no extraction, no source read, no
+// object instances, no explorer rows, no data movement. It is rung 1 of the ladder the surface names
+// honestly — PolicyBoundDataView → TransformationRun → OntologyProjection remain missing.
+//
+// Asserts:
+//   - INERT: a mapping created against an UNREACHABLE source succeeds instantly and never reads it;
+//     object_instances stays 0; ingestion is not wired; the three downstream contracts stay missing.
+//   - Fail-closed on every lane: plaintext secret, missing name, unknown source/ontology/object/
+//     property, invalid source type, incompatible value type, cardinality mismatch, duplicate target,
+//     missing key/title mapping, title must target the object's title_property.
+//   - Receipts + bounded history on create/patch; a malformed patch does NOT bump the revision.
+//   - Honest health: required-property coverage → ready/incomplete; overview names the gaps.
+//   - The ODK Ontology Manager UX renders the mapping as daemon truth (Resources) and the
+//     authority-crossing ladder (ConnectorMapping declared; the rest missing); no object rows appear;
+//     brand-clean, no reference leak.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-connector-mapping.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/connector-mappings/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon connector-mapping plane not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+
+  // Fixtures: a declared data source (#10) pointing at an UNREACHABLE endpoint, and a ready typed
+  // ontology (#11) whose `loan` object has a REQUIRED `loan_id`.
+  const dsR = await jd("POST", "/v1/hypervisor/data-sources", { name: "cmap-verify-src", kind: "postgres", endpoint: "postgres://unreachable.invalid:5432/db", credential_posture: "wallet_credential_lease" });
+  const dataSourceId = dsR.j.data_source?.source_id;
+  if (dataSourceId) cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${dataSourceId}`]);
+  const ontR = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "cmap-verify", canonical_object_model: {
+    value_types: [{ id: "money", name: "Money", base: "double" }],
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" },
+      { id: "amount", name: "Amount", value_type: "money" },
+    ] }],
+    action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }],
+  } });
+  const ontRef = ontR.j.ontology?.ref;
+  const ontId = ontR.j.ontology?.id;
+  if (ontId) cleanup.push(["DELETE", `/v1/hypervisor/odk/domain-ontologies/${ontId}`]);
+  if (!dataSourceId || !ontRef) { console.error("BLOCKED: fixtures failed"); process.exit(2); }
+
+  const KEY = { source_field: "id", property_id: "loan_id", source_type: "string" };
+  const TITLE = { source_field: "disp", property_id: "title", source_type: "string" };
+  const base = (extra) => ({ name: "loan-map", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan", key_mapping: KEY, title_mapping: TITLE, ...extra });
+
+  // 1. INERT valid mapping — against the UNREACHABLE source, instantly, with no read.
+  const t0 = Date.now();
+  const created = await jd("POST", "/v1/hypervisor/odk/connector-mappings", base({ field_mappings: [{ source_field: "amt", property_id: "amount", source_type: "double" }] }));
+  const elapsed = Date.now() - t0;
+  const m = created.j.connector_mapping;
+  if (m?.id) cleanup.push(["DELETE", `/v1/hypervisor/odk/connector-mappings/${m.id}`]);
+  ok("valid mapping declares (201) against an unreachable source, instantly (no source read)", created.status === 201 && !!m?.ref && elapsed < 4000, `${elapsed}ms`);
+  ok("mapping is INERT — ingestion not wired, no object instances", m?.ingestion?.wired === false && m?.health?.object_instances === 0);
+  ok("authority is NOT crossed; the three downstream contracts stay missing", m?.health?.authority_crossed === false && JSON.stringify(m?.health?.missing_contracts) === JSON.stringify(["PolicyBoundDataView", "TransformationRun", "OntologyProjection"]));
+  ok("mapping is declared + receipted + has a history entry", m?.status === "declared" && (m?.receipt_refs || []).length >= 1 && (m?.history || []).length >= 1);
+  ok("receipt ref is a connector-mapping receipt", String((m?.receipt_refs || [])[0] || "").startsWith("agentgres://connector-mapping-receipt/"));
+  ok("health is `ready` (required loan_id covered by the key mapping)", m?.health?.status === "ready", m?.health?.status);
+  ok("no plaintext credential is stored anywhere on the record", !JSON.stringify(m || {}).match(/hunter2|password|api_key|"secret"/i));
+
+  // 2. Honest incomplete — required property left unmapped.
+  const inc = await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "inc-map", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan", key_mapping: { source_field: "a", property_id: "amount", source_type: "double" }, title_mapping: TITLE });
+  if (inc.j.connector_mapping?.id) cleanup.push(["DELETE", `/v1/hypervisor/odk/connector-mappings/${inc.j.connector_mapping.id}`]);
+  ok("required property left unmapped → honest `incomplete` + named gap", inc.j.connector_mapping?.health?.status === "incomplete" && (inc.j.connector_mapping?.health?.required_gaps || []).some((g) => /Loan Id/i.test(g)));
+
+  // 3. Fail-closed lanes.
+  const reject = async (label, body, code) => {
+    const r = await jd("POST", "/v1/hypervisor/odk/connector-mappings", body);
+    ok(`fail-closed: ${label}`, r.status === 400 && r.j.error?.code === code, r.j.error?.code || `status ${r.status}`);
+    if (r.j?.connector_mapping?.id) cleanup.push(["DELETE", `/v1/hypervisor/odk/connector-mappings/${r.j.connector_mapping.id}`]);
+  };
+  await reject("plaintext secret", base({ password: "hunter2" }), "connector_mapping_plaintext_secret_rejected");
+  await reject("missing name", { data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan", key_mapping: KEY, title_mapping: TITLE }, "connector_mapping_name_required");
+  await reject("unknown data source", base({ data_source_id: "ds_nope" }), "connector_mapping_data_source_unknown");
+  await reject("unknown ontology", base({ ontology_ref: "ontology://nope" }), "connector_mapping_ontology_unknown");
+  await reject("unknown object type", base({ object_type_id: "ghost" }), "connector_mapping_object_type_unknown");
+  await reject("missing key mapping", { name: "x", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan", title_mapping: TITLE }, "connector_mapping_key_mapping_required");
+  await reject("missing title mapping", { name: "x", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan", key_mapping: KEY }, "connector_mapping_title_mapping_required");
+  await reject("title must target the title_property", base({ title_mapping: { source_field: "d", property_id: "amount", source_type: "double" } }), "connector_mapping_title_mapping_required");
+  await reject("unknown property", base({ field_mappings: [{ source_field: "z", property_id: "ghost", source_type: "string" }] }), "connector_mapping_property_unknown");
+  await reject("invalid source type", base({ field_mappings: [{ source_field: "z", property_id: "amount", source_type: "blob" }] }), "connector_mapping_source_type_invalid");
+  await reject("incompatible value type", base({ field_mappings: [{ source_field: "z", property_id: "amount", source_type: "string" }] }), "connector_mapping_value_type_incompatible");
+  await reject("cardinality mismatch (multi → scalar)", base({ field_mappings: [{ source_field: "z", property_id: "amount", source_type: "double", source_cardinality: "many" }] }), "connector_mapping_cardinality_mismatch");
+  await reject("duplicate target property", base({ field_mappings: [{ source_field: "a", property_id: "amount", source_type: "double" }, { source_field: "b", property_id: "amount", source_type: "double" }] }), "connector_mapping_duplicate_target");
+
+  // 4. Projections + patch semantics.
+  const health = await jd("GET", `/v1/hypervisor/odk/connector-mappings/${m.id}/health`);
+  ok("/:id/health projects readiness (object_instances 0)", health.status === 200 && health.j.health?.status === "ready" && health.j.health?.object_instances === 0);
+  const hist = await jd("GET", `/v1/hypervisor/odk/connector-mappings/${m.id}/history`);
+  ok("/:id/history returns history + receipts", (hist.j.history || []).length >= 1 && (hist.j.receipts || []).length >= 1);
+  const ov = await jd("GET", "/v1/hypervisor/odk/connector-mappings/overview");
+  ok("overview names the inert/missing-contract governance gaps", (ov.j.governance_gaps || []).some((g) => /INERT|nothing here reads|no extraction/i.test(g)) && JSON.stringify(ov.j.missing_contracts) === JSON.stringify(["PolicyBoundDataView", "TransformationRun", "OntologyProjection"]));
+  const p1 = await jd("PATCH", `/v1/hypervisor/odk/connector-mappings/${m.id}`, { description: "bound" });
+  ok("valid patch bumps revision + history + receipt", p1.j.connector_mapping?.revision === 2 && (p1.j.connector_mapping?.history || []).length === 2 && (p1.j.connector_mapping?.receipt_refs || []).length === 2);
+  const p2 = await jd("PATCH", `/v1/hypervisor/odk/connector-mappings/${m.id}`, { field_mappings: [{ source_field: "z", property_id: "ghost", source_type: "string" }] });
+  ok("malformed patch rejected (ok:false + code)", p2.j.ok === false && p2.j.error?.code === "connector_mapping_property_unknown");
+  const after = await jd("GET", `/v1/hypervisor/odk/connector-mappings/${m.id}/health`);
+  ok("rejected patch does NOT bump the revision", after.j.revision === 2, `rev ${after.j.revision}`);
+
+  // 5. ODK Manager UX renders the mapping as daemon truth; no object rows; brand-clean.
+  const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+  const t = page.text;
+  ok("Ontology Manager renders the mapping as daemon truth (Resources)", page.status === 200 && /Connector mappings \(\d+\)/.test(t) && t.includes(m.id.startsWith("cmap") ? "loan-map" : "loan-map"));
+  ok("authority-crossing ladder shows ConnectorMapping declared", /ConnectorMapping<\/code> <span class="pill ok">declared/.test(t));
+  ok("ladder keeps the three downstream contracts missing", ["PolicyBoundDataView", "TransformationRun", "OntologyProjection"].every((c) => t.includes(c)) && /pill muted">missing/.test(t));
+  ok("mapping row states it is not extracting (inert)", /not extracting/.test(t));
+  ok("no object/explorer rows appear (0 objects boundary preserved)", /0 objects/.test(t));
+  ok("surface is brand-clean (no Palantir/Foundry leak)", !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
+
+  // Cleanup — leave no draft debris.
+  for (const [method, p] of cleanup.reverse()) await jd(method, p);
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`connector-mapping readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -88,6 +88,8 @@ mod marketplace_routes;
 mod microvm;
 #[path = "hypervisor_daemon_routes/data_source_routes.rs"]
 mod data_source_routes;
+#[path = "hypervisor_daemon_routes/connector_mapping_routes.rs"]
+mod connector_mapping_routes;
 #[path = "hypervisor_daemon_routes/harness_routes.rs"]
 mod harness_routes;
 #[path = "hypervisor_daemon_routes/model_routes.rs"]
@@ -1097,6 +1099,31 @@ async fn async_main() -> anyhow::Result<()> {
         .route(
             "/v1/hypervisor/odk/domain-ontologies/:id/history",
             get(odk_routes::handle_odk_ontology_history),
+        )
+        // ConnectorMapping — the first inert authority-crossing brick (declared source fields →
+        // typed object properties). No extraction; object_instances stays 0.
+        .route(
+            "/v1/hypervisor/odk/connector-mappings",
+            get(connector_mapping_routes::handle_connector_mappings_list)
+                .post(connector_mapping_routes::handle_connector_mapping_create),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-mappings/overview",
+            get(connector_mapping_routes::handle_connector_mappings_overview),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-mappings/:id",
+            get(connector_mapping_routes::handle_connector_mapping_get)
+                .patch(connector_mapping_routes::handle_connector_mapping_patch)
+                .delete(connector_mapping_routes::handle_connector_mapping_delete),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-mappings/:id/health",
+            get(connector_mapping_routes::handle_connector_mapping_health),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-mappings/:id/history",
+            get(connector_mapping_routes::handle_connector_mapping_history),
         )
         .route(
             "/v1/hypervisor/odk/data-recipes",

--- a/crates/node/src/bin/hypervisor_daemon_routes/connector_mapping_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/connector_mapping_routes.rs
@@ -1,0 +1,415 @@
+//! ConnectorMapping — the FIRST inert authority-crossing brick. A mapping DECLARES how one registered
+//! data source's fields would bind to one canonical ontology object type's typed properties. It is a
+//! validated, receipted DECLARATION only:
+//!   * it references a declared `data_source_id` (#10 registry) and a typed `ontology_ref` /
+//!     `object_type_id` (#11 ontology-manager contract);
+//!   * it stays INERT — no extraction, no source read, no object instances, no explorer rows, no data
+//!     movement. `object_instances` is always 0.
+//!
+//! It is the first rung of a ladder the surface names honestly: ConnectorMapping (this) → then
+//! PolicyBoundDataView (the authority gate) → then TransformationRun + receipts (auditable runs) →
+//! then OntologyProjection (the model → explorer/runtime bridge). Nothing downstream of this rung
+//! exists yet; declaring a mapping never authorizes or runs anything.
+//!
+//! Fail-closed at write: known source, known ontology/object, known property ids, compatible source
+//! type → property base value type, single-valued only (scalar properties), no duplicate target
+//! property, required key + title mappings present, and NO credential material in the body.
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+
+use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState};
+
+const MAPPING_SCHEMA: &str = "ioi.hypervisor.odk.connector-mapping.v1";
+const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.connector-mapping-receipt.v1";
+const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.connector-mappings-overview.v1";
+const RECORD_DIR: &str = "odk-connector-mappings";
+const RECEIPT_DIR: &str = "odk-connector-mapping-receipts";
+
+/// Source-field shapes an author may declare (the source's shape, not a live read).
+const SOURCE_FIELD_TYPES: &[&str] = &["string", "integer", "double", "boolean", "timestamp", "date", "json"];
+/// The authority contracts still missing downstream of this rung — named honestly on every record.
+const MISSING_CONTRACTS: &[&str] = &["PolicyBoundDataView", "TransformationRun", "OntologyProjection"];
+/// Body keys that would be a plaintext secret — rejected outright (a mapping never carries a credential).
+const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
+
+fn nanos() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0)
+}
+fn s(v: &Value, k: &str, d: &str) -> String {
+    v.get(k).and_then(|x| x.as_str()).unwrap_or(d).to_string()
+}
+fn opt_s(v: &Value, k: &str) -> Option<String> {
+    v.get(k).and_then(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string)
+}
+type VErr = (String, String);
+fn verr(code: &str, msg: String) -> VErr {
+    (code.to_string(), msg)
+}
+
+/// Is a declared source field type compatible with a property's base value type? Conservative — a
+/// source shape only binds where the semantics survive (no lossy or nonsensical coercions).
+fn value_compatible(source_type: &str, base: &str) -> bool {
+    match source_type {
+        "string" => matches!(base, "string" | "markdown" | "enum"),
+        "integer" => matches!(base, "integer" | "double"),
+        "double" => matches!(base, "double"),
+        "boolean" => matches!(base, "boolean"),
+        "timestamp" => matches!(base, "timestamp"),
+        "date" => matches!(base, "date" | "timestamp"),
+        "json" => matches!(base, "markdown" | "attachment" | "geo_point"),
+        _ => false,
+    }
+}
+
+fn load_data_source(data_dir: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, crate::data_source_routes::RECORD_DIR)
+        .into_iter()
+        .find(|r| r.get("source_id").and_then(|v| v.as_str()) == Some(id))
+}
+fn load_ontology(data_dir: &str, oref: &str) -> Option<Value> {
+    // Accept either the canonical `ontology://<id>` ref or a bare id.
+    read_record_dir(data_dir, crate::odk_routes::KIND_ONT).into_iter().find(|r| {
+        r.get("ref").and_then(|v| v.as_str()) == Some(oref)
+            || r.get("id").and_then(|v| v.as_str()) == Some(oref)
+    })
+}
+fn find_object_type<'a>(ont: &'a Value, oid: &str) -> Option<&'a Value> {
+    ont.pointer("/canonical_object_model/object_types")?
+        .as_array()?
+        .iter()
+        .find(|o| o.get("id").and_then(|x| x.as_str()) == Some(oid))
+}
+fn find_property<'a>(obj: &'a Value, pid: &str) -> Option<&'a Value> {
+    obj.get("properties")?.as_array()?.iter().find(|p| p.get("id").and_then(|x| x.as_str()) == Some(pid))
+}
+/// A declared value_type resolves to its base; a base literal resolves to itself. (#11 already
+/// validated the ontology, so every property value_type resolves.)
+fn resolve_base(ont: &Value, value_type: &str) -> String {
+    if let Some(vts) = ont.pointer("/canonical_object_model/value_types").and_then(|v| v.as_array()) {
+        if let Some(vt) = vts.iter().find(|v| v.get("id").and_then(|x| x.as_str()) == Some(value_type)) {
+            return vt.get("base").and_then(|x| x.as_str()).unwrap_or("string").to_string();
+        }
+    }
+    value_type.to_string()
+}
+
+/// One binding (key / title / field) normalized from the body: (role, source_field, property_id,
+/// source_type, source_cardinality).
+fn binding_tuple(role: &str, v: &Value) -> (String, String, String, String, String) {
+    (
+        role.to_string(),
+        s(v, "source_field", ""),
+        s(v, "property_id", ""),
+        s(v, "source_type", "string"),
+        s(v, "source_cardinality", "one"),
+    )
+}
+
+/// Validate a mapping body fail-closed and project its declared record fields + readiness health.
+/// INERT: nothing is read from the source; this only checks shape against declared truth.
+fn validate_and_project(data_dir: &str, body: &Value) -> Result<Value, VErr> {
+    // No credential material ever enters a mapping.
+    if let Some(obj) = body.as_object() {
+        if PLAINTEXT_SECRET_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr(
+                "connector_mapping_plaintext_secret_rejected",
+                "A connector mapping never carries credentials — the data source holds its own posture.".into(),
+            ));
+        }
+    }
+    if opt_s(body, "name").is_none() {
+        return Err(verr("connector_mapping_name_required", "A connector mapping requires a name.".into()));
+    }
+    // Known data source (#10).
+    let data_source_id = opt_s(body, "data_source_id").unwrap_or_default();
+    let ds = load_data_source(data_dir, &data_source_id).ok_or_else(|| {
+        verr("connector_mapping_data_source_unknown", format!("data_source_id '{data_source_id}' does not resolve to a declared data source"))
+    })?;
+    // Known ontology + object type (#11).
+    let ontology_ref = opt_s(body, "ontology_ref").or_else(|| opt_s(body, "ontology_id")).unwrap_or_default();
+    let ont = load_ontology(data_dir, &ontology_ref).ok_or_else(|| {
+        verr("connector_mapping_ontology_unknown", format!("ontology '{ontology_ref}' does not resolve to a declared ontology"))
+    })?;
+    let object_type_id = opt_s(body, "object_type_id").unwrap_or_default();
+    let obj = find_object_type(&ont, &object_type_id).ok_or_else(|| {
+        verr("connector_mapping_object_type_unknown", format!("object_type '{object_type_id}' is not declared in the ontology"))
+    })?;
+    let title_property = obj.get("title_property").and_then(|v| v.as_str()).unwrap_or("");
+
+    // Required key + title mappings.
+    let key = body.get("key_mapping").filter(|v| v.is_object());
+    let key = key.ok_or_else(|| verr("connector_mapping_key_mapping_required", "A primary key_mapping (source_field → property_id) is required.".into()))?;
+    let title = body.get("title_mapping").filter(|v| v.is_object());
+    let title = title.ok_or_else(|| verr("connector_mapping_title_mapping_required", "A title_mapping (source_field → property_id) is required.".into()))?;
+    // The object must declare a title_property, and the title mapping must target it.
+    if title_property.is_empty() {
+        return Err(verr("connector_mapping_title_mapping_required", "The object type declares no title_property — declare one in the ontology before mapping.".into()));
+    }
+    if s(title, "property_id", "") != title_property {
+        return Err(verr("connector_mapping_title_mapping_required", format!("title_mapping must target the object's title_property '{title_property}'")));
+    }
+
+    // Normalize all bindings and validate each against the typed object.
+    let field_mappings: Vec<Value> = body.get("field_mappings").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    let mut bindings = vec![binding_tuple("key", key), binding_tuple("title", title)];
+    bindings.extend(field_mappings.iter().map(|f| binding_tuple("field", f)));
+
+    let mut targets: Vec<String> = Vec::new();
+    for (role, source_field, property_id, source_type, source_cardinality) in &bindings {
+        if source_field.trim().is_empty() {
+            return Err(verr("connector_mapping_source_field_required", format!("{role} mapping requires a source_field")));
+        }
+        let prop = find_property(obj, property_id).ok_or_else(|| {
+            verr("connector_mapping_property_unknown", format!("{role} mapping property '{property_id}' is not a property of object_type '{object_type_id}'"))
+        })?;
+        if !SOURCE_FIELD_TYPES.contains(&source_type.as_str()) {
+            return Err(verr("connector_mapping_source_type_invalid", format!("source_type '{source_type}' is not a known source field type")));
+        }
+        // Scalar properties only — a repeated source field cannot bind to a single-valued property.
+        if source_cardinality == "many" {
+            return Err(verr("connector_mapping_cardinality_mismatch", format!("{role} mapping is multi-valued but property '{property_id}' is single-valued (declare a link_type or repeated property first)")));
+        }
+        if source_cardinality != "one" {
+            return Err(verr("connector_mapping_cardinality_invalid", format!("source_cardinality '{source_cardinality}' must be 'one' or 'many'")));
+        }
+        let base = resolve_base(&ont, prop.get("value_type").and_then(|v| v.as_str()).unwrap_or(""));
+        if !value_compatible(source_type, &base) {
+            return Err(verr("connector_mapping_value_type_incompatible", format!("source_type '{source_type}' is not compatible with property '{property_id}' (base value type '{base}')")));
+        }
+        if targets.iter().any(|t| t == property_id) {
+            return Err(verr("connector_mapping_duplicate_target", format!("property '{property_id}' is targeted by more than one mapping")));
+        }
+        targets.push(property_id.clone());
+    }
+
+    // Readiness — honest: `ready` only when every REQUIRED property is mapped; else `incomplete`
+    // (still a valid declared draft). Coverage is reported either way.
+    let all_props: Vec<&Value> = obj.get("properties").and_then(|v| v.as_array()).map(|a| a.iter().collect()).unwrap_or_default();
+    let total = all_props.len();
+    let required_gaps: Vec<String> = all_props
+        .iter()
+        .filter(|p| p.get("required").and_then(|v| v.as_bool()).unwrap_or(false))
+        .filter(|p| {
+            let pid = p.get("id").and_then(|v| v.as_str()).unwrap_or("");
+            !targets.iter().any(|t| t == pid)
+        })
+        .map(|p| p.get("name").and_then(|v| v.as_str()).or_else(|| p.get("id").and_then(|v| v.as_str())).unwrap_or("").to_string())
+        .collect();
+    let status = if required_gaps.is_empty() { "ready" } else { "incomplete" };
+
+    Ok(json!({
+        "data_source_id": data_source_id,
+        "data_source_ref": ds.get("source_ref").cloned().unwrap_or(Value::Null),
+        "ontology_ref": ont.get("ref").cloned().unwrap_or(Value::Null),
+        "object_type_id": object_type_id,
+        "source_dataset": opt_s(body, "source_dataset"),
+        "key_mapping": key.clone(),
+        "title_mapping": title.clone(),
+        "field_mappings": field_mappings,
+        "health": {
+            "status": status,
+            "mapped_properties": targets.len(),
+            "total_properties": total,
+            "required_gaps": required_gaps,
+            "object_instances": 0,
+            "authority_crossed": false,
+            "missing_contracts": MISSING_CONTRACTS,
+            "note": "declaration only — no extraction; authorization requires PolicyBoundDataView, execution requires TransformationRun"
+        }
+    }))
+}
+
+fn mapping_receipt(data_dir: &str, mapping_ref: &str, op: &str, summary: &str) -> Value {
+    let id = format!("cmr_{:x}", nanos());
+    let receipt_ref = format!("agentgres://connector-mapping-receipt/{id}");
+    let rec = json!({
+        "schema_version": RECEIPT_SCHEMA, "receipt_id": id, "receipt_ref": receipt_ref,
+        "connector_mapping_ref": mapping_ref, "op": op, "outcome": "ok", "summary": summary, "at": iso_now()
+    });
+    let _ = persist_record(data_dir, RECEIPT_DIR, &id, &rec);
+    rec
+}
+fn load_mapping(data_dir: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, RECORD_DIR).into_iter().find(|r| r.get("id").and_then(|v| v.as_str()) == Some(id))
+}
+fn sorted_mappings(data_dir: &str) -> Vec<Value> {
+    let mut items = read_record_dir(data_dir, RECORD_DIR);
+    items.sort_by(|a, b| s(b, "updated_at", "").cmp(&s(a, "updated_at", "")));
+    items
+}
+fn bad(err: VErr) -> (StatusCode, Json<Value>) {
+    (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": err.0, "message": err.1 } })))
+}
+
+/// GET /v1/hypervisor/odk/connector-mappings — declared mappings (newest first).
+pub(crate) async fn handle_connector_mappings_list(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    Json(json!({ "ok": true, "schema_version": MAPPING_SCHEMA, "connector_mappings": sorted_mappings(&st.data_dir), "runtimeTruthSource": "daemon-runtime" }))
+}
+
+/// GET /v1/hypervisor/odk/connector-mappings/overview — vocab + counts + honest missing-contract ladder.
+pub(crate) async fn handle_connector_mappings_overview(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let items = read_record_dir(&st.data_dir, RECORD_DIR);
+    let by_status = |status: &str| items.iter().filter(|r| r.pointer("/health/status").and_then(|v| v.as_str()) == Some(status)).count();
+    Json(json!({
+        "ok": true,
+        "schema_version": OVERVIEW_SCHEMA,
+        "connector_mappings": items.len(),
+        "health": { "ready": by_status("ready"), "incomplete": by_status("incomplete") },
+        "source_field_types": SOURCE_FIELD_TYPES,
+        "missing_contracts": MISSING_CONTRACTS,
+        "governance_gaps": [
+            "INERT: a mapping is a validated declaration only — nothing here reads, extracts, or moves source data",
+            "authorization is a NAMED GAP: reads require a future PolicyBoundDataView; execution requires a future TransformationRun",
+            "object_instances is always 0 — no object plane is produced until an OntologyProjection exists"
+        ],
+        "runtimeTruthSource": "daemon-runtime"
+    }))
+}
+
+/// GET /v1/hypervisor/odk/connector-mappings/:id — one declared mapping.
+pub(crate) async fn handle_connector_mapping_get(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    match load_mapping(&st.data_dir, &id) {
+        Some(r) => (StatusCode::OK, Json(json!({ "ok": true, "connector_mapping": r }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "connector mapping not found" }))),
+    }
+}
+
+/// GET /v1/hypervisor/odk/connector-mappings/:id/health — readiness projection.
+pub(crate) async fn handle_connector_mapping_health(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    match load_mapping(&st.data_dir, &id) {
+        Some(r) => (StatusCode::OK, Json(json!({ "ok": true, "connector_mapping_ref": r.get("ref"), "revision": r.get("revision"), "health": r.get("health") }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "connector mapping not found" }))),
+    }
+}
+
+/// GET /v1/hypervisor/odk/connector-mappings/:id/history — embedded history + persisted receipts.
+pub(crate) async fn handle_connector_mapping_history(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(r) = load_mapping(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "connector mapping not found" })));
+    };
+    let mref = r.get("ref").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let mut receipts = read_record_dir(&st.data_dir, RECEIPT_DIR);
+    receipts.retain(|x| x.get("connector_mapping_ref").and_then(|v| v.as_str()) == Some(mref.as_str()));
+    receipts.sort_by(|a, b| s(b, "at", "").cmp(&s(a, "at", "")));
+    (StatusCode::OK, Json(json!({ "ok": true, "connector_mapping_ref": mref, "revision": r.get("revision"), "history": r.get("history").cloned().unwrap_or(json!([])), "receipts": receipts })))
+}
+
+/// POST /v1/hypervisor/odk/connector-mappings — declare a mapping (fail-closed, receipted, INERT).
+pub(crate) async fn handle_connector_mapping_create(State(st): State<Arc<DaemonState>>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    let projected = match validate_and_project(&st.data_dir, &body) {
+        Ok(p) => p,
+        Err(e) => return bad(e),
+    };
+    let id = format!("cmap_{:x}", nanos());
+    let now = iso_now();
+    let mref = format!("connector-mapping://{id}");
+    let receipt = mapping_receipt(&st.data_dir, &mref, "created", "ConnectorMapping declared");
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    let mut record = json!({
+        "schema_version": MAPPING_SCHEMA,
+        "object": "ioi.hypervisor.odk.connector_mapping",
+        "id": id,
+        "ref": mref,
+        "name": s(&body, "name", "connector-mapping"),
+        "description": s(&body, "description", ""),
+        "status": "declared",
+        "ingestion": { "wired": false, "note": "declaration only — no extraction, no source read, no object instances" },
+        "revision": 1,
+        "receipt_refs": [receipt_ref.clone()],
+        "history": [ { "revision": 1, "op": "created", "at": now.clone(), "summary": "ConnectorMapping declared", "receipt_ref": receipt_ref } ],
+        "created_at": now.clone(),
+        "updated_at": now
+    });
+    // Merge the validated/projected fields (refs, mappings, health) onto the record.
+    if let (Some(obj), Some(proj)) = (record.as_object_mut(), projected.as_object()) {
+        for (k, v) in proj {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    let _ = persist_record(&st.data_dir, RECORD_DIR, record.get("id").and_then(|v| v.as_str()).unwrap_or_default(), &record);
+    (StatusCode::CREATED, Json(json!({ "ok": true, "connector_mapping": record })))
+}
+
+/// PATCH — re-validate the merged mapping; a malformed patch changes nothing (no revision bump).
+pub(crate) async fn handle_connector_mapping_patch(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(patch): Json<Value>) -> Json<Value> {
+    let Some(existing) = load_mapping(&st.data_dir, &id) else {
+        return Json(json!({ "ok": false, "reason": "connector mapping not found" }));
+    };
+    // Build the merged body from existing declared inputs overlaid with the patch, then re-validate.
+    let mut merged = json!({});
+    let mo = merged.as_object_mut().unwrap();
+    for k in ["name", "description", "data_source_id", "ontology_ref", "object_type_id", "source_dataset", "key_mapping", "title_mapping", "field_mappings"] {
+        if let Some(v) = patch.get(k).or_else(|| existing.get(k)) {
+            mo.insert(k.to_string(), v.clone());
+        }
+    }
+    let projected = match validate_and_project(&st.data_dir, &merged) {
+        Ok(p) => p,
+        Err(e) => return Json(json!({ "ok": false, "error": { "code": e.0, "message": e.1 } })),
+    };
+    let mut record = existing;
+    if let Some(v) = patch.get("name") { record["name"] = v.clone(); }
+    if let Some(v) = patch.get("description") { record["description"] = v.clone(); }
+    if let (Some(obj), Some(proj)) = (record.as_object_mut(), projected.as_object()) {
+        for (k, v) in proj {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1) + 1;
+    record["revision"] = json!(rev);
+    let now = iso_now();
+    record["updated_at"] = json!(now.clone());
+    let mref = record.get("ref").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let receipt = mapping_receipt(&st.data_dir, &mref, "patched", "ConnectorMapping re-declared");
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    let mut hist = record.get("history").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    hist.push(json!({ "revision": rev, "op": "patched", "at": now, "summary": "ConnectorMapping re-declared", "receipt_ref": receipt_ref.clone() }));
+    let len = hist.len();
+    if len > 20 { hist = hist[len - 20..].to_vec(); }
+    record["history"] = json!(hist);
+    let mut refs = record.get("receipt_refs").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    refs.push(receipt_ref);
+    record["receipt_refs"] = json!(refs);
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    Json(json!({ "ok": true, "connector_mapping": record }))
+}
+
+/// DELETE /v1/hypervisor/odk/connector-mappings/:id.
+pub(crate) async fn handle_connector_mapping_delete(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> Json<Value> {
+    let removed = remove_record(&st.data_dir, RECORD_DIR, &id);
+    Json(json!({ "ok": removed, "removed": removed, "id": id }))
+}
+
+#[cfg(test)]
+mod connector_mapping_tests {
+    use super::*;
+
+    #[test]
+    fn value_compat_is_conservative() {
+        assert!(value_compatible("string", "enum"));
+        assert!(value_compatible("integer", "double"));
+        assert!(value_compatible("date", "timestamp"));
+        assert!(!value_compatible("string", "double"));
+        assert!(!value_compatible("double", "integer"));
+        assert!(!value_compatible("boolean", "string"));
+    }
+
+    #[test]
+    fn resolve_base_prefers_declared_value_type_then_literal() {
+        let ont = json!({ "canonical_object_model": { "value_types": [{ "id": "money", "base": "double" }] } });
+        assert_eq!(resolve_base(&ont, "money"), "double");
+        assert_eq!(resolve_base(&ont, "string"), "string");
+    }
+
+    #[test]
+    fn source_field_types_and_missing_contracts_are_named() {
+        assert!(SOURCE_FIELD_TYPES.contains(&"timestamp"));
+        assert_eq!(MISSING_CONTRACTS, &["PolicyBoundDataView", "TransformationRun", "OntologyProjection"]);
+        assert!(PLAINTEXT_SECRET_KEYS.contains(&"password"));
+    }
+}

--- a/crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 
 use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState};
 
-const KIND_ONT: &str = "odk-domain-ontologies";
+pub(crate) const KIND_ONT: &str = "odk-domain-ontologies";
 const KIND_RECIPE: &str = "odk-data-recipes";
 const KIND_MANIFEST: &str = "odk-manifests";
 const KIND_SD: &str = "odk-surface-descriptors";


### PR DESCRIPTION
**Stack: this → #12 (reference-UX shell) → #11 → #10 → … → master.** The first rung of the semantic-data-plane closure — **deliberately not the whole thing**. Raw source shape becomes *declared and validated*, but not yet authorized or transformed. The doctrine the whole cut protects: **raw data never becomes semantic truth just because we can see it.**

## What it is
New daemon plane `/v1/hypervisor/odk/connector-mappings` — a mapping binds one declared **data source (#10)** to one typed **ontology object (#11)** by mapping source fields → typed object properties, with required key + title mappings. `list / get / overview / health / history + create / patch / delete`.

## Inert by construction
- No extraction, no source read, no object instances, no explorer rows, no data movement.
- `ingestion.wired: false`, `authority_crossed: false`, `object_instances: 0` — always.
- The three downstream contracts (`PolicyBoundDataView`, `TransformationRun`, `OntologyProjection`) are **named as still-missing** on every record and the overview.
- Proof: a mapping created against an **unreachable** postgres source returns in **2ms** — nothing is contacted.

## Fail-closed at write (every lane a typed code)
plaintext secret · missing name · unknown data_source / ontology / object_type / property · invalid source field type · **value-type incompatible** (conservative compat table) · **cardinality mismatch** (multi source → scalar property) · duplicate target property · missing key mapping · missing title mapping / title must target the object's `title_property`.

Every create/patch is **receipted** with bounded history; a malformed patch is rejected **without** bumping the revision. Health is honest: `ready` only when every **required** property is covered, else `incomplete` with named gaps.

## Surface (the #12 Ontology Manager)
- **Resources** pane renders bound mappings as **daemon truth** (name · data source · object type · field count · health · "not extracting").
- **Object data / Explorer** pane now shows an **authority-crossing ladder** — `ConnectorMapping` **declared** (inert, N mappings) with `PolicyBoundDataView / TransformationRun / OntologyProjection` still visibly **missing**. The 0-objects boundary is preserved.

## Done bar — green
| gate | result |
|---|---|
| connector-mapping | **33/33** |
| cargo test -p ioi-node | **78/78** (+3 unit tests) |
| ontology-manager · ontology-ux-parity | **35/35 · 20/20** |
| data-source · automations · model-catalog · queue-seeds | 17/17 · 12/12 · 11/11 · 45/45 |
| legacy ODK builders | governed-lifecycle 39/39 · p2 20/20 · p3 13/13 |
| source-neutral · fallthrough · diff-check | PASSED · empty · clean |

The ratchet: the **next** rung (`PolicyBoundDataView`) is the actual authority gate; only after it may `TransformationRun` execute anything.

- **master not pushed.** Feature branch, stacked on #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)