### PR TITLE
ODK MaterializingRun lease acquisition — the first live authority crossing

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2962,14 +2962,30 @@ function renderDataSourcesSection(dataSources) {
 function omBoundaryNote(text) {
   return `<div style="border:1px dashed #3a3d46;border-radius:10px;padding:10px 12px;margin:0 0 12px;background:#141519;color:#9a9da6;font-size:12.5px">${text}</div>`;
 }
-function omContractLadder(nMappings, nViews, nRuns, nProjections, nLeasePlans) {
+function omContractLadder(nMappings, nViews, nRuns, nProjections, nLeasePlans, nLeasesObtained) {
   const declared = `<tr><td><code>ConnectorMapping</code> <span class="pill ok">declared</span></td><td>declared source fields → typed object properties</td><td class="sub" style="margin:0">${nMappings} mapping${nMappings === 1 ? "" : "s"} · inert (no extraction)</td></tr>`
     + `<tr><td><code>PolicyBoundDataView</code> <span class="pill ok">declared</span></td><td>the capability envelope — who/what may read · transform · distill · train · evaluate · export · publish · route, for what purpose, under which receipt obligations</td><td class="sub" style="margin:0">${nViews} view${nViews === 1 ? "" : "s"} · gate only (nothing runs)</td></tr>`
     + `<tr><td><code>TransformationRun + receipts</code> <span class="pill ok">declared</span></td><td>auditable plan / dry-run against the gate — validates shape, envelope, intent; every act (and every refusal) receipted</td><td class="sub" style="margin:0">${nRuns} run${nRuns === 1 ? "" : "s"} · plan/dry-run only (no source contact)</td></tr>`
     + `<tr><td><code>OntologyProjection</code> <span class="pill ok">declared</span></td><td>the explorer/search/read SHAPE — what an authorized surface would render, search, filter, relate, and act on</td><td class="sub" style="margin:0">${nProjections} projection${nProjections === 1 ? "" : "s"} · shape only, no materialized objects</td></tr>`
-    + `<tr><td><code>CapabilityLease plan</code> <span class="pill ok">declared</span></td><td>the EXACT lease scope a future materializing run may ask for — subject, purpose, operations, property scope, postures, obligations, bounded TTL; the only gateway is the existing capability-lease primitive</td><td class="sub" style="margin:0">${nLeasePlans} plan${nLeasePlans === 1 ? "" : "s"} · nothing minted, no credential material</td></tr>`
-    + `<tr><td><code>Materializing run (credential authority)</code> <span class="pill muted">missing</span></td><td>the live connector read — a run that obtains a REAL lease from the gateway by citing a declared plan, then extracts under it</td><td class="sub" style="margin:0">the only remaining crossing — a deliberate future cut; until then object_instances stays 0</td></tr>`;
+    + `<tr><td><code>CapabilityLease plan</code> <span class="pill ok">declared</span></td><td>the EXACT lease scope a materializing run may ask for — subject, purpose, operations, property scope, postures, obligations, bounded TTL; the only gateway is the existing capability-lease primitive</td><td class="sub" style="margin:0">${nLeasePlans} plan${nLeasePlans === 1 ? "" : "s"} · nothing minted, no credential material</td></tr>`
+    + `<tr><td><code>CapabilityLease obtained</code> <span class="pill ok">live</span></td><td>the FIRST live crossing — a run cites a declared plan and obtains a REAL wallet-gated lease from the gateway; no source contact, no credential resolution, any bearer token dropped</td><td class="sub" style="margin:0">${nLeasesObtained} lease${nLeasesObtained === 1 ? "" : "s"} obtained · real gateway leases, credential material never surfaced</td></tr>`
+    + `<tr><td><code>Connector execution</code> <span class="pill muted">missing</span></td><td>reading the source under an obtained lease — credential resolution + extraction, receipted before output</td><td class="sub" style="margin:0">the next cut; until then no source is contacted</td></tr>`
+    + `<tr><td><code>Materialized rows</code> <span class="pill muted">missing</span></td><td>registered, receipted output that finally lets a projection's rows exist</td><td class="sub" style="margin:0">after execution — until then object_instances stays 0</td></tr>`;
   return `<table><thead><tr><th>Contract</th><th>What it declares</th><th>Status / unlocks</th></tr></thead><tbody>${declared}</tbody></table>`;
+}
+// Materializing runs bound to the selected ontology — the live lease-acquisition rung.
+function omMaterializingRuns(runs) {
+  runs = Array.isArray(runs) ? runs : [];
+  if (!runs.length) return `<div class="empty">No materializing runs. A run cites a declared lease plan and may obtain a <b>real</b> wallet-gated CapabilityLease from the gateway — no source contact, no credential material, no rows; execution is the next cut.</div>`;
+  const pill = (st) => `<span class="pill ${st === "lease_obtained" ? "ok" : st === "planned" ? "muted" : "warn"}">${CX_ESC(st || "planned")}</span>`;
+  const rows = runs.map((r) => `<tr>
+    <td><b>${CX_ESC(r.name || r.id)}</b><div class="meta" style="color:#878a93;font-size:11.5px;margin-top:2px"><code>${CX_ESC(r.ref || "")}</code></div></td>
+    <td><code>${CX_ESC(r.subject || "—")}</code></td>
+    <td>${r.lease && r.lease.lease_id ? `<code>${CX_ESC(r.lease.lease_id)}</code>` : "—"}</td>
+    <td>${CX_ESC(String(r.ttl_seconds || 0))}s</td>
+    <td>${pill(r.status)} <span class="pill warn" title="no source contact, no credential material, no rows — execution is the next cut">no execution</span></td>
+  </tr>`).join("");
+  return `<table><thead><tr><th>Run</th><th>Subject</th><th>Lease</th><th>TTL</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 // Capability-lease plans bound to the selected ontology — the declared credential authority, minted never.
 function omLeasePlans(plans) {
@@ -3146,6 +3162,7 @@ function renderOntologyManager(ov, lists, selectedId) {
   const truns = (lists.transformation_runs || []).filter((r) => r.ontology_ref === boundRef);
   const projs = (lists.ontology_projections || []).filter((p) => p.ontology_ref === boundRef);
   const lplans = (lists.capability_lease_plans || []).filter((p) => p.ontology_ref === boundRef);
+  const mruns = (lists.materializing_runs || []).filter((r) => r.ontology_ref === boundRef);
   const resourceSection = (title, family, items, nameKey, newLabel) => `<h3 style="display:flex;justify-content:space-between;align-items:center;margin:12px 0 6px">${title} (${items.length}) <a class="act ghost" href="/__ioi/odk/${family}/new">+ ${newLabel}</a></h3>${items.length ? items.map((x) => odkCard(family, x, nameKey)).join("") : `<div class="empty">None bound to this ontology.</div>`}`;
   const resourcesPane = `<h2 id="pane-resources">Resources <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— bound to ${selected ? CX_ESC(selected.domain) : "—"}</span></h2>`
     + `<h3 style="margin:12px 0 6px">Connector mappings (${maps.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— source fields → object properties · daemon truth · inert</span></h3>${omConnectorMappings(maps)}`
@@ -3153,6 +3170,7 @@ function renderOntologyManager(ov, lists, selectedId) {
     + `<h3 style="margin:12px 0 6px">Transformation runs (${truns.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— auditable plans/dry-runs against the gate · daemon truth · no source contact</span></h3>${omTransformationRuns(truns)}`
     + `<h3 style="margin:12px 0 6px">Ontology projections (${projs.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the declared explorer/search shape · daemon truth · no materialized objects</span></h3>${projs.length ? projs.map((p) => `<div class="chips" style="margin:0 0 6px"><b>${CX_ESC(p.name || p.id)}</b> <span class="pill ${p.status === "ready" ? "ok" : p.status === "blocked" ? "warn" : "muted"}">${CX_ESC(p.status || "draft")}</span> <span class="pill muted">${(p.visible_properties || []).length} visible</span> <span class="pill warn" title="shape only — nothing materialized">0 objects</span> <span class="sub" style="margin:0"><code>${CX_ESC(p.ref || "")}</code></span></div>`).join("") : `<div class="empty">No projections. A projection declares what an authorized explorer <b>would</b> render — shape only, never rows.</div>`}`
     + `<h3 style="margin:12px 0 6px">Capability-lease plans (${lplans.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— declared credential authority · gateway: the capability-lease primitive · nothing minted</span></h3>${omLeasePlans(lplans)}`
+    + `<h3 style="margin:12px 0 6px">Materializing runs (${mruns.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— live lease acquisition against the gateway · no execution, no rows</span></h3>${omMaterializingRuns(mruns)}`
     + resourceSection("Data recipes", "data-recipes", recs, "name", "New recipe")
     + resourceSection("Surface descriptors", "surface-descriptors", descs, "name", "New descriptor")
     + resourceSection("ODK manifests", "manifests", mans, "name", "New manifest");
@@ -3169,7 +3187,7 @@ function renderOntologyManager(ov, lists, selectedId) {
     : `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill muted">unavailable</span></h2>`
       + omBoundaryNote(`This ontology binds <b>no object-instance plane</b>, so there are <b>no rows to explore</b> — declare an OntologyProjection to give this lane its read/search shape; rows still require a future materializing run under credential authority. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`);
   const explorerPane = explorerHead
-    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— contract-complete; only the live crossing remains</span></h3>` + omContractLadder(maps.length, pviews.length, truns.length, projs.length, lplans.length);
+    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— five declared rungs + the first live crossing; execution and rows remain</span></h3>` + omContractLadder(maps.length, pviews.length, truns.length, projs.length, lplans.length, mruns.filter((r) => r.status === "lease_obtained").length);
 
   const counts = { "object-types": ots.length, "properties": propCount, "link-types": lts.length, "action-types": nonFuncActs.length, "value-types": vts.length, "groups": 0, "interfaces": 0, "functions": funcs.length };
   const panes = objectTypesPane + propertiesPane + linkPane + actionPane + valuePane
@@ -6722,7 +6740,7 @@ const server = http.createServer((req, res) => {
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
     if (pathname === "/__ioi/odk" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
-      const [ov, o, r, d, m, ds, cm, pv, tr, op, lp] = await Promise.all([
+      const [ov, o, r, d, m, ds, cm, pv, tr, op, lp, mr] = await Promise.all([
         J("/v1/hypervisor/odk/overview"),
         J("/v1/hypervisor/odk/domain-ontologies"),
         J("/v1/hypervisor/odk/data-recipes"),
@@ -6734,6 +6752,7 @@ const server = http.createServer((req, res) => {
         J("/v1/hypervisor/odk/transformation-runs"),
         J("/v1/hypervisor/odk/ontology-projections"),
         J("/v1/hypervisor/odk/capability-lease-plans"),
+        J("/v1/hypervisor/odk/materializing-runs"),
       ]);
       const selectedOntology = new URL(req.url, "http://x").searchParams.get("ontology") || "";
       res.writeHead(200, HTMLH);
@@ -6748,6 +6767,7 @@ const server = http.createServer((req, res) => {
         transformation_runs: tr.transformation_runs || [],
         ontology_projections: op.ontology_projections || [],
         capability_lease_plans: lp.capability_lease_plans || [],
+        materializing_runs: mr.materializing_runs || [],
       }, selectedOntology));
       return;
     }

--- a/apps/hypervisor/scripts/verify-hypervisor-capability-lease-plan.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-capability-lease-plan.mjs
@@ -159,7 +159,7 @@ async function run() {
   const t = page.text;
   ok("Manager renders lease plans as daemon truth (Resources, 'not minted')", page.status === 200 && /Capability-lease plans \(\d+\)/.test(t) && /not minted/.test(t) && t.includes("materialize-loans-lease"));
   ok("ladder rung 5: CapabilityLease plan declared (nothing minted)", /CapabilityLease plan<\/code> <span class="pill ok">declared/.test(t) && /nothing minted/.test(t));
-  ok("Materializing run remains the only missing crossing", /Materializing run \(credential authority\)<\/code> <span class="pill muted">missing/.test(t));
+  ok("execution + rows remain the missing crossings", /Connector execution<\/code> <span class="pill muted">missing/.test(t) && /Materialized rows<\/code> <span class="pill muted">missing/.test(t));
   ok("0-objects boundary preserved; brand-clean", /0 objects/.test(t) && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
 
   // Cleanup — leave no draft debris.

--- a/apps/hypervisor/scripts/verify-hypervisor-materializing-run.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-materializing-run.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// MaterializingRun (lease acquisition) done-bar — THE FIRST LIVE AUTHORITY CROSSING, kept small.
+//
+// A run cites one declared CapabilityLease plan and may obtain a REAL wallet-gated CapabilityLease
+// from the EXISTING gateway. It must NOT contact the source, resolve or unwrap credential material,
+// extract rows, move data, or create object instances. Connector execution and materialization are
+// the next cut.
+//
+// Asserts:
+//   - THE CROSSING IS REAL: acquire without a grant → the gateway's 403 challenge (verbatim, with
+//     policy/request hashes; refusal receipted); a real dcrypt-signed grant bound to those hashes →
+//     lease_obtained; the gateway audit-trail count INCREASES BY ONE and contains our lease id.
+//   - NO CREDENTIAL MATERIAL: authority-only crossing (no backing credential resolved); no token/
+//     secret in any response, record, or receipt; env-credential fallback rejected.
+//   - Narrow-only: subject/purpose unchanged; operations/properties/TTL ⊆ the plan; every widening
+//     attempt rejected. After obtaining, the scope is FROZEN.
+//   - Drift discipline: a degraded ladder (deleted projection) blocks acquisition with a named code.
+//   - Receipts record request, gateway decision, lease id, TTL, scope, refusals, release/cancel.
+//   - object_instances stays 0; the UX ladder reads: … CapabilityLease plan ✓ · CapabilityLease
+//     obtained (live) · Connector execution missing · Materialized rows missing. Brand-clean.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-materializing-run.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+import { mintApprovalGrant } from "../../../scripts/lib/mint-approval-grant.mjs";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+const gatewayLeases = async () => (await jd("GET", "/v1/hypervisor/capability-leases")).j.leases || [];
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/materializing-runs/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon materializing-run plane not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+  const track = (kind, id) => { if (id) cleanup.push(["DELETE", `/v1/hypervisor/odk/${kind}/${id}`]); };
+
+  // Full ladder + declared plan over an UNREACHABLE source.
+  const dsR = await jd("POST", "/v1/hypervisor/data-sources", { name: "mrun-verify-src", kind: "postgres", endpoint: "postgres://unreachable.invalid:5432/db", credential_posture: "wallet_credential_lease" });
+  const dataSourceId = dsR.j.data_source?.source_id;
+  if (dataSourceId) cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${dataSourceId}`]);
+  const ontR = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "mrun-verify", canonical_object_model: {
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" } ] }],
+    action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }],
+  } });
+  const ontId = ontR.j.ontology?.id; const ontRef = ontR.j.ontology?.ref;
+  track("domain-ontologies", ontId);
+  const mapR = await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "mrun-verify-map", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" } });
+  const mapId = mapR.j.connector_mapping?.id;
+  track("connector-mappings", mapId);
+  const viewR = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: mapId, name: "mrun-verify-gate", authority_subjects: ["agent://materializer"],
+    allowed_operations: ["read", "transform"], purpose: "underwriting analysis", property_scope: ["loan_id", "title"], retention_posture: "bounded" });
+  const viewId = viewR.j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", viewId);
+  const trunR = await jd("POST", "/v1/hypervisor/odk/transformation-runs", { connector_mapping_id: mapId, policy_view_id: viewId, name: "mrun-verify-trun" });
+  const trunId = trunR.j.transformation_run?.id;
+  track("transformation-runs", trunId);
+  await jd("POST", `/v1/hypervisor/odk/transformation-runs/${trunId}/dry-run`);
+  const projR = await jd("POST", "/v1/hypervisor/odk/ontology-projections", { connector_mapping_id: mapId, policy_view_id: viewId, name: "mrun-verify-explorer", visible_properties: ["loan_id", "title"] });
+  const projId = projR.j.ontology_projection?.id;
+  track("ontology-projections", projId);
+  const planR = await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", { data_source_id: dataSourceId, connector_mapping_id: mapId, policy_view_id: viewId,
+    transformation_run_id: trunId, ontology_projection_id: projId, name: "mrun-verify-plan", subject: "agent://materializer", ttl_seconds: 900 });
+  const planId = planR.j.capability_lease_plan?.id;
+  track("capability-lease-plans", planId);
+  if (!dataSourceId || !ontId || !mapId || !viewId || !trunId || !projId || !planId) { console.error("BLOCKED: fixtures failed"); process.exit(2); }
+
+  // 1. Run admitted (planned; TTL narrowed 600 ≤ 900); inert; no lease yet.
+  const t0 = Date.now();
+  const created = await jd("POST", "/v1/hypervisor/odk/materializing-runs", { capability_lease_plan_id: planId, name: "materialize-loans", ttl_seconds: 600 });
+  const elapsed = Date.now() - t0;
+  const r0 = created.j.materializing_run;
+  track("materializing-runs", r0?.id);
+  ok("run admitted (201) instantly against an unreachable source — no contact", created.status === 201 && r0?.status === "planned" && elapsed < 4000, `${elapsed}ms`);
+  ok("narrowed TTL accepted (600 ≤ plan's 900); lease not yet obtained", r0?.ttl_seconds === 600 && r0?.lease?.obtained === false);
+  ok("inert invariants + both remaining cuts named", r0?.execution?.source_contacted === false && r0?.execution?.object_instances === 0 && JSON.stringify(r0?.missing_authority) === JSON.stringify(["ConnectorExecution", "MaterializedRows"]));
+
+  // 2. THE CROSSING. No grant → the gateway's 403 challenge, verbatim, refusal receipted.
+  const before = (await gatewayLeases()).length;
+  const ch = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${r0.id}/acquire-lease`, {});
+  ok("without a wallet grant the gateway's 403 challenge returns verbatim (hashes present)", ch.status === 403 && ch.j.reason === "odk_materialize_lease_authority_required" && !!ch.j.approval?.policy_hash && !!ch.j.approval?.request_hash);
+  // Mint a REAL dcrypt-signed grant bound to the challenge hashes; retry.
+  const grant = mintApprovalGrant({ policyHash: ch.j.approval.policy_hash, requestHash: ch.j.approval.request_hash });
+  const got = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${r0.id}/acquire-lease`, { wallet_approval_grant: grant });
+  const rr = got.j.materializing_run;
+  ok("with the bound grant the run obtains its lease (lease_obtained)", got.status === 200 && rr?.status === "lease_obtained" && !!rr?.lease?.lease_id, rr?.lease?.lease_id);
+  const after = await gatewayLeases();
+  ok("REAL MINT PROOF: the gateway audit trail grew by exactly one", after.length === before + 1, `${before} → ${after.length}`);
+  ok("our lease is IN the gateway audit trail (the existing primitive, not a copy)", after.some((l) => l.lease_id === rr?.lease?.lease_id));
+  ok("lease record carries safe fields only (grant_ref, hashes, expiry, tools) — credential_material false", rr?.lease?.credential_material === false && !!rr?.lease?.grant_ref && !!rr?.lease?.policy_hash && (rr?.lease?.allowed_tools || []).every((t) => String(t).startsWith("odk.materialize.")));
+  ok("NO token/secret anywhere in the response", !JSON.stringify(got.j).match(/"token"|hunter2|secret_key|private_key/i));
+  ok("still no execution: source_contacted false, object_instances 0", rr?.execution?.source_contacted === false && rr?.execution?.object_instances === 0);
+
+  // 3. Post-obtain guards.
+  const again = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${r0.id}/acquire-lease`, { wallet_approval_grant: grant });
+  ok("re-acquire refused (a run holds one lease)", again.j.error?.code === "materializing_run_lease_already_obtained");
+  const frozen = await jd("PATCH", `/v1/hypervisor/odk/materializing-runs/${r0.id}`, { ttl_seconds: 300 });
+  ok("scope is FROZEN after obtaining (receipted refusal)", frozen.j.error?.code === "materializing_run_scope_frozen");
+  const meta = await jd("PATCH", `/v1/hypervisor/odk/materializing-runs/${r0.id}`, { description: "holds its lease" });
+  ok("metadata patch still allowed (history kept)", meta.j.materializing_run?.revision === 2);
+
+  // 4. Fail-closed lanes at create.
+  const reject = async (label, body, code) => {
+    const r = await jd("POST", "/v1/hypervisor/odk/materializing-runs", body);
+    ok(`fail-closed: ${label}`, r.status === 400 && r.j.error?.code === code, r.j.error?.code || `status ${r.status}`);
+    track("materializing-runs", r.j?.materializing_run?.id);
+  };
+  await reject("plaintext secret", { capability_lease_plan_id: planId, name: "x", password: "h" }, "materializing_run_plaintext_secret_rejected");
+  await reject("raw query body", { capability_lease_plan_id: planId, name: "x", sql: "SELECT 1" }, "materializing_run_raw_query_rejected");
+  await reject("env-credential fallback", { capability_lease_plan_id: planId, name: "x", from_env: "PGPASSWORD" }, "materializing_run_env_fallback_rejected");
+  await reject("missing name", { capability_lease_plan_id: planId }, "materializing_run_name_required");
+  await reject("unknown plan", { capability_lease_plan_id: "clp_nope", name: "x" }, "materializing_run_plan_unknown");
+  await reject("subject re-assignment", { capability_lease_plan_id: planId, name: "x", subject: "agent://other" }, "materializing_run_subject_mismatch");
+  await reject("purpose drift", { capability_lease_plan_id: planId, name: "x", purpose: "resale" }, "materializing_run_purpose_mismatch");
+  await reject("operation widening (export not in the plan)", { capability_lease_plan_id: planId, name: "x", requested_operations: ["read", "transform", "export"] }, "materializing_run_operation_widening_rejected");
+  await reject("property widening", { capability_lease_plan_id: planId, name: "x", requested_properties: ["loan_id", "ghost"] }, "materializing_run_scope_widening_rejected");
+  await reject("TTL widening (3600 > plan's 900)", { capability_lease_plan_id: planId, name: "x", ttl_seconds: 3600 }, "materializing_run_ttl_widening_rejected");
+
+  // 5. Release (terminal), then acquire is immutable.
+  const rel = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${r0.id}/release-lease`);
+  ok("release-lease is receipted + terminal (obtained → false)", rel.j.materializing_run?.status === "lease_released" && rel.j.materializing_run?.lease?.obtained === false);
+  const acq2 = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${r0.id}/acquire-lease`, {});
+  ok("a released run is immutable", acq2.j.error?.code === "materializing_run_terminal_immutable");
+
+  // 6. Drift lane: a second run whose ladder degrades before acquisition.
+  const r2R = await jd("POST", "/v1/hypervisor/odk/materializing-runs", { capability_lease_plan_id: planId, name: "drift-run" });
+  const r2 = r2R.j.materializing_run;
+  track("materializing-runs", r2?.id);
+  await jd("DELETE", `/v1/hypervisor/odk/ontology-projections/${projId}`);
+  const drifted = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${r2.id}/acquire-lease`, {});
+  ok("acquire after ladder drift (projection deleted) → refused with a named drift code (receipted)", drifted.status === 400 && drifted.j.error?.code === "materializing_run_plan_drift");
+
+  // 7. History + overview honesty.
+  const hist = await jd("GET", `/v1/hypervisor/odk/materializing-runs/${r0.id}/history`);
+  const opsSeen = (hist.j.receipts || []).map((x) => x.op);
+  ok("receipts record request, refusal, decision, release (the full crossing story)", ["created", "lease_requested", "lease_refused", "lease_obtained", "lease_released"].every((o) => opsSeen.includes(o)), opsSeen.join(","));
+  ok("no credential material in any receipt", !JSON.stringify(hist.j.receipts || []).match(/"token"|hunter2|secret_key/i));
+  const ov = await jd("GET", "/v1/hypervisor/odk/materializing-runs/overview");
+  ok("overview: lifecycle + lease-acquisition-only governance gaps", JSON.stringify(ov.j.lifecycle_states) === JSON.stringify(["planned", "lease_obtained", "lease_released", "cancelled"]) && (ov.j.governance_gaps || []).some((g) => /never contacts the source/i.test(g)));
+  const allRuns = await jd("GET", "/v1/hypervisor/odk/materializing-runs");
+  ok("no run anywhere reports execution or object instances", (allRuns.j.materializing_runs || []).every((r) => r.execution?.source_contacted === false && r.execution?.object_instances === 0));
+
+  // 8. UX ladder — the crossing rendered honestly.
+  const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+  const t = page.text;
+  ok("Manager renders materializing runs (Resources, 'no execution')", page.status === 200 && /Materializing runs \(\d+\)/.test(t) && /no execution/.test(t));
+  ok("ladder rung 6: CapabilityLease obtained (live)", /CapabilityLease obtained<\/code> <span class="pill ok">live/.test(t));
+  ok("ladder: Connector execution + Materialized rows missing", /Connector execution<\/code> <span class="pill muted">missing/.test(t) && /Materialized rows<\/code> <span class="pill muted">missing/.test(t));
+  ok("0-objects boundary preserved; brand-clean", /0 objects/.test(t) && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
+
+  // Cleanup — draft/test records removed; the minted lease REMAINS in the gateway audit trail
+  // (an audit trail is append-only by nature; the crossing happened and is recorded).
+  for (const [method, p] of cleanup.reverse()) await jd(method, p);
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`materializing-run readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-projection.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-projection.mjs
@@ -171,7 +171,7 @@ async function run() {
   ok("Explorer pane renders the DECLARED shape (projection declared · no materialized objects)", page.status === 200 && /projection declared/.test(t) && /no materialized objects/.test(t) && t.includes("loan-explorer"));
   ok("declared shape shows columns + 0-objects boundary cell (no fabricated rows)", /0 objects — projection declared, nothing materialized/.test(t));
   ok("ladder is CONTRACT-COMPLETE: all four rungs declared", (t.match(/(ConnectorMapping|PolicyBoundDataView|TransformationRun \+ receipts|OntologyProjection)<\/code> <span class="pill ok">declared/g) || []).length === 4);
-  ok("only the live crossing (materializing run under credential authority) remains missing", /Materializing run \(credential authority\)<\/code> <span class="pill muted">missing/.test(t));
+  ok("execution + materialized rows remain the missing crossings", /Connector execution<\/code> <span class="pill muted">missing/.test(t) && /Materialized rows<\/code> <span class="pill muted">missing/.test(t));
   ok("brand-clean (no Palantir/Foundry leak)", !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
 
   // Cleanup.

--- a/apps/hypervisor/scripts/verify-hypervisor-transformation-run.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-transformation-run.mjs
@@ -167,7 +167,7 @@ async function run() {
   const t = page.text;
   ok("Manager renders transformation runs as daemon truth (Resources)", page.status === 200 && /Transformation runs \(\d+\)/.test(t) && /no source contact/.test(t));
   ok("ladder: ConnectorMapping + PolicyBoundDataView + TransformationRun all declared", /ConnectorMapping<\/code> <span class="pill ok">declared/.test(t) && /PolicyBoundDataView<\/code> <span class="pill ok">declared/.test(t) && /TransformationRun \+ receipts<\/code> <span class="pill ok">declared/.test(t));
-  ok("ladder: OntologyProjection named; only the live crossing (credential authority) missing", /OntologyProjection<\/code>/.test(t) && /credential authority\)<\/code> <span class="pill muted">missing/.test(t));
+  ok("ladder: OntologyProjection named; execution + rows still missing", /OntologyProjection<\/code>/.test(t) && /Connector execution<\/code> <span class="pill muted">missing/.test(t) && /Materialized rows<\/code> <span class="pill muted">missing/.test(t));
   ok("0-objects boundary preserved; brand-clean", /0 objects/.test(t) && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
 
   // Cleanup — leave no draft debris.

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -98,6 +98,8 @@ mod transformation_run_routes;
 mod ontology_projection_routes;
 #[path = "hypervisor_daemon_routes/capability_lease_plan_routes.rs"]
 mod capability_lease_plan_routes;
+#[path = "hypervisor_daemon_routes/materializing_run_routes.rs"]
+mod materializing_run_routes;
 #[path = "hypervisor_daemon_routes/harness_routes.rs"]
 mod harness_routes;
 #[path = "hypervisor_daemon_routes/model_routes.rs"]
@@ -1241,6 +1243,40 @@ async fn async_main() -> anyhow::Result<()> {
         .route(
             "/v1/hypervisor/odk/capability-lease-plans/:id/revoke",
             post(capability_lease_plan_routes::handle_plan_revoke),
+        )
+        // MaterializingRun (lease acquisition) — THE first live authority crossing: obtains a REAL
+        // wallet-gated CapabilityLease from the existing gateway by citing a declared plan. No
+        // source contact, no credential resolution, no rows; execution is the next cut.
+        .route(
+            "/v1/hypervisor/odk/materializing-runs",
+            get(materializing_run_routes::handle_mruns_list)
+                .post(materializing_run_routes::handle_mrun_create),
+        )
+        .route(
+            "/v1/hypervisor/odk/materializing-runs/overview",
+            get(materializing_run_routes::handle_mruns_overview),
+        )
+        .route(
+            "/v1/hypervisor/odk/materializing-runs/:id",
+            get(materializing_run_routes::handle_mrun_get)
+                .patch(materializing_run_routes::handle_mrun_patch)
+                .delete(materializing_run_routes::handle_mrun_delete),
+        )
+        .route(
+            "/v1/hypervisor/odk/materializing-runs/:id/history",
+            get(materializing_run_routes::handle_mrun_history),
+        )
+        .route(
+            "/v1/hypervisor/odk/materializing-runs/:id/acquire-lease",
+            post(materializing_run_routes::handle_mrun_acquire_lease),
+        )
+        .route(
+            "/v1/hypervisor/odk/materializing-runs/:id/release-lease",
+            post(materializing_run_routes::handle_mrun_release_lease),
+        )
+        .route(
+            "/v1/hypervisor/odk/materializing-runs/:id/cancel",
+            post(materializing_run_routes::handle_mrun_cancel),
         )
         .route(
             "/v1/hypervisor/odk/data-recipes",

--- a/crates/node/src/bin/hypervisor_daemon_routes/capability_lease_plan_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/capability_lease_plan_routes.rs
@@ -26,7 +26,7 @@ use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState
 const PLAN_SCHEMA: &str = "ioi.hypervisor.odk.capability-lease-plan.v1";
 const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.capability-lease-plan-receipt.v1";
 const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.capability-lease-plans-overview.v1";
-const RECORD_DIR: &str = "odk-capability-lease-plans";
+pub(crate) const RECORD_DIR: &str = "odk-capability-lease-plans";
 const RECEIPT_DIR: &str = "odk-capability-lease-plan-receipts";
 
 /// The ONLY authority gateway a materializing run may cross. Cited, never duplicated.

--- a/crates/node/src/bin/hypervisor_daemon_routes/materializing_run_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/materializing_run_routes.rs
@@ -1,0 +1,549 @@
+//! MaterializingRun (lease acquisition) — the FIRST LIVE AUTHORITY CROSSING, kept deliberately
+//! small: a run cites one ready CapabilityLease PLAN (#17) and may request and obtain a REAL
+//! CapabilityLease from the EXISTING gateway (`authorize_capability_lease` — wallet-grant-verified,
+//! persisted in the capability-leases audit trail). It must NOT contact the source, resolve or
+//! unwrap credential material, extract rows, move data, or create object instances yet. Connector
+//! execution and materialization are the NEXT cut (#19); this one proves only that wallet authority
+//! can cross for exactly the declared shape.
+//!
+//! The crossing is authority-only by construction: `credential_connector_id: None` +
+//! `credential_required: false` — the gateway verifies the bound wallet grant and mints the
+//! no-secret lease descriptor WITHOUT resolving any backing credential. The returned bearer token
+//! (if any) is DROPPED, never stored, never logged, never returned.
+//!
+//! Fail-closed: the cited plan must be `declared` and must still match CURRENT ladder truth
+//! (re-checked at create AND at acquire — never cached); run-level overrides may only NARROW the
+//! plan (operations ⊆ plan's and include transform; properties ⊆ plan's; ttl ≤ plan's; subject and
+//! purpose unchanged); no plaintext secret, no env fallback, no raw query. After the lease is
+//! obtained the scope is FROZEN (scope-affecting patches refused). Receipts record the request, the
+//! gateway decision, the lease id/ref, bounded TTL, scope, refusal reasons, and release/cancel —
+//! never credential material.
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+
+use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState};
+use crate::lifecycle_routes::{authorize_capability_lease, CapabilityLeaseRequest};
+
+const RUN_SCHEMA: &str = "ioi.hypervisor.odk.materializing-run.v1";
+const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.materializing-run-receipt.v1";
+const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.materializing-runs-overview.v1";
+const RECORD_DIR: &str = "odk-materializing-runs";
+const RECEIPT_DIR: &str = "odk-materializing-run-receipts";
+
+/// Lifecycle: a run exists, may obtain its lease, and may release it — nothing executes.
+const LIFECYCLE_STATES: &[&str] = &["planned", "lease_obtained", "lease_released", "cancelled"];
+/// What still does not exist after this rung — the two remaining cuts, named.
+const MISSING_AUTHORITY: &[&str] = &["ConnectorExecution", "MaterializedRows"];
+const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
+const RAW_QUERY_KEYS: &[&str] = &["query", "sql", "raw_query", "statement", "command"];
+const ENV_FALLBACK_KEYS: &[&str] = &["env", "env_var", "env_credential", "credential_env", "from_env"];
+
+fn nanos() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0)
+}
+fn s(v: &Value, k: &str, d: &str) -> String {
+    v.get(k).and_then(|x| x.as_str()).unwrap_or(d).to_string()
+}
+fn opt_s(v: &Value, k: &str) -> Option<String> {
+    v.get(k).and_then(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string)
+}
+fn str_list(v: &Value, k: &str) -> Vec<String> {
+    v.get(k)
+        .and_then(|x| x.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string).collect())
+        .unwrap_or_default()
+}
+type VErr = (String, String);
+fn verr(code: &str, msg: String) -> VErr {
+    (code.to_string(), msg)
+}
+fn find_by_key(data_dir: &str, dir: &str, key: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, dir).into_iter().find(|r| r.get(key).and_then(|v| v.as_str()) == Some(id))
+}
+fn health_status(rec: &Value) -> String {
+    rec.pointer("/health/status").and_then(|v| v.as_str()).unwrap_or("incomplete").to_string()
+}
+fn subset_of(sub: &[String], sup: &[String]) -> Option<String> {
+    sub.iter().find(|x| !sup.iter().any(|y| y == *x)).cloned()
+}
+
+/// The run's validated shape: the cited plan (fresh from disk) + the (possibly narrowed) ask.
+struct RunInputs {
+    plan: Value,
+    subject: String,
+    purpose: String,
+    operations: Vec<String>,
+    properties: Vec<String>,
+    ttl_seconds: u64,
+}
+
+/// Re-verify the cited plan against CURRENT ladder truth — the same drift discipline as every rung:
+/// the gate is checked at each act, never cached. Returns the drifted thing's name on failure.
+fn check_plan_against_truth(data_dir: &str, plan: &Value) -> Result<(), String> {
+    let source_id = s(plan, "data_source_id", "");
+    let source = find_by_key(data_dir, crate::data_source_routes::RECORD_DIR, "source_id", &source_id)
+        .ok_or_else(|| format!("data source '{source_id}' no longer resolves"))?;
+    if s(&source, "credential_posture", "") != "wallet_credential_lease" {
+        return Err(format!("data source '{source_id}' posture is no longer wallet-leaseable"));
+    }
+    let mapping_id = s(plan, "connector_mapping_id", "");
+    let mapping = find_by_key(data_dir, crate::connector_mapping_routes::RECORD_DIR, "id", &mapping_id)
+        .ok_or_else(|| format!("mapping '{mapping_id}' no longer resolves"))?;
+    if health_status(&mapping) != "ready" {
+        return Err(format!("mapping '{mapping_id}' is no longer ready"));
+    }
+    let view_id = s(plan, "policy_view_id", "");
+    let view = find_by_key(data_dir, crate::policy_bound_data_view_routes::RECORD_DIR, "id", &view_id)
+        .ok_or_else(|| format!("policy view '{view_id}' no longer resolves"))?;
+    if health_status(&view) != "ready" {
+        return Err(format!("policy view '{view_id}' is no longer ready"));
+    }
+    let run_id = s(plan, "transformation_run_id", "");
+    let trun = find_by_key(data_dir, crate::transformation_run_routes::RECORD_DIR, "id", &run_id)
+        .ok_or_else(|| format!("transformation run '{run_id}' no longer resolves"))?;
+    if s(&trun, "status", "") != "dry_run_ready" {
+        return Err(format!("transformation run '{run_id}' is no longer dry_run_ready"));
+    }
+    let proj_id = s(plan, "ontology_projection_id", "");
+    let proj = find_by_key(data_dir, crate::ontology_projection_routes::RECORD_DIR, "id", &proj_id)
+        .ok_or_else(|| format!("projection '{proj_id}' no longer resolves"))?;
+    if s(&proj, "status", "") != "ready" {
+        return Err(format!("projection '{proj_id}' is no longer ready"));
+    }
+    // The gate must still authorize what the plan declared.
+    let subjects = str_list(&view, "authority_subjects");
+    if !subjects.iter().any(|x| x == &s(plan, "subject", "")) {
+        return Err("the plan's subject is no longer authorized by the policy view".into());
+    }
+    if s(&view, "purpose", "") != s(plan, "purpose", "") {
+        return Err("the plan's purpose no longer matches the policy view".into());
+    }
+    let view_ops = str_list(&view, "allowed_operations");
+    if let Some(bad) = subset_of(&str_list(plan, "requested_operations"), &view_ops) {
+        return Err(format!("the plan's operation '{bad}' is no longer authorized by the policy view"));
+    }
+    let scope = str_list(&view, "property_scope");
+    let visible = str_list(&proj, "visible_properties");
+    for p in str_list(plan, "requested_properties") {
+        if !scope.iter().any(|x| x == &p) || !visible.iter().any(|x| x == &p) {
+            return Err(format!("the plan's property '{p}' is no longer within policy scope + projection visibility"));
+        }
+    }
+    Ok(())
+}
+
+/// Validate a run body fail-closed: bypass guards, a declared + truth-matching plan, and overrides
+/// that only ever NARROW the plan.
+fn validate_inputs(data_dir: &str, body: &Value) -> Result<RunInputs, VErr> {
+    if let Some(obj) = body.as_object() {
+        if PLAINTEXT_SECRET_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("materializing_run_plaintext_secret_rejected", "A materializing run never carries credential material.".into()));
+        }
+        if RAW_QUERY_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("materializing_run_raw_query_rejected", "A materializing run never carries a raw source query.".into()));
+        }
+        if ENV_FALLBACK_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("materializing_run_env_fallback_rejected", "Environment-credential fallback is an authority bypass — the only gateway is the CapabilityLease primitive.".into()));
+        }
+    }
+    if opt_s(body, "name").is_none() {
+        return Err(verr("materializing_run_name_required", "A materializing run requires a name.".into()));
+    }
+    let plan_id = opt_s(body, "capability_lease_plan_id").unwrap_or_default();
+    let plan = find_by_key(data_dir, crate::capability_lease_plan_routes::RECORD_DIR, "id", &plan_id)
+        .ok_or_else(|| verr("materializing_run_plan_unknown", format!("capability_lease_plan_id '{plan_id}' does not resolve to a declared plan")))?;
+    if s(&plan, "status", "") != "declared" {
+        return Err(verr("materializing_run_plan_not_declared", format!("plan '{plan_id}' is '{}' — a run cites only a declared plan", s(&plan, "status", ""))));
+    }
+    if let Err(drift) = check_plan_against_truth(data_dir, &plan) {
+        return Err(verr("materializing_run_plan_drift", format!("the cited plan no longer matches current truth: {drift}")));
+    }
+    // Subject + purpose: UNCHANGED (inherited when absent).
+    let plan_subject = s(&plan, "subject", "");
+    let subject = opt_s(body, "subject").unwrap_or_else(|| plan_subject.clone());
+    if subject != plan_subject {
+        return Err(verr("materializing_run_subject_mismatch", format!("run subject '{subject}' differs from the plan's '{plan_subject}' — a run cannot re-assign authority")));
+    }
+    let plan_purpose = s(&plan, "purpose", "");
+    let purpose = opt_s(body, "purpose").unwrap_or_else(|| plan_purpose.clone());
+    if purpose != plan_purpose {
+        return Err(verr("materializing_run_purpose_mismatch", format!("run purpose '{purpose}' differs from the plan's '{plan_purpose}'")));
+    }
+    // Operations / properties / TTL: unchanged or NARROWED, never widened.
+    let plan_ops = str_list(&plan, "requested_operations");
+    let mut operations = str_list(body, "requested_operations");
+    if operations.is_empty() {
+        operations = plan_ops.clone();
+    }
+    if let Some(bad) = subset_of(&operations, &plan_ops) {
+        return Err(verr("materializing_run_operation_widening_rejected", format!("operation '{bad}' is not in the cited plan — a run can only narrow, never widen")));
+    }
+    if !operations.iter().any(|o| o == "transform") {
+        return Err(verr("materializing_run_operation_widening_rejected", "a materializing run must retain 'transform'".into()));
+    }
+    let plan_props = str_list(&plan, "requested_properties");
+    let mut properties = str_list(body, "requested_properties");
+    if properties.is_empty() {
+        properties = plan_props.clone();
+    }
+    if let Some(bad) = subset_of(&properties, &plan_props) {
+        return Err(verr("materializing_run_scope_widening_rejected", format!("property '{bad}' is not in the cited plan — a run can only narrow, never widen")));
+    }
+    let plan_ttl = plan.get("ttl_seconds").and_then(|v| v.as_u64()).unwrap_or(0);
+    let ttl_seconds = body.get("ttl_seconds").and_then(|v| v.as_u64()).unwrap_or(plan_ttl);
+    if ttl_seconds == 0 || ttl_seconds > plan_ttl {
+        return Err(verr("materializing_run_ttl_widening_rejected", format!("ttl_seconds must be 1..={plan_ttl} (the plan's bound) — a run can only narrow, never widen")));
+    }
+    Ok(RunInputs { plan, subject, purpose, operations, properties, ttl_seconds })
+}
+
+fn run_receipt(data_dir: &str, run_ref: &str, op: &str, outcome: &str, summary: &str) -> Value {
+    let id = format!("mrr_{:x}", nanos());
+    let receipt_ref = format!("agentgres://materializing-run-receipt/{id}");
+    let rec = json!({
+        "schema_version": RECEIPT_SCHEMA, "receipt_id": id, "receipt_ref": receipt_ref,
+        "materializing_run_ref": run_ref, "op": op, "outcome": outcome, "summary": summary, "at": iso_now()
+    });
+    let _ = persist_record(data_dir, RECEIPT_DIR, &id, &rec);
+    rec
+}
+fn push_history(record: &mut Value, op: &str, summary: &str, receipt_ref: Value) {
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1);
+    let mut hist = record.get("history").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    hist.push(json!({ "revision": rev, "op": op, "at": iso_now(), "summary": summary, "receipt_ref": receipt_ref.clone() }));
+    let len = hist.len();
+    if len > 20 {
+        hist = hist[len - 20..].to_vec();
+    }
+    record["history"] = json!(hist);
+    let mut refs = record.get("receipt_refs").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    refs.push(receipt_ref);
+    record["receipt_refs"] = json!(refs);
+}
+fn apply_inputs(record: &mut Value, i: &RunInputs) {
+    record["capability_lease_plan_id"] = i.plan.get("id").cloned().unwrap_or(Value::Null);
+    record["capability_lease_plan_ref"] = i.plan.get("ref").cloned().unwrap_or(Value::Null);
+    record["data_source_id"] = i.plan.get("data_source_id").cloned().unwrap_or(Value::Null);
+    record["ontology_ref"] = i.plan.get("ontology_ref").cloned().unwrap_or(Value::Null);
+    record["object_type_id"] = i.plan.get("object_type_id").cloned().unwrap_or(Value::Null);
+    record["subject"] = json!(i.subject);
+    record["purpose"] = json!(i.purpose);
+    record["requested_operations"] = json!(i.operations);
+    record["requested_properties"] = json!(i.properties);
+    record["ttl_seconds"] = json!(i.ttl_seconds);
+    record["execution"] = json!({ "source_contacted": false, "data_moved": false, "rows_extracted": 0, "object_instances": 0, "note": "lease acquisition only — connector execution and materialization are the next cut" });
+    record["missing_authority"] = json!(MISSING_AUTHORITY);
+}
+fn bad(data_dir: &str, op: &str, err: VErr) -> (StatusCode, Json<Value>) {
+    let _ = run_receipt(data_dir, "materializing-run://unadmitted", op, &err.0, &err.1);
+    (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": err.0, "message": err.1 } })))
+}
+fn load_run(data_dir: &str, id: &str) -> Option<Value> {
+    find_by_key(data_dir, RECORD_DIR, "id", id)
+}
+
+/// GET /v1/hypervisor/odk/materializing-runs.
+pub(crate) async fn handle_mruns_list(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let mut items = read_record_dir(&st.data_dir, RECORD_DIR);
+    items.sort_by(|a, b| s(b, "updated_at", "").cmp(&s(a, "updated_at", "")));
+    Json(json!({ "ok": true, "schema_version": RUN_SCHEMA, "materializing_runs": items, "runtimeTruthSource": "daemon-runtime" }))
+}
+
+/// GET /v1/hypervisor/odk/materializing-runs/overview.
+pub(crate) async fn handle_mruns_overview(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let items = read_record_dir(&st.data_dir, RECORD_DIR);
+    let by = |status: &str| items.iter().filter(|r| s(r, "status", "") == status).count();
+    Json(json!({
+        "ok": true,
+        "schema_version": OVERVIEW_SCHEMA,
+        "materializing_runs": items.len(),
+        "lifecycle": { "planned": by("planned"), "lease_obtained": by("lease_obtained"), "lease_released": by("lease_released"), "cancelled": by("cancelled") },
+        "lifecycle_states": LIFECYCLE_STATES,
+        "missing_authority": MISSING_AUTHORITY,
+        "governance_gaps": [
+            "LEASE ACQUISITION ONLY — a run may obtain a real wallet-gated CapabilityLease from the existing gateway; it never contacts the source, resolves credentials, extracts rows, or creates object instances",
+            "the crossing is authority-only by construction: no backing credential is resolved; any bearer token is dropped, never stored, never logged, never returned",
+            "connector execution and materialized rows are the NEXT cut — object_instances stays 0",
+            "receipts record request, gateway decision, lease id/ref, TTL, scope, refusals, release/cancel — never credential material"
+        ],
+        "runtimeTruthSource": "daemon-runtime"
+    }))
+}
+
+/// GET /v1/hypervisor/odk/materializing-runs/:id.
+pub(crate) async fn handle_mrun_get(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    match load_run(&st.data_dir, &id) {
+        Some(r) => (StatusCode::OK, Json(json!({ "ok": true, "materializing_run": r }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "materializing run not found" }))),
+    }
+}
+
+/// GET /v1/hypervisor/odk/materializing-runs/:id/history.
+pub(crate) async fn handle_mrun_history(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(r) = load_run(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "materializing run not found" })));
+    };
+    let rref = s(&r, "ref", "");
+    let mut receipts = read_record_dir(&st.data_dir, RECEIPT_DIR);
+    receipts.retain(|x| x.get("materializing_run_ref").and_then(|v| v.as_str()) == Some(rref.as_str()));
+    receipts.sort_by(|a, b| s(b, "at", "").cmp(&s(a, "at", "")));
+    (StatusCode::OK, Json(json!({ "ok": true, "materializing_run_ref": rref, "revision": r.get("revision"), "status": r.get("status"), "history": r.get("history").cloned().unwrap_or(json!([])), "receipts": receipts })))
+}
+
+/// POST /v1/hypervisor/odk/materializing-runs — admit a run (planned; no lease yet).
+pub(crate) async fn handle_mrun_create(State(st): State<Arc<DaemonState>>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    let inputs = match validate_inputs(&st.data_dir, &body) {
+        Ok(i) => i,
+        Err(e) => return bad(&st.data_dir, "create_rejected", e),
+    };
+    let id = format!("mrun_{:x}", nanos());
+    let now = iso_now();
+    let rref = format!("materializing-run://{id}");
+    let receipt = run_receipt(&st.data_dir, &rref, "created", "ok", "MaterializingRun admitted (no lease yet)");
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    let mut record = json!({
+        "schema_version": RUN_SCHEMA,
+        "object": "ioi.hypervisor.odk.materializing_run",
+        "id": id,
+        "ref": rref,
+        "name": s(&body, "name", "materializing-run"),
+        "description": s(&body, "description", ""),
+        "status": "planned",
+        "lease": { "obtained": false, "credential_material": false },
+        "revision": 1,
+        "receipt_refs": [receipt_ref.clone()],
+        "history": [ { "revision": 1, "op": "created", "at": now.clone(), "summary": "MaterializingRun admitted (no lease yet)", "receipt_ref": receipt_ref } ],
+        "created_at": now.clone(),
+        "updated_at": now
+    });
+    apply_inputs(&mut record, &inputs);
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::CREATED, Json(json!({ "ok": true, "materializing_run": record })))
+}
+
+/// POST /:id/acquire-lease — THE live crossing. Re-checks the plan against current truth, then asks
+/// the EXISTING gateway for a real lease under the run's (narrowed) shape. Without a bound wallet
+/// grant the gateway's 403 challenge is returned verbatim (and the refusal receipted). On success
+/// the lease descriptor's SAFE fields land on the record; any bearer token is dropped.
+pub(crate) async fn handle_mrun_acquire_lease(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    let Some(mut record) = load_run(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "materializing run not found" })));
+    };
+    let status = s(&record, "status", "");
+    if status == "lease_obtained" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "materializing_run_lease_already_obtained", "message": "the run already holds its lease" } })));
+    }
+    if status == "cancelled" || status == "lease_released" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "materializing_run_terminal_immutable", "message": format!("a {status} run is immutable") } })));
+    }
+    let rref = s(&record, "ref", "");
+    // Re-validate the cited plan against CURRENT truth — the gate is never cached.
+    let plan_id = s(&record, "capability_lease_plan_id", "");
+    let Some(plan) = find_by_key(&st.data_dir, crate::capability_lease_plan_routes::RECORD_DIR, "id", &plan_id) else {
+        let e = verr("materializing_run_plan_drift", format!("the cited plan '{plan_id}' no longer resolves"));
+        let _ = run_receipt(&st.data_dir, &rref, "lease_refused", &e.0, &e.1);
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": e.0, "message": e.1 } })));
+    };
+    if s(&plan, "status", "") != "declared" {
+        let e = verr("materializing_run_plan_not_declared", "the cited plan is no longer declared".into());
+        let _ = run_receipt(&st.data_dir, &rref, "lease_refused", &e.0, &e.1);
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": e.0, "message": e.1 } })));
+    }
+    if let Err(drift) = check_plan_against_truth(&st.data_dir, &plan) {
+        let e = verr("materializing_run_plan_drift", format!("the cited plan no longer matches current truth: {drift}"));
+        let _ = run_receipt(&st.data_dir, &rref, "lease_refused", &e.0, &e.1);
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": e.0, "message": e.1 } })));
+    }
+    // Build the gateway request — authority-only: no credential resolution in this cut.
+    let operations = str_list(&record, "requested_operations");
+    let properties = str_list(&record, "requested_properties");
+    let ttl = record.get("ttl_seconds").and_then(|v| v.as_u64()).unwrap_or(0);
+    let lease_req = CapabilityLeaseRequest {
+        authority_provider_ref: "wallet.network".to_string(),
+        backing_provider: "none".to_string(),
+        allowed_tools: operations.iter().map(|o| format!("odk.materialize.{o}")).collect(),
+        resource_refs: vec![
+            s(&plan, "ref", ""),
+            s(&plan, "connector_mapping_ref", ""),
+            s(&plan, "policy_view_ref", ""),
+            s(&plan, "transformation_run_ref", ""),
+            s(&plan, "ontology_projection_ref", ""),
+            s(&plan, "data_source_ref", ""),
+        ],
+        scopes: operations.clone(),
+        policy_domain: "hypervisor.odk.materialize.policy.v1".to_string(),
+        request_domain: "hypervisor.odk.materialize.request.v1".to_string(),
+        request_facets: json!({
+            "materializing_run_id": s(&record, "id", ""),
+            "capability_lease_plan_ref": s(&plan, "ref", ""),
+            "subject": s(&record, "subject", ""),
+            "purpose": s(&record, "purpose", ""),
+            "properties": properties,
+            "ttl_seconds": ttl
+        }),
+        credential_connector_id: None,
+        credential_store: "connector-credentials".to_string(),
+        credential_required: false,
+        github_host_fallback: false,
+        receipt_required: true,
+        revocation_ref: format!("odk-materializing-runs/{id}/lease"),
+        authority_reason: "odk_materialize_lease_authority_required".to_string(),
+        grant_value: body.get("wallet_approval_grant").cloned().unwrap_or(Value::Null),
+    };
+    let _ = run_receipt(&st.data_dir, &rref, "lease_requested", "ok", &format!("lease requested at the gateway: {} ops · {} properties · ttl {ttl}s", operations.len(), properties.len()));
+    match authorize_capability_lease(&st, &lease_req).await {
+        Err((code, challenge)) => {
+            // The gateway refused (403 authority challenge / other). Receipt the decision; return verbatim.
+            let reason = challenge.get("reason").and_then(|v| v.as_str()).unwrap_or("refused").to_string();
+            let _ = run_receipt(&st.data_dir, &rref, "lease_refused", &reason, "gateway refused the crossing (challenge returned verbatim; no lease minted)");
+            (code, Json(challenge))
+        }
+        Ok(lease) => {
+            // SAFE fields only — the descriptor carries no secret; the bearer token is DROPPED here.
+            drop(lease.token);
+            let d = &lease.descriptor;
+            let lease_id = s(d, "lease_id", "");
+            record["status"] = json!("lease_obtained");
+            record["lease"] = json!({
+                "obtained": true,
+                "credential_material": false,
+                "lease_id": lease_id,
+                "lease_ref": format!("capability-lease://{lease_id}"),
+                "grant_ref": lease.grant_ref,
+                "policy_hash": d.get("policy_hash").cloned().unwrap_or(Value::Null),
+                "request_hash": d.get("request_hash").cloned().unwrap_or(Value::Null),
+                "allowed_tools": d.get("allowed_tools").cloned().unwrap_or(json!([])),
+                "expires_at": d.get("expires_at").cloned().unwrap_or(Value::Null),
+                "ttl_seconds": ttl,
+                "note": "real gateway lease — authority-only (no credential resolved); execution is the next cut"
+            });
+            record["updated_at"] = json!(iso_now());
+            let receipt = run_receipt(&st.data_dir, &rref, "lease_obtained", "ok", &format!("gateway minted lease {lease_id} (ttl {ttl}s, {} properties) — no credential material", properties.len()));
+            push_history(&mut record, "lease_obtained", &format!("lease {lease_id} obtained from the gateway"), receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+            let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+            (StatusCode::OK, Json(json!({ "ok": true, "materializing_run": record })))
+        }
+    }
+}
+
+/// POST /:id/release-lease — receipted release of the held lease (terminal for this run).
+pub(crate) async fn handle_mrun_release_lease(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(mut record) = load_run(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "materializing run not found" })));
+    };
+    if s(&record, "status", "") != "lease_obtained" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "materializing_run_no_lease_to_release", "message": "the run holds no lease" } })));
+    }
+    let lease_id = record.pointer("/lease/lease_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let receipt = run_receipt(&st.data_dir, &s(&record, "ref", ""), "lease_released", "ok", &format!("lease {lease_id} released (never used — no execution exists)"));
+    record["status"] = json!("lease_released");
+    record["lease"]["obtained"] = json!(false);
+    record["lease"]["released_at"] = json!(iso_now());
+    record["updated_at"] = json!(iso_now());
+    push_history(&mut record, "lease_released", &format!("lease {lease_id} released"), receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::OK, Json(json!({ "ok": true, "materializing_run": record })))
+}
+
+/// POST /:id/cancel — terminal from `planned`, receipted.
+pub(crate) async fn handle_mrun_cancel(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(mut record) = load_run(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "materializing run not found" })));
+    };
+    if s(&record, "status", "") != "planned" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "materializing_run_terminal_immutable", "message": "only a planned run can be cancelled (release the lease instead)" } })));
+    }
+    let receipt = run_receipt(&st.data_dir, &s(&record, "ref", ""), "cancelled", "ok", "MaterializingRun cancelled before any crossing");
+    record["status"] = json!("cancelled");
+    record["updated_at"] = json!(iso_now());
+    push_history(&mut record, "cancelled", "MaterializingRun cancelled before any crossing", receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::OK, Json(json!({ "ok": true, "materializing_run": record })))
+}
+
+/// PATCH — name/description freely; scope keys re-validate narrow-only while `planned`; once the
+/// lease is obtained the scope is FROZEN. Malformed patch is a receipted refusal, no state change.
+pub(crate) async fn handle_mrun_patch(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(patch): Json<Value>) -> Json<Value> {
+    let Some(existing) = load_run(&st.data_dir, &id) else {
+        return Json(json!({ "ok": false, "reason": "materializing run not found" }));
+    };
+    let status = s(&existing, "status", "");
+    if status == "cancelled" || status == "lease_released" {
+        return Json(json!({ "ok": false, "error": { "code": "materializing_run_terminal_immutable", "message": format!("a {status} run is immutable") } }));
+    }
+    let scope_keys = ["capability_lease_plan_id", "subject", "purpose", "requested_operations", "requested_properties", "ttl_seconds"];
+    let scope_affecting = scope_keys.iter().any(|k| patch.get(*k).is_some());
+    if scope_affecting && status == "lease_obtained" {
+        let _ = run_receipt(&st.data_dir, &s(&existing, "ref", ""), "patch_rejected", "materializing_run_scope_frozen", "scope-affecting patch refused — the obtained lease's scope is frozen");
+        return Json(json!({ "ok": false, "error": { "code": "materializing_run_scope_frozen", "message": "the lease is obtained — its scope is frozen; release it to re-plan" } }));
+    }
+    let mut record = existing;
+    if scope_affecting {
+        let mut merged = json!({});
+        let mo = merged.as_object_mut().unwrap();
+        for k in ["name", "capability_lease_plan_id", "subject", "purpose", "requested_operations", "requested_properties", "ttl_seconds"] {
+            if let Some(v) = patch.get(k).or_else(|| record.get(k)) {
+                mo.insert(k.to_string(), v.clone());
+            }
+        }
+        let inputs = match validate_inputs(&st.data_dir, &merged) {
+            Ok(i) => i,
+            Err(e) => {
+                let _ = run_receipt(&st.data_dir, &s(&record, "ref", ""), "patch_rejected", &e.0, &e.1);
+                return Json(json!({ "ok": false, "error": { "code": e.0, "message": e.1 } }));
+            }
+        };
+        apply_inputs(&mut record, &inputs);
+    }
+    if let Some(v) = patch.get("name") { record["name"] = v.clone(); }
+    if let Some(v) = patch.get("description") { record["description"] = v.clone(); }
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1) + 1;
+    record["revision"] = json!(rev);
+    record["updated_at"] = json!(iso_now());
+    let receipt = run_receipt(&st.data_dir, &s(&record, "ref", ""), "patched", "ok", if scope_affecting { "run re-narrowed against the plan" } else { "metadata edit" });
+    push_history(&mut record, "patched", if scope_affecting { "run re-narrowed against the plan" } else { "metadata edit" }, receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    Json(json!({ "ok": true, "materializing_run": record }))
+}
+
+/// DELETE — receipted removal.
+pub(crate) async fn handle_mrun_delete(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> Json<Value> {
+    let rref = load_run(&st.data_dir, &id)
+        .and_then(|r| r.get("ref").and_then(|v| v.as_str()).map(str::to_string))
+        .unwrap_or_else(|| format!("materializing-run://{id}"));
+    let removed = remove_record(&st.data_dir, RECORD_DIR, &id);
+    if removed {
+        let _ = run_receipt(&st.data_dir, &rref, "deleted", "ok", "MaterializingRun removed");
+    }
+    Json(json!({ "ok": removed, "removed": removed, "id": id }))
+}
+
+#[cfg(test)]
+mod materializing_run_tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_and_missing_authority_are_explicit() {
+        assert_eq!(LIFECYCLE_STATES, &["planned", "lease_obtained", "lease_released", "cancelled"]);
+        assert_eq!(MISSING_AUTHORITY, &["ConnectorExecution", "MaterializedRows"]);
+    }
+
+    #[test]
+    fn bypass_keys_are_named() {
+        assert!(PLAINTEXT_SECRET_KEYS.contains(&"token"));
+        assert!(RAW_QUERY_KEYS.contains(&"sql"));
+        assert!(ENV_FALLBACK_KEYS.contains(&"from_env"));
+    }
+
+    #[test]
+    fn subset_of_finds_the_widening_element() {
+        let sup = vec!["read".to_string(), "transform".to_string()];
+        assert_eq!(subset_of(&["transform".to_string()], &sup), None);
+        assert_eq!(subset_of(&["transform".to_string(), "export".to_string()], &sup), Some("export".to_string()));
+    }
+}


### PR DESCRIPTION
**Base: master** (#17 merged). The first live crossing, split exactly as directed: **lease acquisition only** — not credential handling, not extraction, not materialization. A run cites one declared CapabilityLease plan and obtains a **real** wallet-gated CapabilityLease from the **existing** gateway. Nothing else crosses.

## The crossing
`POST /v1/hypervisor/odk/materializing-runs/:id/acquire-lease`:
1. Re-validates the cited plan against **current** ladder truth (never cached; drift → named, receipted refusal).
2. Asks `authorize_capability_lease` — **authority-only by construction**: `credential_connector_id: None` + `credential_required: false`. The gateway verifies the **bound wallet grant** (its 403 challenge with `policy_hash`/`request_hash` returns verbatim otherwise) and mints the no-secret descriptor **without resolving any backing credential**.
3. Any bearer token is **dropped** — never stored, never logged, never returned. Safe fields only land on the run (lease_id · grant_ref · hashes · expiry · tools).

## Proven, not asserted
| proof | result |
|---|---|
| 403 challenge without grant (verbatim, hashes present, refusal receipted) | ✔ |
| real dcrypt-signed grant bound to the hashes → `lease_obtained` | ✔ |
| **gateway audit trail grew by exactly one and contains our lease id** | 1366 → 1367 |
| no token/secret in any response, record, or receipt | ✔ |
| `source_contacted:false · data_moved:false · object_instances:0` throughout | ✔ |

## Fail-closed (13 typed lanes)
secret · raw query · **env-credential fallback** · missing name · unknown/undeclared plan · **plan drift** (any rung degraded, subject de-authorized, purpose changed, scope uncovered) · subject re-assignment · purpose drift · **operation/property/TTL widening** (a run may only narrow its plan; must retain `transform`) · lease already obtained · terminal immutability. **After obtaining, the scope is frozen** — scope-affecting patches are receipted refusals.

## Receipts
Request · gateway decision · lease id/ref · bounded TTL · scope · refusal reasons · release/cancel — never credential material. Full story observed: `created → lease_requested → lease_refused → lease_requested → lease_obtained → patch_rejected → lease_released`.

## Surface
`ConnectorMapping ✓ · PolicyBoundDataView ✓ · TransformationRun dry-run ✓ · OntologyProjection ✓ · CapabilityLease plan ✓ · CapabilityLease obtained (live) · Connector execution missing · Materialized rows missing` — `object_instances` remains 0.

## Done bar — green
materializing-run **34/34** · cargo **97/97** (+3) · lease-plan 41/41 · projection 36/36 · t-run 36/36 · view 35/35 · mapping 33/33 · manager 35/35 · ux-parity 20/20 · data-source 17/17 · estate + legacy suites · source-neutral PASSED · fallthrough empty · diff clean. (#15/#16/#17 ladder asserts evolved.)

**PR #19** (connector execution / materialization) is the cut that may finally read under this lease, emit pre-output receipts, register materialized output, and let a projection go nonzero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)