### PR TITLE
ODK sealed connector session — the credential-handling crossing (no source contact)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2962,16 +2962,31 @@ function renderDataSourcesSection(dataSources) {
 function omBoundaryNote(text) {
   return `<div style="border:1px dashed #3a3d46;border-radius:10px;padding:10px 12px;margin:0 0 12px;background:#141519;color:#9a9da6;font-size:12.5px">${text}</div>`;
 }
-function omContractLadder(nMappings, nViews, nRuns, nProjections, nLeasePlans, nLeasesObtained) {
+function omContractLadder(nMappings, nViews, nRuns, nProjections, nLeasePlans, nLeasesObtained, nSessions) {
   const declared = `<tr><td><code>ConnectorMapping</code> <span class="pill ok">declared</span></td><td>declared source fields → typed object properties</td><td class="sub" style="margin:0">${nMappings} mapping${nMappings === 1 ? "" : "s"} · inert (no extraction)</td></tr>`
     + `<tr><td><code>PolicyBoundDataView</code> <span class="pill ok">declared</span></td><td>the capability envelope — who/what may read · transform · distill · train · evaluate · export · publish · route, for what purpose, under which receipt obligations</td><td class="sub" style="margin:0">${nViews} view${nViews === 1 ? "" : "s"} · gate only (nothing runs)</td></tr>`
     + `<tr><td><code>TransformationRun + receipts</code> <span class="pill ok">declared</span></td><td>auditable plan / dry-run against the gate — validates shape, envelope, intent; every act (and every refusal) receipted</td><td class="sub" style="margin:0">${nRuns} run${nRuns === 1 ? "" : "s"} · plan/dry-run only (no source contact)</td></tr>`
     + `<tr><td><code>OntologyProjection</code> <span class="pill ok">declared</span></td><td>the explorer/search/read SHAPE — what an authorized surface would render, search, filter, relate, and act on</td><td class="sub" style="margin:0">${nProjections} projection${nProjections === 1 ? "" : "s"} · shape only, no materialized objects</td></tr>`
     + `<tr><td><code>CapabilityLease plan</code> <span class="pill ok">declared</span></td><td>the EXACT lease scope a materializing run may ask for — subject, purpose, operations, property scope, postures, obligations, bounded TTL; the only gateway is the existing capability-lease primitive</td><td class="sub" style="margin:0">${nLeasePlans} plan${nLeasePlans === 1 ? "" : "s"} · nothing minted, no credential material</td></tr>`
     + `<tr><td><code>CapabilityLease obtained</code> <span class="pill ok">live</span></td><td>the FIRST live crossing — a run cites a declared plan and obtains a REAL wallet-gated lease from the gateway; no source contact, no credential resolution, any bearer token dropped</td><td class="sub" style="margin:0">${nLeasesObtained} lease${nLeasesObtained === 1 ? "" : "s"} obtained · real gateway leases, credential material never surfaced</td></tr>`
+    + `<tr><td><code>Sealed connector session</code> <span class="pill ok">live</span></td><td>the credential-handling crossing — the gateway resolves the SEALED credential server-side for the exact lease scope; labels only, material never surfaced</td><td class="sub" style="margin:0">${nSessions} session${nSessions === 1 ? "" : "s"} obtained · no source contact</td></tr>`
     + `<tr><td><code>Connector execution</code> <span class="pill muted">missing</span></td><td>reading the source under an obtained lease — credential resolution + extraction, receipted before output</td><td class="sub" style="margin:0">the next cut; until then no source is contacted</td></tr>`
     + `<tr><td><code>Materialized rows</code> <span class="pill muted">missing</span></td><td>registered, receipted output that finally lets a projection's rows exist</td><td class="sub" style="margin:0">after execution — until then object_instances stays 0</td></tr>`;
   return `<table><thead><tr><th>Contract</th><th>What it declares</th><th>Status / unlocks</th></tr></thead><tbody>${declared}</tbody></table>`;
+}
+// Sealed connector sessions — the credential-handling rung: resolution proven, material never surfaced.
+function omConnectorSessions(sessions) {
+  sessions = Array.isArray(sessions) ? sessions : [];
+  if (!sessions.length) return `<div class="empty">No sealed connector sessions. A lease-holding run may open one — the gateway resolves the <b>sealed</b> credential server-side for the exact lease scope; only labels land here. No source contact; execution is the next cut.</div>`;
+  const pill = (st) => `<span class="pill ${st === "session_obtained" ? "ok" : st === "requested" ? "muted" : "warn"}">${CX_ESC(st || "requested")}</span>`;
+  const rows = sessions.map((c) => `<tr>
+    <td><b>${CX_ESC(c.name || c.id)}</b><div class="meta" style="color:#878a93;font-size:11.5px;margin-top:2px"><code>${CX_ESC(c.ref || "")}</code></div></td>
+    <td><code>${CX_ESC(c.connector_id || "—")}</code></td>
+    <td>${c.session && c.session.session_ref ? `<code>${CX_ESC(c.session.session_ref)}</code>` : "—"}</td>
+    <td>${CX_ESC(String(c.ttl_seconds || 0))}s</td>
+    <td>${pill(c.status)} <span class="pill warn" title="credential material never surfaced; no source contact">sealed · no contact</span></td>
+  </tr>`).join("");
+  return `<table><thead><tr><th>Session</th><th>Connector</th><th>Session ref</th><th>TTL</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 // Materializing runs bound to the selected ontology — the live lease-acquisition rung.
 function omMaterializingRuns(runs) {
@@ -3163,6 +3178,7 @@ function renderOntologyManager(ov, lists, selectedId) {
   const projs = (lists.ontology_projections || []).filter((p) => p.ontology_ref === boundRef);
   const lplans = (lists.capability_lease_plans || []).filter((p) => p.ontology_ref === boundRef);
   const mruns = (lists.materializing_runs || []).filter((r) => r.ontology_ref === boundRef);
+  const csns = (lists.connector_sessions || []).filter((c) => c.ontology_ref === boundRef);
   const resourceSection = (title, family, items, nameKey, newLabel) => `<h3 style="display:flex;justify-content:space-between;align-items:center;margin:12px 0 6px">${title} (${items.length}) <a class="act ghost" href="/__ioi/odk/${family}/new">+ ${newLabel}</a></h3>${items.length ? items.map((x) => odkCard(family, x, nameKey)).join("") : `<div class="empty">None bound to this ontology.</div>`}`;
   const resourcesPane = `<h2 id="pane-resources">Resources <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— bound to ${selected ? CX_ESC(selected.domain) : "—"}</span></h2>`
     + `<h3 style="margin:12px 0 6px">Connector mappings (${maps.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— source fields → object properties · daemon truth · inert</span></h3>${omConnectorMappings(maps)}`
@@ -3171,6 +3187,7 @@ function renderOntologyManager(ov, lists, selectedId) {
     + `<h3 style="margin:12px 0 6px">Ontology projections (${projs.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the declared explorer/search shape · daemon truth · no materialized objects</span></h3>${projs.length ? projs.map((p) => `<div class="chips" style="margin:0 0 6px"><b>${CX_ESC(p.name || p.id)}</b> <span class="pill ${p.status === "ready" ? "ok" : p.status === "blocked" ? "warn" : "muted"}">${CX_ESC(p.status || "draft")}</span> <span class="pill muted">${(p.visible_properties || []).length} visible</span> <span class="pill warn" title="shape only — nothing materialized">0 objects</span> <span class="sub" style="margin:0"><code>${CX_ESC(p.ref || "")}</code></span></div>`).join("") : `<div class="empty">No projections. A projection declares what an authorized explorer <b>would</b> render — shape only, never rows.</div>`}`
     + `<h3 style="margin:12px 0 6px">Capability-lease plans (${lplans.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— declared credential authority · gateway: the capability-lease primitive · nothing minted</span></h3>${omLeasePlans(lplans)}`
     + `<h3 style="margin:12px 0 6px">Materializing runs (${mruns.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— live lease acquisition against the gateway · no execution, no rows</span></h3>${omMaterializingRuns(mruns)}`
+    + `<h3 style="margin:12px 0 6px">Sealed connector sessions (${csns.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— credential resolution proven, material never surfaced · no source contact</span></h3>${omConnectorSessions(csns)}`
     + resourceSection("Data recipes", "data-recipes", recs, "name", "New recipe")
     + resourceSection("Surface descriptors", "surface-descriptors", descs, "name", "New descriptor")
     + resourceSection("ODK manifests", "manifests", mans, "name", "New manifest");
@@ -3187,7 +3204,7 @@ function renderOntologyManager(ov, lists, selectedId) {
     : `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill muted">unavailable</span></h2>`
       + omBoundaryNote(`This ontology binds <b>no object-instance plane</b>, so there are <b>no rows to explore</b> — declare an OntologyProjection to give this lane its read/search shape; rows still require a future materializing run under credential authority. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`);
   const explorerPane = explorerHead
-    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— five declared rungs + the first live crossing; execution and rows remain</span></h3>` + omContractLadder(maps.length, pviews.length, truns.length, projs.length, lplans.length, mruns.filter((r) => r.status === "lease_obtained").length);
+    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— five declared rungs + the first live crossing; execution and rows remain</span></h3>` + omContractLadder(maps.length, pviews.length, truns.length, projs.length, lplans.length, mruns.filter((r) => r.status === "lease_obtained").length, csns.filter((c) => c.status === "session_obtained").length);
 
   const counts = { "object-types": ots.length, "properties": propCount, "link-types": lts.length, "action-types": nonFuncActs.length, "value-types": vts.length, "groups": 0, "interfaces": 0, "functions": funcs.length };
   const panes = objectTypesPane + propertiesPane + linkPane + actionPane + valuePane
@@ -6740,7 +6757,7 @@ const server = http.createServer((req, res) => {
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
     if (pathname === "/__ioi/odk" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
-      const [ov, o, r, d, m, ds, cm, pv, tr, op, lp, mr] = await Promise.all([
+      const [ov, o, r, d, m, ds, cm, pv, tr, op, lp, mr, cs] = await Promise.all([
         J("/v1/hypervisor/odk/overview"),
         J("/v1/hypervisor/odk/domain-ontologies"),
         J("/v1/hypervisor/odk/data-recipes"),
@@ -6753,6 +6770,7 @@ const server = http.createServer((req, res) => {
         J("/v1/hypervisor/odk/ontology-projections"),
         J("/v1/hypervisor/odk/capability-lease-plans"),
         J("/v1/hypervisor/odk/materializing-runs"),
+        J("/v1/hypervisor/odk/connector-sessions"),
       ]);
       const selectedOntology = new URL(req.url, "http://x").searchParams.get("ontology") || "";
       res.writeHead(200, HTMLH);
@@ -6768,6 +6786,7 @@ const server = http.createServer((req, res) => {
         ontology_projections: op.ontology_projections || [],
         capability_lease_plans: lp.capability_lease_plans || [],
         materializing_runs: mr.materializing_runs || [],
+        connector_sessions: cs.connector_sessions || [],
       }, selectedOntology));
       return;
     }

--- a/apps/hypervisor/scripts/verify-hypervisor-connector-session.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-connector-session.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// Sealed connector session done-bar — the CREDENTIAL-HANDLING crossing, split from execution.
+//
+// A MaterializingRun that HOLDS its CapabilityLease may open a sealed connector session: a SECOND
+// crossing through the SAME gateway with credential_required:true. The gateway resolves the SEALED
+// credential server-side and mints the session's lease; the session PROVES resolution is authorized
+// for the exact lease scope — and nothing more. No credential material is stored, logged, returned,
+// or receipted; no source is contacted; no rows exist. Execution is the next cut (#20).
+//
+// Asserts:
+//   - THE 428 LANE: without a sealed credential the gateway fails closed (verbatim, receipted)
+//     BEFORE any wallet consideration.
+//   - THE CROSSING: seal a SENTINEL bearer into the connector estate → 403 challenge → real
+//     dcrypt-signed grant → session_obtained; the gateway audit trail grows; only non-secret labels
+//     (credential_source, credential_key_source) land on the record.
+//   - SENTINEL LEAK SWEEP: the raw token appears NOWHERE — response, session records dir, receipts
+//     dir, run records dir.
+//   - Scope discipline: scope is never restated (verbatim from the lease); TTL narrows only; scope
+//     frozen; every bypass lane rejected; run must HOLD its lease; ladder drift blocks; local
+//     source kinds refused.
+//   - Receipts: created/session_requested/session_refused/session_obtained/session_released (+
+//     patch_rejected) — the full crossing story, credential-free.
+//   - object_instances stays 0; ladder shows Sealed connector session (live) with Connector
+//     execution + Materialized rows still missing; brand-clean.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-connector-session.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { mintApprovalGrant } from "../../../scripts/lib/mint-approval-grant.mjs";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+const DATA = process.env.IOI_HYPERVISOR_DATA_DIR || path.join(os.homedir(), ".ioi", "hypervisor", "data");
+const SENTINEL = "fixture-bearer-SENTINEL-do-not-leak";
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+function dirContains(dir, needle) {
+  try {
+    return readdirSync(dir).some((f) => {
+      try { return readFileSync(path.join(dir, f), "utf8").includes(needle); } catch { return false; }
+    });
+  } catch { return false; }
+}
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/connector-sessions/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon connector-session plane not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+  const track = (kind, id) => { if (id) cleanup.push(["DELETE", `/v1/hypervisor/odk/${kind}/${id}`]); };
+
+  // Full ladder → plan → run → OBTAINED lease (the #18 crossing, exercised as a fixture).
+  const dsR = await jd("POST", "/v1/hypervisor/data-sources", { name: "csn-verify-src", kind: "postgres", endpoint: "postgres://unreachable.invalid:5432/db", credential_posture: "wallet_credential_lease" });
+  const dataSourceId = dsR.j.data_source?.source_id;
+  if (dataSourceId) cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${dataSourceId}`]);
+  const ontR = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "csn-verify", canonical_object_model: {
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" } ] }],
+    action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }],
+  } });
+  const ontId = ontR.j.ontology?.id; const ontRef = ontR.j.ontology?.ref;
+  track("domain-ontologies", ontId);
+  const mapR = await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "csn-verify-map", data_source_id: dataSourceId, ontology_ref: ontRef, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" } });
+  const mapId = mapR.j.connector_mapping?.id;
+  track("connector-mappings", mapId);
+  const viewR = await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: mapId, name: "csn-verify-gate", authority_subjects: ["agent://materializer"],
+    allowed_operations: ["read", "transform"], purpose: "underwriting analysis", property_scope: ["loan_id", "title"], retention_posture: "bounded" });
+  const viewId = viewR.j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", viewId);
+  const trunR = await jd("POST", "/v1/hypervisor/odk/transformation-runs", { connector_mapping_id: mapId, policy_view_id: viewId, name: "csn-verify-trun" });
+  const trunId = trunR.j.transformation_run?.id;
+  track("transformation-runs", trunId);
+  await jd("POST", `/v1/hypervisor/odk/transformation-runs/${trunId}/dry-run`);
+  const projR = await jd("POST", "/v1/hypervisor/odk/ontology-projections", { connector_mapping_id: mapId, policy_view_id: viewId, name: "csn-verify-explorer", visible_properties: ["loan_id", "title"] });
+  const projId = projR.j.ontology_projection?.id;
+  track("ontology-projections", projId);
+  const planR = await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", { data_source_id: dataSourceId, connector_mapping_id: mapId, policy_view_id: viewId,
+    transformation_run_id: trunId, ontology_projection_id: projId, name: "csn-verify-plan", subject: "agent://materializer", ttl_seconds: 900 });
+  const planId = planR.j.capability_lease_plan?.id;
+  track("capability-lease-plans", planId);
+  const mrunR = await jd("POST", "/v1/hypervisor/odk/materializing-runs", { capability_lease_plan_id: planId, name: "csn-verify-mrun" });
+  const mrunId = mrunR.j.materializing_run?.id;
+  track("materializing-runs", mrunId);
+  const ch1 = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrunId}/acquire-lease`, {});
+  const g1 = mintApprovalGrant({ policyHash: ch1.j.approval?.policy_hash, requestHash: ch1.j.approval?.request_hash });
+  const leased = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrunId}/acquire-lease`, { wallet_approval_grant: g1 });
+  ok("fixture: the run HOLDS its lease (#18 crossing green)", leased.j.materializing_run?.status === "lease_obtained");
+  // A second, lease-less run for the not-obtained lane.
+  const mrun2R = await jd("POST", "/v1/hypervisor/odk/materializing-runs", { capability_lease_plan_id: planId, name: "csn-verify-noleaserun" });
+  const mrun2Id = mrun2R.j.materializing_run?.id;
+  track("materializing-runs", mrun2Id);
+  // Connector fixture (NO credential yet).
+  const connR = await jd("POST", "/v1/hypervisor/connectors", { service: "odk-csn-fixture", base_url: "https://db.invalid", name: "ODK Session Fixture" });
+  const connId = connR.j.connector?.connector_id || connR.j.connector_id;
+  if (!dataSourceId || !mapId || !viewId || !trunId || !projId || !planId || !mrunId || !connId) { console.error("BLOCKED: fixtures failed"); process.exit(2); }
+
+  // 1. Session request admitted — scope inherited VERBATIM, never restated.
+  const sR = await jd("POST", "/v1/hypervisor/odk/connector-sessions", { materializing_run_id: mrunId, connector_id: connId, name: "loans-session", ttl_seconds: 300 });
+  const s0 = sR.j.connector_session;
+  track("connector-sessions", s0?.id);
+  ok("session request admitted (201, requested) with the lease scope snapshotted verbatim", sR.status === 201 && s0?.status === "requested" && JSON.stringify(s0?.properties) === JSON.stringify(["loan_id", "title"]) && JSON.stringify(s0?.operations) === JSON.stringify(["read", "transform"]));
+  ok("session TTL narrows the run's (300 ≤ 900); inert; both cuts named", s0?.ttl_seconds === 300 && s0?.execution?.object_instances === 0 && JSON.stringify(s0?.missing_authority) === JSON.stringify(["ConnectorExecution", "MaterializedRows"]));
+
+  // 2. THE 428 LANE: no sealed credential → fail-closed before any wallet consideration.
+  const r428 = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${s0.id}/open`, {});
+  ok("without a sealed credential the gateway fails closed 428 (verbatim, receipted)", r428.status === 428 && /credential_required/.test(r428.j.reason || ""));
+
+  // 3. Seal the SENTINEL bearer → 403 challenge → real grant → session_obtained.
+  const bind = await jd("POST", `/v1/hypervisor/connectors/${connId}/credential`, { token: SENTINEL });
+  ok("SENTINEL bearer sealed into the connector estate (token-lease:bound)", bind.j.ok === true && bind.j.auth_posture === "token-lease:bound");
+  const ch2 = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${s0.id}/open`, {});
+  ok("with the credential sealed, the wallet gate challenges (403 + hashes)", ch2.status === 403 && ch2.j.reason === "odk_connector_session_authority_required" && !!ch2.j.approval?.policy_hash);
+  const g2 = mintApprovalGrant({ policyHash: ch2.j.approval.policy_hash, requestHash: ch2.j.approval.request_hash });
+  const before = ((await jd("GET", "/v1/hypervisor/capability-leases")).j.leases || []).length;
+  const opened = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${s0.id}/open`, { wallet_approval_grant: g2 });
+  const ss = opened.j.connector_session;
+  ok("session obtained — the gateway resolved the sealed credential and minted the session lease", opened.status === 200 && ss?.status === "session_obtained" && String(ss?.session?.session_ref || "").startsWith("sealed-session://"));
+  const after = ((await jd("GET", "/v1/hypervisor/capability-leases")).j.leases || []).length;
+  ok("the session lease is REAL (gateway audit trail grew)", after === before + 1, `${before} → ${after}`);
+  ok("only non-secret labels landed (credential_source/credential_key_source)", ss?.session?.credential_descriptor?.credential_source === "connector" && !!ss?.session?.credential_descriptor?.credential_key_source && ss?.session?.credential_material === false);
+  ok("still inert: source_contacted false, object_instances 0", ss?.execution?.source_contacted === false && ss?.execution?.object_instances === 0);
+
+  // 4. SENTINEL LEAK SWEEP — the raw bearer exists ONLY in the sealed store, nowhere else.
+  ok("SENTINEL absent from the open response", !JSON.stringify(opened.j).includes(SENTINEL));
+  ok("SENTINEL absent from session records on disk", !dirContains(path.join(DATA, "odk-connector-sessions"), SENTINEL));
+  ok("SENTINEL absent from session receipts on disk", !dirContains(path.join(DATA, "odk-connector-session-receipts"), SENTINEL));
+  ok("SENTINEL absent from materializing-run records on disk", !dirContains(path.join(DATA, "odk-materializing-runs"), SENTINEL));
+  ok("SENTINEL absent from the gateway lease descriptors", !((await jd("GET", "/v1/hypervisor/capability-leases")).j.leases || []).some((l) => JSON.stringify(l).includes(SENTINEL)));
+
+  // 5. Guards + fail-closed lanes.
+  const reopen = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${s0.id}/open`, { wallet_approval_grant: g2 });
+  ok("re-open refused (one session per request)", reopen.j.error?.code === "session_already_obtained");
+  const frozen = await jd("PATCH", `/v1/hypervisor/odk/connector-sessions/${s0.id}`, { ttl_seconds: 60 });
+  ok("scope frozen from birth (receipted refusal)", frozen.j.error?.code === "session_scope_frozen");
+  const reject = async (label, body, code) => {
+    const r = await jd("POST", "/v1/hypervisor/odk/connector-sessions", body);
+    ok(`fail-closed: ${label}`, r.status === 400 && r.j.error?.code === code, r.j.error?.code || `status ${r.status}`);
+    track("connector-sessions", r.j?.connector_session?.id);
+  };
+  await reject("scope restated (verbatim binding, no restatement)", { materializing_run_id: mrunId, connector_id: connId, name: "x", requested_properties: ["loan_id"] }, "session_scope_widening_rejected");
+  await reject("plaintext secret", { materializing_run_id: mrunId, connector_id: connId, name: "x", password: "h" }, "session_plaintext_secret_rejected");
+  await reject("raw query body", { materializing_run_id: mrunId, connector_id: connId, name: "x", sql: "SELECT 1" }, "session_raw_query_rejected");
+  await reject("env-credential fallback", { materializing_run_id: mrunId, connector_id: connId, name: "x", from_env: "PGPASSWORD" }, "session_env_fallback_rejected");
+  await reject("missing name", { materializing_run_id: mrunId, connector_id: connId }, "session_name_required");
+  await reject("unknown run", { materializing_run_id: "mrun_nope", connector_id: connId, name: "x" }, "session_run_unknown");
+  await reject("run does not HOLD its lease", { materializing_run_id: mrun2Id, connector_id: connId, name: "x" }, "session_lease_not_obtained");
+  await reject("unknown connector", { materializing_run_id: mrunId, connector_id: "conn_nope", name: "x" }, "session_connector_unknown");
+  await reject("TTL widening (9999 > run's 900)", { materializing_run_id: mrunId, connector_id: connId, name: "x", ttl_seconds: 9999 }, "session_ttl_widening_rejected");
+
+  // 6. Release + receipts tell the whole story, credential-free.
+  const rel = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${s0.id}/release`);
+  ok("release is receipted + terminal", rel.j.connector_session?.status === "session_released" && rel.j.connector_session?.session?.obtained === false);
+  const hist = await jd("GET", `/v1/hypervisor/odk/connector-sessions/${s0.id}/history`);
+  const opsSeen = (hist.j.receipts || []).map((x) => x.op);
+  ok("receipts: created/session_requested/session_refused/session_obtained/session_released", ["created", "session_requested", "session_refused", "session_obtained", "session_released"].every((o) => opsSeen.includes(o)), opsSeen.join(","));
+  const ov = await jd("GET", "/v1/hypervisor/odk/connector-sessions/overview");
+  ok("overview: credential-handling-only governance gaps + labels-only doctrine", (ov.j.governance_gaps || []).some((g) => /never stored, logged, returned/i.test(g)) && (ov.j.governance_gaps || []).some((g) => /NEXT cut/i.test(g)));
+  const allS = await jd("GET", "/v1/hypervisor/odk/connector-sessions");
+  ok("no session anywhere reports contact or instances", (allS.j.connector_sessions || []).every((c) => c.execution?.source_contacted === false && c.execution?.object_instances === 0));
+
+  // 7. UX ladder.
+  const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+  const t = page.text;
+  ok("Manager renders sealed sessions (Resources, 'sealed · no contact')", page.status === 200 && /Sealed connector sessions \(\d+\)/.test(t) && /sealed · no contact/.test(t));
+  ok("ladder rung 7: Sealed connector session (live)", /Sealed connector session<\/code> <span class="pill ok">live/.test(t));
+  ok("ladder: Connector execution + Materialized rows still missing", /Connector execution<\/code> <span class="pill muted">missing/.test(t) && /Materialized rows<\/code> <span class="pill muted">missing/.test(t));
+  ok("0-objects boundary preserved; brand-clean", /0 objects/.test(t) && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
+
+  // Cleanup — draft/test records removed; connector credential revoked; connector removed.
+  for (const [method, p] of cleanup.reverse()) await jd(method, p);
+  await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}/credential`, { method: "DELETE" }).catch(() => {});
+  await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}`, { method: "DELETE" }).catch(() => {});
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`connector-session readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -100,6 +100,8 @@ mod ontology_projection_routes;
 mod capability_lease_plan_routes;
 #[path = "hypervisor_daemon_routes/materializing_run_routes.rs"]
 mod materializing_run_routes;
+#[path = "hypervisor_daemon_routes/connector_session_routes.rs"]
+mod connector_session_routes;
 #[path = "hypervisor_daemon_routes/harness_routes.rs"]
 mod harness_routes;
 #[path = "hypervisor_daemon_routes/model_routes.rs"]
@@ -1277,6 +1279,40 @@ async fn async_main() -> anyhow::Result<()> {
         .route(
             "/v1/hypervisor/odk/materializing-runs/:id/cancel",
             post(materializing_run_routes::handle_mrun_cancel),
+        )
+        // Sealed connector session — the credential-handling crossing: a lease-holding run opens a
+        // sealed session through the SAME gateway (credential_required:true). Labels only, no
+        // credential material, no source contact; execution is the next cut.
+        .route(
+            "/v1/hypervisor/odk/connector-sessions",
+            get(connector_session_routes::handle_sessions_list)
+                .post(connector_session_routes::handle_session_create),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-sessions/overview",
+            get(connector_session_routes::handle_sessions_overview),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-sessions/:id",
+            get(connector_session_routes::handle_session_get)
+                .patch(connector_session_routes::handle_session_patch)
+                .delete(connector_session_routes::handle_session_delete),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-sessions/:id/history",
+            get(connector_session_routes::handle_session_history),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-sessions/:id/open",
+            post(connector_session_routes::handle_session_open),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-sessions/:id/release",
+            post(connector_session_routes::handle_session_release),
+        )
+        .route(
+            "/v1/hypervisor/odk/connector-sessions/:id/cancel",
+            post(connector_session_routes::handle_session_cancel),
         )
         .route(
             "/v1/hypervisor/odk/data-recipes",

--- a/crates/node/src/bin/hypervisor_daemon_routes/connector_session_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/connector_session_routes.rs
@@ -1,0 +1,475 @@
+//! Sealed connector session — the CREDENTIAL-HANDLING crossing, split from execution. A
+//! MaterializingRun that HOLDS its CapabilityLease (#18) may request a sealed connector session:
+//! a SECOND crossing through the SAME gateway, this time with `credential_required: true` — the
+//! gateway resolves the SEALED backing credential server-side (fail-closed 428 if unresolved),
+//! verifies a fresh bound wallet grant, and mints the session's lease descriptor. The session
+//! PROVES credential resolution is authorized for the exact lease scope — and nothing more:
+//! it does not expose credential material and does not contact the source.
+//!
+//! Boundaries held hard:
+//!   * the resolved bearer token is DROPPED — never stored, logged, returned, or receipted;
+//!     only non-secret LABELS land on the record (credential_source, credential_key_source);
+//!   * no source rows are extracted, no data transformed, no output registered, no object
+//!     instances created, no explorer rows — connector execution is the NEXT cut (#20);
+//!   * the session binds the run's lease scope VERBATIM — restating or widening scope is refused;
+//!     the session TTL may only narrow the run's;
+//!   * receipts record session_requested, the gateway decision, the session/descriptor refs, the
+//!     lease id, bounded TTL, scope, refusal reasons, release/cancel.
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+
+use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState};
+use crate::lifecycle_routes::{authorize_capability_lease, CapabilityLeaseRequest};
+
+const SESSION_SCHEMA: &str = "ioi.hypervisor.odk.connector-session.v1";
+const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.connector-session-receipt.v1";
+const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.connector-sessions-overview.v1";
+const RECORD_DIR: &str = "odk-connector-sessions";
+const RECEIPT_DIR: &str = "odk-connector-session-receipts";
+
+/// Lifecycle: a session request exists, may be opened (the crossing), and released — nothing reads.
+const LIFECYCLE_STATES: &[&str] = &["requested", "session_obtained", "session_released", "cancelled"];
+/// What still does not exist after this rung.
+const MISSING_AUTHORITY: &[&str] = &["ConnectorExecution", "MaterializedRows"];
+const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
+const RAW_QUERY_KEYS: &[&str] = &["query", "sql", "raw_query", "statement", "command"];
+const ENV_FALLBACK_KEYS: &[&str] = &["env", "env_var", "env_credential", "credential_env", "from_env"];
+/// A session may not restate the lease scope at all — the lease scope binds verbatim.
+const SCOPE_KEYS: &[&str] = &["requested_properties", "requested_operations", "subject", "purpose", "property_scope"];
+
+fn nanos() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0)
+}
+fn now_ms() -> i64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as i64).unwrap_or(0)
+}
+fn s(v: &Value, k: &str, d: &str) -> String {
+    v.get(k).and_then(|x| x.as_str()).unwrap_or(d).to_string()
+}
+fn opt_s(v: &Value, k: &str) -> Option<String> {
+    v.get(k).and_then(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string)
+}
+fn str_list(v: &Value, k: &str) -> Vec<String> {
+    v.get(k)
+        .and_then(|x| x.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str()).map(str::trim).filter(|x| !x.is_empty()).map(str::to_string).collect())
+        .unwrap_or_default()
+}
+type VErr = (String, String);
+fn verr(code: &str, msg: String) -> VErr {
+    (code.to_string(), msg)
+}
+fn find_by_key(data_dir: &str, dir: &str, key: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, dir).into_iter().find(|r| r.get(key).and_then(|v| v.as_str()) == Some(id))
+}
+/// A lease is expired only when it DECLARES an expiry in the past.
+fn lease_expired(expires_at: &Value, now_millis: i64) -> bool {
+    expires_at.as_i64().map(|e| e < now_millis).unwrap_or(false)
+}
+/// The #10 source kinds that need a network session (local kinds have nothing to open).
+fn source_kind_networked(kind: &str) -> bool {
+    !matches!(kind, "file_drop" | "local_folder")
+}
+
+/// Everything a session needs, resolved fresh: the run (holding its lease), its plan, the connector.
+struct SessionInputs {
+    run: Value,
+    connector_id: String,
+    ttl_seconds: u64,
+}
+
+/// Validate fail-closed against CURRENT truth: bypass guards, a lease-holding run whose ladder still
+/// matches, a networked source, a registered connector, and a TTL that only narrows the run's.
+fn validate_inputs(data_dir: &str, body: &Value) -> Result<SessionInputs, VErr> {
+    if let Some(obj) = body.as_object() {
+        if PLAINTEXT_SECRET_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("session_plaintext_secret_rejected", "A connector session never carries credential material — the gateway resolves the sealed credential server-side.".into()));
+        }
+        if RAW_QUERY_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("session_raw_query_rejected", "A connector session never carries a raw source query.".into()));
+        }
+        if ENV_FALLBACK_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("session_env_fallback_rejected", "Environment-credential fallback is an authority bypass.".into()));
+        }
+        if SCOPE_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return Err(verr("session_scope_widening_rejected", "A session binds the run's lease scope VERBATIM — scope is not restated here, narrower or wider.".into()));
+        }
+    }
+    if opt_s(body, "name").is_none() {
+        return Err(verr("session_name_required", "A connector session requires a name.".into()));
+    }
+    // The run: must exist and HOLD its lease.
+    let run_id = opt_s(body, "materializing_run_id").unwrap_or_default();
+    let run = find_by_key(data_dir, crate::materializing_run_routes::RECORD_DIR, "id", &run_id)
+        .ok_or_else(|| verr("session_run_unknown", format!("materializing_run_id '{run_id}' does not resolve")))?;
+    if s(&run, "status", "") != "lease_obtained" {
+        return Err(verr("session_lease_not_obtained", format!("run '{run_id}' is '{}' — a session requires a run that HOLDS its lease", s(&run, "status", ""))));
+    }
+    if lease_expired(run.pointer("/lease/expires_at").unwrap_or(&Value::Null), now_ms()) {
+        return Err(verr("session_lease_expired", "the run's lease has expired — re-acquire before opening a session".into()));
+    }
+    // The ladder beneath the lease must STILL match (drift discipline — same check as #18, reused).
+    let plan_id = s(&run, "capability_lease_plan_id", "");
+    let plan = find_by_key(data_dir, crate::capability_lease_plan_routes::RECORD_DIR, "id", &plan_id)
+        .ok_or_else(|| verr("session_ladder_drift", format!("the run's plan '{plan_id}' no longer resolves")))?;
+    if let Err(drift) = crate::materializing_run_routes::check_plan_against_truth(data_dir, &plan) {
+        return Err(verr("session_ladder_drift", format!("the ladder no longer matches the lease scope: {drift}")));
+    }
+    // The source must be a networked kind (a local kind has no session to open) — its posture was
+    // already proven wallet-leaseable by the drift check.
+    let source_id = s(&plan, "data_source_id", "");
+    let source = find_by_key(data_dir, crate::data_source_routes::RECORD_DIR, "source_id", &source_id)
+        .ok_or_else(|| verr("session_ladder_drift", format!("data source '{source_id}' no longer resolves")))?;
+    let kind = s(&source, "kind", "");
+    if !source_kind_networked(&kind) {
+        return Err(verr("session_source_kind_unsupported", format!("source kind '{kind}' has no connector session to open (local kinds are read in-place by a future execution cut)")));
+    }
+    // The connector that HOLDS the sealed credential must be registered in the connector estate.
+    let connector_id = opt_s(body, "connector_id").unwrap_or_default();
+    if find_by_key(data_dir, "connectors", "connector_id", &connector_id).is_none() {
+        return Err(verr("session_connector_unknown", format!("connector_id '{connector_id}' is not registered in the connector estate")));
+    }
+    // TTL: bounded by the run's (which was bounded by the plan's).
+    let run_ttl = run.get("ttl_seconds").and_then(|v| v.as_u64()).unwrap_or(0);
+    let ttl_seconds = body.get("ttl_seconds").and_then(|v| v.as_u64()).unwrap_or(run_ttl);
+    if ttl_seconds == 0 || ttl_seconds > run_ttl {
+        return Err(verr("session_ttl_widening_rejected", format!("ttl_seconds must be 1..={run_ttl} (the run's lease bound) — a session can only narrow")));
+    }
+    Ok(SessionInputs { run, connector_id, ttl_seconds })
+}
+
+fn session_receipt(data_dir: &str, session_ref: &str, op: &str, outcome: &str, summary: &str) -> Value {
+    let id = format!("csr_{:x}", nanos());
+    let receipt_ref = format!("agentgres://connector-session-receipt/{id}");
+    let rec = json!({
+        "schema_version": RECEIPT_SCHEMA, "receipt_id": id, "receipt_ref": receipt_ref,
+        "connector_session_ref": session_ref, "op": op, "outcome": outcome, "summary": summary, "at": iso_now()
+    });
+    let _ = persist_record(data_dir, RECEIPT_DIR, &id, &rec);
+    rec
+}
+fn push_history(record: &mut Value, op: &str, summary: &str, receipt_ref: Value) {
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1);
+    let mut hist = record.get("history").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    hist.push(json!({ "revision": rev, "op": op, "at": iso_now(), "summary": summary, "receipt_ref": receipt_ref.clone() }));
+    let len = hist.len();
+    if len > 20 {
+        hist = hist[len - 20..].to_vec();
+    }
+    record["history"] = json!(hist);
+    let mut refs = record.get("receipt_refs").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    refs.push(receipt_ref);
+    record["receipt_refs"] = json!(refs);
+}
+fn bad(data_dir: &str, op: &str, err: VErr) -> (StatusCode, Json<Value>) {
+    let _ = session_receipt(data_dir, "connector-session://unadmitted", op, &err.0, &err.1);
+    (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": err.0, "message": err.1 } })))
+}
+fn load_session(data_dir: &str, id: &str) -> Option<Value> {
+    find_by_key(data_dir, RECORD_DIR, "id", id)
+}
+
+/// GET /v1/hypervisor/odk/connector-sessions.
+pub(crate) async fn handle_sessions_list(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let mut items = read_record_dir(&st.data_dir, RECORD_DIR);
+    items.sort_by(|a, b| s(b, "updated_at", "").cmp(&s(a, "updated_at", "")));
+    Json(json!({ "ok": true, "schema_version": SESSION_SCHEMA, "connector_sessions": items, "runtimeTruthSource": "daemon-runtime" }))
+}
+
+/// GET /v1/hypervisor/odk/connector-sessions/overview.
+pub(crate) async fn handle_sessions_overview(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let items = read_record_dir(&st.data_dir, RECORD_DIR);
+    let by = |status: &str| items.iter().filter(|r| s(r, "status", "") == status).count();
+    Json(json!({
+        "ok": true,
+        "schema_version": OVERVIEW_SCHEMA,
+        "connector_sessions": items.len(),
+        "lifecycle": { "requested": by("requested"), "session_obtained": by("session_obtained"), "session_released": by("session_released"), "cancelled": by("cancelled") },
+        "lifecycle_states": LIFECYCLE_STATES,
+        "missing_authority": MISSING_AUTHORITY,
+        "governance_gaps": [
+            "CREDENTIAL-HANDLING crossing only — the gateway resolves the SEALED credential server-side and mints the session; the session proves resolution is authorized for the exact lease scope",
+            "credential material is never stored, logged, returned, or receipted — only non-secret labels (credential_source, credential_key_source) land on the record",
+            "the source is never contacted; no rows are extracted, no output registered — connector execution and materialized rows are the NEXT cut",
+            "the session binds the run's lease scope VERBATIM; restating scope is refused; TTL may only narrow"
+        ],
+        "runtimeTruthSource": "daemon-runtime"
+    }))
+}
+
+/// GET /v1/hypervisor/odk/connector-sessions/:id.
+pub(crate) async fn handle_session_get(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    match load_session(&st.data_dir, &id) {
+        Some(r) => (StatusCode::OK, Json(json!({ "ok": true, "connector_session": r }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "connector session not found" }))),
+    }
+}
+
+/// GET /v1/hypervisor/odk/connector-sessions/:id/history.
+pub(crate) async fn handle_session_history(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(r) = load_session(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "connector session not found" })));
+    };
+    let sref = s(&r, "ref", "");
+    let mut receipts = read_record_dir(&st.data_dir, RECEIPT_DIR);
+    receipts.retain(|x| x.get("connector_session_ref").and_then(|v| v.as_str()) == Some(sref.as_str()));
+    receipts.sort_by(|a, b| s(b, "at", "").cmp(&s(a, "at", "")));
+    (StatusCode::OK, Json(json!({ "ok": true, "connector_session_ref": sref, "revision": r.get("revision"), "status": r.get("status"), "history": r.get("history").cloned().unwrap_or(json!([])), "receipts": receipts })))
+}
+
+/// POST /v1/hypervisor/odk/connector-sessions — admit a session request (no crossing yet).
+pub(crate) async fn handle_session_create(State(st): State<Arc<DaemonState>>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    let inputs = match validate_inputs(&st.data_dir, &body) {
+        Ok(i) => i,
+        Err(e) => return bad(&st.data_dir, "create_rejected", e),
+    };
+    let id = format!("csn_{:x}", nanos());
+    let now = iso_now();
+    let sref = format!("connector-session://{id}");
+    let receipt = session_receipt(&st.data_dir, &sref, "created", "ok", "connector session requested (no crossing yet)");
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    let run = &inputs.run;
+    let record = json!({
+        "schema_version": SESSION_SCHEMA,
+        "object": "ioi.hypervisor.odk.connector_session",
+        "id": id,
+        "ref": sref,
+        "name": s(&body, "name", "connector-session"),
+        "description": s(&body, "description", ""),
+        "status": "requested",
+        "materializing_run_id": run.get("id").cloned().unwrap_or(Value::Null),
+        "materializing_run_ref": run.get("ref").cloned().unwrap_or(Value::Null),
+        "lease_id": run.pointer("/lease/lease_id").cloned().unwrap_or(Value::Null),
+        "ontology_ref": run.get("ontology_ref").cloned().unwrap_or(Value::Null),
+        "object_type_id": run.get("object_type_id").cloned().unwrap_or(Value::Null),
+        "connector_id": inputs.connector_id,
+        // The lease scope binds VERBATIM — snapshotted for the record, never restated by the caller.
+        "subject": run.get("subject").cloned().unwrap_or(Value::Null),
+        "purpose": run.get("purpose").cloned().unwrap_or(Value::Null),
+        "operations": run.get("requested_operations").cloned().unwrap_or(json!([])),
+        "properties": run.get("requested_properties").cloned().unwrap_or(json!([])),
+        "ttl_seconds": inputs.ttl_seconds,
+        "session": { "obtained": false, "credential_material": false },
+        "execution": { "source_contacted": false, "data_moved": false, "rows_extracted": 0, "object_instances": 0, "note": "credential-handling crossing only — execution is the next cut" },
+        "missing_authority": MISSING_AUTHORITY,
+        "revision": 1,
+        "receipt_refs": [receipt_ref.clone()],
+        "history": [ { "revision": 1, "op": "created", "at": now.clone(), "summary": "connector session requested (no crossing yet)", "receipt_ref": receipt_ref } ],
+        "created_at": now.clone(),
+        "updated_at": now
+    });
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::CREATED, Json(json!({ "ok": true, "connector_session": record })))
+}
+
+/// POST /:id/open — THE credential-handling crossing. Re-validates everything, then crosses the
+/// SAME gateway with credential_required:true: the sealed credential resolves server-side (428 if
+/// unresolved), a fresh bound wallet grant is verified (403 challenge otherwise), and the session's
+/// lease descriptor mints. The resolved bearer is DROPPED; only non-secret labels land.
+pub(crate) async fn handle_session_open(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    let Some(mut record) = load_session(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "connector session not found" })));
+    };
+    let status = s(&record, "status", "");
+    if status == "session_obtained" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "session_already_obtained", "message": "the session is already open" } })));
+    }
+    if status == "cancelled" || status == "session_released" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "session_terminal_immutable", "message": format!("a {status} session is immutable") } })));
+    }
+    let sref = s(&record, "ref", "");
+    // Re-validate the whole chain at the moment of crossing — never cached.
+    let revalidation = json!({
+        "name": record.get("name").cloned().unwrap_or(Value::Null),
+        "materializing_run_id": record.get("materializing_run_id").cloned().unwrap_or(Value::Null),
+        "connector_id": record.get("connector_id").cloned().unwrap_or(Value::Null),
+        "ttl_seconds": record.get("ttl_seconds").cloned().unwrap_or(Value::Null),
+    });
+    if let Err(e) = validate_inputs(&st.data_dir, &revalidation) {
+        let _ = session_receipt(&st.data_dir, &sref, "session_refused", &e.0, &e.1);
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": e.0, "message": e.1 } })));
+    }
+    let connector_id = s(&record, "connector_id", "");
+    let operations = str_list(&record, "operations");
+    let properties = str_list(&record, "properties");
+    let ttl = record.get("ttl_seconds").and_then(|v| v.as_u64()).unwrap_or(0);
+    let lease_req = CapabilityLeaseRequest {
+        authority_provider_ref: "wallet.network".to_string(),
+        backing_provider: format!("connector:{connector_id}"),
+        allowed_tools: operations.iter().map(|o| format!("odk.session.{o}")).collect(),
+        resource_refs: vec![
+            s(&record, "materializing_run_ref", ""),
+            format!("capability-lease://{}", s(&record, "lease_id", "")),
+            connector_id.clone(),
+        ],
+        scopes: operations.clone(),
+        policy_domain: "hypervisor.odk.connector-session.policy.v1".to_string(),
+        request_domain: "hypervisor.odk.connector-session.request.v1".to_string(),
+        request_facets: json!({
+            "connector_session_id": s(&record, "id", ""),
+            "materializing_run_ref": s(&record, "materializing_run_ref", ""),
+            "lease_id": s(&record, "lease_id", ""),
+            "connector_id": connector_id,
+            "properties": properties,
+            "ttl_seconds": ttl
+        }),
+        credential_connector_id: Some(connector_id.clone()),
+        credential_store: "connector-credentials".to_string(),
+        credential_required: true,
+        github_host_fallback: false,
+        receipt_required: true,
+        revocation_ref: format!("connectors/{connector_id}/credential"),
+        authority_reason: "odk_connector_session_authority_required".to_string(),
+        grant_value: body.get("wallet_approval_grant").cloned().unwrap_or(Value::Null),
+    };
+    let _ = session_receipt(&st.data_dir, &sref, "session_requested", "ok", &format!("sealed session requested at the gateway: connector {connector_id} · ttl {ttl}s · {} properties", properties.len()));
+    match authorize_capability_lease(&st, &lease_req).await {
+        Err((code, challenge)) => {
+            // 428 (sealed credential unresolved) or 403 (authority challenge) — verbatim, receipted.
+            let reason = challenge.get("reason").and_then(|v| v.as_str()).unwrap_or("refused").to_string();
+            let _ = session_receipt(&st.data_dir, &sref, "session_refused", &reason, "gateway refused the crossing (challenge returned verbatim; no session opened)");
+            (code, Json(challenge))
+        }
+        Ok(lease) => {
+            // Non-secret labels ONLY; the resolved bearer is dropped here and nowhere else exists.
+            let credential_source = lease.credential_source.clone();
+            let credential_key_source = lease.credential_key_source.clone();
+            drop(lease.token);
+            let d = &lease.descriptor;
+            let session_lease_id = s(d, "lease_id", "");
+            record["status"] = json!("session_obtained");
+            record["session"] = json!({
+                "obtained": true,
+                "credential_material": false,
+                "session_ref": format!("sealed-session://{session_lease_id}"),
+                "gateway_lease_id": session_lease_id,
+                "credential_descriptor": {
+                    "credential_source": credential_source,
+                    "credential_key_source": credential_key_source,
+                    "note": "labels only — the sealed credential resolved server-side and was dropped"
+                },
+                "grant_ref": lease.grant_ref,
+                "policy_hash": d.get("policy_hash").cloned().unwrap_or(Value::Null),
+                "request_hash": d.get("request_hash").cloned().unwrap_or(Value::Null),
+                "expires_at": d.get("expires_at").cloned().unwrap_or(Value::Null),
+                "ttl_seconds": ttl
+            });
+            record["updated_at"] = json!(iso_now());
+            let receipt = session_receipt(&st.data_dir, &sref, "session_obtained", "ok", &format!("gateway opened sealed session {session_lease_id} (connector {}, ttl {ttl}s) — credential resolved server-side, labels only", s(&record, "connector_id", "")));
+            push_history(&mut record, "session_obtained", &format!("sealed session {session_lease_id} obtained"), receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+            let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+            (StatusCode::OK, Json(json!({ "ok": true, "connector_session": record })))
+        }
+    }
+}
+
+/// POST /:id/release — receipted release (terminal for this session).
+pub(crate) async fn handle_session_release(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(mut record) = load_session(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "connector session not found" })));
+    };
+    if s(&record, "status", "") != "session_obtained" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "session_nothing_to_release", "message": "the session is not open" } })));
+    }
+    let slid = record.pointer("/session/gateway_lease_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let receipt = session_receipt(&st.data_dir, &s(&record, "ref", ""), "session_released", "ok", &format!("sealed session {slid} released (never used — no execution exists)"));
+    record["status"] = json!("session_released");
+    record["session"]["obtained"] = json!(false);
+    record["session"]["released_at"] = json!(iso_now());
+    record["updated_at"] = json!(iso_now());
+    push_history(&mut record, "session_released", &format!("sealed session {slid} released"), receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::OK, Json(json!({ "ok": true, "connector_session": record })))
+}
+
+/// POST /:id/cancel — terminal from `requested`, receipted.
+pub(crate) async fn handle_session_cancel(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    let Some(mut record) = load_session(&st.data_dir, &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "connector session not found" })));
+    };
+    if s(&record, "status", "") != "requested" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "session_terminal_immutable", "message": "only a requested session can be cancelled (release an open one)" } })));
+    }
+    let receipt = session_receipt(&st.data_dir, &s(&record, "ref", ""), "cancelled", "ok", "connector session cancelled before any crossing");
+    record["status"] = json!("cancelled");
+    record["updated_at"] = json!(iso_now());
+    push_history(&mut record, "cancelled", "connector session cancelled before any crossing", receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    (StatusCode::OK, Json(json!({ "ok": true, "connector_session": record })))
+}
+
+/// PATCH — name/description ONLY; a session's scope is the lease's scope, frozen from birth.
+pub(crate) async fn handle_session_patch(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(patch): Json<Value>) -> Json<Value> {
+    let Some(mut record) = load_session(&st.data_dir, &id) else {
+        return Json(json!({ "ok": false, "reason": "connector session not found" }));
+    };
+    let status = s(&record, "status", "");
+    if status == "cancelled" || status == "session_released" {
+        return Json(json!({ "ok": false, "error": { "code": "session_terminal_immutable", "message": format!("a {status} session is immutable") } }));
+    }
+    let frozen = ["materializing_run_id", "connector_id", "ttl_seconds"];
+    if frozen.iter().chain(SCOPE_KEYS.iter()).any(|k| patch.get(*k).is_some()) {
+        let _ = session_receipt(&st.data_dir, &s(&record, "ref", ""), "patch_rejected", "session_scope_frozen", "scope-affecting patch refused — a session's scope is the lease's scope, frozen from birth");
+        return Json(json!({ "ok": false, "error": { "code": "session_scope_frozen", "message": "a session's scope binds the lease verbatim and is frozen — cancel and request a new one" } }));
+    }
+    if let Some(v) = patch.get("name") { record["name"] = v.clone(); }
+    if let Some(v) = patch.get("description") { record["description"] = v.clone(); }
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1) + 1;
+    record["revision"] = json!(rev);
+    record["updated_at"] = json!(iso_now());
+    let receipt = session_receipt(&st.data_dir, &s(&record, "ref", ""), "patched", "ok", "metadata edit");
+    push_history(&mut record, "patched", "metadata edit", receipt.get("receipt_ref").cloned().unwrap_or(Value::Null));
+    let _ = persist_record(&st.data_dir, RECORD_DIR, &id, &record);
+    Json(json!({ "ok": true, "connector_session": record }))
+}
+
+/// DELETE — receipted removal.
+pub(crate) async fn handle_session_delete(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> Json<Value> {
+    let sref = load_session(&st.data_dir, &id)
+        .and_then(|r| r.get("ref").and_then(|v| v.as_str()).map(str::to_string))
+        .unwrap_or_else(|| format!("connector-session://{id}"));
+    let removed = remove_record(&st.data_dir, RECORD_DIR, &id);
+    if removed {
+        let _ = session_receipt(&st.data_dir, &sref, "deleted", "ok", "connector session removed");
+    }
+    Json(json!({ "ok": removed, "removed": removed, "id": id }))
+}
+
+#[cfg(test)]
+mod connector_session_tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_and_missing_authority_are_explicit() {
+        assert_eq!(LIFECYCLE_STATES, &["requested", "session_obtained", "session_released", "cancelled"]);
+        assert_eq!(MISSING_AUTHORITY, &["ConnectorExecution", "MaterializedRows"]);
+    }
+
+    #[test]
+    fn lease_expiry_only_when_declared_and_past() {
+        assert!(lease_expired(&json!(1000), 2000));
+        assert!(!lease_expired(&json!(3000), 2000));
+        assert!(!lease_expired(&Value::Null, 2000));
+    }
+
+    #[test]
+    fn local_source_kinds_have_no_session() {
+        assert!(source_kind_networked("postgres"));
+        assert!(source_kind_networked("rest_api"));
+        assert!(!source_kind_networked("local_folder"));
+        assert!(!source_kind_networked("file_drop"));
+    }
+
+    #[test]
+    fn scope_keys_cover_every_restatement_path() {
+        for k in ["requested_properties", "requested_operations", "subject", "purpose", "property_scope"] {
+            assert!(SCOPE_KEYS.contains(&k));
+        }
+        assert!(ENV_FALLBACK_KEYS.contains(&"from_env"));
+    }
+}

--- a/crates/node/src/bin/hypervisor_daemon_routes/materializing_run_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/materializing_run_routes.rs
@@ -32,7 +32,7 @@ use crate::lifecycle_routes::{authorize_capability_lease, CapabilityLeaseRequest
 const RUN_SCHEMA: &str = "ioi.hypervisor.odk.materializing-run.v1";
 const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.materializing-run-receipt.v1";
 const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.materializing-runs-overview.v1";
-const RECORD_DIR: &str = "odk-materializing-runs";
+pub(crate) const RECORD_DIR: &str = "odk-materializing-runs";
 const RECEIPT_DIR: &str = "odk-materializing-run-receipts";
 
 /// Lifecycle: a run exists, may obtain its lease, and may release it — nothing executes.
@@ -84,7 +84,7 @@ struct RunInputs {
 
 /// Re-verify the cited plan against CURRENT ladder truth — the same drift discipline as every rung:
 /// the gate is checked at each act, never cached. Returns the drifted thing's name on failure.
-fn check_plan_against_truth(data_dir: &str, plan: &Value) -> Result<(), String> {
+pub(crate) fn check_plan_against_truth(data_dir: &str, plan: &Value) -> Result<(), String> {
     let source_id = s(plan, "data_source_id", "");
     let source = find_by_key(data_dir, crate::data_source_routes::RECORD_DIR, "source_id", &source_id)
         .ok_or_else(|| format!("data source '{source_id}' no longer resolves"))?;


### PR DESCRIPTION
**Base: master** (#18 merged). The second live crossing, split exactly as directed — **sealed credential handling only**: not extraction, not transformation, not materialization. The three remaining authorities stay separated: lease issuance (#18) · **credential handling (this)** · semantic materialization (#20).

## The crossing
A MaterializingRun that **holds** its CapabilityLease may open a sealed connector session — a **second crossing through the same gateway**, this time `credential_required: true`:
1. The gateway resolves the **sealed** backing credential server-side — **428 fail-closed if unresolved, before any wallet consideration**.
2. A **fresh** bound wallet grant is verified (403 challenge verbatim otherwise) — credential handling is its own authority, not inherited from the lease.
3. The session's lease descriptor mints. The resolved bearer is **dropped**; only non-secret labels land (`credential_source: "connector"`, `credential_key_source: "wallet-secret-pass"`).

## Proven, not asserted
| proof | result |
|---|---|
| 428 without a sealed credential (verbatim, receipted) | ✔ |
| seal a **sentinel** bearer → 403 → real grant → `session_obtained` | ✔ |
| session lease REAL (gateway audit trail +1) | 1372 → 1373 |
| **sentinel leak sweep: raw bearer appears NOWHERE** — open response · session records · receipts · run records · gateway descriptors | **5/5 clean** |
| `source_contacted:false · object_instances:0` throughout | ✔ |

## Scope discipline
The session binds the run's lease scope **verbatim** — restating scope at all (narrower *or* wider) is refused; TTL may only narrow; scope frozen from birth. 12 fail-closed lanes: bypass keys (secret/raw-query/env-fallback), run must **hold** its lease, lease not expired, **ladder drift re-checked** (the #18 drift check, reused), local source kinds refused, unknown connector, TTL widening, terminal immutability.

## Receipts
`created → session_requested → session_refused (428) → session_requested → session_refused (403) → session_requested → session_obtained → patch_rejected → session_released` — the full crossing story, credential-free.

## Surface
`… CapabilityLease obtained (live) · Sealed connector session (live) · Connector execution missing · Materialized rows missing` — `object_instances` remains 0.

## Done bar — green
connector-session **34/34** · cargo **101/101** (+4) · materializing-run 34/34 · lease-plan 41/41 · projection 36/36 · t-run 36/36 · view 35/35 · mapping 33/33 · manager 35/35 · ux-parity 20/20 · data-source 17/17 · estate + legacy suites · source-neutral PASSED · fallthrough empty · diff clean.

**PR #20** is the true first materialization: read under the sealed session, emit pre-output receipts, register materialized output, and finally let projection `object_instances` become nonzero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)