### PR TITLE
ODK OntologyProjection — the fourth inert rung; the ladder is contract-complete (stacked on #15)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2955,23 +2955,35 @@ function renderDataSourcesSection(dataSources) {
 // authority (receipts, policy gates, substrate readiness, conformance, source-neutrality) is threaded
 // SIDEWAYS into that familiar IA rather than replacing it.
 
-// The authority-crossing LADDER. ConnectorMapping (rung 1), PolicyBoundDataView (rung 2, the
-// capability gate) and TransformationRun (rung 3, plan/dry-run only — the first "a run may exist"
-// rung, NOT live source contact) are real inert daemon contracts; OntologyProjection remains
-// named-but-missing. Each rung must exist before the next is allowed to do anything — this is the
-// honest boundary the whole surface is careful about.
-const OM_MISSING_CONTRACTS = [
-  ["OntologyProjection", "the explicit model → explorer / search / runtime bridge", "Object Explorer rows & saved object sets"],
-];
+// The authority-crossing LADDER — CONTRACT-COMPLETE: all four rungs (ConnectorMapping,
+// PolicyBoundDataView, TransformationRun plan/dry-run, OntologyProjection) are real inert daemon
+// contracts. What remains missing is not a contract but the LIVE CROSSING itself: a materializing
+// run under credential authority. object_instances stays 0 everywhere until that future cut.
 function omBoundaryNote(text) {
   return `<div style="border:1px dashed #3a3d46;border-radius:10px;padding:10px 12px;margin:0 0 12px;background:#141519;color:#9a9da6;font-size:12.5px">${text}</div>`;
 }
-function omContractLadder(nMappings, nViews, nRuns) {
+function omContractLadder(nMappings, nViews, nRuns, nProjections) {
   const declared = `<tr><td><code>ConnectorMapping</code> <span class="pill ok">declared</span></td><td>declared source fields → typed object properties</td><td class="sub" style="margin:0">${nMappings} mapping${nMappings === 1 ? "" : "s"} · inert (no extraction)</td></tr>`
     + `<tr><td><code>PolicyBoundDataView</code> <span class="pill ok">declared</span></td><td>the capability envelope — who/what may read · transform · distill · train · evaluate · export · publish · route, for what purpose, under which receipt obligations</td><td class="sub" style="margin:0">${nViews} view${nViews === 1 ? "" : "s"} · gate only (nothing runs)</td></tr>`
-    + `<tr><td><code>TransformationRun + receipts</code> <span class="pill ok">declared</span></td><td>auditable plan / dry-run against the gate — validates shape, envelope, intent; every act (and every refusal) receipted</td><td class="sub" style="margin:0">${nRuns} run${nRuns === 1 ? "" : "s"} · plan/dry-run only (no source contact; live reads are a future connector-adapter cut)</td></tr>`;
-  const missing = OM_MISSING_CONTRACTS.map(([name, what, unlocks]) => `<tr><td><code>${CX_ESC(name)}</code> <span class="pill muted">missing</span></td><td>${CX_ESC(what)}</td><td class="sub" style="margin:0">unlocks ${CX_ESC(unlocks)}</td></tr>`).join("");
-  return `<table><thead><tr><th>Contract</th><th>What it declares</th><th>Status / unlocks</th></tr></thead><tbody>${declared}${missing}</tbody></table>`;
+    + `<tr><td><code>TransformationRun + receipts</code> <span class="pill ok">declared</span></td><td>auditable plan / dry-run against the gate — validates shape, envelope, intent; every act (and every refusal) receipted</td><td class="sub" style="margin:0">${nRuns} run${nRuns === 1 ? "" : "s"} · plan/dry-run only (no source contact)</td></tr>`
+    + `<tr><td><code>OntologyProjection</code> <span class="pill ok">declared</span></td><td>the explorer/search/read SHAPE — what an authorized surface would render, search, filter, relate, and act on</td><td class="sub" style="margin:0">${nProjections} projection${nProjections === 1 ? "" : "s"} · shape only, no materialized objects</td></tr>`
+    + `<tr><td><code>Materializing run (credential authority)</code> <span class="pill muted">missing</span></td><td>the live connector read — how a credential posture becomes an actual sealed credential a run may use</td><td class="sub" style="margin:0">the only remaining crossing — a deliberate future cut; until then object_instances stays 0</td></tr>`;
+  return `<table><thead><tr><th>Contract</th><th>What it declares</th><th>Status / unlocks</th></tr></thead><tbody>${declared}</tbody></table>`;
+}
+// The DECLARED explorer shape from a ready OntologyProjection — daemon truth about what an
+// authorized surface WOULD render. Zero rows, always: projection declared ≠ objects materialized.
+function omDeclaredExplorerShape(proj) {
+  const cols = (proj.visible_properties || []).map((p) => `<th>${CX_ESC(p)}${p === proj.title_field ? ` <span class="pill ok" style="margin-left:4px">title</span>` : ""}${p === proj.key_field ? ` <span class="pill muted" style="margin-left:4px">key</span>` : ""}</th>`).join("");
+  const affordance = (arr, idKey, kind) => (arr || []).map((a) => `<span class="pill ${a.enabled ? "ok" : "muted"}" title="${a.enabled ? "enabled (gated by the policy view)" : "declared, not enabled"}">${CX_ESC(a[idKey] || "")} · ${kind}${a.enabled ? "" : " (declared)"}</span>`).join(" ");
+  return `<div style="border:1px solid #24262d;border-radius:10px;padding:12px 14px;margin:0 0 12px;background:#15171c">
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:8px"><b>${CX_ESC(proj.name || proj.id)}</b> <code style="font-size:11px">${CX_ESC(proj.ref || "")}</code> <span class="pill ${proj.status === "ready" ? "ok" : "warn"}">${CX_ESC(proj.status || "draft")}</span> <span class="pill muted">${CX_ESC(proj.layout || "table")}</span></div>
+    <table><thead><tr>${cols}</tr></thead><tbody><tr><td colspan="${(proj.visible_properties || []).length || 1}" style="text-align:center;color:#878a93;padding:18px 8px">0 objects — projection declared, nothing materialized. Rows require a future materializing run under credential authority.</td></tr></tbody></table>
+    <div class="chips" style="margin-top:8px"><span class="chiplabel">Facets</span>${(proj.facet_properties || []).length ? proj.facet_properties.map((f) => `<span class="pill muted">${CX_ESC(f)}</span>`).join("") : `<span class="sub" style="margin:0">none</span>`}</div>
+    <div class="chips"><span class="chiplabel">Sort</span>${(proj.sort_fields || []).length ? proj.sort_fields.map((f) => `<span class="pill muted">${CX_ESC(f)}</span>`).join("") : `<span class="sub" style="margin:0">none</span>`}</div>
+    <div class="chips"><span class="chiplabel">Actions</span>${(proj.action_affordances || []).length ? affordance(proj.action_affordances, "action_type_id", "action") : `<span class="sub" style="margin:0">none</span>`}</div>
+    <div class="chips"><span class="chiplabel">Links</span>${(proj.relationship_affordances || []).length ? affordance(proj.relationship_affordances, "link_type_id", "link") : `<span class="sub" style="margin:0">none</span>`} <span class="sub" style="margin:0">— link affordances are declare-only in v1 (no object plane resolves rows)</span></div>
+    <div class="chips"><span class="chiplabel">Export</span><span class="pill ${proj.export_affordance_enabled ? "ok" : "muted"}">${proj.export_affordance_enabled ? "enabled (receipted, gated)" : "not enabled"}</span></div>
+  </div>`;
 }
 // Transformation runs bound to the selected ontology — daemon truth: auditable plans/dry-runs only.
 function omTransformationRuns(runs) {
@@ -3118,22 +3130,30 @@ function renderOntologyManager(ov, lists, selectedId) {
   const maps = (lists.connector_mappings || []).filter((m) => m.ontology_ref === boundRef);
   const pviews = (lists.policy_views || []).filter((v) => v.ontology_ref === boundRef);
   const truns = (lists.transformation_runs || []).filter((r) => r.ontology_ref === boundRef);
+  const projs = (lists.ontology_projections || []).filter((p) => p.ontology_ref === boundRef);
   const resourceSection = (title, family, items, nameKey, newLabel) => `<h3 style="display:flex;justify-content:space-between;align-items:center;margin:12px 0 6px">${title} (${items.length}) <a class="act ghost" href="/__ioi/odk/${family}/new">+ ${newLabel}</a></h3>${items.length ? items.map((x) => odkCard(family, x, nameKey)).join("") : `<div class="empty">None bound to this ontology.</div>`}`;
   const resourcesPane = `<h2 id="pane-resources">Resources <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— bound to ${selected ? CX_ESC(selected.domain) : "—"}</span></h2>`
     + `<h3 style="margin:12px 0 6px">Connector mappings (${maps.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— source fields → object properties · daemon truth · inert</span></h3>${omConnectorMappings(maps)}`
     + `<h3 style="margin:12px 0 6px">Policy-bound data views (${pviews.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the capability gate over mapped data · daemon truth · declarative</span></h3>${omPolicyViews(pviews)}`
     + `<h3 style="margin:12px 0 6px">Transformation runs (${truns.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— auditable plans/dry-runs against the gate · daemon truth · no source contact</span></h3>${omTransformationRuns(truns)}`
+    + `<h3 style="margin:12px 0 6px">Ontology projections (${projs.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the declared explorer/search shape · daemon truth · no materialized objects</span></h3>${projs.length ? projs.map((p) => `<div class="chips" style="margin:0 0 6px"><b>${CX_ESC(p.name || p.id)}</b> <span class="pill ${p.status === "ready" ? "ok" : p.status === "blocked" ? "warn" : "muted"}">${CX_ESC(p.status || "draft")}</span> <span class="pill muted">${(p.visible_properties || []).length} visible</span> <span class="pill warn" title="shape only — nothing materialized">0 objects</span> <span class="sub" style="margin:0"><code>${CX_ESC(p.ref || "")}</code></span></div>`).join("") : `<div class="empty">No projections. A projection declares what an authorized explorer <b>would</b> render — shape only, never rows.</div>`}`
     + resourceSection("Data recipes", "data-recipes", recs, "name", "New recipe")
     + resourceSection("Surface descriptors", "surface-descriptors", descs, "name", "New descriptor")
     + resourceSection("ODK manifests", "manifests", mans, "name", "New manifest");
 
   const dataPane = `<div id="pane-data">${renderDataSourcesSection(lists.data_sources || [])}</div>`;
 
-  // ---- Object data / Explorer: the honest unavailable lane + the authority-crossing ladder
-  //      (ConnectorMapping now declared/inert; the rest still missing).
-  const explorerPane = `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill muted">unavailable</span></h2>`
-    + omBoundaryNote(`This ontology binds <b>no object-instance plane</b>, so there are <b>no rows to explore</b> — the reference Object Explorer is a search surface over real objects; ours stays empty until the authority crossing below is made. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`)
-    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder</h3>` + omContractLadder(maps.length, pviews.length, truns.length);
+  // ---- Object data / Explorer: with a declared projection the DECLARED SHAPE renders (0 rows,
+  //      boundary loud); without one the lane stays honestly unavailable. Plus the ladder.
+  const activeProjs = projs.filter((p) => p.status !== "retired");
+  const explorerHead = activeProjs.length
+    ? `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill ok">projection declared</span> <span class="pill warn">no materialized objects</span></h2>`
+      + omBoundaryNote(`<b>Projection declared, no materialized objects.</b> The explorer shape below is daemon truth — what an authorized surface <b>would</b> render, search, filter, relate, and act on. There are <b>no rows</b>: object_instances stays 0 until a future materializing run executes under credential authority. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`)
+      + activeProjs.map((p) => omDeclaredExplorerShape(p)).join("")
+    : `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill muted">unavailable</span></h2>`
+      + omBoundaryNote(`This ontology binds <b>no object-instance plane</b>, so there are <b>no rows to explore</b> — declare an OntologyProjection to give this lane its read/search shape; rows still require a future materializing run under credential authority. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`);
+  const explorerPane = explorerHead
+    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— contract-complete; only the live crossing remains</span></h3>` + omContractLadder(maps.length, pviews.length, truns.length, projs.length);
 
   const counts = { "object-types": ots.length, "properties": propCount, "link-types": lts.length, "action-types": nonFuncActs.length, "value-types": vts.length, "groups": 0, "interfaces": 0, "functions": funcs.length };
   const panes = objectTypesPane + propertiesPane + linkPane + actionPane + valuePane
@@ -6686,7 +6706,7 @@ const server = http.createServer((req, res) => {
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
     if (pathname === "/__ioi/odk" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
-      const [ov, o, r, d, m, ds, cm, pv, tr] = await Promise.all([
+      const [ov, o, r, d, m, ds, cm, pv, tr, op] = await Promise.all([
         J("/v1/hypervisor/odk/overview"),
         J("/v1/hypervisor/odk/domain-ontologies"),
         J("/v1/hypervisor/odk/data-recipes"),
@@ -6696,6 +6716,7 @@ const server = http.createServer((req, res) => {
         J("/v1/hypervisor/odk/connector-mappings"),
         J("/v1/hypervisor/odk/policy-bound-data-views"),
         J("/v1/hypervisor/odk/transformation-runs"),
+        J("/v1/hypervisor/odk/ontology-projections"),
       ]);
       const selectedOntology = new URL(req.url, "http://x").searchParams.get("ontology") || "";
       res.writeHead(200, HTMLH);
@@ -6708,6 +6729,7 @@ const server = http.createServer((req, res) => {
         connector_mappings: cm.connector_mappings || [],
         policy_views: pv.policy_bound_data_views || [],
         transformation_runs: tr.transformation_runs || [],
+        ontology_projections: op.ontology_projections || [],
       }, selectedOntology));
       return;
     }

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-projection.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-projection.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// OntologyProjection done-bar — the FOURTH and final inert ODK authority-crossing rung, completing
+// the CONTRACT-COMPLETE skeleton: source → model → mapping → policy → run plan → projection.
+//
+// A projection declares the explorer/search/read SHAPE: "if authorized object data existed, what
+// would this surface be allowed to render, search, filter, relate, and act on?" It binds a ready
+// mapping + a ready READ-authorizing policy view (+ optionally a dry_run_ready run plan) and stays
+// INERT: no live connector reads, no credential use, no extraction, no materialization —
+// object_instances stays 0 and materialized stays false.
+//
+// Asserts:
+//   - No source contact (instant create vs unreachable source); no object rows; no materialized
+//     explorer results (the declared shape renders with a 0-objects boundary cell).
+//   - Fail-closed on every lane: secret, raw query, missing name, unknown/not-ready mapping,
+//     unknown/not-ready/mismatched view, view without `read`, unknown/not-ready/mismatched run,
+//     unscoped visible/facet/sort/title/key properties, invalid layout, unknown action / wrong
+//     object, action ENABLED without transform authorization, link affordance ENABLED (always a
+//     false promise in v1), export affordance without export authorization + obligations.
+//   - Honest health/lifecycle: empty visible → draft+gap; recheck drift → blocked (named);
+//     retire is terminal + immutable; malformed patch is a receipted refusal, no rev bump.
+//   - Receipts + bounded history on create/patch/recheck/retire; refusals receipted.
+//   - The ODK Manager ladder is CONTRACT-COMPLETE: all four rungs declared; only the live crossing
+//     (materializing run under credential authority) missing. Brand-clean; 0 objects everywhere.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-ontology-projection.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/ontology-projections/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon ontology-projection plane not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+  const track = (kind, id) => { if (id) cleanup.push(["DELETE", `/v1/hypervisor/odk/${kind}/${id}`]); };
+
+  // Full-ladder fixtures over an UNREACHABLE source.
+  const dsR = await jd("POST", "/v1/hypervisor/data-sources", { name: "oproj-verify-src", kind: "postgres", endpoint: "postgres://unreachable.invalid:5432/db", credential_posture: "wallet_credential_lease" });
+  const dataSourceId = dsR.j.data_source?.source_id;
+  if (dataSourceId) cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${dataSourceId}`]);
+  const ontR = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "oproj-verify", canonical_object_model: {
+    value_types: [{ id: "money", name: "Money", base: "double" }],
+    object_types: [
+      { id: "loan", name: "Loan", title_property: "title", properties: [
+        { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+        { id: "title", name: "Title", value_type: "string" },
+        { id: "amount", name: "Amount", value_type: "money" } ] },
+      { id: "borrower", name: "Borrower", title_property: "name", properties: [{ id: "name", name: "Name", value_type: "string" }] },
+    ],
+    link_types: [{ id: "held_by", name: "Held by", from: "loan", to: "borrower", cardinality: "one_to_many" }],
+    action_types: [
+      { id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" },
+      { id: "audit_b", name: "Audit Borrower", kind: "modify_object", applies_to: "borrower" } ],
+  } });
+  const ontId = ontR.j.ontology?.id; const ontRef = ontR.j.ontology?.ref;
+  track("domain-ontologies", ontId);
+  const mapR = await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "oproj-verify-map", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" },
+    field_mappings: [{ source_field: "amt", property_id: "amount", source_type: "double" }] });
+  const mapId = mapR.j.connector_mapping?.id;
+  track("connector-mappings", mapId);
+  const viewR = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: mapId, name: "oproj-verify-gate", authority_subjects: ["agent://planner"],
+    allowed_operations: ["read", "transform", "export"], purpose: "underwriting analysis", property_scope: ["loan_id", "title", "amount"], retention_posture: "bounded",
+    export_posture: "receipted_export_only", receipt_obligations: ["export: one receipt per exported batch"] });
+  const viewId = viewR.j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", viewId);
+  const readOnlyR = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: mapId, name: "oproj-verify-readonly", authority_subjects: ["agent://reader"],
+    allowed_operations: ["read"], purpose: "browse", property_scope: ["loan_id", "title"], retention_posture: "ephemeral" });
+  const readOnlyId = readOnlyR.j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", readOnlyId);
+  const noReadR = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: mapId, name: "oproj-verify-noread", authority_subjects: ["agent://t"],
+    allowed_operations: ["transform"], purpose: "no read", property_scope: ["title"], retention_posture: "ephemeral" });
+  const noReadId = noReadR.j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", noReadId);
+  const runR = await jd("POST", "/v1/hypervisor/odk/transformation-runs", { connector_mapping_id: mapId, policy_view_id: viewId, name: "oproj-verify-plan" });
+  const runId = runR.j.transformation_run?.id;
+  track("transformation-runs", runId);
+  await jd("POST", `/v1/hypervisor/odk/transformation-runs/${runId}/dry-run`);
+  if (!dataSourceId || !ontId || !mapId || !viewId || !runId) { console.error("BLOCKED: fixtures failed"); process.exit(2); }
+
+  const base = (extra) => ({ connector_mapping_id: mapId, policy_view_id: viewId, name: "loan-explorer", ...extra });
+
+  // 1. Ready projection with the full declared shape, citing the dry_run_ready plan.
+  const t0 = Date.now();
+  const created = await jd("POST", "/v1/hypervisor/odk/ontology-projections", base({
+    transformation_run_id: runId,
+    visible_properties: ["loan_id", "title", "amount"], facet_properties: ["amount"], sort_fields: ["title"],
+    layout: "table",
+    action_affordances: [{ action_type_id: "approve", enabled: true }],
+    relationship_affordances: [{ link_type_id: "held_by", enabled: false }],
+    export_affordance_enabled: true,
+  }));
+  const elapsed = Date.now() - t0;
+  const p0 = created.j.ontology_projection;
+  track("ontology-projections", p0?.id);
+  ok("projection declares (201) instantly against an unreachable source — no contact", created.status === 201 && elapsed < 4000, `${elapsed}ms`);
+  ok("projection is ready + INERT: 0 instances, not materialized, missing authority named", p0?.status === "ready" && p0?.health?.object_instances === 0 && p0?.health?.materialized === false && /credential authority/.test(p0?.health?.missing_authority || ""));
+  ok("title/key display default from the mapping (mapped + scoped)", p0?.title_field === "title" && p0?.key_field === "loan_id");
+  ok("declared shape carries facets/sorts/layout + the cited dry_run_ready plan", (p0?.facet_properties || [])[0] === "amount" && p0?.layout === "table" && String(p0?.transformation_run_ref || "").startsWith("transformation-run://"));
+  ok("affordances validated: action enabled (transform authorized) · link declared-only · export gated", p0?.action_affordances?.[0]?.enabled === true && p0?.relationship_affordances?.[0]?.enabled === false && p0?.export_affordance_enabled === true);
+  ok("create is receipted + history", (p0?.receipt_refs || []).length === 1 && (p0?.history || []).length === 1);
+
+  // 2. Fail-closed lanes.
+  const reject = async (label, body, code) => {
+    const r = await jd("POST", "/v1/hypervisor/odk/ontology-projections", body);
+    ok(`fail-closed: ${label}`, r.status === 400 && r.j.error?.code === code, r.j.error?.code || `status ${r.status}`);
+    track("ontology-projections", r.j?.ontology_projection?.id);
+  };
+  await reject("plaintext secret", base({ password: "hunter2" }), "projection_plaintext_secret_rejected");
+  await reject("raw query body", base({ sql: "SELECT 1" }), "projection_raw_query_rejected");
+  await reject("missing name", { connector_mapping_id: mapId, policy_view_id: viewId }, "projection_name_required");
+  await reject("unknown mapping", base({ connector_mapping_id: "cmap_nope" }), "projection_mapping_unknown");
+  await reject("unknown policy view", base({ policy_view_id: "pbdv_nope" }), "projection_policy_view_unknown");
+  await reject("policy view without read (a projection is a read/search shape)", base({ policy_view_id: noReadId }), "projection_read_not_authorized");
+  await reject("unknown transformation run", base({ transformation_run_id: "trun_nope" }), "projection_run_unknown");
+  await reject("visible property outside mapped+policy scope", base({ visible_properties: ["ghost"] }), "projection_property_unscoped");
+  await reject("facet property outside scope", base({ facet_properties: ["ghost"] }), "projection_property_unscoped");
+  await reject("invalid layout", base({ layout: "hologram" }), "projection_layout_invalid");
+  await reject("unknown action affordance", base({ action_affordances: [{ action_type_id: "ghost" }] }), "projection_action_affordance_unknown");
+  await reject("action affordance for a different object type", base({ action_affordances: [{ action_type_id: "audit_b" }] }), "projection_action_affordance_unknown");
+  await reject("action ENABLED without transform authorization", { connector_mapping_id: mapId, policy_view_id: readOnlyId, name: "x", action_affordances: [{ action_type_id: "approve", enabled: true }] }, "projection_action_affordance_not_authorized");
+  await reject("unknown link affordance", base({ relationship_affordances: [{ link_type_id: "ghost" }] }), "projection_link_affordance_unknown");
+  await reject("link affordance ENABLED (false promise — no object plane resolves rows)", base({ relationship_affordances: [{ link_type_id: "held_by", enabled: true }] }), "projection_link_affordance_unresolved");
+  await reject("export affordance without export authorization + obligations", { connector_mapping_id: mapId, policy_view_id: readOnlyId, name: "x", export_affordance_enabled: true }, "projection_export_affordance_not_authorized");
+
+  // 3. Honest health: explicitly empty visible properties → draft + named gap (not rejected).
+  const empty = await jd("POST", "/v1/hypervisor/odk/ontology-projections", base({ name: "empty-vis", visible_properties: [] }));
+  track("ontology-projections", empty.j.ontology_projection?.id);
+  ok("empty visible properties → honest draft/incomplete with a named gap", empty.status === 201 && empty.j.ontology_projection?.status === "draft" && (empty.j.ontology_projection?.health?.gaps || []).some((g) => /visible/.test(g)));
+
+  // 4. Recheck drift → blocked; patch semantics; retire immutability.
+  const driftViewR = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: mapId, name: "oproj-drift-gate", authority_subjects: ["agent://d"],
+    allowed_operations: ["read"], purpose: "drift", property_scope: ["loan_id", "title"], retention_posture: "ephemeral" });
+  const driftViewId = driftViewR.j.policy_bound_data_view?.id;
+  const driftProjR = await jd("POST", "/v1/hypervisor/odk/ontology-projections", { connector_mapping_id: mapId, policy_view_id: driftViewId, name: "drift-proj" });
+  const driftProj = driftProjR.j.ontology_projection;
+  track("ontology-projections", driftProj?.id);
+  await jd("DELETE", `/v1/hypervisor/odk/policy-bound-data-views/${driftViewId}`);
+  const blocked = await jd("POST", `/v1/hypervisor/odk/ontology-projections/${driftProj.id}/recheck`);
+  ok("recheck after gate drift → BLOCKED with a named reason (never cached)", blocked.j.ontology_projection?.status === "blocked" && blocked.j.ontology_projection?.blocked_reasons?.[0]?.code === "projection_policy_view_unknown");
+  const p1 = await jd("PATCH", `/v1/hypervisor/odk/ontology-projections/${p0.id}`, { description: "main loan explorer" });
+  ok("valid patch bumps revision + receipt", p1.j.ontology_projection?.revision === 2 && (p1.j.ontology_projection?.receipt_refs || []).length === 2);
+  const p2 = await jd("PATCH", `/v1/hypervisor/odk/ontology-projections/${p0.id}`, { visible_properties: ["ghost"] });
+  ok("malformed patch is a receipted refusal (no state change)", p2.j.ok === false && p2.j.error?.code === "projection_property_unscoped");
+  const after = await jd("GET", `/v1/hypervisor/odk/ontology-projections/${p0.id}`);
+  ok("rejected patch does NOT bump the revision", after.j.ontology_projection?.revision === 2, `rev ${after.j.ontology_projection?.revision}`);
+  const retired = await jd("POST", `/v1/hypervisor/odk/ontology-projections/${driftProj.id}/retire`);
+  const pR = await jd("PATCH", `/v1/hypervisor/odk/ontology-projections/${driftProj.id}`, { name: "z" });
+  const rcR = await jd("POST", `/v1/hypervisor/odk/ontology-projections/${driftProj.id}/recheck`);
+  ok("retire is terminal + immutable (patch + recheck refused)", retired.j.ontology_projection?.status === "retired" && pR.j.error?.code === "projection_retired_immutable" && rcR.j.error?.code === "projection_retired_immutable");
+
+  // 5. Projections + overview honesty.
+  const hist = await jd("GET", `/v1/hypervisor/odk/ontology-projections/${p0.id}/history`);
+  ok("/:id/history returns bounded history + persisted receipts (incl. the refused patch)", (hist.j.history || []).length >= 2 && (hist.j.receipts || []).length >= 3);
+  const ov = await jd("GET", "/v1/hypervisor/odk/ontology-projections/overview");
+  ok("overview: declarative lifecycle + missing live authority + no-rows governance gaps", JSON.stringify(ov.j.lifecycle_states) === JSON.stringify(["draft", "ready", "blocked", "retired"]) && /credential authority/.test(ov.j.missing_authority || "") && (ov.j.governance_gaps || []).some((g) => /never rows|no materialized/i.test(g)));
+  const all = await jd("GET", "/v1/hypervisor/odk/ontology-projections");
+  ok("no projection anywhere reports instances or materialization", (all.j.ontology_projections || []).every((p) => p.health?.object_instances === 0 && p.health?.materialized === false));
+
+  // 6. ODK Manager UX — declared explorer shape + contract-complete ladder.
+  const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+  const t = page.text;
+  ok("Explorer pane renders the DECLARED shape (projection declared · no materialized objects)", page.status === 200 && /projection declared/.test(t) && /no materialized objects/.test(t) && t.includes("loan-explorer"));
+  ok("declared shape shows columns + 0-objects boundary cell (no fabricated rows)", /0 objects — projection declared, nothing materialized/.test(t));
+  ok("ladder is CONTRACT-COMPLETE: all four rungs declared", (t.match(/(ConnectorMapping|PolicyBoundDataView|TransformationRun \+ receipts|OntologyProjection)<\/code> <span class="pill ok">declared/g) || []).length === 4);
+  ok("only the live crossing (materializing run under credential authority) remains missing", /Materializing run \(credential authority\)<\/code> <span class="pill muted">missing/.test(t));
+  ok("brand-clean (no Palantir/Foundry leak)", !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
+
+  // Cleanup.
+  for (const [method, p] of cleanup.reverse()) await jd(method, p);
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`ontology-projection readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/apps/hypervisor/scripts/verify-hypervisor-policy-bound-data-view.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-policy-bound-data-view.mjs
@@ -139,7 +139,7 @@ async function run() {
   ok("view row declares 'no execution' (declarative gate)", /no execution/.test(t));
   ok("ladder: ConnectorMapping declared", /ConnectorMapping<\/code> <span class="pill ok">declared/.test(t));
   ok("ladder: PolicyBoundDataView declared (gate only)", /PolicyBoundDataView<\/code> <span class="pill ok">declared/.test(t) && /gate only/.test(t));
-  ok("ladder: downstream rungs named (TransformationRun present; OntologyProjection still missing)", /TransformationRun \+ receipts<\/code>/.test(t) && /OntologyProjection<\/code> <span class="pill muted">missing/.test(t));
+  ok("ladder: downstream rungs named (TransformationRun + OntologyProjection present; live crossing missing)", /TransformationRun \+ receipts<\/code>/.test(t) && /OntologyProjection<\/code>/.test(t) && /pill muted">missing/.test(t));
   ok("0-objects boundary preserved (no object rows anywhere)", /0 objects/.test(t));
   ok("surface is brand-clean (no Palantir/Foundry leak)", !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
 

--- a/apps/hypervisor/scripts/verify-hypervisor-transformation-run.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-transformation-run.mjs
@@ -167,7 +167,7 @@ async function run() {
   const t = page.text;
   ok("Manager renders transformation runs as daemon truth (Resources)", page.status === 200 && /Transformation runs \(\d+\)/.test(t) && /no source contact/.test(t));
   ok("ladder: ConnectorMapping + PolicyBoundDataView + TransformationRun all declared", /ConnectorMapping<\/code> <span class="pill ok">declared/.test(t) && /PolicyBoundDataView<\/code> <span class="pill ok">declared/.test(t) && /TransformationRun \+ receipts<\/code> <span class="pill ok">declared/.test(t));
-  ok("ladder: OntologyProjection is the only remaining missing rung", /OntologyProjection<\/code> <span class="pill muted">missing/.test(t));
+  ok("ladder: OntologyProjection named; only the live crossing (credential authority) missing", /OntologyProjection<\/code>/.test(t) && /credential authority\)<\/code> <span class="pill muted">missing/.test(t));
   ok("0-objects boundary preserved; brand-clean", /0 objects/.test(t) && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
 
   // Cleanup — leave no draft debris.

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -94,6 +94,8 @@ mod connector_mapping_routes;
 mod policy_bound_data_view_routes;
 #[path = "hypervisor_daemon_routes/transformation_run_routes.rs"]
 mod transformation_run_routes;
+#[path = "hypervisor_daemon_routes/ontology_projection_routes.rs"]
+mod ontology_projection_routes;
 #[path = "hypervisor_daemon_routes/harness_routes.rs"]
 mod harness_routes;
 #[path = "hypervisor_daemon_routes/model_routes.rs"]
@@ -1182,6 +1184,35 @@ async fn async_main() -> anyhow::Result<()> {
         .route(
             "/v1/hypervisor/odk/transformation-runs/:id/cancel",
             post(transformation_run_routes::handle_run_cancel),
+        )
+        // OntologyProjection — the fourth and final inert rung: the explorer/search/read SHAPE for
+        // ontology-bound data. Projection declared, no materialized objects (object_instances 0).
+        .route(
+            "/v1/hypervisor/odk/ontology-projections",
+            get(ontology_projection_routes::handle_projections_list)
+                .post(ontology_projection_routes::handle_projection_create),
+        )
+        .route(
+            "/v1/hypervisor/odk/ontology-projections/overview",
+            get(ontology_projection_routes::handle_projections_overview),
+        )
+        .route(
+            "/v1/hypervisor/odk/ontology-projections/:id",
+            get(ontology_projection_routes::handle_projection_get)
+                .patch(ontology_projection_routes::handle_projection_patch)
+                .delete(ontology_projection_routes::handle_projection_delete),
+        )
+        .route(
+            "/v1/hypervisor/odk/ontology-projections/:id/history",
+            get(ontology_projection_routes::handle_projection_history),
+        )
+        .route(
+            "/v1/hypervisor/odk/ontology-projections/:id/recheck",
+            post(ontology_projection_routes::handle_projection_recheck),
+        )
+        .route(
+            "/v1/hypervisor/odk/ontology-projections/:id/retire",
+            post(ontology_projection_routes::handle_projection_retire),
         )
         .route(
             "/v1/hypervisor/odk/data-recipes",

--- a/crates/node/src/bin/hypervisor_daemon_routes/ontology_projection_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/ontology_projection_routes.rs
@@ -1,0 +1,582 @@
+//! OntologyProjection — the FOURTH and final inert ODK authority-crossing rung. A projection
+//! declares the EXPLORER/SEARCH/READ SHAPE for ontology-bound data: "if authorized object data
+//! existed, what would this surface be allowed to render, search, filter, relate, and act on?"
+//! It binds one ontology object model to the declared semantic-data plane — a ready ConnectorMapping
+//! (#13), a ready read-authorizing PolicyBoundDataView (#14), and optionally a dry_run_ready
+//! TransformationRun plan (#15) — and declares visible properties, title/key display, facets, sorts,
+//! relationship/action/export affordances, and layout.
+//!
+//! Still INERT: no live connector reads, no credential use, no extraction, no materialization —
+//! `object_instances` stays 0 and `materialized` stays false until a FUTURE materializing run
+//! executes under credential authority. Affordances are gated hard:
+//!   * an action affordance can be ENABLED only with a matching ontology action type AND a policy
+//!     view that authorizes the write-ish operation (`transform`);
+//!   * a relationship affordance can be DECLARED but never ENABLED in v1 — no object plane resolves
+//!     anywhere, so "browse related rows" would be a false promise;
+//!   * an export affordance requires export authorization + named receipt obligations on the view.
+//!
+//! Lifecycle (declarative): `draft` | `ready` | `blocked` | `retired`. Every create/patch/recheck/
+//! retire — and every refusal — emits a receipt with bounded history.
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+
+use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState};
+
+const PROJ_SCHEMA: &str = "ioi.hypervisor.odk.ontology-projection.v1";
+const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.ontology-projection-receipt.v1";
+const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.ontology-projections-overview.v1";
+const RECORD_DIR: &str = "odk-ontology-projections";
+const RECEIPT_DIR: &str = "odk-ontology-projection-receipts";
+
+/// Declarative lifecycle. There is no "live"/"serving" state — a projection never serves rows here.
+const LIFECYCLE_STATES: &[&str] = &["draft", "ready", "blocked", "retired"];
+/// Result layouts a projection may declare for the (future) explorer surface.
+const LAYOUTS: &[&str] = &["table", "cards", "split"];
+/// The authority still missing before any row can exist. Not a contract rung — the live crossing.
+const MISSING_AUTHORITY: &str =
+    "materializing run under credential authority (live connector read) — a future cut";
+const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
+const RAW_QUERY_KEYS: &[&str] = &["query", "sql", "raw_query", "statement", "command"];
+
+fn nanos() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0)
+}
+fn s(v: &Value, k: &str, d: &str) -> String {
+    v.get(k).and_then(|x| x.as_str()).unwrap_or(d).to_string()
+}
+fn opt_s(v: &Value, k: &str) -> Option<String> {
+    v.get(k).and_then(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string)
+}
+fn str_list(v: &Value, k: &str) -> Vec<String> {
+    v.get(k)
+        .and_then(|x| x.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string).collect())
+        .unwrap_or_default()
+}
+type VErr = (String, String);
+fn verr(code: &str, msg: String) -> VErr {
+    (code.to_string(), msg)
+}
+
+fn find_by_id(data_dir: &str, dir: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, dir).into_iter().find(|r| r.get("id").and_then(|v| v.as_str()) == Some(id))
+}
+fn load_ontology(data_dir: &str, oref: &str) -> Option<Value> {
+    read_record_dir(data_dir, crate::odk_routes::KIND_ONT).into_iter().find(|r| {
+        r.get("ref").and_then(|v| v.as_str()) == Some(oref) || r.get("id").and_then(|v| v.as_str()) == Some(oref)
+    })
+}
+fn health_status(rec: &Value) -> String {
+    rec.pointer("/health/status").and_then(|v| v.as_str()).unwrap_or("incomplete").to_string()
+}
+/// Every property the mapping actually maps (key + title + fields).
+fn mapped_property_ids(mapping: &Value) -> Vec<String> {
+    let mut ids: Vec<String> = Vec::new();
+    for k in ["key_mapping", "title_mapping"] {
+        if let Some(pid) = mapping.get(k).and_then(|m| m.get("property_id")).and_then(|v| v.as_str()) {
+            ids.push(pid.to_string());
+        }
+    }
+    if let Some(fs) = mapping.get("field_mappings").and_then(|v| v.as_array()) {
+        for f in fs {
+            if let Some(pid) = f.get("property_id").and_then(|v| v.as_str()) {
+                ids.push(pid.to_string());
+            }
+        }
+    }
+    ids
+}
+/// Link types in the ontology that touch this object type (either end).
+fn links_touching<'a>(ont: &'a Value, object_type_id: &str) -> Vec<&'a Value> {
+    ont.pointer("/canonical_object_model/link_types")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter(|l| {
+                    l.get("from").and_then(|v| v.as_str()) == Some(object_type_id)
+                        || l.get("to").and_then(|v| v.as_str()) == Some(object_type_id)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+fn action_types<'a>(ont: &'a Value) -> Vec<&'a Value> {
+    ont.pointer("/canonical_object_model/action_types")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().collect())
+        .unwrap_or_default()
+}
+
+/// The validated projection shape, resolved from the current daemon state.
+struct ProjInputs {
+    mapping: Value,
+    view: Value,
+    run_ref: Value,
+    title_field: String,
+    key_field: String,
+    visible_properties: Vec<String>,
+    facet_properties: Vec<String>,
+    sort_fields: Vec<String>,
+    layout: String,
+    action_affordances: Vec<Value>,
+    relationship_affordances: Vec<Value>,
+    export_affordance_enabled: bool,
+}
+
+/// Validate a projection body fail-closed against CURRENT declared truth. No source contact, no
+/// materialization — this only checks the declared explorer shape against the ladder beneath it.
+fn validate_inputs(data_dir: &str, body: &Value) -> Result<ProjInputs, VErr> {
+    if let Some(obj) = body.as_object() {
+        if PLAINTEXT_SECRET_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("projection_plaintext_secret_rejected", "A projection never carries credentials.".into()));
+        }
+        if RAW_QUERY_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("projection_raw_query_rejected", "A projection never carries a raw source query — its shape comes from the declared ladder.".into()));
+        }
+    }
+    if opt_s(body, "name").is_none() {
+        return Err(verr("projection_name_required", "An ontology projection requires a name.".into()));
+    }
+    // Ready mapping.
+    let mapping_id = opt_s(body, "connector_mapping_id").unwrap_or_default();
+    let mapping = find_by_id(data_dir, crate::connector_mapping_routes::RECORD_DIR, &mapping_id)
+        .ok_or_else(|| verr("projection_mapping_unknown", format!("connector_mapping_id '{mapping_id}' does not resolve to a declared mapping")))?;
+    if health_status(&mapping) != "ready" {
+        return Err(verr("projection_mapping_not_ready", format!("mapping '{mapping_id}' is not ready")));
+    }
+    // Ready view, same mapping, read-authorizing.
+    let view_id = opt_s(body, "policy_view_id").unwrap_or_default();
+    let view = find_by_id(data_dir, crate::policy_bound_data_view_routes::RECORD_DIR, &view_id)
+        .ok_or_else(|| verr("projection_policy_view_unknown", format!("policy_view_id '{view_id}' does not resolve to a declared policy-bound data view")))?;
+    if health_status(&view) != "ready" {
+        return Err(verr("projection_policy_view_not_ready", format!("policy view '{view_id}' is not ready")));
+    }
+    if view.get("connector_mapping_id").and_then(|v| v.as_str()) != Some(mapping_id.as_str()) {
+        return Err(verr("projection_policy_view_mapping_mismatch", "the policy view does not bind the referenced mapping".into()));
+    }
+    let ops = str_list(&view, "allowed_operations");
+    if !ops.iter().any(|o| o == "read") {
+        return Err(verr("projection_read_not_authorized", "the policy view does not authorize 'read' — a projection is a read/search shape and needs a read-authorizing gate".into()));
+    }
+    // Optional run: must exist, be dry_run_ready, and bind the same mapping.
+    let mut run_ref = Value::Null;
+    if let Some(run_id) = opt_s(body, "transformation_run_id") {
+        let run = find_by_id(data_dir, crate::transformation_run_routes::RECORD_DIR, &run_id)
+            .ok_or_else(|| verr("projection_run_unknown", format!("transformation_run_id '{run_id}' does not resolve to a declared run")))?;
+        if s(&run, "status", "") != "dry_run_ready" {
+            return Err(verr("projection_run_not_ready", format!("transformation run '{run_id}' is not dry_run_ready — a projection may only cite a validated plan")));
+        }
+        if run.get("connector_mapping_id").and_then(|v| v.as_str()) != Some(mapping_id.as_str()) {
+            return Err(verr("projection_run_mismatch", "the transformation run does not bind the referenced mapping".into()));
+        }
+        run_ref = run.get("ref").cloned().unwrap_or(Value::Null);
+    }
+    // Ontology + object type still declared (the semantic model is live truth, not a cached copy).
+    let ontology_ref = s(&mapping, "ontology_ref", "");
+    let object_type_id = s(&mapping, "object_type_id", "");
+    let ont = load_ontology(data_dir, &ontology_ref)
+        .ok_or_else(|| verr("projection_object_type_unknown", format!("ontology '{ontology_ref}' no longer resolves")))?;
+    let obj_exists = ont
+        .pointer("/canonical_object_model/object_types")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().any(|o| o.get("id").and_then(|x| x.as_str()) == Some(object_type_id.as_str())))
+        .unwrap_or(false);
+    if !obj_exists {
+        return Err(verr("projection_object_type_unknown", format!("object_type '{object_type_id}' is no longer declared in the ontology")));
+    }
+
+    // Display fields: everything rendered must be mapped AND policy-scoped (scope ⊆ mapped already).
+    let scope = str_list(&view, "property_scope");
+    let mapped = mapped_property_ids(&mapping);
+    let in_scope = |pid: &str| scope.iter().any(|x| x == pid) && mapped.iter().any(|x| x == pid);
+    let key_default = mapping.pointer("/key_mapping/property_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let title_default = mapping.pointer("/title_mapping/property_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let title_field = opt_s(body, "title_field").unwrap_or(title_default);
+    let key_field = opt_s(body, "key_field").unwrap_or(key_default);
+    if title_field.is_empty() || key_field.is_empty() {
+        return Err(verr("projection_title_key_required", "a projection requires title and key display fields".into()));
+    }
+    let visible_properties = if body.get("visible_properties").is_some() { str_list(body, "visible_properties") } else { scope.clone() };
+    let facet_properties = str_list(body, "facet_properties");
+    let sort_fields = str_list(body, "sort_fields");
+    for (label, list) in [
+        ("title_field", &vec![title_field.clone()]),
+        ("key_field", &vec![key_field.clone()]),
+        ("visible_properties", &visible_properties),
+        ("facet_properties", &facet_properties),
+        ("sort_fields", &sort_fields),
+    ] {
+        for pid in list {
+            if !in_scope(pid) {
+                return Err(verr("projection_property_unscoped", format!("{label} '{pid}' is not mapped + policy-scoped — a projection cannot render unauthorized data")));
+            }
+        }
+    }
+    // Layout enum.
+    let layout = opt_s(body, "layout").unwrap_or_else(|| "table".into());
+    if !LAYOUTS.contains(&layout.as_str()) {
+        return Err(verr("projection_layout_invalid", format!("layout '{layout}' must be one of {LAYOUTS:?}")));
+    }
+    // Action affordances: known action type applying to this object (or a function); ENABLED needs
+    // the view to authorize the write-ish operation.
+    let acts = action_types(&ont);
+    let action_affordances: Vec<Value> = body.get("action_affordances").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    for a in &action_affordances {
+        let aid = s(a, "action_type_id", "");
+        let found = acts.iter().find(|x| x.get("id").and_then(|v| v.as_str()) == Some(aid.as_str()));
+        let Some(found) = found else {
+            return Err(verr("projection_action_affordance_unknown", format!("action affordance '{aid}' is not a declared action type")));
+        };
+        let applies_to = found.get("applies_to").and_then(|v| v.as_str()).unwrap_or("");
+        let kind = found.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+        if kind != "function" && applies_to != object_type_id {
+            return Err(verr("projection_action_affordance_unknown", format!("action '{aid}' does not apply to object_type '{object_type_id}'")));
+        }
+        if a.get("enabled").and_then(|v| v.as_bool()).unwrap_or(false) && !ops.iter().any(|o| o == "transform") {
+            return Err(verr("projection_action_affordance_not_authorized", format!("action affordance '{aid}' cannot be enabled — the policy view does not authorize 'transform' (writeback)")));
+        }
+    }
+    // Relationship affordances: known link touching this object; NEVER enabled in v1 — no object
+    // plane resolves anywhere, so "browse related rows" would be a false promise.
+    let links = links_touching(&ont, &object_type_id);
+    let relationship_affordances: Vec<Value> = body.get("relationship_affordances").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    for l in &relationship_affordances {
+        let lid = s(l, "link_type_id", "");
+        if !links.iter().any(|x| x.get("id").and_then(|v| v.as_str()) == Some(lid.as_str())) {
+            return Err(verr("projection_link_affordance_unknown", format!("relationship affordance '{lid}' is not a declared link type touching '{object_type_id}'")));
+        }
+        if l.get("enabled").and_then(|v| v.as_bool()).unwrap_or(false) {
+            return Err(verr("projection_link_affordance_unresolved", format!("relationship affordance '{lid}' cannot be enabled — no object plane resolves rows anywhere (materialization is a future cut); declare it, don't promise it")));
+        }
+    }
+    // Export affordance: needs export authorization + named receipt obligation on the view.
+    let export_affordance_enabled = body.get("export_affordance_enabled").and_then(|v| v.as_bool()).unwrap_or(false);
+    if export_affordance_enabled {
+        let obligations = str_list(&view, "receipt_obligations");
+        if !ops.iter().any(|o| o == "export") || !obligations.iter().any(|o| o.to_lowercase().contains("export")) {
+            return Err(verr("projection_export_affordance_not_authorized", "an export affordance requires the policy view to authorize 'export' with a named receipt obligation".into()));
+        }
+    }
+    Ok(ProjInputs {
+        mapping,
+        view,
+        run_ref,
+        title_field,
+        key_field,
+        visible_properties,
+        facet_properties,
+        sort_fields,
+        layout,
+        action_affordances,
+        relationship_affordances,
+        export_affordance_enabled,
+    })
+}
+
+/// Honest readiness — ready only with ≥1 visible property (everything else was enforced at write).
+fn project_health(inputs: &ProjInputs) -> Value {
+    let mut gaps: Vec<String> = Vec::new();
+    if inputs.visible_properties.is_empty() {
+        gaps.push("no visible properties declared — an explorer shape with nothing to render".into());
+    }
+    let status = if gaps.is_empty() { "ready" } else { "incomplete" };
+    json!({
+        "status": status,
+        "gaps": gaps,
+        "visible_properties": inputs.visible_properties.len(),
+        "object_instances": 0,
+        "materialized": false,
+        "missing_authority": MISSING_AUTHORITY,
+        "note": "projection declared, no materialized objects — object_instances stays 0 until a future materializing run executes under credential authority"
+    })
+}
+
+fn proj_receipt(data_dir: &str, proj_ref: &str, op: &str, outcome: &str, summary: &str) -> Value {
+    let id = format!("opr_{:x}", nanos());
+    let receipt_ref = format!("agentgres://ontology-projection-receipt/{id}");
+    let rec = json!({
+        "schema_version": RECEIPT_SCHEMA, "receipt_id": id, "receipt_ref": receipt_ref,
+        "ontology_projection_ref": proj_ref, "op": op, "outcome": outcome, "summary": summary, "at": iso_now()
+    });
+    let _ = persist_record(data_dir, RECEIPT_DIR, &id, &rec);
+    rec
+}
+fn push_history(record: &mut Value, op: &str, summary: &str, receipt_ref: Value) {
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1);
+    let mut hist = record.get("history").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    hist.push(json!({ "revision": rev, "op": op, "at": iso_now(), "summary": summary, "receipt_ref": receipt_ref.clone() }));
+    let len = hist.len();
+    if len > 20 {
+        hist = hist[len - 20..].to_vec();
+    }
+    record["history"] = json!(hist);
+    let mut refs = record.get("receipt_refs").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    refs.push(receipt_ref);
+    record["receipt_refs"] = json!(refs);
+}
+/// Merge validated inputs onto a record (shared by create + patch + recheck).
+fn apply_inputs(record: &mut Value, inputs: &ProjInputs) {
+    let health = project_health(inputs);
+    let status = if health["status"] == "ready" { "ready" } else { "draft" };
+    record["connector_mapping_id"] = inputs.mapping.get("id").cloned().unwrap_or(Value::Null);
+    record["connector_mapping_ref"] = inputs.mapping.get("ref").cloned().unwrap_or(Value::Null);
+    record["policy_view_id"] = inputs.view.get("id").cloned().unwrap_or(Value::Null);
+    record["policy_view_ref"] = inputs.view.get("ref").cloned().unwrap_or(Value::Null);
+    record["transformation_run_ref"] = inputs.run_ref.clone();
+    record["ontology_ref"] = inputs.mapping.get("ontology_ref").cloned().unwrap_or(Value::Null);
+    record["object_type_id"] = inputs.mapping.get("object_type_id").cloned().unwrap_or(Value::Null);
+    record["title_field"] = json!(inputs.title_field);
+    record["key_field"] = json!(inputs.key_field);
+    record["visible_properties"] = json!(inputs.visible_properties);
+    record["facet_properties"] = json!(inputs.facet_properties);
+    record["sort_fields"] = json!(inputs.sort_fields);
+    record["layout"] = json!(inputs.layout);
+    record["action_affordances"] = json!(inputs.action_affordances);
+    record["relationship_affordances"] = json!(inputs.relationship_affordances);
+    record["export_affordance_enabled"] = json!(inputs.export_affordance_enabled);
+    record["health"] = health;
+    record["status"] = json!(status);
+    record["blocked_reasons"] = json!([]);
+}
+fn bad(data_dir: &str, op: &str, err: VErr) -> (StatusCode, Json<Value>) {
+    let _ = proj_receipt(data_dir, "ontology-projection://unadmitted", op, &err.0, &err.1);
+    (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": err.0, "message": err.1 } })))
+}
+/// The body a stored record re-validates as (its own declared inputs).
+fn body_of(record: &Value) -> Value {
+    let mut body = json!({});
+    let bo = body.as_object_mut().unwrap();
+    for k in [
+        "name", "connector_mapping_id", "policy_view_id", "title_field", "key_field",
+        "visible_properties", "facet_properties", "sort_fields", "layout",
+        "action_affordances", "relationship_affordances", "export_affordance_enabled",
+    ] {
+        if let Some(v) = record.get(k) {
+            bo.insert(k.to_string(), v.clone());
+        }
+    }
+    // The optional run is stored as a ref — recover its id for re-validation.
+    if let Some(rref) = record.get("transformation_run_ref").and_then(|v| v.as_str()) {
+        if let Some(id) = rref.strip_prefix("transformation-run://") {
+            bo.insert("transformation_run_id".into(), json!(id));
+        }
+    }
+    body
+}
+
+/// GET /v1/hypervisor/odk/ontology-projections.
+pub(crate) async fn handle_projections_list(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let mut items = read_record_dir(&st.data_dir, RECORD_DIR);
+    items.sort_by(|a, b| s(b, "updated_at", "").cmp(&s(a, "updated_at", "")));
+    Json(json!({ "ok": true, "schema_version": PROJ_SCHEMA, "ontology_projections": items, "runtimeTruthSource": "daemon-runtime" }))
+}
+
+/// GET /v1/hypervisor/odk/ontology-projections/overview.
+pub(crate) async fn handle_projections_overview(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let items = read_record_dir(&st.data_dir, RECORD_DIR);
+    let by = |status: &str| items.iter().filter(|r| s(r, "status", "") == status).count();
+    Json(json!({
+        "ok": true,
+        "schema_version": OVERVIEW_SCHEMA,
+        "ontology_projections": items.len(),
+        "lifecycle": { "draft": by("draft"), "ready": by("ready"), "blocked": by("blocked"), "retired": by("retired") },
+        "lifecycle_states": LIFECYCLE_STATES,
+        "layouts": LAYOUTS,
+        "missing_authority": MISSING_AUTHORITY,
+        "governance_gaps": [
+            "PROJECTION declared, no materialized objects — this is the read/search SHAPE, never rows",
+            "object_instances stays 0 everywhere until a future materializing run executes under credential authority",
+            "relationship affordances are declare-only in v1 — no object plane resolves rows anywhere, so enabling one would be a false promise",
+            "every create, patch, recheck, retire — and every refusal — is receipted"
+        ],
+        "runtimeTruthSource": "daemon-runtime"
+    }))
+}
+
+/// GET /v1/hypervisor/odk/ontology-projections/:id.
+pub(crate) async fn handle_projection_get(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    match find_by_id(&st.data_dir, RECORD_DIR, &id) {
+        Some(r) => (StatusCode::OK, Json(json!({ "ok": true, "ontology_projection": r }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "ontology projection not found" }))),
+    }
+}
+
+/// GET /v1/hypervisor/odk/ontology-projections/:id/history.
+pub(crate) async fn handle_projection_history(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(r) = find_by_id(&st.data_dir, RECORD_DIR, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "ontology projection not found" })));
+    };
+    let pref = s(&r, "ref", "");
+    let mut receipts = read_record_dir(&st.data_dir, RECEIPT_DIR);
+    receipts.retain(|x| x.get("ontology_projection_ref").and_then(|v| v.as_str()) == Some(pref.as_str()));
+    receipts.sort_by(|a, b| s(b, "at", "").cmp(&s(a, "at", "")));
+    (StatusCode::OK, Json(json!({ "ok": true, "ontology_projection_ref": pref, "revision": r.get("revision"), "status": r.get("status"), "history": r.get("history").cloned().unwrap_or(json!([])), "receipts": receipts })))
+}
+
+/// POST /v1/hypervisor/odk/ontology-projections — declare a projection (fail-closed, receipted).
+pub(crate) async fn handle_projection_create(State(st): State<Arc<DaemonState>>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    let inputs = match validate_inputs(&st.data_dir, &body) {
+        Ok(i) => i,
+        Err(e) => return bad(&st.data_dir, "create_rejected", e),
+    };
+    let id = format!("oproj_{:x}", nanos());
+    let now = iso_now();
+    let pref = format!("ontology-projection://{id}");
+    let receipt = proj_receipt(&st.data_dir, &pref, "created", "ok", "OntologyProjection declared");
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    let mut record = json!({
+        "schema_version": PROJ_SCHEMA,
+        "object": "ioi.hypervisor.odk.ontology_projection",
+        "id": id,
+        "ref": pref,
+        "name": s(&body, "name", "ontology-projection"),
+        "description": s(&body, "description", ""),
+        "revision": 1,
+        "receipt_refs": [receipt_ref.clone()],
+        "history": [ { "revision": 1, "op": "created", "at": now.clone(), "summary": "OntologyProjection declared", "receipt_ref": receipt_ref } ],
+        "created_at": now.clone(),
+        "updated_at": now
+    });
+    apply_inputs(&mut record, &inputs);
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::CREATED, Json(json!({ "ok": true, "ontology_projection": record })))
+}
+
+/// PATCH — re-validate the merged shape; a malformed patch is a receipted refusal, no state change.
+pub(crate) async fn handle_projection_patch(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(patch): Json<Value>) -> Json<Value> {
+    let Some(existing) = find_by_id(&st.data_dir, RECORD_DIR, &id) else {
+        return Json(json!({ "ok": false, "reason": "ontology projection not found" }));
+    };
+    if s(&existing, "status", "") == "retired" {
+        return Json(json!({ "ok": false, "error": { "code": "projection_retired_immutable", "message": "a retired projection is immutable" } }));
+    }
+    let mut merged = body_of(&existing);
+    let mo = merged.as_object_mut().unwrap();
+    for k in [
+        "name", "description", "connector_mapping_id", "policy_view_id", "transformation_run_id",
+        "title_field", "key_field", "visible_properties", "facet_properties", "sort_fields",
+        "layout", "action_affordances", "relationship_affordances", "export_affordance_enabled",
+    ] {
+        if let Some(v) = patch.get(k) {
+            mo.insert(k.to_string(), v.clone());
+        }
+    }
+    let inputs = match validate_inputs(&st.data_dir, &merged) {
+        Ok(i) => i,
+        Err(e) => {
+            let _ = proj_receipt(&st.data_dir, &s(&existing, "ref", ""), "patch_rejected", &e.0, &e.1);
+            return Json(json!({ "ok": false, "error": { "code": e.0, "message": e.1 } }));
+        }
+    };
+    let mut record = existing;
+    if let Some(v) = patch.get("name") { record["name"] = v.clone(); }
+    if let Some(v) = patch.get("description") { record["description"] = v.clone(); }
+    apply_inputs(&mut record, &inputs);
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1) + 1;
+    record["revision"] = json!(rev);
+    record["updated_at"] = json!(iso_now());
+    let receipt = proj_receipt(&st.data_dir, &s(&record, "ref", ""), "patched", "ok", "OntologyProjection re-declared");
+    push_history(&mut record, "patched", "OntologyProjection re-declared", receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    Json(json!({ "ok": true, "ontology_projection": record }))
+}
+
+/// POST /:id/recheck — re-validate against CURRENT declared truth; drift → blocked, named.
+pub(crate) async fn handle_projection_recheck(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(mut record) = find_by_id(&st.data_dir, RECORD_DIR, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "ontology projection not found" })));
+    };
+    if s(&record, "status", "") == "retired" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "projection_retired_immutable", "message": "a retired projection is immutable" } })));
+    }
+    let pref = s(&record, "ref", "");
+    match validate_inputs(&st.data_dir, &body_of(&record)) {
+        Err((code, msg)) => {
+            let receipt = proj_receipt(&st.data_dir, &pref, "recheck_blocked", &code, &msg);
+            let summary = format!("blocked: {code}");
+            record["status"] = json!("blocked");
+            record["blocked_reasons"] = json!([{ "code": code, "message": msg }]);
+            record["updated_at"] = json!(iso_now());
+            push_history(&mut record, "recheck_blocked", &summary, receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+            let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+            (StatusCode::OK, Json(json!({ "ok": true, "ontology_projection": record })))
+        }
+        Ok(inputs) => {
+            let receipt = proj_receipt(&st.data_dir, &pref, "recheck", "ok", "projection re-validated against the current ladder");
+            apply_inputs(&mut record, &inputs);
+            record["updated_at"] = json!(iso_now());
+            push_history(&mut record, "recheck", "projection re-validated against the current ladder", receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+            let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+            (StatusCode::OK, Json(json!({ "ok": true, "ontology_projection": record })))
+        }
+    }
+}
+
+/// POST /:id/retire — declarative end-of-life, receipted; retired is immutable.
+pub(crate) async fn handle_projection_retire(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(mut record) = find_by_id(&st.data_dir, RECORD_DIR, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "ontology projection not found" })));
+    };
+    if s(&record, "status", "") == "retired" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "projection_retired_immutable", "message": "the projection is already retired" } })));
+    }
+    let receipt = proj_receipt(&st.data_dir, &s(&record, "ref", ""), "retired", "ok", "OntologyProjection retired");
+    record["status"] = json!("retired");
+    record["updated_at"] = json!(iso_now());
+    push_history(&mut record, "retired", "OntologyProjection retired", receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::OK, Json(json!({ "ok": true, "ontology_projection": record })))
+}
+
+/// DELETE — receipted removal.
+pub(crate) async fn handle_projection_delete(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> Json<Value> {
+    let pref = find_by_id(&st.data_dir, RECORD_DIR, &id)
+        .and_then(|r| r.get("ref").and_then(|v| v.as_str()).map(str::to_string))
+        .unwrap_or_else(|| format!("ontology-projection://{id}"));
+    let removed = remove_record(&st.data_dir, RECORD_DIR, &id);
+    if removed {
+        let _ = proj_receipt(&st.data_dir, &pref, "deleted", "ok", "OntologyProjection removed");
+    }
+    Json(json!({ "ok": removed, "removed": removed, "id": id }))
+}
+
+#[cfg(test)]
+mod ontology_projection_tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_and_layouts_are_declarative() {
+        assert_eq!(LIFECYCLE_STATES, &["draft", "ready", "blocked", "retired"]);
+        assert_eq!(LAYOUTS, &["table", "cards", "split"]);
+        assert!(MISSING_AUTHORITY.contains("credential authority"));
+    }
+
+    #[test]
+    fn links_touching_matches_either_end() {
+        let ont = json!({ "canonical_object_model": { "link_types": [
+            { "id": "held_by", "from": "loan", "to": "borrower" },
+            { "id": "unrelated", "from": "a", "to": "b" }
+        ] } });
+        assert_eq!(links_touching(&ont, "loan").len(), 1);
+        assert_eq!(links_touching(&ont, "borrower").len(), 1);
+        assert_eq!(links_touching(&ont, "z").len(), 0);
+    }
+
+    #[test]
+    fn body_of_recovers_run_id_from_ref() {
+        let rec = json!({ "name": "p", "transformation_run_ref": "transformation-run://trun_9" });
+        let b = body_of(&rec);
+        assert_eq!(b.get("transformation_run_id").and_then(|v| v.as_str()), Some("trun_9"));
+    }
+
+    #[test]
+    fn raw_query_and_secret_keys_are_named() {
+        assert!(RAW_QUERY_KEYS.contains(&"sql"));
+        assert!(PLAINTEXT_SECRET_KEYS.contains(&"token"));
+    }
+}

--- a/crates/node/src/bin/hypervisor_daemon_routes/transformation_run_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/transformation_run_routes.rs
@@ -28,7 +28,7 @@ use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState
 const RUN_SCHEMA: &str = "ioi.hypervisor.odk.transformation-run.v1";
 const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.transformation-run-receipt.v1";
 const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.transformation-runs-overview.v1";
-const RECORD_DIR: &str = "odk-transformation-runs";
+pub(crate) const RECORD_DIR: &str = "odk-transformation-runs";
 const RECEIPT_DIR: &str = "odk-transformation-run-receipts";
 
 /// v1 lifecycle. `executed`/`materialized` are reserved for a future connector-adapter cut.


### PR DESCRIPTION
**Stack: this → #15 (TransformationRun) → #14 → #13 → #12 → #11 → #10 → … → master.** The fourth and final inert rung — the **explorer/search projection contract, not materialization**. A projection answers: *"if authorized object data existed, what would this surface be allowed to render, search, filter, relate, and act on?"* — and `object_instances` stays **0**.

## What a projection is
New daemon plane `/v1/hypervisor/odk/ontology-projections` (list / overview / get / history + create / patch / receipted delete + `POST :id/recheck` + `POST :id/retire`). It binds one ontology object model to the declared plane — a **ready** mapping, a **ready read-authorizing** view (same mapping), optionally a **dry_run_ready** run plan — and declares: visible properties · title/key display (defaulted from the mapping's key/title bindings) · facets · sorts · relationship/action/export affordances · layout.

## Affordance gates (16 fail-closed lanes total)
- Every rendered property (visible/facet/sort/title/key) must be **mapped + policy-scoped** — a projection cannot render unauthorized data.
- **Action affordances** need a matching ontology action type applying to this object; **enabled** only when the view authorizes the write-ish operation.
- **Relationship affordances may be declared but never enabled in v1** — no object plane resolves rows anywhere, so "browse related rows" would be a false promise.
- **Export affordance** requires export authorization + named receipt obligations on the view.
- Plus: view without `read` rejected (a projection is a read/search shape), raw query bodies rejected, no credentials, layout enum only.

## Declarative lifecycle, honest health
`draft | ready | blocked | retired`. Ready only with valid title/key display + ≥1 visible property (explicitly empty → draft with a named gap). `recheck` re-validates against **current** truth — gate drift → **blocked, named**. Retired is immutable. Every create/patch/recheck/retire — and every refusal — receipted with bounded history; malformed patch never bumps the revision.

## Surface — the boundary loud
The Object-data/Explorer pane now renders the **declared shape**: columns with title/key pills, facets, sorts, gated affordances — and a 0-objects boundary cell: *"projection declared, nothing materialized."* The ladder is **contract-complete**:

`ConnectorMapping ✓ · PolicyBoundDataView ✓ · TransformationRun plan/dry-run ✓ · OntologyProjection ✓ · Materializing run (credential authority) — missing`

## Done bar — green
| gate | result |
|---|---|
| ontology-projection | **36/36** |
| cargo test -p ioi-node | **90/90** (+4 unit tests) |
| transformation-run · policy-view · mapping (asserts evolved) | 36/36 · 35/35 · 33/33 |
| ontology-manager · ux-parity | 35/35 · 20/20 |
| data-source · automations · model-catalog · queue-seeds | 17/17 · 12/12 · 11/11 · 45/45 |
| legacy ODK builders | 39/39 · 20/20 · 13/13 |
| source-neutral · fallthrough · diff-check | PASSED · empty · clean |

**The ODK skeleton is contract-complete: source → model → mapping → policy → run plan → projection.** The credential/connector cut now has a finished authority map to plug into instead of inventing semantics while it executes.

- **master not pushed.** Feature branch, stacked on #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)