### PR TITLE
ODK CapabilityLease plan — credential-authority planning; nothing minted

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2962,13 +2962,27 @@ function renderDataSourcesSection(dataSources) {
 function omBoundaryNote(text) {
   return `<div style="border:1px dashed #3a3d46;border-radius:10px;padding:10px 12px;margin:0 0 12px;background:#141519;color:#9a9da6;font-size:12.5px">${text}</div>`;
 }
-function omContractLadder(nMappings, nViews, nRuns, nProjections) {
+function omContractLadder(nMappings, nViews, nRuns, nProjections, nLeasePlans) {
   const declared = `<tr><td><code>ConnectorMapping</code> <span class="pill ok">declared</span></td><td>declared source fields → typed object properties</td><td class="sub" style="margin:0">${nMappings} mapping${nMappings === 1 ? "" : "s"} · inert (no extraction)</td></tr>`
     + `<tr><td><code>PolicyBoundDataView</code> <span class="pill ok">declared</span></td><td>the capability envelope — who/what may read · transform · distill · train · evaluate · export · publish · route, for what purpose, under which receipt obligations</td><td class="sub" style="margin:0">${nViews} view${nViews === 1 ? "" : "s"} · gate only (nothing runs)</td></tr>`
     + `<tr><td><code>TransformationRun + receipts</code> <span class="pill ok">declared</span></td><td>auditable plan / dry-run against the gate — validates shape, envelope, intent; every act (and every refusal) receipted</td><td class="sub" style="margin:0">${nRuns} run${nRuns === 1 ? "" : "s"} · plan/dry-run only (no source contact)</td></tr>`
     + `<tr><td><code>OntologyProjection</code> <span class="pill ok">declared</span></td><td>the explorer/search/read SHAPE — what an authorized surface would render, search, filter, relate, and act on</td><td class="sub" style="margin:0">${nProjections} projection${nProjections === 1 ? "" : "s"} · shape only, no materialized objects</td></tr>`
-    + `<tr><td><code>Materializing run (credential authority)</code> <span class="pill muted">missing</span></td><td>the live connector read — how a credential posture becomes an actual sealed credential a run may use</td><td class="sub" style="margin:0">the only remaining crossing — a deliberate future cut; until then object_instances stays 0</td></tr>`;
+    + `<tr><td><code>CapabilityLease plan</code> <span class="pill ok">declared</span></td><td>the EXACT lease scope a future materializing run may ask for — subject, purpose, operations, property scope, postures, obligations, bounded TTL; the only gateway is the existing capability-lease primitive</td><td class="sub" style="margin:0">${nLeasePlans} plan${nLeasePlans === 1 ? "" : "s"} · nothing minted, no credential material</td></tr>`
+    + `<tr><td><code>Materializing run (credential authority)</code> <span class="pill muted">missing</span></td><td>the live connector read — a run that obtains a REAL lease from the gateway by citing a declared plan, then extracts under it</td><td class="sub" style="margin:0">the only remaining crossing — a deliberate future cut; until then object_instances stays 0</td></tr>`;
   return `<table><thead><tr><th>Contract</th><th>What it declares</th><th>Status / unlocks</th></tr></thead><tbody>${declared}</tbody></table>`;
+}
+// Capability-lease plans bound to the selected ontology — the declared credential authority, minted never.
+function omLeasePlans(plans) {
+  plans = Array.isArray(plans) ? plans : [];
+  if (!plans.length) return `<div class="empty">No capability-lease plans. A plan declares the <b>exact lease</b> a future materializing run may request from the capability-lease gateway — subject, purpose, operations, scope, bounded TTL. Nothing is minted; no credential material exists here.</div>`;
+  const rows = plans.map((p) => `<tr>
+    <td><b>${CX_ESC(p.name || p.id)}</b><div class="meta" style="color:#878a93;font-size:11.5px;margin-top:2px"><code>${CX_ESC(p.ref || "")}</code></div></td>
+    <td><code>${CX_ESC(p.subject || "—")}</code></td>
+    <td>${(p.requested_operations || []).map((o) => `<span class="pill muted">${CX_ESC(o)}</span>`).join(" ")}</td>
+    <td>${CX_ESC(String(p.ttl_seconds || 0))}s</td>
+    <td><span class="pill ${p.status === "declared" ? "ok" : "muted"}">${CX_ESC(p.status || "declared")}</span> <span class="pill warn" title="plan only — no lease minted, no credential material">not minted</span></td>
+  </tr>`).join("");
+  return `<table><thead><tr><th>Lease plan</th><th>Subject</th><th>Operations</th><th>TTL</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 // The DECLARED explorer shape from a ready OntologyProjection — daemon truth about what an
 // authorized surface WOULD render. Zero rows, always: projection declared ≠ objects materialized.
@@ -3131,12 +3145,14 @@ function renderOntologyManager(ov, lists, selectedId) {
   const pviews = (lists.policy_views || []).filter((v) => v.ontology_ref === boundRef);
   const truns = (lists.transformation_runs || []).filter((r) => r.ontology_ref === boundRef);
   const projs = (lists.ontology_projections || []).filter((p) => p.ontology_ref === boundRef);
+  const lplans = (lists.capability_lease_plans || []).filter((p) => p.ontology_ref === boundRef);
   const resourceSection = (title, family, items, nameKey, newLabel) => `<h3 style="display:flex;justify-content:space-between;align-items:center;margin:12px 0 6px">${title} (${items.length}) <a class="act ghost" href="/__ioi/odk/${family}/new">+ ${newLabel}</a></h3>${items.length ? items.map((x) => odkCard(family, x, nameKey)).join("") : `<div class="empty">None bound to this ontology.</div>`}`;
   const resourcesPane = `<h2 id="pane-resources">Resources <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— bound to ${selected ? CX_ESC(selected.domain) : "—"}</span></h2>`
     + `<h3 style="margin:12px 0 6px">Connector mappings (${maps.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— source fields → object properties · daemon truth · inert</span></h3>${omConnectorMappings(maps)}`
     + `<h3 style="margin:12px 0 6px">Policy-bound data views (${pviews.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the capability gate over mapped data · daemon truth · declarative</span></h3>${omPolicyViews(pviews)}`
     + `<h3 style="margin:12px 0 6px">Transformation runs (${truns.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— auditable plans/dry-runs against the gate · daemon truth · no source contact</span></h3>${omTransformationRuns(truns)}`
     + `<h3 style="margin:12px 0 6px">Ontology projections (${projs.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the declared explorer/search shape · daemon truth · no materialized objects</span></h3>${projs.length ? projs.map((p) => `<div class="chips" style="margin:0 0 6px"><b>${CX_ESC(p.name || p.id)}</b> <span class="pill ${p.status === "ready" ? "ok" : p.status === "blocked" ? "warn" : "muted"}">${CX_ESC(p.status || "draft")}</span> <span class="pill muted">${(p.visible_properties || []).length} visible</span> <span class="pill warn" title="shape only — nothing materialized">0 objects</span> <span class="sub" style="margin:0"><code>${CX_ESC(p.ref || "")}</code></span></div>`).join("") : `<div class="empty">No projections. A projection declares what an authorized explorer <b>would</b> render — shape only, never rows.</div>`}`
+    + `<h3 style="margin:12px 0 6px">Capability-lease plans (${lplans.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— declared credential authority · gateway: the capability-lease primitive · nothing minted</span></h3>${omLeasePlans(lplans)}`
     + resourceSection("Data recipes", "data-recipes", recs, "name", "New recipe")
     + resourceSection("Surface descriptors", "surface-descriptors", descs, "name", "New descriptor")
     + resourceSection("ODK manifests", "manifests", mans, "name", "New manifest");
@@ -3153,7 +3169,7 @@ function renderOntologyManager(ov, lists, selectedId) {
     : `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill muted">unavailable</span></h2>`
       + omBoundaryNote(`This ontology binds <b>no object-instance plane</b>, so there are <b>no rows to explore</b> — declare an OntologyProjection to give this lane its read/search shape; rows still require a future materializing run under credential authority. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`);
   const explorerPane = explorerHead
-    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— contract-complete; only the live crossing remains</span></h3>` + omContractLadder(maps.length, pviews.length, truns.length, projs.length);
+    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— contract-complete; only the live crossing remains</span></h3>` + omContractLadder(maps.length, pviews.length, truns.length, projs.length, lplans.length);
 
   const counts = { "object-types": ots.length, "properties": propCount, "link-types": lts.length, "action-types": nonFuncActs.length, "value-types": vts.length, "groups": 0, "interfaces": 0, "functions": funcs.length };
   const panes = objectTypesPane + propertiesPane + linkPane + actionPane + valuePane
@@ -6706,7 +6722,7 @@ const server = http.createServer((req, res) => {
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
     if (pathname === "/__ioi/odk" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
-      const [ov, o, r, d, m, ds, cm, pv, tr, op] = await Promise.all([
+      const [ov, o, r, d, m, ds, cm, pv, tr, op, lp] = await Promise.all([
         J("/v1/hypervisor/odk/overview"),
         J("/v1/hypervisor/odk/domain-ontologies"),
         J("/v1/hypervisor/odk/data-recipes"),
@@ -6717,6 +6733,7 @@ const server = http.createServer((req, res) => {
         J("/v1/hypervisor/odk/policy-bound-data-views"),
         J("/v1/hypervisor/odk/transformation-runs"),
         J("/v1/hypervisor/odk/ontology-projections"),
+        J("/v1/hypervisor/odk/capability-lease-plans"),
       ]);
       const selectedOntology = new URL(req.url, "http://x").searchParams.get("ontology") || "";
       res.writeHead(200, HTMLH);
@@ -6730,6 +6747,7 @@ const server = http.createServer((req, res) => {
         policy_views: pv.policy_bound_data_views || [],
         transformation_runs: tr.transformation_runs || [],
         ontology_projections: op.ontology_projections || [],
+        capability_lease_plans: lp.capability_lease_plans || [],
       }, selectedOntology));
       return;
     }

--- a/apps/hypervisor/scripts/verify-hypervisor-capability-lease-plan.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-capability-lease-plan.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+// CapabilityLease PLAN done-bar — credential-authority PLANNING for ODK materialization.
+//
+// The first credential-crossing contract a future materializing run would have to cite: it declares
+// the EXACT CapabilityLease scope such a run may ask for — and mints NOTHING. Wallet authority
+// becomes explicit BEFORE execution, but nothing operational crosses. The ONLY gateway is the
+// EXISTING capability-lease primitive; this plane never becomes a second lease system.
+//
+// Asserts:
+//   - NO source contact (instant create vs unreachable source); NO lease minted (the real
+//     /v1/hypervisor/capability-leases count is UNCHANGED by planning); no credential material
+//     accepted or emitted; object_instances stays 0.
+//   - Binds the COMPLETE landed ladder (source → mapping → view → dry_run_ready run → ready
+//     projection) and rejects every mismatch/degradation.
+//   - Every scope-widening attempt rejected: properties beyond policy scope, properties beyond
+//     projection-visible, operations beyond the view, unauthorized subject, purpose drift,
+//     posture relaxation, unbounded TTL.
+//   - Bypass lanes rejected: plaintext secret, raw query, env-credential fallback.
+//   - Receipts/history on create/patch/revoke and every refusal; malformed patch no rev bump;
+//     revoked is immutable.
+//   - The ODK Manager renders the plan honestly (Resources + ladder rung 5 declared, Materializing
+//     run still missing); brand-clean.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-capability-lease-plan.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+const gatewayCount = async () => (await jd("GET", "/v1/hypervisor/capability-leases")).j.leases?.length ?? -1;
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/capability-lease-plans/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon lease-plan plane not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+  const track = (kind, id) => { if (id) cleanup.push(["DELETE", `/v1/hypervisor/odk/${kind}/${id}`]); };
+
+  // Complete-ladder fixtures over an UNREACHABLE source (+ a non-leaseable source).
+  const dsR = await jd("POST", "/v1/hypervisor/data-sources", { name: "clp-verify-src", kind: "postgres", endpoint: "postgres://unreachable.invalid:5432/db", credential_posture: "wallet_credential_lease" });
+  const dataSourceId = dsR.j.data_source?.source_id;
+  if (dataSourceId) cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${dataSourceId}`]);
+  const dsNL = await jd("POST", "/v1/hypervisor/data-sources", { name: "clp-verify-nolease", kind: "local_folder", credential_posture: "no_credentials_required" });
+  const noLeaseId = dsNL.j.data_source?.source_id;
+  if (noLeaseId) cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${noLeaseId}`]);
+  const ontR = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "clp-verify", canonical_object_model: {
+    value_types: [{ id: "money", name: "Money", base: "double" }],
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" },
+      { id: "amount", name: "Amount", value_type: "money" } ] }],
+    action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }],
+  } });
+  const ontId = ontR.j.ontology?.id; const ontRef = ontR.j.ontology?.ref;
+  track("domain-ontologies", ontId);
+  const mapR = await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "clp-verify-map", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" },
+    field_mappings: [{ source_field: "amt", property_id: "amount", source_type: "double" }] });
+  const mapId = mapR.j.connector_mapping?.id;
+  track("connector-mappings", mapId);
+  const viewR = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: mapId, name: "clp-verify-gate", authority_subjects: ["agent://materializer"],
+    allowed_operations: ["read", "transform", "export"], purpose: "underwriting analysis", property_scope: ["loan_id", "title", "amount"], retention_posture: "bounded",
+    export_posture: "receipted_export_only", receipt_obligations: ["export: one receipt per exported batch"] });
+  const viewId = viewR.j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", viewId);
+  const runR = await jd("POST", "/v1/hypervisor/odk/transformation-runs", { connector_mapping_id: mapId, policy_view_id: viewId, name: "clp-verify-run" });
+  const runId = runR.j.transformation_run?.id;
+  track("transformation-runs", runId);
+  await jd("POST", `/v1/hypervisor/odk/transformation-runs/${runId}/dry-run`);
+  const projR = await jd("POST", "/v1/hypervisor/odk/ontology-projections", { connector_mapping_id: mapId, policy_view_id: viewId, name: "clp-verify-explorer", visible_properties: ["loan_id", "title"] });
+  const projId = projR.j.ontology_projection?.id;
+  track("ontology-projections", projId);
+  if (!dataSourceId || !noLeaseId || !ontId || !mapId || !viewId || !runId || !projId) { console.error("BLOCKED: fixtures failed"); process.exit(2); }
+
+  const base = (extra) => ({ data_source_id: dataSourceId, connector_mapping_id: mapId, policy_view_id: viewId, transformation_run_id: runId, ontology_projection_id: projId,
+    name: "materialize-loans-lease", subject: "agent://materializer", ttl_seconds: 900, ...extra });
+
+  // 1. NO MINTING: gateway count before/after planning is UNCHANGED.
+  const before = await gatewayCount();
+  const t0 = Date.now();
+  const created = await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", base({}));
+  const elapsed = Date.now() - t0;
+  const p0 = created.j.capability_lease_plan;
+  track("capability-lease-plans", p0?.id);
+  const after = await gatewayCount();
+  ok("plan declares (201) instantly against an unreachable source — no contact", created.status === 201 && elapsed < 4000, `${elapsed}ms`);
+  ok("NO LEASE MINTED — the real capability-lease gateway count is unchanged by planning", before >= 0 && before === after, `${before} → ${after}`);
+  ok("inert invariants: minted=false, credential_material=false, contacted=false, moved=false, instances=0", p0?.lease?.minted === false && p0?.lease?.credential_material === false && p0?.execution?.source_contacted === false && p0?.execution?.data_moved === false && p0?.execution?.object_instances === 0);
+  ok("gateway is the EXISTING capability-lease primitive (cited, not duplicated)", p0?.gateway?.primitive === "ioi.hypervisor.capability-lease.v1" && p0?.gateway?.route === "/v1/hypervisor/capability-leases");
+  ok("the plan binds the COMPLETE ladder (all five refs present)", String(p0?.data_source_ref || "").startsWith("data-source:") && ["connector_mapping_ref", "policy_view_ref", "transformation_run_ref", "ontology_projection_ref"].every((k) => typeof p0?.[k] === "string" && p0[k].includes("://")));
+  ok("scope defaults are the NARROWEST (projection-visible; read+transform; view postures echoed)", JSON.stringify(p0?.requested_properties) === JSON.stringify(["loan_id", "title"]) && JSON.stringify(p0?.requested_operations) === JSON.stringify(["read", "transform"]) && p0?.retention_posture === "bounded");
+  ok("bounded TTL + missing MaterializingRun named", p0?.ttl_seconds === 900 && /MaterializingRun/.test(p0?.missing_authority || ""));
+  ok("no secret material anywhere on the record", !JSON.stringify(p0 || {}).match(/hunter2|password|api_key|"secret"/i));
+  ok("create receipted + history", (p0?.receipt_refs || []).length === 1 && (p0?.history || []).length === 1);
+
+  // 2. Fail-closed lanes — bypasses, ladder degradation, and every scope-widening attempt.
+  const reject = async (label, body, code) => {
+    const r = await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", body);
+    ok(`fail-closed: ${label}`, r.status === 400 && r.j.error?.code === code, r.j.error?.code || `status ${r.status}`);
+    track("capability-lease-plans", r.j?.capability_lease_plan?.id);
+  };
+  await reject("plaintext secret", base({ password: "hunter2" }), "lease_plan_plaintext_secret_rejected");
+  await reject("raw query body", base({ sql: "SELECT 1" }), "lease_plan_raw_query_rejected");
+  await reject("env-credential fallback (authority bypass)", base({ from_env: "PGPASSWORD" }), "lease_plan_env_fallback_rejected");
+  await reject("missing name", { ...base({}), name: undefined }, "lease_plan_name_required");
+  await reject("unknown data source", base({ data_source_id: "ds_nope" }), "lease_plan_data_source_unknown");
+  await reject("source posture not wallet-leaseable", base({ data_source_id: noLeaseId }), "lease_plan_posture_not_leaseable");
+  await reject("unknown mapping", base({ connector_mapping_id: "cmap_nope" }), "lease_plan_mapping_unknown");
+  await reject("unknown policy view", base({ policy_view_id: "pbdv_nope" }), "lease_plan_policy_view_unknown");
+  await reject("unknown run", base({ transformation_run_id: "trun_nope" }), "lease_plan_run_unknown");
+  await reject("unknown projection", base({ ontology_projection_id: "oproj_nope" }), "lease_plan_projection_unknown");
+  await reject("subject not explicitly authorized by the view", base({ subject: "agent://stranger" }), "lease_plan_subject_not_authorized");
+  await reject("purpose drift from the gate", base({ purpose: "resale" }), "lease_plan_purpose_mismatch");
+  await reject("operation beyond the view (publish)", base({ requested_operations: ["read", "transform", "publish"] }), "lease_plan_operation_not_authorized");
+  await reject("materializing lease without transform", base({ requested_operations: ["read"] }), "lease_plan_operation_not_authorized");
+  await reject("scope widening beyond POLICY scope", base({ requested_properties: ["loan_id", "ghost"] }), "lease_plan_scope_widening_rejected");
+  await reject("scope widening beyond PROJECTION-visible (amount is policy-scoped but not visible)", base({ requested_properties: ["loan_id", "amount"] }), "lease_plan_scope_widening_rejected");
+  await reject("posture relaxation (durable vs the gate's bounded)", base({ retention_posture: "durable" }), "lease_plan_posture_conflict");
+  await reject("TTL zero (unbounded)", base({ ttl_seconds: 0 }), "lease_plan_ttl_unbounded");
+  await reject("TTL over the maximum", base({ ttl_seconds: 999999 }), "lease_plan_ttl_unbounded");
+  // High-risk op WITH view authorization + obligations is admitted.
+  const hr = await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", base({ name: "export-lease", requested_operations: ["read", "transform", "export"] }));
+  track("capability-lease-plans", hr.j.capability_lease_plan?.id);
+  ok("high-risk export WITH view authorization + named obligations is admitted", hr.status === 201 && hr.j.capability_lease_plan?.status === "declared");
+  // Binding mismatch: a second ready mapping the rest of the ladder does not bind.
+  const map2R = await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "clp-verify-map2", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" } });
+  track("connector-mappings", map2R.j.connector_mapping?.id);
+  await reject("mixed ladder (view/run/projection bind a different mapping)", base({ connector_mapping_id: map2R.j.connector_mapping?.id }), "lease_plan_binding_mismatch");
+
+  // 3. Patch + revoke semantics.
+  const p1 = await jd("PATCH", `/v1/hypervisor/odk/capability-lease-plans/${p0.id}`, { description: "the exact lease a run may request" });
+  ok("valid patch bumps revision + receipt", p1.j.capability_lease_plan?.revision === 2 && (p1.j.capability_lease_plan?.receipt_refs || []).length === 2);
+  const p2 = await jd("PATCH", `/v1/hypervisor/odk/capability-lease-plans/${p0.id}`, { ttl_seconds: 999999 });
+  ok("malformed patch is a receipted refusal (no state change)", p2.j.ok === false && p2.j.error?.code === "lease_plan_ttl_unbounded");
+  const afterBad = await jd("GET", `/v1/hypervisor/odk/capability-lease-plans/${p0.id}`);
+  ok("rejected patch does NOT bump the revision", afterBad.j.capability_lease_plan?.revision === 2, `rev ${afterBad.j.capability_lease_plan?.revision}`);
+  const revoked = await jd("POST", `/v1/hypervisor/odk/capability-lease-plans/${hr.j.capability_lease_plan.id}/revoke`);
+  const pR = await jd("PATCH", `/v1/hypervisor/odk/capability-lease-plans/${hr.j.capability_lease_plan.id}`, { name: "z" });
+  ok("revoke is terminal + receipted; revoked is immutable", revoked.j.capability_lease_plan?.status === "revoked" && pR.j.error?.code === "lease_plan_revoked_immutable");
+
+  // 4. Projections + overview honesty; and STILL nothing minted after all of the above.
+  const hist = await jd("GET", `/v1/hypervisor/odk/capability-lease-plans/${p0.id}/history`);
+  ok("/:id/history returns bounded history + persisted receipts (incl. the refused patch)", (hist.j.history || []).length >= 2 && (hist.j.receipts || []).length >= 3);
+  const ov = await jd("GET", "/v1/hypervisor/odk/capability-lease-plans/overview");
+  ok("overview: gateway cited + bounded TTL + plan-only governance gaps", ov.j.gateway?.route === "/v1/hypervisor/capability-leases" && ov.j.max_ttl_seconds === 3600 && (ov.j.governance_gaps || []).some((g) => /no lease is minted/i.test(g)));
+  const finalCount = await gatewayCount();
+  ok("after ALL planning activity the gateway is STILL unchanged (nothing ever minted)", finalCount === before, `${before} → ${finalCount}`);
+
+  // 5. ODK Manager UX — honest credential-authority plan.
+  const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+  const t = page.text;
+  ok("Manager renders lease plans as daemon truth (Resources, 'not minted')", page.status === 200 && /Capability-lease plans \(\d+\)/.test(t) && /not minted/.test(t) && t.includes("materialize-loans-lease"));
+  ok("ladder rung 5: CapabilityLease plan declared (nothing minted)", /CapabilityLease plan<\/code> <span class="pill ok">declared/.test(t) && /nothing minted/.test(t));
+  ok("Materializing run remains the only missing crossing", /Materializing run \(credential authority\)<\/code> <span class="pill muted">missing/.test(t));
+  ok("0-objects boundary preserved; brand-clean", /0 objects/.test(t) && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
+
+  // Cleanup — leave no draft debris.
+  for (const [method, p] of cleanup.reverse()) await jd(method, p);
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`capability-lease-plan readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -96,6 +96,8 @@ mod policy_bound_data_view_routes;
 mod transformation_run_routes;
 #[path = "hypervisor_daemon_routes/ontology_projection_routes.rs"]
 mod ontology_projection_routes;
+#[path = "hypervisor_daemon_routes/capability_lease_plan_routes.rs"]
+mod capability_lease_plan_routes;
 #[path = "hypervisor_daemon_routes/harness_routes.rs"]
 mod harness_routes;
 #[path = "hypervisor_daemon_routes/model_routes.rs"]
@@ -1213,6 +1215,32 @@ async fn async_main() -> anyhow::Result<()> {
         .route(
             "/v1/hypervisor/odk/ontology-projections/:id/retire",
             post(ontology_projection_routes::handle_projection_retire),
+        )
+        // CapabilityLease PLAN — credential-authority planning for ODK materialization. Declares the
+        // exact lease scope a future materializing run may ask for; mints NOTHING. The only gateway
+        // is the existing capability-lease primitive.
+        .route(
+            "/v1/hypervisor/odk/capability-lease-plans",
+            get(capability_lease_plan_routes::handle_plans_list)
+                .post(capability_lease_plan_routes::handle_plan_create),
+        )
+        .route(
+            "/v1/hypervisor/odk/capability-lease-plans/overview",
+            get(capability_lease_plan_routes::handle_plans_overview),
+        )
+        .route(
+            "/v1/hypervisor/odk/capability-lease-plans/:id",
+            get(capability_lease_plan_routes::handle_plan_get)
+                .patch(capability_lease_plan_routes::handle_plan_patch)
+                .delete(capability_lease_plan_routes::handle_plan_delete),
+        )
+        .route(
+            "/v1/hypervisor/odk/capability-lease-plans/:id/history",
+            get(capability_lease_plan_routes::handle_plan_history),
+        )
+        .route(
+            "/v1/hypervisor/odk/capability-lease-plans/:id/revoke",
+            post(capability_lease_plan_routes::handle_plan_revoke),
         )
         .route(
             "/v1/hypervisor/odk/data-recipes",

--- a/crates/node/src/bin/hypervisor_daemon_routes/capability_lease_plan_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/capability_lease_plan_routes.rs
@@ -1,0 +1,457 @@
+//! CapabilityLease PLAN — the credential-authority PLANNING contract for ODK materialization.
+//! The first credential-crossing contract a future materializing run would have to cite: it declares
+//! the EXACT CapabilityLease scope such a run would be allowed to ask for — and mints NOTHING.
+//!
+//! Doctrine: wallet authority becomes explicit BEFORE execution, but nothing operational crosses.
+//! A plan binds the COMPLETE landed ODK ladder — DataSource → ConnectorMapping → PolicyBoundDataView
+//! → TransformationRun (dry_run_ready) → OntologyProjection (ready) — and declares subject, purpose,
+//! permitted operations, property scope, retention/export posture, receipt obligations, bounded TTL,
+//! and credential posture. The ONLY authority gateway is the EXISTING CapabilityLease primitive
+//! (`ioi.hypervisor.capability-lease.v1` at /v1/hypervisor/capability-leases); this plane never
+//! becomes a second lease system.
+//!
+//! Inert invariants (always): lease.minted=false · credential_material=false · source_contacted=false
+//! · data_moved=false · object_instances=0. No plaintext secret, no raw query, no env-credential
+//! fallback, no source contact. Every create/patch/revoke — and every refusal — is receipted.
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+
+use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState};
+
+const PLAN_SCHEMA: &str = "ioi.hypervisor.odk.capability-lease-plan.v1";
+const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.capability-lease-plan-receipt.v1";
+const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.capability-lease-plans-overview.v1";
+const RECORD_DIR: &str = "odk-capability-lease-plans";
+const RECEIPT_DIR: &str = "odk-capability-lease-plan-receipts";
+
+/// The ONLY authority gateway a materializing run may cross. Cited, never duplicated.
+const LEASE_GATEWAY_PRIMITIVE: &str = "ioi.hypervisor.capability-lease.v1";
+const LEASE_GATEWAY_ROUTE: &str = "/v1/hypervisor/capability-leases";
+/// Data-source credential postures this plan can request a wallet lease against.
+const LEASEABLE_POSTURES: &[&str] = &["wallet_credential_lease"];
+/// A lease TTL must be bounded — a materializing run's credential is short-lived by construction.
+const MAX_TTL_SECONDS: u64 = 3600;
+/// Operations whose lease authorization requires named receipt obligations on the policy view.
+const HIGH_RISK_OPERATIONS: &[&str] = &["export", "publish", "train", "evaluate"];
+/// What still does not exist after this plan: the run that would cite it.
+const MISSING_AUTHORITY: &str = "MaterializingRun — the live connector adapter that would cite this plan; a deliberate future cut";
+const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
+const RAW_QUERY_KEYS: &[&str] = &["query", "sql", "raw_query", "statement", "command"];
+/// Env-credential fallback is an authority bypass — rejected outright.
+const ENV_FALLBACK_KEYS: &[&str] = &["env", "env_var", "env_credential", "credential_env", "from_env"];
+
+fn nanos() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0)
+}
+fn s(v: &Value, k: &str, d: &str) -> String {
+    v.get(k).and_then(|x| x.as_str()).unwrap_or(d).to_string()
+}
+fn opt_s(v: &Value, k: &str) -> Option<String> {
+    v.get(k).and_then(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string)
+}
+fn str_list(v: &Value, k: &str) -> Vec<String> {
+    v.get(k)
+        .and_then(|x| x.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string).collect())
+        .unwrap_or_default()
+}
+type VErr = (String, String);
+fn verr(code: &str, msg: String) -> VErr {
+    (code.to_string(), msg)
+}
+fn find_by_key(data_dir: &str, dir: &str, key: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, dir).into_iter().find(|r| r.get(key).and_then(|v| v.as_str()) == Some(id))
+}
+fn health_status(rec: &Value) -> String {
+    rec.pointer("/health/status").and_then(|v| v.as_str()).unwrap_or("incomplete").to_string()
+}
+fn subset_of(sub: &[String], sup: &[String]) -> Option<String> {
+    sub.iter().find(|x| !sup.iter().any(|y| y == *x)).cloned()
+}
+
+/// The fully-resolved, agreed ladder a plan binds.
+struct PlanInputs {
+    source: Value,
+    mapping: Value,
+    view: Value,
+    run: Value,
+    projection: Value,
+    subject: String,
+    purpose: String,
+    operations: Vec<String>,
+    properties: Vec<String>,
+    ttl_seconds: u64,
+}
+
+/// Validate a plan body fail-closed against the CURRENT landed ladder. No source contact, no
+/// minting, no secret material — this only proves the lease shape a run would be allowed to request.
+fn validate_inputs(data_dir: &str, body: &Value) -> Result<PlanInputs, VErr> {
+    if let Some(obj) = body.as_object() {
+        if PLAINTEXT_SECRET_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("lease_plan_plaintext_secret_rejected", "A lease plan never carries credential material.".into()));
+        }
+        if RAW_QUERY_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("lease_plan_raw_query_rejected", "A lease plan never carries a raw source query.".into()));
+        }
+        if ENV_FALLBACK_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("lease_plan_env_fallback_rejected", "Environment-credential fallback is an authority bypass — the ONLY gateway is the CapabilityLease primitive.".into()));
+        }
+    }
+    if opt_s(body, "name").is_none() {
+        return Err(verr("lease_plan_name_required", "A capability-lease plan requires a name.".into()));
+    }
+    // Data source: known, and its declared posture must be wallet-leaseable.
+    let data_source_id = opt_s(body, "data_source_id").unwrap_or_default();
+    let source = find_by_key(data_dir, crate::data_source_routes::RECORD_DIR, "source_id", &data_source_id)
+        .ok_or_else(|| verr("lease_plan_data_source_unknown", format!("data_source_id '{data_source_id}' does not resolve to a declared data source")))?;
+    let posture = s(&source, "credential_posture", "");
+    if !LEASEABLE_POSTURES.contains(&posture.as_str()) {
+        return Err(verr(
+            "lease_plan_posture_not_leaseable",
+            format!("data source posture '{posture}' is not wallet-leaseable — this plan requests a wallet credential lease and the source must declare one"),
+        ));
+    }
+    // The complete ladder, each rung at its required readiness.
+    let mapping_id = opt_s(body, "connector_mapping_id").unwrap_or_default();
+    let mapping = find_by_key(data_dir, crate::connector_mapping_routes::RECORD_DIR, "id", &mapping_id)
+        .ok_or_else(|| verr("lease_plan_mapping_unknown", format!("connector_mapping_id '{mapping_id}' does not resolve")))?;
+    if health_status(&mapping) != "ready" {
+        return Err(verr("lease_plan_mapping_not_ready", format!("mapping '{mapping_id}' is not ready")));
+    }
+    let view_id = opt_s(body, "policy_view_id").unwrap_or_default();
+    let view = find_by_key(data_dir, crate::policy_bound_data_view_routes::RECORD_DIR, "id", &view_id)
+        .ok_or_else(|| verr("lease_plan_policy_view_unknown", format!("policy_view_id '{view_id}' does not resolve")))?;
+    if health_status(&view) != "ready" {
+        return Err(verr("lease_plan_policy_view_not_ready", format!("policy view '{view_id}' is not ready")));
+    }
+    let run_id = opt_s(body, "transformation_run_id").unwrap_or_default();
+    let run = find_by_key(data_dir, crate::transformation_run_routes::RECORD_DIR, "id", &run_id)
+        .ok_or_else(|| verr("lease_plan_run_unknown", format!("transformation_run_id '{run_id}' does not resolve")))?;
+    if s(&run, "status", "") != "dry_run_ready" {
+        return Err(verr("lease_plan_run_not_ready", format!("transformation run '{run_id}' is not dry_run_ready — a lease is planned only against a validated plan")));
+    }
+    let projection_id = opt_s(body, "ontology_projection_id").unwrap_or_default();
+    let projection = find_by_key(data_dir, crate::ontology_projection_routes::RECORD_DIR, "id", &projection_id)
+        .ok_or_else(|| verr("lease_plan_projection_unknown", format!("ontology_projection_id '{projection_id}' does not resolve")))?;
+    if s(&projection, "status", "") != "ready" {
+        return Err(verr("lease_plan_projection_not_ready", format!("projection '{projection_id}' is not ready")));
+    }
+    // ALL bindings must agree — a lease plan cannot mix gates or ladders.
+    let agrees = mapping.get("data_source_id").and_then(|v| v.as_str()) == Some(data_source_id.as_str())
+        && view.get("connector_mapping_id").and_then(|v| v.as_str()) == Some(mapping_id.as_str())
+        && run.get("connector_mapping_id").and_then(|v| v.as_str()) == Some(mapping_id.as_str())
+        && run.get("policy_view_id").and_then(|v| v.as_str()) == Some(view_id.as_str())
+        && projection.get("connector_mapping_id").and_then(|v| v.as_str()) == Some(mapping_id.as_str())
+        && projection.get("policy_view_id").and_then(|v| v.as_str()) == Some(view_id.as_str());
+    if !agrees {
+        return Err(verr("lease_plan_binding_mismatch", "the cited ladder does not agree on source/mapping/policy bindings — a lease plan cannot mix ladders".into()));
+    }
+    // Subject: explicitly one of the view's authorized subjects (wildcards were never `ready`).
+    let subject = opt_s(body, "subject").unwrap_or_default();
+    let subjects = str_list(&view, "authority_subjects");
+    if subject.is_empty() || !subjects.iter().any(|x| x == &subject) {
+        return Err(verr("lease_plan_subject_not_authorized", format!("subject '{subject}' is not explicitly authorized by the policy view")));
+    }
+    // Purpose must match the gate's purpose (inherited when absent).
+    let view_purpose = s(&view, "purpose", "");
+    let purpose = opt_s(body, "purpose").unwrap_or_else(|| view_purpose.clone());
+    if purpose != view_purpose {
+        return Err(verr("lease_plan_purpose_mismatch", format!("plan purpose '{purpose}' does not match the policy view's purpose '{view_purpose}'")));
+    }
+    // Permitted operations ⊆ the view's; a materializing run is a transform, so transform must be in.
+    let view_ops = str_list(&view, "allowed_operations");
+    let mut operations = str_list(body, "requested_operations");
+    if operations.is_empty() {
+        operations = vec!["read".into(), "transform".into()];
+    }
+    if let Some(bad) = subset_of(&operations, &view_ops) {
+        return Err(verr("lease_plan_operation_not_authorized", format!("requested operation '{bad}' is not authorized by the policy view")));
+    }
+    if !operations.iter().any(|o| o == "transform") {
+        return Err(verr("lease_plan_operation_not_authorized", "a materializing-run lease must request 'transform'".into()));
+    }
+    // High-risk requested operations require named receipt obligations on the view.
+    let obligations = str_list(&view, "receipt_obligations");
+    for op in &operations {
+        if HIGH_RISK_OPERATIONS.contains(&op.as_str()) && !obligations.iter().any(|o| o.to_lowercase().contains(op.as_str())) {
+            return Err(verr("lease_plan_receipt_obligation_required", format!("requested operation '{op}' is high-risk and the policy view carries no receipt obligation naming it")));
+        }
+    }
+    // Property scope ⊆ policy scope AND ⊆ projection visible — a lease can never widen the ladder.
+    let policy_scope = str_list(&view, "property_scope");
+    let projection_visible = str_list(&projection, "visible_properties");
+    let mut properties = str_list(body, "requested_properties");
+    if properties.is_empty() {
+        properties = projection_visible.clone();
+    }
+    if let Some(bad) = subset_of(&properties, &policy_scope) {
+        return Err(verr("lease_plan_scope_widening_rejected", format!("requested property '{bad}' is outside the policy scope — a lease plan cannot widen its gate")));
+    }
+    if let Some(bad) = subset_of(&properties, &projection_visible) {
+        return Err(verr("lease_plan_scope_widening_rejected", format!("requested property '{bad}' is outside the projection's visible scope — a lease plan cannot widen the declared read shape")));
+    }
+    // Postures: echo the view's; a provided value that differs is a conflict (never relaxable here).
+    for (key, view_key) in [("retention_posture", "retention_posture"), ("export_posture", "export_posture")] {
+        if let Some(provided) = opt_s(body, key) {
+            let gate = s(&view, view_key, "");
+            if provided != gate {
+                return Err(verr("lease_plan_posture_conflict", format!("{key} '{provided}' differs from the policy view's '{gate}' — a lease plan echoes the gate, it never relaxes it")));
+            }
+        }
+    }
+    // TTL: bounded, always.
+    let ttl_seconds = body.get("ttl_seconds").and_then(|v| v.as_u64()).unwrap_or(0);
+    if ttl_seconds == 0 || ttl_seconds > MAX_TTL_SECONDS {
+        return Err(verr("lease_plan_ttl_unbounded", format!("ttl_seconds must be 1..={MAX_TTL_SECONDS} — a materializing-run credential is short-lived by construction")));
+    }
+    Ok(PlanInputs { source, mapping, view, run, projection, subject, purpose, operations, properties, ttl_seconds })
+}
+
+fn plan_receipt(data_dir: &str, plan_ref: &str, op: &str, outcome: &str, summary: &str) -> Value {
+    let id = format!("clpr_{:x}", nanos());
+    let receipt_ref = format!("agentgres://capability-lease-plan-receipt/{id}");
+    let rec = json!({
+        "schema_version": RECEIPT_SCHEMA, "receipt_id": id, "receipt_ref": receipt_ref,
+        "capability_lease_plan_ref": plan_ref, "op": op, "outcome": outcome, "summary": summary, "at": iso_now()
+    });
+    let _ = persist_record(data_dir, RECEIPT_DIR, &id, &rec);
+    rec
+}
+fn push_history(record: &mut Value, op: &str, summary: &str, receipt_ref: Value) {
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1);
+    let mut hist = record.get("history").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    hist.push(json!({ "revision": rev, "op": op, "at": iso_now(), "summary": summary, "receipt_ref": receipt_ref.clone() }));
+    let len = hist.len();
+    if len > 20 {
+        hist = hist[len - 20..].to_vec();
+    }
+    record["history"] = json!(hist);
+    let mut refs = record.get("receipt_refs").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    refs.push(receipt_ref);
+    record["receipt_refs"] = json!(refs);
+}
+/// Merge the validated lease shape onto the record — including the INERT invariants, every time.
+fn apply_inputs(record: &mut Value, i: &PlanInputs) {
+    record["data_source_id"] = i.source.get("source_id").cloned().unwrap_or(Value::Null);
+    record["data_source_ref"] = i.source.get("source_ref").cloned().unwrap_or(Value::Null);
+    record["credential_posture"] = i.source.get("credential_posture").cloned().unwrap_or(Value::Null);
+    record["connector_mapping_id"] = i.mapping.get("id").cloned().unwrap_or(Value::Null);
+    record["connector_mapping_ref"] = i.mapping.get("ref").cloned().unwrap_or(Value::Null);
+    record["policy_view_id"] = i.view.get("id").cloned().unwrap_or(Value::Null);
+    record["policy_view_ref"] = i.view.get("ref").cloned().unwrap_or(Value::Null);
+    record["transformation_run_id"] = i.run.get("id").cloned().unwrap_or(Value::Null);
+    record["transformation_run_ref"] = i.run.get("ref").cloned().unwrap_or(Value::Null);
+    record["ontology_projection_id"] = i.projection.get("id").cloned().unwrap_or(Value::Null);
+    record["ontology_projection_ref"] = i.projection.get("ref").cloned().unwrap_or(Value::Null);
+    record["ontology_ref"] = i.mapping.get("ontology_ref").cloned().unwrap_or(Value::Null);
+    record["object_type_id"] = i.mapping.get("object_type_id").cloned().unwrap_or(Value::Null);
+    record["subject"] = json!(i.subject);
+    record["purpose"] = json!(i.purpose);
+    record["requested_operations"] = json!(i.operations);
+    record["requested_properties"] = json!(i.properties);
+    record["retention_posture"] = i.view.get("retention_posture").cloned().unwrap_or(Value::Null);
+    record["export_posture"] = i.view.get("export_posture").cloned().unwrap_or(Value::Null);
+    record["receipt_obligations"] = i.view.get("receipt_obligations").cloned().unwrap_or(json!([]));
+    record["ttl_seconds"] = json!(i.ttl_seconds);
+    record["gateway"] = json!({
+        "primitive": LEASE_GATEWAY_PRIMITIVE,
+        "route": LEASE_GATEWAY_ROUTE,
+        "note": "the ONLY authority gateway — a future materializing run must obtain its lease HERE, citing this plan; this plane never mints"
+    });
+    record["lease"] = json!({ "minted": false, "credential_material": false, "note": "plan only — no usable credential exists or is produced here" });
+    record["execution"] = json!({ "source_contacted": false, "data_moved": false, "object_instances": 0 });
+    record["missing_authority"] = json!(MISSING_AUTHORITY);
+}
+fn bad(data_dir: &str, op: &str, err: VErr) -> (StatusCode, Json<Value>) {
+    let _ = plan_receipt(data_dir, "capability-lease-plan://unadmitted", op, &err.0, &err.1);
+    (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": err.0, "message": err.1 } })))
+}
+fn load_plan(data_dir: &str, id: &str) -> Option<Value> {
+    find_by_key(data_dir, RECORD_DIR, "id", id)
+}
+
+/// GET /v1/hypervisor/odk/capability-lease-plans.
+pub(crate) async fn handle_plans_list(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let mut items = read_record_dir(&st.data_dir, RECORD_DIR);
+    items.sort_by(|a, b| s(b, "updated_at", "").cmp(&s(a, "updated_at", "")));
+    Json(json!({ "ok": true, "schema_version": PLAN_SCHEMA, "capability_lease_plans": items, "runtimeTruthSource": "daemon-runtime" }))
+}
+
+/// GET /v1/hypervisor/odk/capability-lease-plans/overview.
+pub(crate) async fn handle_plans_overview(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let items = read_record_dir(&st.data_dir, RECORD_DIR);
+    let by = |status: &str| items.iter().filter(|r| s(r, "status", "") == status).count();
+    Json(json!({
+        "ok": true,
+        "schema_version": OVERVIEW_SCHEMA,
+        "capability_lease_plans": items.len(),
+        "lifecycle": { "declared": by("declared"), "revoked": by("revoked") },
+        "gateway": { "primitive": LEASE_GATEWAY_PRIMITIVE, "route": LEASE_GATEWAY_ROUTE },
+        "leaseable_postures": LEASEABLE_POSTURES,
+        "max_ttl_seconds": MAX_TTL_SECONDS,
+        "missing_authority": MISSING_AUTHORITY,
+        "governance_gaps": [
+            "PLAN only — no lease is minted, no credential material exists or is produced here",
+            "the ONLY authority gateway is the existing CapabilityLease primitive; this plane never becomes a second lease system",
+            "a MaterializingRun (live connector adapter) does not exist — it is the deliberate future cut that would cite a plan like this",
+            "object_instances stays 0 everywhere; every refusal is receipted"
+        ],
+        "runtimeTruthSource": "daemon-runtime"
+    }))
+}
+
+/// GET /v1/hypervisor/odk/capability-lease-plans/:id.
+pub(crate) async fn handle_plan_get(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    match load_plan(&st.data_dir, &id) {
+        Some(r) => (StatusCode::OK, Json(json!({ "ok": true, "capability_lease_plan": r }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "capability-lease plan not found" }))),
+    }
+}
+
+/// GET /v1/hypervisor/odk/capability-lease-plans/:id/history.
+pub(crate) async fn handle_plan_history(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(r) = load_plan(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "capability-lease plan not found" })));
+    };
+    let pref = s(&r, "ref", "");
+    let mut receipts = read_record_dir(&st.data_dir, RECEIPT_DIR);
+    receipts.retain(|x| x.get("capability_lease_plan_ref").and_then(|v| v.as_str()) == Some(pref.as_str()));
+    receipts.sort_by(|a, b| s(b, "at", "").cmp(&s(a, "at", "")));
+    (StatusCode::OK, Json(json!({ "ok": true, "capability_lease_plan_ref": pref, "revision": r.get("revision"), "status": r.get("status"), "history": r.get("history").cloned().unwrap_or(json!([])), "receipts": receipts })))
+}
+
+/// POST /v1/hypervisor/odk/capability-lease-plans — declare a lease plan (fail-closed, receipted).
+pub(crate) async fn handle_plan_create(State(st): State<Arc<DaemonState>>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    let inputs = match validate_inputs(&st.data_dir, &body) {
+        Ok(i) => i,
+        Err(e) => return bad(&st.data_dir, "create_rejected", e),
+    };
+    let id = format!("clp_{:x}", nanos());
+    let now = iso_now();
+    let pref = format!("capability-lease-plan://{id}");
+    let receipt = plan_receipt(&st.data_dir, &pref, "created", "ok", "CapabilityLease plan declared (nothing minted)");
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    let mut record = json!({
+        "schema_version": PLAN_SCHEMA,
+        "object": "ioi.hypervisor.odk.capability_lease_plan",
+        "id": id,
+        "ref": pref,
+        "name": s(&body, "name", "capability-lease-plan"),
+        "description": s(&body, "description", ""),
+        "status": "declared",
+        "revision": 1,
+        "receipt_refs": [receipt_ref.clone()],
+        "history": [ { "revision": 1, "op": "created", "at": now.clone(), "summary": "CapabilityLease plan declared (nothing minted)", "receipt_ref": receipt_ref } ],
+        "created_at": now.clone(),
+        "updated_at": now
+    });
+    apply_inputs(&mut record, &inputs);
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::CREATED, Json(json!({ "ok": true, "capability_lease_plan": record })))
+}
+
+/// PATCH — re-validate the merged plan against the CURRENT ladder; a malformed patch is a receipted
+/// refusal with no state change. A revoked plan is immutable.
+pub(crate) async fn handle_plan_patch(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(patch): Json<Value>) -> Json<Value> {
+    let Some(existing) = load_plan(&st.data_dir, &id) else {
+        return Json(json!({ "ok": false, "reason": "capability-lease plan not found" }));
+    };
+    if s(&existing, "status", "") == "revoked" {
+        return Json(json!({ "ok": false, "error": { "code": "lease_plan_revoked_immutable", "message": "a revoked plan is immutable" } }));
+    }
+    let mut merged = json!({});
+    let mo = merged.as_object_mut().unwrap();
+    for k in [
+        "name", "description", "data_source_id", "connector_mapping_id", "policy_view_id",
+        "transformation_run_id", "ontology_projection_id", "subject", "purpose",
+        "requested_operations", "requested_properties", "retention_posture", "export_posture", "ttl_seconds",
+    ] {
+        if let Some(v) = patch.get(k).or_else(|| existing.get(k)) {
+            mo.insert(k.to_string(), v.clone());
+        }
+    }
+    let inputs = match validate_inputs(&st.data_dir, &merged) {
+        Ok(i) => i,
+        Err(e) => {
+            let _ = plan_receipt(&st.data_dir, &s(&existing, "ref", ""), "patch_rejected", &e.0, &e.1);
+            return Json(json!({ "ok": false, "error": { "code": e.0, "message": e.1 } }));
+        }
+    };
+    let mut record = existing;
+    if let Some(v) = patch.get("name") { record["name"] = v.clone(); }
+    if let Some(v) = patch.get("description") { record["description"] = v.clone(); }
+    apply_inputs(&mut record, &inputs);
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1) + 1;
+    record["revision"] = json!(rev);
+    record["updated_at"] = json!(iso_now());
+    let receipt = plan_receipt(&st.data_dir, &s(&record, "ref", ""), "patched", "ok", "CapabilityLease plan re-declared");
+    push_history(&mut record, "patched", "CapabilityLease plan re-declared", receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    Json(json!({ "ok": true, "capability_lease_plan": record }))
+}
+
+/// POST /:id/revoke — terminal, receipted (withdrawing a declared lease request is auditable).
+pub(crate) async fn handle_plan_revoke(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(mut record) = load_plan(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "capability-lease plan not found" })));
+    };
+    if s(&record, "status", "") == "revoked" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "lease_plan_revoked_immutable", "message": "the plan is already revoked" } })));
+    }
+    let receipt = plan_receipt(&st.data_dir, &s(&record, "ref", ""), "revoked", "ok", "CapabilityLease plan revoked");
+    record["status"] = json!("revoked");
+    record["updated_at"] = json!(iso_now());
+    push_history(&mut record, "revoked", "CapabilityLease plan revoked", receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::OK, Json(json!({ "ok": true, "capability_lease_plan": record })))
+}
+
+/// DELETE — receipted removal.
+pub(crate) async fn handle_plan_delete(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> Json<Value> {
+    let pref = load_plan(&st.data_dir, &id)
+        .and_then(|r| r.get("ref").and_then(|v| v.as_str()).map(str::to_string))
+        .unwrap_or_else(|| format!("capability-lease-plan://{id}"));
+    let removed = remove_record(&st.data_dir, RECORD_DIR, &id);
+    if removed {
+        let _ = plan_receipt(&st.data_dir, &pref, "deleted", "ok", "CapabilityLease plan removed");
+    }
+    Json(json!({ "ok": removed, "removed": removed, "id": id }))
+}
+
+#[cfg(test)]
+mod capability_lease_plan_tests {
+    use super::*;
+
+    #[test]
+    fn gateway_is_the_existing_primitive_and_ttl_is_bounded() {
+        assert_eq!(LEASE_GATEWAY_PRIMITIVE, "ioi.hypervisor.capability-lease.v1");
+        assert_eq!(LEASE_GATEWAY_ROUTE, "/v1/hypervisor/capability-leases");
+        assert_eq!(MAX_TTL_SECONDS, 3600);
+        assert_eq!(LEASEABLE_POSTURES, &["wallet_credential_lease"]);
+    }
+
+    #[test]
+    fn bypass_keys_are_named() {
+        assert!(ENV_FALLBACK_KEYS.contains(&"from_env"));
+        assert!(RAW_QUERY_KEYS.contains(&"sql"));
+        assert!(PLAINTEXT_SECRET_KEYS.contains(&"api_key"));
+    }
+
+    #[test]
+    fn subset_of_finds_the_widening_element() {
+        let sup = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(subset_of(&["a".to_string()], &sup), None);
+        assert_eq!(subset_of(&["a".to_string(), "c".to_string()], &sup), Some("c".to_string()));
+    }
+
+    #[test]
+    fn high_risk_ops_match_the_view_contract() {
+        assert_eq!(HIGH_RISK_OPERATIONS, &["export", "publish", "train", "evaluate"]);
+        assert!(MISSING_AUTHORITY.contains("MaterializingRun"));
+    }
+}

--- a/crates/node/src/bin/hypervisor_daemon_routes/ontology_projection_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/ontology_projection_routes.rs
@@ -30,7 +30,7 @@ use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState
 const PROJ_SCHEMA: &str = "ioi.hypervisor.odk.ontology-projection.v1";
 const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.ontology-projection-receipt.v1";
 const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.ontology-projections-overview.v1";
-const RECORD_DIR: &str = "odk-ontology-projections";
+pub(crate) const RECORD_DIR: &str = "odk-ontology-projections";
 const RECEIPT_DIR: &str = "odk-ontology-projection-receipts";
 
 /// Declarative lifecycle. There is no "live"/"serving" state — a projection never serves rows here.


### PR DESCRIPTION
**Base: master** (the landed ladder, `f109bae5d`). The first credential-crossing contract — scoped exactly as directed: **credential authority planning, not a live adapter.** *Wallet authority becomes explicit before execution, but nothing operational crosses.*

## What a plan is
New daemon plane `/v1/hypervisor/odk/capability-lease-plans` — a plan binds the **complete landed ladder** (`DataSource → ConnectorMapping → PolicyBoundDataView → TransformationRun dry-run → OntologyProjection`) and declares the **exact CapabilityLease scope** a future materializing run may ask for: subject · purpose · permitted operations · property scope · retention/export posture · receipt obligations · **bounded TTL (≤3600s)** · credential posture.

**The only gateway is the existing CapabilityLease primitive** (`ioi.hypervisor.capability-lease.v1` at `/v1/hypervisor/capability-leases`) — cited on every record, never duplicated. This plane never becomes a second lease system.

## Fail-closed (19 typed lanes)
- Bypasses: plaintext secret · raw query · **env-credential fallback rejected** (an authority bypass).
- Ladder integrity: known source with **wallet-leaseable posture only**; ready mapping; ready view; **dry_run_ready** run; **ready** projection; **all bindings must agree** — a plan cannot mix ladders.
- Scope discipline: subject **explicitly** authorized by the view · purpose matches the gate · operations ⊆ the view's and must include `transform` · high-risk ops need named obligations · **properties ⊆ policy scope AND ⊆ projection-visible** (a lease can never widen the ladder) · postures echo the gate, never relax · TTL bounded, always.

## Inert — proven, not asserted
`lease.minted:false · credential_material:false · source_contacted:false · data_moved:false · object_instances:0` on every record. **Live proof: the real capability-leases gateway count is unchanged by all planning activity (1365 → 1365).** Every create/patch/revoke — and every refusal — receipted; malformed patch never bumps the revision; revoked is immutable.

## Surface
The Manager's ladder now reads exactly:
`ConnectorMapping ✓ · PolicyBoundDataView ✓ · TransformationRun dry-run ✓ · OntologyProjection ✓ · CapabilityLease plan declared · Materializing run missing`
Resources renders plans (subject · operations · TTL · **"not minted"**). `object_instances` remains 0 everywhere.

## Done bar — green
| gate | result |
|---|---|
| capability-lease-plan | **41/41** (incl. gateway before/after no-mint proof) |
| cargo test -p ioi-node | **94/94** (+4 unit tests) |
| ladder regressions | projection 36/36 · run 36/36 · view 35/35 · mapping 33/33 · manager 35/35 · ux-parity 20/20 · data-source 17/17 |
| estate regressions | automations 12/12 · model-catalog 11/11 · queue-seeds 45/45 · legacy builders 39/20/13 |
| source-neutral · fallthrough · diff-check | PASSED · empty · clean |

The doctrine holds: this plan **proves the exact lease shape** a materializing run is allowed to ask for. The first live connector adapter comes only after this shape is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)