### PR TITLE
ODK PolicyBoundDataView — the second inert authority-crossing rung (stacked on #13)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2955,21 +2955,37 @@ function renderDataSourcesSection(dataSources) {
 // authority (receipts, policy gates, substrate readiness, conformance, source-neutrality) is threaded
 // SIDEWAYS into that familiar IA rather than replacing it.
 
-// The authority-crossing LADDER. ConnectorMapping (rung 1) is now a real inert daemon contract;
-// the rest remain named-but-missing. Each rung must exist before the next is allowed to do anything —
-// this is the honest boundary the whole surface is careful about.
+// The authority-crossing LADDER. ConnectorMapping (rung 1) and PolicyBoundDataView (rung 2, the
+// capability gate) are real inert daemon contracts; the rest remain named-but-missing. Each rung
+// must exist before the next is allowed to do anything — this is the honest boundary the whole
+// surface is careful about.
 const OM_MISSING_CONTRACTS = [
-  ["PolicyBoundDataView", "who/what may read · transform · distill · train · evaluate · export · publish · route", "governed reads over object data"],
   ["TransformationRun + receipts", "auditable mapping runs recorded before any projection exists", "object projections you can trust"],
   ["OntologyProjection", "the explicit model → explorer / search / runtime bridge", "Object Explorer rows & saved object sets"],
 ];
 function omBoundaryNote(text) {
   return `<div style="border:1px dashed #3a3d46;border-radius:10px;padding:10px 12px;margin:0 0 12px;background:#141519;color:#9a9da6;font-size:12.5px">${text}</div>`;
 }
-function omContractLadder(nMappings) {
-  const declared = `<tr><td><code>ConnectorMapping</code> <span class="pill ok">declared</span></td><td>declared source fields → typed object properties</td><td class="sub" style="margin:0">${nMappings} mapping${nMappings === 1 ? "" : "s"} · inert (no extraction)</td></tr>`;
+function omContractLadder(nMappings, nViews) {
+  const declared = `<tr><td><code>ConnectorMapping</code> <span class="pill ok">declared</span></td><td>declared source fields → typed object properties</td><td class="sub" style="margin:0">${nMappings} mapping${nMappings === 1 ? "" : "s"} · inert (no extraction)</td></tr>`
+    + `<tr><td><code>PolicyBoundDataView</code> <span class="pill ok">declared</span></td><td>the capability envelope — who/what may read · transform · distill · train · evaluate · export · publish · route, for what purpose, under which receipt obligations</td><td class="sub" style="margin:0">${nViews} view${nViews === 1 ? "" : "s"} · gate only (nothing runs)</td></tr>`;
   const missing = OM_MISSING_CONTRACTS.map(([name, what, unlocks]) => `<tr><td><code>${CX_ESC(name)}</code> <span class="pill muted">missing</span></td><td>${CX_ESC(what)}</td><td class="sub" style="margin:0">unlocks ${CX_ESC(unlocks)}</td></tr>`).join("");
   return `<table><thead><tr><th>Contract</th><th>What it declares</th><th>Status / unlocks</th></tr></thead><tbody>${declared}${missing}</tbody></table>`;
+}
+// Policy-bound data views bound to the selected ontology — daemon truth: the declared capability
+// gates over the mapped data. Declarative only; a view authorizes nothing to run.
+function omPolicyViews(views) {
+  views = Array.isArray(views) ? views : [];
+  if (!views.length) return `<div class="empty">No policy-bound data views. A view declares the <b>capability envelope</b> over a ready mapping's would-be data — allowed operations, subjects, purpose, scope, postures, receipt obligations. Declarative only; nothing runs.</div>`;
+  const pill = (h) => { const st = (h && h.status) || "incomplete"; return `<span class="pill ${st === "ready" ? "ok" : "warn"}">${CX_ESC(st)}</span>`; };
+  const rows = views.map((v) => `<tr>
+    <td><b>${CX_ESC(v.name || v.id)}</b><div class="meta" style="color:#878a93;font-size:11.5px;margin-top:2px"><code>${CX_ESC(v.ref || "")}</code></div></td>
+    <td>${(v.allowed_operations || []).map((o) => `<span class="pill muted">${CX_ESC(o)}</span>`).join(" ")}</td>
+    <td>${(v.authority_subjects || []).length} subject${(v.authority_subjects || []).length === 1 ? "" : "s"}</td>
+    <td class="sub" style="margin:0">${CX_ESC(v.purpose || "—")}</td>
+    <td>${pill(v.health)} <span class="pill warn" title="declarative gate only — nothing is authorized to run">no execution</span></td>
+  </tr>`).join("");
+  return `<table><thead><tr><th>View</th><th>Operations</th><th>Subjects</th><th>Purpose</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 // Connector mappings bound to the selected ontology — daemon truth (declared, inert).
 function omConnectorMappings(mappings) {
@@ -3085,9 +3101,11 @@ function renderOntologyManager(ov, lists, selectedId) {
   const descs = (lists.surface_descriptors || []).filter((d) => d.ontology_ref === boundRef);
   const mans = (lists.manifests || []).filter((m) => (m.ontology_refs || []).includes(boundRef));
   const maps = (lists.connector_mappings || []).filter((m) => m.ontology_ref === boundRef);
+  const pviews = (lists.policy_views || []).filter((v) => v.ontology_ref === boundRef);
   const resourceSection = (title, family, items, nameKey, newLabel) => `<h3 style="display:flex;justify-content:space-between;align-items:center;margin:12px 0 6px">${title} (${items.length}) <a class="act ghost" href="/__ioi/odk/${family}/new">+ ${newLabel}</a></h3>${items.length ? items.map((x) => odkCard(family, x, nameKey)).join("") : `<div class="empty">None bound to this ontology.</div>`}`;
   const resourcesPane = `<h2 id="pane-resources">Resources <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— bound to ${selected ? CX_ESC(selected.domain) : "—"}</span></h2>`
     + `<h3 style="margin:12px 0 6px">Connector mappings (${maps.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— source fields → object properties · daemon truth · inert</span></h3>${omConnectorMappings(maps)}`
+    + `<h3 style="margin:12px 0 6px">Policy-bound data views (${pviews.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the capability gate over mapped data · daemon truth · declarative</span></h3>${omPolicyViews(pviews)}`
     + resourceSection("Data recipes", "data-recipes", recs, "name", "New recipe")
     + resourceSection("Surface descriptors", "surface-descriptors", descs, "name", "New descriptor")
     + resourceSection("ODK manifests", "manifests", mans, "name", "New manifest");
@@ -3098,7 +3116,7 @@ function renderOntologyManager(ov, lists, selectedId) {
   //      (ConnectorMapping now declared/inert; the rest still missing).
   const explorerPane = `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill muted">unavailable</span></h2>`
     + omBoundaryNote(`This ontology binds <b>no object-instance plane</b>, so there are <b>no rows to explore</b> — the reference Object Explorer is a search surface over real objects; ours stays empty until the authority crossing below is made. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`)
-    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder</h3>` + omContractLadder(maps.length);
+    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder</h3>` + omContractLadder(maps.length, pviews.length);
 
   const counts = { "object-types": ots.length, "properties": propCount, "link-types": lts.length, "action-types": nonFuncActs.length, "value-types": vts.length, "groups": 0, "interfaces": 0, "functions": funcs.length };
   const panes = objectTypesPane + propertiesPane + linkPane + actionPane + valuePane
@@ -6651,7 +6669,7 @@ const server = http.createServer((req, res) => {
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
     if (pathname === "/__ioi/odk" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
-      const [ov, o, r, d, m, ds, cm] = await Promise.all([
+      const [ov, o, r, d, m, ds, cm, pv] = await Promise.all([
         J("/v1/hypervisor/odk/overview"),
         J("/v1/hypervisor/odk/domain-ontologies"),
         J("/v1/hypervisor/odk/data-recipes"),
@@ -6659,6 +6677,7 @@ const server = http.createServer((req, res) => {
         J("/v1/hypervisor/odk/manifests"),
         J("/v1/hypervisor/data-sources"),
         J("/v1/hypervisor/odk/connector-mappings"),
+        J("/v1/hypervisor/odk/policy-bound-data-views"),
       ]);
       const selectedOntology = new URL(req.url, "http://x").searchParams.get("ontology") || "";
       res.writeHead(200, HTMLH);
@@ -6669,6 +6688,7 @@ const server = http.createServer((req, res) => {
         manifests: m.manifests || [],
         data_sources: ds.data_sources || [],
         connector_mappings: cm.connector_mappings || [],
+        policy_views: pv.policy_bound_data_views || [],
       }, selectedOntology));
       return;
     }

--- a/apps/hypervisor/scripts/verify-hypervisor-policy-bound-data-view.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-policy-bound-data-view.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// PolicyBoundDataView done-bar — the SECOND inert authority-crossing rung.
+//
+// A view declares the CAPABILITY ENVELOPE over a ready ConnectorMapping's would-be ontology-shaped
+// data: allowed operations, authorized subjects, purpose, property scope, retention/export/training/
+// evaluation/publish postures, and receipt obligations. It is capability-over-semantic-data, not an
+// ACL table — the gate a future TransformationRun must satisfy. Declarative/INERT: a view executes
+// nothing, reads nothing, mints no object rows, and implies no approval.
+//
+// Asserts:
+//   - DECLARATIVE only: created instantly against an unreachable-source mapping; authority.crossed
+//     false; object_instances 0; TransformationRun + OntologyProjection named still-missing.
+//   - Fail-closed on every lane: plaintext secret, missing name, unknown mapping, mapping not ready,
+//     empty/invalid operations, empty subjects, wildcard without draft, unscoped property, invalid
+//     posture, posture conflicting an allowed operation, high-risk operation without a named receipt
+//     obligation.
+//   - No automatic authority: wildcard-all only as an explicit draft, and then never `ready`.
+//   - Receipts + bounded history on create/patch; receipted delete; malformed patch does not bump
+//     the revision.
+//   - Honest health: ready only with purpose + retention + scoped properties + narrow subjects.
+//   - The ODK Manager renders views as daemon truth and the ladder as: ConnectorMapping declared,
+//     PolicyBoundDataView declared, TransformationRun+receipts missing, OntologyProjection missing.
+//     0-objects boundary preserved; brand-clean.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-policy-bound-data-view.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/policy-bound-data-views/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon policy-view plane not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+
+  // Fixtures: data source (unreachable) → ready ontology → READY mapping + an INCOMPLETE mapping.
+  const dsR = await jd("POST", "/v1/hypervisor/data-sources", { name: "pbdv-verify-src", kind: "postgres", endpoint: "postgres://unreachable.invalid:5432/db", credential_posture: "wallet_credential_lease" });
+  const dataSourceId = dsR.j.data_source?.source_id;
+  if (dataSourceId) cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${dataSourceId}`]);
+  const ontR = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "pbdv-verify", canonical_object_model: {
+    value_types: [{ id: "money", name: "Money", base: "double" }],
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" },
+      { id: "amount", name: "Amount", value_type: "money" },
+    ] }],
+    action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }],
+  } });
+  const ontRef = ontR.j.ontology?.ref;
+  const ontId = ontR.j.ontology?.id;
+  if (ontId) cleanup.push(["DELETE", `/v1/hypervisor/odk/domain-ontologies/${ontId}`]);
+  const mapR = await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "pbdv-verify-map", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" },
+    field_mappings: [{ source_field: "amt", property_id: "amount", source_type: "double" }] });
+  const mapId = mapR.j.connector_mapping?.id;
+  if (mapId) cleanup.push(["DELETE", `/v1/hypervisor/odk/connector-mappings/${mapId}`]);
+  const incMapR = await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "pbdv-verify-inc", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan",
+    key_mapping: { source_field: "a", property_id: "amount", source_type: "double" },
+    title_mapping: { source_field: "d", property_id: "title", source_type: "string" } });
+  const incMapId = incMapR.j.connector_mapping?.id;
+  if (incMapId) cleanup.push(["DELETE", `/v1/hypervisor/odk/connector-mappings/${incMapId}`]);
+  if (!dataSourceId || !ontRef || !mapId || !incMapId) { console.error("BLOCKED: fixtures failed"); process.exit(2); }
+  ok("fixture mapping is ready; sibling mapping incomplete (for the not-ready lane)", mapR.j.connector_mapping?.health?.status === "ready" && incMapR.j.connector_mapping?.health?.status === "incomplete");
+
+  const base = (extra) => ({ connector_mapping_id: mapId, name: "loan-gate", authority_subjects: ["agent://underwriting-planner"], allowed_operations: ["read", "transform"], purpose: "underwriting analysis", property_scope: ["loan_id", "title", "amount"], retention_posture: "bounded", ...extra });
+
+  // 1. DECLARATIVE valid view — instantly, ready, receipted, nothing crossed.
+  const t0 = Date.now();
+  const created = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", base({}));
+  const elapsed = Date.now() - t0;
+  const v = created.j.policy_bound_data_view;
+  if (v?.id) cleanup.push(["DELETE", `/v1/hypervisor/odk/policy-bound-data-views/${v.id}`]);
+  ok("valid view declares (201) instantly — no source contact, no execution", created.status === 201 && !!v?.ref && elapsed < 4000, `${elapsed}ms`);
+  ok("view is a capability envelope over the mapping (refs + scope + ops + subjects + purpose)", v?.connector_mapping_ref?.startsWith("connector-mapping://") && (v?.allowed_operations || []).length === 2 && (v?.property_scope || []).length === 3 && v?.purpose === "underwriting analysis");
+  ok("NO automatic authority: authority.crossed false, object_instances 0", v?.authority?.crossed === false && v?.health?.object_instances === 0);
+  ok("downstream contracts named still-missing (TransformationRun, OntologyProjection)", JSON.stringify(v?.health?.missing_contracts) === JSON.stringify(["TransformationRun", "OntologyProjection"]));
+  ok("view is declared + receipted + history", v?.status === "declared" && (v?.receipt_refs || []).length >= 1 && (v?.history || []).length >= 1);
+  ok("health is honest `ready` (purpose + retention + scope + narrow subjects)", v?.health?.status === "ready", v?.health?.status);
+
+  // 2. High-risk needs named receipt obligations (and a non-conflicting posture).
+  const hrOk = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", base({ name: "export-gate", allowed_operations: ["read", "export"], export_posture: "receipted_export_only", receipt_obligations: ["export: one receipt per exported batch"] }));
+  if (hrOk.j.policy_bound_data_view?.id) cleanup.push(["DELETE", `/v1/hypervisor/odk/policy-bound-data-views/${hrOk.j.policy_bound_data_view.id}`]);
+  ok("high-risk op WITH named obligation + posture declares ready", hrOk.status === 201 && hrOk.j.policy_bound_data_view?.health?.status === "ready");
+
+  // 3. Fail-closed lanes.
+  const reject = async (label, body, code) => {
+    const r = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", body);
+    ok(`fail-closed: ${label}`, r.status === 400 && r.j.error?.code === code, r.j.error?.code || `status ${r.status}`);
+    if (r.j?.policy_bound_data_view?.id) cleanup.push(["DELETE", `/v1/hypervisor/odk/policy-bound-data-views/${r.j.policy_bound_data_view.id}`]);
+  };
+  await reject("plaintext secret", base({ password: "hunter2" }), "policy_view_plaintext_secret_rejected");
+  await reject("missing name", { connector_mapping_id: mapId, authority_subjects: ["a"], allowed_operations: ["read"] }, "policy_view_name_required");
+  await reject("unknown mapping", base({ connector_mapping_id: "cmap_nope" }), "policy_view_mapping_unknown");
+  await reject("mapping not ready (binds only validated shape)", base({ connector_mapping_id: incMapId }), "policy_view_mapping_not_ready");
+  await reject("empty operations", base({ allowed_operations: [] }), "policy_view_operations_required");
+  await reject("invalid operation", base({ allowed_operations: ["teleport"] }), "policy_view_operation_invalid");
+  await reject("empty subjects", base({ authority_subjects: [] }), "policy_view_subjects_required");
+  await reject("wildcard-all authority without draft", base({ authority_subjects: ["*"] }), "policy_view_wildcard_authority_rejected");
+  await reject("property not mapped (cannot authorize unmapped data)", base({ property_scope: ["ghost_prop"] }), "policy_view_property_unscoped");
+  await reject("invalid posture value", base({ retention_posture: "forever" }), "policy_view_posture_invalid");
+  await reject("posture conflicts an allowed op (export vs no_export)", base({ allowed_operations: ["export"], export_posture: "no_export", receipt_obligations: ["export: receipt"] }), "policy_view_posture_conflict");
+  await reject("high-risk op without named receipt obligation", base({ allowed_operations: ["export"], export_posture: "receipted_export_only", receipt_obligations: [] }), "policy_view_receipt_obligation_required");
+
+  // 4. Wildcard as an explicit draft is tolerated but NEVER ready.
+  const wc = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", base({ name: "wc-draft", draft: true, authority_subjects: ["*"] }));
+  if (wc.j.policy_bound_data_view?.id) cleanup.push(["DELETE", `/v1/hypervisor/odk/policy-bound-data-views/${wc.j.policy_bound_data_view.id}`]);
+  ok("wildcard draft is held as draft + incomplete with a named gap (never ready)", wc.status === 201 && wc.j.policy_bound_data_view?.status === "draft" && wc.j.policy_bound_data_view?.health?.status === "incomplete" && (wc.j.policy_bound_data_view?.health?.gaps || []).some((g) => /wildcard/i.test(g)));
+
+  // 5. Projections + patch/delete semantics.
+  const health = await jd("GET", `/v1/hypervisor/odk/policy-bound-data-views/${v.id}/health`);
+  ok("/:id/health projects readiness (object_instances 0)", health.status === 200 && health.j.health?.status === "ready" && health.j.health?.object_instances === 0);
+  const hist = await jd("GET", `/v1/hypervisor/odk/policy-bound-data-views/${v.id}/history`);
+  ok("/:id/history returns history + receipts", (hist.j.history || []).length >= 1 && (hist.j.receipts || []).length >= 1);
+  const ov = await jd("GET", "/v1/hypervisor/odk/policy-bound-data-views/overview");
+  ok("overview: operation vocab + high-risk set + declarative governance gaps", JSON.stringify(ov.j.high_risk_operations) === JSON.stringify(["export", "publish", "train", "evaluate"]) && (ov.j.governance_gaps || []).some((g) => /DECLARATIVE|authorizes nothing/i.test(g)));
+  const p1 = await jd("PATCH", `/v1/hypervisor/odk/policy-bound-data-views/${v.id}`, { description: "gate for underwriting" });
+  ok("valid patch bumps revision + history + receipt", p1.j.policy_bound_data_view?.revision === 2 && (p1.j.policy_bound_data_view?.history || []).length === 2 && (p1.j.policy_bound_data_view?.receipt_refs || []).length === 2);
+  const p2 = await jd("PATCH", `/v1/hypervisor/odk/policy-bound-data-views/${v.id}`, { allowed_operations: ["teleport"] });
+  ok("malformed patch rejected (ok:false + code)", p2.j.ok === false && p2.j.error?.code === "policy_view_operation_invalid");
+  const after = await jd("GET", `/v1/hypervisor/odk/policy-bound-data-views/${v.id}/health`);
+  ok("rejected patch does NOT bump the revision", after.j.revision === 2, `rev ${after.j.revision}`);
+  // Receipted delete: remove the export-gate fixture and find its delete receipt via a fresh view's history route is gone —
+  // assert instead on the receipt store through the remaining view's history endpoint shape + the delete result.
+  const delR = await jd("DELETE", `/v1/hypervisor/odk/policy-bound-data-views/${hrOk.j.policy_bound_data_view.id}`);
+  ok("delete removes the declared capability (receipted revocation)", delR.j.ok === true && delR.j.removed === true);
+
+  // 6. ODK Manager UX — views as daemon truth; the ladder reads exactly as directed.
+  const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+  const t = page.text;
+  ok("Manager renders policy views as daemon truth (Resources)", page.status === 200 && /Policy-bound data views \(\d+\)/.test(t) && t.includes("loan-gate"));
+  ok("view row declares 'no execution' (declarative gate)", /no execution/.test(t));
+  ok("ladder: ConnectorMapping declared", /ConnectorMapping<\/code> <span class="pill ok">declared/.test(t));
+  ok("ladder: PolicyBoundDataView declared (gate only)", /PolicyBoundDataView<\/code> <span class="pill ok">declared/.test(t) && /gate only/.test(t));
+  ok("ladder: TransformationRun+receipts and OntologyProjection still missing", /TransformationRun \+ receipts<\/code> <span class="pill muted">missing/.test(t) && /OntologyProjection<\/code> <span class="pill muted">missing/.test(t));
+  ok("0-objects boundary preserved (no object rows anywhere)", /0 objects/.test(t));
+  ok("surface is brand-clean (no Palantir/Foundry leak)", !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
+
+  // Cleanup — leave no draft debris.
+  for (const [method, p] of cleanup.reverse()) await jd(method, p);
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`policy-bound-data-view readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -90,6 +90,8 @@ mod microvm;
 mod data_source_routes;
 #[path = "hypervisor_daemon_routes/connector_mapping_routes.rs"]
 mod connector_mapping_routes;
+#[path = "hypervisor_daemon_routes/policy_bound_data_view_routes.rs"]
+mod policy_bound_data_view_routes;
 #[path = "hypervisor_daemon_routes/harness_routes.rs"]
 mod harness_routes;
 #[path = "hypervisor_daemon_routes/model_routes.rs"]
@@ -1124,6 +1126,31 @@ async fn async_main() -> anyhow::Result<()> {
         .route(
             "/v1/hypervisor/odk/connector-mappings/:id/history",
             get(connector_mapping_routes::handle_connector_mapping_history),
+        )
+        // PolicyBoundDataView — the second inert authority-crossing rung: the capability envelope a
+        // future TransformationRun must satisfy. Declarative gate only; nothing runs.
+        .route(
+            "/v1/hypervisor/odk/policy-bound-data-views",
+            get(policy_bound_data_view_routes::handle_policy_views_list)
+                .post(policy_bound_data_view_routes::handle_policy_view_create),
+        )
+        .route(
+            "/v1/hypervisor/odk/policy-bound-data-views/overview",
+            get(policy_bound_data_view_routes::handle_policy_views_overview),
+        )
+        .route(
+            "/v1/hypervisor/odk/policy-bound-data-views/:id",
+            get(policy_bound_data_view_routes::handle_policy_view_get)
+                .patch(policy_bound_data_view_routes::handle_policy_view_patch)
+                .delete(policy_bound_data_view_routes::handle_policy_view_delete),
+        )
+        .route(
+            "/v1/hypervisor/odk/policy-bound-data-views/:id/health",
+            get(policy_bound_data_view_routes::handle_policy_view_health),
+        )
+        .route(
+            "/v1/hypervisor/odk/policy-bound-data-views/:id/history",
+            get(policy_bound_data_view_routes::handle_policy_view_history),
         )
         .route(
             "/v1/hypervisor/odk/data-recipes",

--- a/crates/node/src/bin/hypervisor_daemon_routes/connector_mapping_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/connector_mapping_routes.rs
@@ -27,7 +27,7 @@ use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState
 const MAPPING_SCHEMA: &str = "ioi.hypervisor.odk.connector-mapping.v1";
 const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.connector-mapping-receipt.v1";
 const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.connector-mappings-overview.v1";
-const RECORD_DIR: &str = "odk-connector-mappings";
+pub(crate) const RECORD_DIR: &str = "odk-connector-mappings";
 const RECEIPT_DIR: &str = "odk-connector-mapping-receipts";
 
 /// Source-field shapes an author may declare (the source's shape, not a live read).

--- a/crates/node/src/bin/hypervisor_daemon_routes/policy_bound_data_view_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/policy_bound_data_view_routes.rs
@@ -1,0 +1,495 @@
+//! PolicyBoundDataView — the SECOND inert authority-crossing rung. Given a validated ConnectorMapping
+//! (#13), a view declares the AUTHORITY ENVELOPE for the would-be ontology-shaped data: which
+//! operations are allowed, for which subjects/actors, for what purpose, over which property scope,
+//! under which retention/export/training/evaluation/publish postures, and with which receipt
+//! obligations. It is a CAPABILITY over semantic data — not a thin ACL table — so a future
+//! TransformationRun has a real gate to satisfy instead of inventing authorization at execution time.
+//!
+//! Declarative/inert like the mapping it binds: a view never executes a run, never reads the source,
+//! never mints object rows, and never implies approval. `object_instances` stays 0;
+//! `authority.crossed` stays false. Declaring a view authorizes NOTHING to run — it declares what a
+//! run would have to prove.
+//!
+//! Fail-closed at write: known + READY mapping; operations from the enum only; non-empty subject set;
+//! wildcard-all authority only on an explicit draft (and then never `ready`); property scope must be
+//! a subset of what the mapping actually maps; postures from their enums, and never contradicting an
+//! allowed operation; high-risk operations (export/publish/train/evaluate) require named receipt
+//! obligations; no credential material.
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+
+use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState};
+
+const VIEW_SCHEMA: &str = "ioi.hypervisor.odk.policy-bound-data-view.v1";
+const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.policy-bound-data-view-receipt.v1";
+const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.policy-bound-data-views-overview.v1";
+const RECORD_DIR: &str = "odk-policy-bound-data-views";
+const RECEIPT_DIR: &str = "odk-policy-bound-data-view-receipts";
+
+/// The operations an autonomous system could be authorized to perform over the mapped data.
+const ALLOWED_OPERATIONS: &[&str] = &[
+    "read", "transform", "distill", "train", "evaluate", "export", "publish", "route",
+];
+/// Operations whose authorization ALWAYS requires a named receipt obligation.
+const HIGH_RISK_OPERATIONS: &[&str] = &["export", "publish", "train", "evaluate"];
+/// Wildcard subject spellings — authority-for-everyone is only ever a draft, never ready.
+const WILDCARD_SUBJECTS: &[&str] = &["*", "all", "everyone", "any"];
+/// Posture enums. A posture that contradicts an allowed operation is a fail-closed conflict.
+const RETENTION_POSTURES: &[&str] = &["ephemeral", "bounded", "durable"];
+const EXPORT_POSTURES: &[&str] = &["no_export", "receipted_export_only"];
+const TRAINING_POSTURES: &[&str] = &["no_training", "receipted_training_only"];
+const EVALUATION_POSTURES: &[&str] = &["no_evaluation", "receipted_evaluation_only"];
+const PUBLISH_ROUTE_POSTURES: &[&str] = &["no_publish_route", "receipted_publish_route_only"];
+/// The contracts still missing downstream of this rung.
+const MISSING_CONTRACTS: &[&str] = &["TransformationRun", "OntologyProjection"];
+/// Body keys that would be a plaintext secret — rejected outright.
+const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
+
+fn nanos() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0)
+}
+fn s(v: &Value, k: &str, d: &str) -> String {
+    v.get(k).and_then(|x| x.as_str()).unwrap_or(d).to_string()
+}
+fn opt_s(v: &Value, k: &str) -> Option<String> {
+    v.get(k).and_then(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string)
+}
+fn str_list(v: &Value, k: &str) -> Vec<String> {
+    v.get(k)
+        .and_then(|x| x.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string).collect())
+        .unwrap_or_default()
+}
+type VErr = (String, String);
+fn verr(code: &str, msg: String) -> VErr {
+    (code.to_string(), msg)
+}
+
+fn is_wildcard(subject: &str) -> bool {
+    WILDCARD_SUBJECTS.contains(&subject.to_lowercase().as_str())
+}
+/// Which posture field (and its enum + "forbidden" value) governs an operation, if any.
+fn posture_for_operation(op: &str) -> Option<(&'static str, &'static [&'static str], &'static str)> {
+    match op {
+        "export" => Some(("export_posture", EXPORT_POSTURES, "no_export")),
+        "train" => Some(("training_posture", TRAINING_POSTURES, "no_training")),
+        "evaluate" => Some(("evaluation_posture", EVALUATION_POSTURES, "no_evaluation")),
+        "publish" | "route" => Some(("publish_route_posture", PUBLISH_ROUTE_POSTURES, "no_publish_route")),
+        _ => None,
+    }
+}
+
+fn load_mapping(data_dir: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, crate::connector_mapping_routes::RECORD_DIR)
+        .into_iter()
+        .find(|r| r.get("id").and_then(|v| v.as_str()) == Some(id))
+}
+/// Every property the mapping actually maps (key + title + fields) — the widest scope a view may claim.
+fn mapped_property_ids(mapping: &Value) -> Vec<String> {
+    let mut ids: Vec<String> = Vec::new();
+    for k in ["key_mapping", "title_mapping"] {
+        if let Some(pid) = mapping.get(k).and_then(|m| m.get("property_id")).and_then(|v| v.as_str()) {
+            ids.push(pid.to_string());
+        }
+    }
+    if let Some(fs) = mapping.get("field_mappings").and_then(|v| v.as_array()) {
+        for f in fs {
+            if let Some(pid) = f.get("property_id").and_then(|v| v.as_str()) {
+                ids.push(pid.to_string());
+            }
+        }
+    }
+    ids
+}
+
+/// Validate a view body fail-closed and project the declared record fields + honest health.
+/// INERT: nothing is authorized to run; this only validates the declared envelope.
+fn validate_and_project(data_dir: &str, body: &Value) -> Result<Value, VErr> {
+    if let Some(obj) = body.as_object() {
+        if PLAINTEXT_SECRET_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr(
+                "policy_view_plaintext_secret_rejected",
+                "A policy-bound data view never carries credentials.".into(),
+            ));
+        }
+    }
+    if opt_s(body, "name").is_none() {
+        return Err(verr("policy_view_name_required", "A policy-bound data view requires a name.".into()));
+    }
+    // Known + READY mapping — a view binds validated shape, never a half-declared one.
+    let mapping_id = opt_s(body, "connector_mapping_id").unwrap_or_default();
+    let mapping = load_mapping(data_dir, &mapping_id).ok_or_else(|| {
+        verr("policy_view_mapping_unknown", format!("connector_mapping_id '{mapping_id}' does not resolve to a declared mapping"))
+    })?;
+    let mapping_health = mapping.pointer("/health/status").and_then(|v| v.as_str()).unwrap_or("incomplete");
+    if mapping_health != "ready" {
+        return Err(verr(
+            "policy_view_mapping_not_ready",
+            format!("mapping '{mapping_id}' health is '{mapping_health}' — a view binds only a ready mapping"),
+        ));
+    }
+
+    // Allowed operations: enum only, at least one.
+    let operations = str_list(body, "allowed_operations");
+    if operations.is_empty() {
+        return Err(verr("policy_view_operations_required", "At least one allowed operation is required.".into()));
+    }
+    for op in &operations {
+        if !ALLOWED_OPERATIONS.contains(&op.as_str()) {
+            return Err(verr("policy_view_operation_invalid", format!("operation '{op}' is not a known operation")));
+        }
+    }
+
+    // Authority subjects: non-empty; wildcard-all only on an explicit draft.
+    let subjects = str_list(body, "authority_subjects");
+    if subjects.is_empty() {
+        return Err(verr("policy_view_subjects_required", "A non-empty authority subject set is required.".into()));
+    }
+    let is_draft = body.get("draft").and_then(|v| v.as_bool()).unwrap_or(false);
+    let has_wildcard = subjects.iter().any(|x| is_wildcard(x));
+    if has_wildcard && !is_draft {
+        return Err(verr(
+            "policy_view_wildcard_authority_rejected",
+            "Wildcard-all authority is never granted implicitly — mark the view draft:true to hold it as an incomplete draft.".into(),
+        ));
+    }
+
+    // Property scope must be a subset of what the mapping actually maps.
+    let mapped = mapped_property_ids(&mapping);
+    let property_scope = str_list(body, "property_scope");
+    for pid in &property_scope {
+        if !mapped.iter().any(|m| m == pid) {
+            return Err(verr(
+                "policy_view_property_unscoped",
+                format!("property '{pid}' is not mapped by the bound connector mapping — a view cannot authorize unmapped data"),
+            ));
+        }
+    }
+
+    // Postures: enum-valid, and never contradicting an allowed operation.
+    let posture = |key: &str, allowed: &[&str], default: &str| -> Result<String, VErr> {
+        let val = opt_s(body, key).unwrap_or_else(|| default.to_string());
+        if !allowed.contains(&val.as_str()) {
+            return Err(verr("policy_view_posture_invalid", format!("{key} '{val}' must be one of {allowed:?}")));
+        }
+        Ok(val)
+    };
+    let retention_posture = opt_s(body, "retention_posture");
+    if let Some(rp) = &retention_posture {
+        if !RETENTION_POSTURES.contains(&rp.as_str()) {
+            return Err(verr("policy_view_posture_invalid", format!("retention_posture '{rp}' must be one of {RETENTION_POSTURES:?}")));
+        }
+    }
+    let export_posture = posture("export_posture", EXPORT_POSTURES, "no_export")?;
+    let training_posture = posture("training_posture", TRAINING_POSTURES, "no_training")?;
+    let evaluation_posture = posture("evaluation_posture", EVALUATION_POSTURES, "no_evaluation")?;
+    let publish_route_posture = posture("publish_route_posture", PUBLISH_ROUTE_POSTURES, "no_publish_route")?;
+    let posture_value = |key: &str| -> &str {
+        match key {
+            "export_posture" => &export_posture,
+            "training_posture" => &training_posture,
+            "evaluation_posture" => &evaluation_posture,
+            _ => &publish_route_posture,
+        }
+    };
+    for op in &operations {
+        if let Some((key, _, forbidden)) = posture_for_operation(op) {
+            if posture_value(key) == forbidden {
+                return Err(verr(
+                    "policy_view_posture_conflict",
+                    format!("operation '{op}' is allowed but {key} declares '{forbidden}' — the capability contradicts its own posture"),
+                ));
+            }
+        }
+    }
+
+    // High-risk operations require a NAMED receipt obligation (an obligation string naming the op).
+    let receipt_obligations = str_list(body, "receipt_obligations");
+    for op in &operations {
+        if HIGH_RISK_OPERATIONS.contains(&op.as_str())
+            && !receipt_obligations.iter().any(|o| o.to_lowercase().contains(op.as_str()))
+        {
+            return Err(verr(
+                "policy_view_receipt_obligation_required",
+                format!("operation '{op}' is high-risk and requires a named receipt obligation (e.g. \"{op}: receipt per batch\")"),
+            ));
+        }
+    }
+
+    // Honest readiness — ready ONLY when the envelope is complete: purpose, retention, scoped
+    // properties, no wildcard. (Subjects/operations/obligations were enforced at write.)
+    let purpose = s(body, "purpose", "");
+    let mut gaps: Vec<String> = Vec::new();
+    if purpose.trim().is_empty() {
+        gaps.push("no purpose declared — a capability without a purpose is not grantable".into());
+    }
+    if retention_posture.is_none() {
+        gaps.push("no retention posture declared".into());
+    }
+    if property_scope.is_empty() {
+        gaps.push("no property scope declared — scope the view to mapped properties".into());
+    }
+    if has_wildcard {
+        gaps.push("wildcard-all authority — narrow the subject set before this view can be ready".into());
+    }
+    let status = if gaps.is_empty() { "ready" } else { "incomplete" };
+    let (n_subjects, n_operations, n_scope) = (subjects.len(), operations.len(), property_scope.len());
+
+    Ok(json!({
+        "connector_mapping_id": mapping_id,
+        "connector_mapping_ref": mapping.get("ref").cloned().unwrap_or(Value::Null),
+        "ontology_ref": mapping.get("ontology_ref").cloned().unwrap_or(Value::Null),
+        "object_type_id": mapping.get("object_type_id").cloned().unwrap_or(Value::Null),
+        "allowed_operations": operations,
+        "authority_subjects": subjects,
+        "purpose": purpose,
+        "property_scope": property_scope,
+        "object_scope": body.get("object_scope").cloned().unwrap_or(Value::Null),
+        "retention_posture": retention_posture,
+        "export_posture": export_posture,
+        "training_posture": training_posture,
+        "evaluation_posture": evaluation_posture,
+        "publish_route_posture": publish_route_posture,
+        "receipt_obligations": receipt_obligations,
+        "health": {
+            "status": status,
+            "gaps": gaps,
+            "authorized_subjects": n_subjects,
+            "allowed_operations": n_operations,
+            "scoped_properties": n_scope,
+            "object_instances": 0,
+            "missing_contracts": MISSING_CONTRACTS,
+            "note": "declarative gate only — nothing is authorized to RUN; a future TransformationRun must satisfy this view before any execution"
+        },
+        "authority": { "crossed": false, "note": "declaring a view implies no approval and executes nothing" }
+    }))
+}
+
+fn view_receipt(data_dir: &str, view_ref: &str, op: &str, summary: &str) -> Value {
+    let id = format!("pbdvr_{:x}", nanos());
+    let receipt_ref = format!("agentgres://policy-bound-data-view-receipt/{id}");
+    let rec = json!({
+        "schema_version": RECEIPT_SCHEMA, "receipt_id": id, "receipt_ref": receipt_ref,
+        "policy_view_ref": view_ref, "op": op, "outcome": "ok", "summary": summary, "at": iso_now()
+    });
+    let _ = persist_record(data_dir, RECEIPT_DIR, &id, &rec);
+    rec
+}
+fn load_view(data_dir: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, RECORD_DIR).into_iter().find(|r| r.get("id").and_then(|v| v.as_str()) == Some(id))
+}
+fn bad(err: VErr) -> (StatusCode, Json<Value>) {
+    (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": err.0, "message": err.1 } })))
+}
+
+/// GET /v1/hypervisor/odk/policy-bound-data-views — declared views (newest first).
+pub(crate) async fn handle_policy_views_list(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let mut items = read_record_dir(&st.data_dir, RECORD_DIR);
+    items.sort_by(|a, b| s(b, "updated_at", "").cmp(&s(a, "updated_at", "")));
+    Json(json!({ "ok": true, "schema_version": VIEW_SCHEMA, "policy_bound_data_views": items, "runtimeTruthSource": "daemon-runtime" }))
+}
+
+/// GET /v1/hypervisor/odk/policy-bound-data-views/overview — vocab + counts + honest gaps.
+pub(crate) async fn handle_policy_views_overview(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let items = read_record_dir(&st.data_dir, RECORD_DIR);
+    let by_status = |status: &str| items.iter().filter(|r| r.pointer("/health/status").and_then(|v| v.as_str()) == Some(status)).count();
+    Json(json!({
+        "ok": true,
+        "schema_version": OVERVIEW_SCHEMA,
+        "policy_bound_data_views": items.len(),
+        "health": { "ready": by_status("ready"), "incomplete": by_status("incomplete") },
+        "allowed_operations": ALLOWED_OPERATIONS,
+        "high_risk_operations": HIGH_RISK_OPERATIONS,
+        "postures": {
+            "retention": RETENTION_POSTURES,
+            "export": EXPORT_POSTURES,
+            "training": TRAINING_POSTURES,
+            "evaluation": EVALUATION_POSTURES,
+            "publish_route": PUBLISH_ROUTE_POSTURES
+        },
+        "missing_contracts": MISSING_CONTRACTS,
+        "governance_gaps": [
+            "DECLARATIVE gate only — a view authorizes nothing to run; it declares what a run would have to prove",
+            "execution is a NAMED GAP: a future TransformationRun must satisfy a ready view before anything executes",
+            "no object plane exists — object_instances is 0 until an OntologyProjection is built",
+            "wildcard-all authority is never granted implicitly; high-risk operations always carry named receipt obligations"
+        ],
+        "runtimeTruthSource": "daemon-runtime"
+    }))
+}
+
+/// GET /v1/hypervisor/odk/policy-bound-data-views/:id.
+pub(crate) async fn handle_policy_view_get(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    match load_view(&st.data_dir, &id) {
+        Some(r) => (StatusCode::OK, Json(json!({ "ok": true, "policy_bound_data_view": r }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "policy-bound data view not found" }))),
+    }
+}
+
+/// GET /v1/hypervisor/odk/policy-bound-data-views/:id/health.
+pub(crate) async fn handle_policy_view_health(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    match load_view(&st.data_dir, &id) {
+        Some(r) => (StatusCode::OK, Json(json!({ "ok": true, "policy_view_ref": r.get("ref"), "revision": r.get("revision"), "health": r.get("health") }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "policy-bound data view not found" }))),
+    }
+}
+
+/// GET /v1/hypervisor/odk/policy-bound-data-views/:id/history — embedded history + receipts.
+pub(crate) async fn handle_policy_view_history(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(r) = load_view(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "policy-bound data view not found" })));
+    };
+    let vref = r.get("ref").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let mut receipts = read_record_dir(&st.data_dir, RECEIPT_DIR);
+    receipts.retain(|x| x.get("policy_view_ref").and_then(|v| v.as_str()) == Some(vref.as_str()));
+    receipts.sort_by(|a, b| s(b, "at", "").cmp(&s(a, "at", "")));
+    (StatusCode::OK, Json(json!({ "ok": true, "policy_view_ref": vref, "revision": r.get("revision"), "history": r.get("history").cloned().unwrap_or(json!([])), "receipts": receipts })))
+}
+
+/// POST /v1/hypervisor/odk/policy-bound-data-views — declare a view (fail-closed, receipted, INERT).
+pub(crate) async fn handle_policy_view_create(State(st): State<Arc<DaemonState>>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    let projected = match validate_and_project(&st.data_dir, &body) {
+        Ok(p) => p,
+        Err(e) => return bad(e),
+    };
+    let id = format!("pbdv_{:x}", nanos());
+    let now = iso_now();
+    let vref = format!("policy-bound-data-view://{id}");
+    let receipt = view_receipt(&st.data_dir, &vref, "created", "PolicyBoundDataView declared");
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    let is_draft = body.get("draft").and_then(|v| v.as_bool()).unwrap_or(false);
+    let mut record = json!({
+        "schema_version": VIEW_SCHEMA,
+        "object": "ioi.hypervisor.odk.policy_bound_data_view",
+        "id": id,
+        "ref": vref,
+        "name": s(&body, "name", "policy-bound-data-view"),
+        "description": s(&body, "description", ""),
+        "status": if is_draft { "draft" } else { "declared" },
+        "revision": 1,
+        "receipt_refs": [receipt_ref.clone()],
+        "history": [ { "revision": 1, "op": "created", "at": now.clone(), "summary": "PolicyBoundDataView declared", "receipt_ref": receipt_ref } ],
+        "created_at": now.clone(),
+        "updated_at": now
+    });
+    if let (Some(obj), Some(proj)) = (record.as_object_mut(), projected.as_object()) {
+        for (k, v) in proj {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    let _ = persist_record(&st.data_dir, RECORD_DIR, record.get("id").and_then(|v| v.as_str()).unwrap_or_default(), &record);
+    (StatusCode::CREATED, Json(json!({ "ok": true, "policy_bound_data_view": record })))
+}
+
+/// PATCH — re-validate the merged view; a malformed patch changes nothing (no revision bump).
+pub(crate) async fn handle_policy_view_patch(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(patch): Json<Value>) -> Json<Value> {
+    let Some(existing) = load_view(&st.data_dir, &id) else {
+        return Json(json!({ "ok": false, "reason": "policy-bound data view not found" }));
+    };
+    let mut merged = json!({});
+    let mo = merged.as_object_mut().unwrap();
+    for k in [
+        "name", "description", "connector_mapping_id", "allowed_operations", "authority_subjects",
+        "purpose", "property_scope", "object_scope", "retention_posture", "export_posture",
+        "training_posture", "evaluation_posture", "publish_route_posture", "receipt_obligations", "draft",
+    ] {
+        if let Some(v) = patch.get(k).or_else(|| existing.get(k)) {
+            mo.insert(k.to_string(), v.clone());
+        }
+    }
+    // `draft` is not persisted verbatim on the record — reconstruct it from status when not patched.
+    if patch.get("draft").is_none() && existing.get("status").and_then(|v| v.as_str()) == Some("draft") {
+        mo.insert("draft".into(), json!(true));
+    }
+    let projected = match validate_and_project(&st.data_dir, &merged) {
+        Ok(p) => p,
+        Err(e) => return Json(json!({ "ok": false, "error": { "code": e.0, "message": e.1 } })),
+    };
+    let mut record = existing;
+    if let Some(v) = patch.get("name") { record["name"] = v.clone(); }
+    if let Some(v) = patch.get("description") { record["description"] = v.clone(); }
+    if let Some(v) = patch.get("draft").and_then(|v| v.as_bool()) {
+        record["status"] = json!(if v { "draft" } else { "declared" });
+    }
+    if let (Some(obj), Some(proj)) = (record.as_object_mut(), projected.as_object()) {
+        for (k, v) in proj {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1) + 1;
+    record["revision"] = json!(rev);
+    let now = iso_now();
+    record["updated_at"] = json!(now.clone());
+    let vref = record.get("ref").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let receipt = view_receipt(&st.data_dir, &vref, "patched", "PolicyBoundDataView re-declared");
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    let mut hist = record.get("history").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    hist.push(json!({ "revision": rev, "op": "patched", "at": now, "summary": "PolicyBoundDataView re-declared", "receipt_ref": receipt_ref.clone() }));
+    let len = hist.len();
+    if len > 20 { hist = hist[len - 20..].to_vec(); }
+    record["history"] = json!(hist);
+    let mut refs = record.get("receipt_refs").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    refs.push(receipt_ref);
+    record["receipt_refs"] = json!(refs);
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    Json(json!({ "ok": true, "policy_bound_data_view": record }))
+}
+
+/// DELETE — receipted removal (revoking a declared capability is itself an auditable act).
+pub(crate) async fn handle_policy_view_delete(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> Json<Value> {
+    let vref = load_view(&st.data_dir, &id)
+        .and_then(|r| r.get("ref").and_then(|v| v.as_str()).map(str::to_string))
+        .unwrap_or_else(|| format!("policy-bound-data-view://{id}"));
+    let removed = remove_record(&st.data_dir, RECORD_DIR, &id);
+    if removed {
+        let _ = view_receipt(&st.data_dir, &vref, "deleted", "PolicyBoundDataView removed (declared capability revoked)");
+    }
+    Json(json!({ "ok": removed, "removed": removed, "id": id }))
+}
+
+#[cfg(test)]
+mod policy_bound_data_view_tests {
+    use super::*;
+
+    #[test]
+    fn operation_enum_and_high_risk_are_named() {
+        assert!(ALLOWED_OPERATIONS.contains(&"distill"));
+        assert!(ALLOWED_OPERATIONS.contains(&"route"));
+        assert!(!ALLOWED_OPERATIONS.contains(&"delete"));
+        assert_eq!(HIGH_RISK_OPERATIONS, &["export", "publish", "train", "evaluate"]);
+        assert_eq!(MISSING_CONTRACTS, &["TransformationRun", "OntologyProjection"]);
+    }
+
+    #[test]
+    fn wildcard_subjects_are_detected_case_insensitively() {
+        assert!(is_wildcard("*"));
+        assert!(is_wildcard("ALL"));
+        assert!(is_wildcard("Everyone"));
+        assert!(!is_wildcard("agent://planner"));
+    }
+
+    #[test]
+    fn posture_governs_the_right_operations() {
+        assert_eq!(posture_for_operation("export").unwrap().0, "export_posture");
+        assert_eq!(posture_for_operation("train").unwrap().0, "training_posture");
+        assert_eq!(posture_for_operation("publish").unwrap().0, "publish_route_posture");
+        assert_eq!(posture_for_operation("route").unwrap().0, "publish_route_posture");
+        assert!(posture_for_operation("read").is_none());
+        assert!(posture_for_operation("transform").is_none());
+    }
+
+    #[test]
+    fn mapped_property_ids_cover_key_title_and_fields() {
+        let mapping = json!({
+            "key_mapping": { "property_id": "loan_id" },
+            "title_mapping": { "property_id": "title" },
+            "field_mappings": [{ "property_id": "amount" }]
+        });
+        assert_eq!(mapped_property_ids(&mapping), vec!["loan_id", "title", "amount"]);
+    }
+}


### PR DESCRIPTION
**Stack: this → #13 (ConnectorMapping) → #12 → #11 → #10 → … → master.** The second rung of the semantic-data-plane closure: **the capability gate**. Given a validated mapping, a view declares under what authority any downstream system may `read / transform / distill / train / evaluate / export / publish / route` the projected data. It does **not** execute a run, read the source, mint object rows, or imply approval — it declares the gate `TransformationRun` will later have to satisfy.

## The product call: capability over semantic data, not an ACL table
A view is the full envelope: allowed operations · authorized subjects · **purpose** · property scope · object scope (declared) · retention/export/training/evaluation/publish **postures** · **receipt obligations** · policy status. It answers *what an autonomous system is allowed to do with the mapped ontology-shaped data, for what purpose, under what receipt obligations* — so authorization is never invented at execution time.

## Fail-closed at write (every lane a typed code)
- plaintext secret · missing name · unknown mapping · **mapping must be READY to bind** (a view binds validated shape only)
- operations from the enum only, ≥1 · non-empty subject set
- **wildcard-all authority only on an explicit draft — and then never `ready`** (named gap)
- property scope must be a subset of what the mapping actually maps — *a view cannot authorize unmapped data*
- postures from their enums, and **never contradicting an allowed operation** (allowing `export` while `export_posture: no_export` → `policy_view_posture_conflict`)
- **high-risk operations (export/publish/train/evaluate) require named receipt obligations**

Receipts + bounded history on create/patch; **DELETE is receipted** (revoking a declared capability is itself auditable); a malformed patch does not bump the revision. Health is honest: `ready` only with purpose + retention + scoped properties + narrow subjects.

## Inert by construction
`authority.crossed: false` · `object_instances: 0` · created in **2ms** against an unreachable-source mapping — nothing contacted, nothing runs. `TransformationRun` + `OntologyProjection` named still-missing on every record and the overview.

## Surface (the #12 Ontology Manager)
Resources renders views as **daemon truth** (operations · subjects · purpose · health · "no execution"). The authority-crossing ladder now reads exactly as directed:
`ConnectorMapping` **declared** · `PolicyBoundDataView` **declared** (gate only, nothing runs) · `TransformationRun + receipts` **missing** · `OntologyProjection` **missing**. `object_instances` remains 0 everywhere.

## Done bar — green
| gate | result |
|---|---|
| policy-bound-data-view | **35/35** |
| cargo test -p ioi-node | **82/82** (+4 unit tests) |
| connector-mapping · ontology-manager · ux-parity | 33/33 · 35/35 · 20/20 |
| data-source · automations · model-catalog · queue-seeds | 17/17 · 12/12 · 11/11 · 45/45 |
| legacy ODK builders | 39/39 · 20/20 · 13/13 |
| source-neutral · fallthrough · diff-check | PASSED · empty · clean |

The ratchet: only now that this gate exists may the **next** rung (`TransformationRun + receipts`) be allowed to execute anything — and it will have to satisfy a **ready** view to do it.

- **master not pushed.** Feature branch, stacked on #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)