### PR TITLE
ODK connector execution + materialized rows — the final rung; a projection goes nonzero

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2962,7 +2962,7 @@ function renderDataSourcesSection(dataSources) {
 function omBoundaryNote(text) {
   return `<div style="border:1px dashed #3a3d46;border-radius:10px;padding:10px 12px;margin:0 0 12px;background:#141519;color:#9a9da6;font-size:12.5px">${text}</div>`;
 }
-function omContractLadder(nMappings, nViews, nRuns, nProjections, nLeasePlans, nLeasesObtained, nSessions) {
+function omContractLadder(nMappings, nViews, nRuns, nProjections, nLeasePlans, nLeasesObtained, nSessions, nExecutions, nInstances) {
   const declared = `<tr><td><code>ConnectorMapping</code> <span class="pill ok">declared</span></td><td>declared source fields → typed object properties</td><td class="sub" style="margin:0">${nMappings} mapping${nMappings === 1 ? "" : "s"} · inert (no extraction)</td></tr>`
     + `<tr><td><code>PolicyBoundDataView</code> <span class="pill ok">declared</span></td><td>the capability envelope — who/what may read · transform · distill · train · evaluate · export · publish · route, for what purpose, under which receipt obligations</td><td class="sub" style="margin:0">${nViews} view${nViews === 1 ? "" : "s"} · gate only (nothing runs)</td></tr>`
     + `<tr><td><code>TransformationRun + receipts</code> <span class="pill ok">declared</span></td><td>auditable plan / dry-run against the gate — validates shape, envelope, intent; every act (and every refusal) receipted</td><td class="sub" style="margin:0">${nRuns} run${nRuns === 1 ? "" : "s"} · plan/dry-run only (no source contact)</td></tr>`
@@ -2970,8 +2970,12 @@ function omContractLadder(nMappings, nViews, nRuns, nProjections, nLeasePlans, n
     + `<tr><td><code>CapabilityLease plan</code> <span class="pill ok">declared</span></td><td>the EXACT lease scope a materializing run may ask for — subject, purpose, operations, property scope, postures, obligations, bounded TTL; the only gateway is the existing capability-lease primitive</td><td class="sub" style="margin:0">${nLeasePlans} plan${nLeasePlans === 1 ? "" : "s"} · nothing minted, no credential material</td></tr>`
     + `<tr><td><code>CapabilityLease obtained</code> <span class="pill ok">live</span></td><td>the FIRST live crossing — a run cites a declared plan and obtains a REAL wallet-gated lease from the gateway; no source contact, no credential resolution, any bearer token dropped</td><td class="sub" style="margin:0">${nLeasesObtained} lease${nLeasesObtained === 1 ? "" : "s"} obtained · real gateway leases, credential material never surfaced</td></tr>`
     + `<tr><td><code>Sealed connector session</code> <span class="pill ok">live</span></td><td>the credential-handling crossing — the gateway resolves the SEALED credential server-side for the exact lease scope; labels only, material never surfaced</td><td class="sub" style="margin:0">${nSessions} session${nSessions === 1 ? "" : "s"} obtained · no source contact</td></tr>`
-    + `<tr><td><code>Connector execution</code> <span class="pill muted">missing</span></td><td>reading the source under an obtained lease — credential resolution + extraction, receipted before output</td><td class="sub" style="margin:0">the next cut; until then no source is contacted</td></tr>`
-    + `<tr><td><code>Materialized rows</code> <span class="pill muted">missing</span></td><td>registered, receipted output that finally lets a projection's rows exist</td><td class="sub" style="margin:0">after execution — until then object_instances stays 0</td></tr>`;
+    + (nExecutions > 0
+      ? `<tr><td><code>Connector execution</code> <span class="pill ok">live</span></td><td>one allowlisted read-only adapter path — the declared endpoint, one bounded batch, receipted before output</td><td class="sub" style="margin:0">${nExecutions} execution${nExecutions === 1 ? "" : "s"} · read-only, all-or-nothing</td></tr>`
+      : `<tr><td><code>Connector execution</code> <span class="pill muted">missing</span></td><td>reading the source under an obtained lease + sealed session — one bounded read-only batch, receipted before output</td><td class="sub" style="margin:0">no execution has run for this ontology</td></tr>`)
+    + (nInstances > 0
+      ? `<tr><td><code>Materialized rows</code> <span class="pill ok">live</span></td><td>registered, receipted object sets — the projection's rows finally exist</td><td class="sub" style="margin:0">${nInstances} object instance${nInstances === 1 ? "" : "s"} · hashes + provenance, never secrets</td></tr>`
+      : `<tr><td><code>Materialized rows</code> <span class="pill muted">missing</span></td><td>registered, receipted output that finally lets a projection's rows exist</td><td class="sub" style="margin:0">until an execution registers a batch, object_instances stays 0</td></tr>`);
   return `<table><thead><tr><th>Contract</th><th>What it declares</th><th>Status / unlocks</th></tr></thead><tbody>${declared}</tbody></table>`;
 }
 // Sealed connector sessions — the credential-handling rung: resolution proven, material never surfaced.
@@ -3017,12 +3021,12 @@ function omLeasePlans(plans) {
 }
 // The DECLARED explorer shape from a ready OntologyProjection — daemon truth about what an
 // authorized surface WOULD render. Zero rows, always: projection declared ≠ objects materialized.
-function omDeclaredExplorerShape(proj) {
+function omDeclaredExplorerShape(proj, mset) {
   const cols = (proj.visible_properties || []).map((p) => `<th>${CX_ESC(p)}${p === proj.title_field ? ` <span class="pill ok" style="margin-left:4px">title</span>` : ""}${p === proj.key_field ? ` <span class="pill muted" style="margin-left:4px">key</span>` : ""}</th>`).join("");
   const affordance = (arr, idKey, kind) => (arr || []).map((a) => `<span class="pill ${a.enabled ? "ok" : "muted"}" title="${a.enabled ? "enabled (gated by the policy view)" : "declared, not enabled"}">${CX_ESC(a[idKey] || "")} · ${kind}${a.enabled ? "" : " (declared)"}</span>`).join(" ");
   return `<div style="border:1px solid #24262d;border-radius:10px;padding:12px 14px;margin:0 0 12px;background:#15171c">
-    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:8px"><b>${CX_ESC(proj.name || proj.id)}</b> <code style="font-size:11px">${CX_ESC(proj.ref || "")}</code> <span class="pill ${proj.status === "ready" ? "ok" : "warn"}">${CX_ESC(proj.status || "draft")}</span> <span class="pill muted">${CX_ESC(proj.layout || "table")}</span></div>
-    <table><thead><tr>${cols}</tr></thead><tbody><tr><td colspan="${(proj.visible_properties || []).length || 1}" style="text-align:center;color:#878a93;padding:18px 8px">0 objects — projection declared, nothing materialized. Rows require a future materializing run under credential authority.</td></tr></tbody></table>
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:8px"><b>${CX_ESC(proj.name || proj.id)}</b> <code style="font-size:11px">${CX_ESC(proj.ref || "")}</code> <span class="pill ${proj.status === "ready" ? "ok" : "warn"}">${CX_ESC(proj.status || "draft")}</span> <span class="pill muted">${CX_ESC(proj.layout || "table")}</span>${(mset && (mset.objects || []).length) ? ` <span class="pill ok">${mset.count} objects · materialized</span> <span class="pill muted" title="registered all-or-nothing behind a pre-output receipt"><code style="font-size:10px">${CX_ESC(mset.ref || "")}</code></span>` : ""}</div>
+    <table><thead><tr>${cols}</tr></thead><tbody>${(mset && (mset.objects || []).length) ? mset.objects.slice(0, 20).map((o) => `<tr>${(proj.visible_properties || []).map((vp) => `<td>${CX_ESC(String((o.properties || {})[vp] ?? ""))}</td>`).join("")}</tr>`).join("") : `<tr><td colspan="${(proj.visible_properties || []).length || 1}" style="text-align:center;color:#878a93;padding:18px 8px">0 objects — projection declared, nothing materialized. Rows require a future materializing run under credential authority.</td></tr>`}</tbody></table>
     <div class="chips" style="margin-top:8px"><span class="chiplabel">Facets</span>${(proj.facet_properties || []).length ? proj.facet_properties.map((f) => `<span class="pill muted">${CX_ESC(f)}</span>`).join("") : `<span class="sub" style="margin:0">none</span>`}</div>
     <div class="chips"><span class="chiplabel">Sort</span>${(proj.sort_fields || []).length ? proj.sort_fields.map((f) => `<span class="pill muted">${CX_ESC(f)}</span>`).join("") : `<span class="sub" style="margin:0">none</span>`}</div>
     <div class="chips"><span class="chiplabel">Actions</span>${(proj.action_affordances || []).length ? affordance(proj.action_affordances, "action_type_id", "action") : `<span class="sub" style="margin:0">none</span>`}</div>
@@ -3101,6 +3105,8 @@ function renderOntologyManager(ov, lists, selectedId) {
   const funcs = ats.filter((a) => a.kind === "function");
   const nonFuncActs = ats.filter((a) => a.kind !== "function");
   const health = (selected && selected.health) || {};
+  const msets = (lists.materialized_sets || []).filter((m) => selected && m.ontology_ref === selected.ref);
+  const totalInstances = msets.reduce((a, m) => a + (m.count || 0), 0);
   const rollup = o.ontology_health || {};
   const propCount = ots.reduce((n, x) => n + (Array.isArray(x.properties) ? x.properties.length : 0), 0);
   const idc = (x) => `<code>${CX_ESC(x || "")}</code>`;
@@ -3115,10 +3121,10 @@ function renderOntologyManager(ov, lists, selectedId) {
 
   // ---- Panes.
   const objectTypesPane = `<h2 id="pane-object-types" style="display:flex;justify-content:space-between;align-items:center">Object types <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">(${ots.length})</span> <a class="act" href="/__ioi/odk/ontologies/${selected ? encodeURIComponent(selected.id) : "new"}${selected ? "/edit" : ""}">Configure model</a></h2>`
-    + omBoundaryNote(`<b>0 objects</b> across all types — the object-instance plane is <b>not bound</b>. Object counts stay 0 until an <code>OntologyProjection</code> exists; nothing here fabricates rows.`)
+    + omBoundaryNote(totalInstances > 0 ? `<b>${totalInstances} objects</b> materialized across ${msets.length} receipted set${msets.length === 1 ? "" : "s"} — bounded read-only batches under held leases + sealed sessions; hashes + provenance, never secrets.` : `<b>0 objects</b> across all types — the object-instance plane is <b>not bound</b>. Object counts stay 0 until an <code>OntologyProjection</code> exists; nothing here fabricates rows.`)
     + (ots.length ? ots.map((t) => {
         const props = Array.isArray(t.properties) ? t.properties : [];
-        return `<div style="border:1px solid #24262d;border-radius:10px;padding:11px 13px;margin:0 0 9px;background:#15171c"><div style="display:flex;justify-content:space-between;align-items:center"><div style="font-weight:600">${CX_ESC(t.name || t.id)} ${idc(t.id)}</div><a class="act ghost" href="/__ioi/odk/ontologies/${encodeURIComponent(selected.id)}">Configure</a></div><div class="sub" style="margin:4px 0 0">${props.length} propert${props.length === 1 ? "y" : "ies"} · <b>0</b> objects · title <code>${CX_ESC(t.title_property || "—")}</code></div></div>`;
+        return `<div style="border:1px solid #24262d;border-radius:10px;padding:11px 13px;margin:0 0 9px;background:#15171c"><div style="display:flex;justify-content:space-between;align-items:center"><div style="font-weight:600">${CX_ESC(t.name || t.id)} ${idc(t.id)}</div><a class="act ghost" href="/__ioi/odk/ontologies/${encodeURIComponent(selected.id)}">Configure</a></div><div class="sub" style="margin:4px 0 0">${props.length} propert${props.length === 1 ? "y" : "ies"} · <b>${msets.filter((m) => m.object_type_id === t.id).reduce((a, m) => a + (m.count || 0), 0)}</b> objects · title <code>${CX_ESC(t.title_property || "—")}</code></div></div>`;
       }).join("") : `<div class="empty">No object types yet. ${selected ? `<a href="/__ioi/odk/ontologies/${encodeURIComponent(selected.id)}/edit">Add typed object types →</a>` : `<a href="/__ioi/odk/ontologies/new">Create an ontology →</a>`}</div>`);
 
   const propRows = ots.flatMap((t) => (Array.isArray(t.properties) ? t.properties : []).map((p) => `<tr><td>${CX_ESC(t.name || t.id)}</td><td>${CX_ESC(p.name || p.id)} ${idc(p.id)}</td><td><code>${CX_ESC(p.value_type || "")}</code></td><td>${p.required ? "yes" : "—"}${t.title_property === p.id ? ` <span class="pill ok">title</span>` : ""}</td></tr>`)).join("");
@@ -3188,6 +3194,7 @@ function renderOntologyManager(ov, lists, selectedId) {
     + `<h3 style="margin:12px 0 6px">Capability-lease plans (${lplans.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— declared credential authority · gateway: the capability-lease primitive · nothing minted</span></h3>${omLeasePlans(lplans)}`
     + `<h3 style="margin:12px 0 6px">Materializing runs (${mruns.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— live lease acquisition against the gateway · no execution, no rows</span></h3>${omMaterializingRuns(mruns)}`
     + `<h3 style="margin:12px 0 6px">Sealed connector sessions (${csns.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— credential resolution proven, material never surfaced · no source contact</span></h3>${omConnectorSessions(csns)}`
+    + `<h3 style="margin:12px 0 6px">Materialized object sets (${msets.length}) <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— bounded, receipted, all-or-nothing · hashes + provenance</span></h3>${msets.length ? `<table><thead><tr><th>Set</th><th>Object type</th><th>Objects</th><th>Registered</th></tr></thead><tbody>${msets.map((m) => `<tr><td><code>${CX_ESC(m.ref || "")}</code></td><td><code>${CX_ESC(m.object_type_id || "")}</code></td><td><b>${m.count || 0}</b></td><td class="sub" style="margin:0">${CX_ESC(m.registered_at || "")}</td></tr>`).join("")}</tbody></table>` : `<div class="empty">No materialized sets. Execution registers one bounded batch, all-or-nothing, behind a pre-output receipt.</div>`}`
     + resourceSection("Data recipes", "data-recipes", recs, "name", "New recipe")
     + resourceSection("Surface descriptors", "surface-descriptors", descs, "name", "New descriptor")
     + resourceSection("ODK manifests", "manifests", mans, "name", "New manifest");
@@ -3200,11 +3207,11 @@ function renderOntologyManager(ov, lists, selectedId) {
   const explorerHead = activeProjs.length
     ? `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill ok">projection declared</span> <span class="pill warn">no materialized objects</span></h2>`
       + omBoundaryNote(`<b>Projection declared, no materialized objects.</b> The explorer shape below is daemon truth — what an authorized surface <b>would</b> render, search, filter, relate, and act on. There are <b>no rows</b>: object_instances stays 0 until a future materializing run executes under credential authority. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`)
-      + activeProjs.map((p) => omDeclaredExplorerShape(p)).join("")
+      + activeProjs.map((p) => omDeclaredExplorerShape(p, msets.find((m) => m.ontology_projection_id === p.id))).join("")
     : `<h2 id="pane-explorer">Object data &amp; Explorer <span class="pill muted">unavailable</span></h2>`
       + omBoundaryNote(`This ontology binds <b>no object-instance plane</b>, so there are <b>no rows to explore</b> — declare an OntologyProjection to give this lane its read/search shape; rows still require a future materializing run under credential authority. The <a href="/__apps/explorer">Object Explorer reference grammar ↗</a> is secondary, never a rebound surface.`);
   const explorerPane = explorerHead
-    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— five declared rungs + the first live crossing; execution and rows remain</span></h3>` + omContractLadder(maps.length, pviews.length, truns.length, projs.length, lplans.length, mruns.filter((r) => r.status === "lease_obtained").length, csns.filter((c) => c.status === "session_obtained").length);
+    + `<h3 style="margin:12px 0 6px">Authority-crossing ladder <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— five declared rungs + the first live crossing; execution and rows remain</span></h3>` + omContractLadder(maps.length, pviews.length, truns.length, projs.length, lplans.length, mruns.filter((r) => ["lease_obtained", "executed"].includes(r.status)).length, csns.filter((c) => c.status === "session_obtained").length, mruns.filter((r) => r.status === "executed").length, totalInstances);
 
   const counts = { "object-types": ots.length, "properties": propCount, "link-types": lts.length, "action-types": nonFuncActs.length, "value-types": vts.length, "groups": 0, "interfaces": 0, "functions": funcs.length };
   const panes = objectTypesPane + propertiesPane + linkPane + actionPane + valuePane
@@ -6757,7 +6764,7 @@ const server = http.createServer((req, res) => {
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
     if (pathname === "/__ioi/odk" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
-      const [ov, o, r, d, m, ds, cm, pv, tr, op, lp, mr, cs] = await Promise.all([
+      const [ov, o, r, d, m, ds, cm, pv, tr, op, lp, mr, cs, ms] = await Promise.all([
         J("/v1/hypervisor/odk/overview"),
         J("/v1/hypervisor/odk/domain-ontologies"),
         J("/v1/hypervisor/odk/data-recipes"),
@@ -6771,6 +6778,7 @@ const server = http.createServer((req, res) => {
         J("/v1/hypervisor/odk/capability-lease-plans"),
         J("/v1/hypervisor/odk/materializing-runs"),
         J("/v1/hypervisor/odk/connector-sessions"),
+        J("/v1/hypervisor/odk/materialized-object-sets"),
       ]);
       const selectedOntology = new URL(req.url, "http://x").searchParams.get("ontology") || "";
       res.writeHead(200, HTMLH);
@@ -6787,6 +6795,7 @@ const server = http.createServer((req, res) => {
         capability_lease_plans: lp.capability_lease_plans || [],
         materializing_runs: mr.materializing_runs || [],
         connector_sessions: cs.connector_sessions || [],
+        materialized_sets: ms.materialized_object_sets || [],
       }, selectedOntology));
       return;
     }

--- a/apps/hypervisor/scripts/verify-hypervisor-connector-execution.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-connector-execution.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// Connector execution + materialized rows done-bar — the FINAL rung of the ODK ratchet: one real
+// read, one sealed session, one receipted batch, one projection goes NONZERO.
+//
+// One narrow read-only adapter path (rest_api GET of the DECLARED endpoint), not a generic ingestion
+// engine. Execution requires a HELD lease (#18) + an OPEN sealed session (#19); rows transform
+// through the landed ladder and validate all-or-nothing; the pre-output receipt lands BEFORE any
+// output; the materialized set stores hashes + provenance, never secrets; ONLY the tied projection's
+// object_instances changes.
+//
+// Asserts:
+//   - FIRST NONZERO object_instances only after the pre-output receipt (history order proves it).
+//   - Source-contact evidence on BOTH sides: the fixture server received exactly the adapter's GET,
+//     WITH the sealed bearer — while the sentinel sweep proves that bearer exists nowhere in
+//     responses, run records, set records, or receipts.
+//   - No raw-query path; unsupported connector kinds refused; malformed batch registers ZERO
+//     objects; projection row count matches the materialized output; rerun is explicitly refused
+//     (one bounded batch per run); set deletion resets the projection (no dangling counts).
+//   - Receipts cover execution_requested, source_contact_started/completed, validation_result,
+//     pre_output_receipt, materialized_output_registered (+ refusals).
+//   - The Manager explorer shows the first bounded rows for the tied projection; the ladder reads
+//     all nine rungs; fresh ontologies keep honest zeros. Brand-clean.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-connector-execution.mjs
+// Exit 2 = BLOCKED (daemon not running).
+
+import http from "node:http";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { mintApprovalGrant } from "../../../scripts/lib/mint-approval-grant.mjs";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+const DATA = process.env.IOI_HYPERVISOR_DATA_DIR || path.join(os.homedir(), ".ioi", "hypervisor", "data");
+const SENTINEL = "fixture-bearer-SENTINEL-verify-exec";
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+function dirContains(dir, needle) {
+  try {
+    return readdirSync(dir).some((f) => {
+      try { return readFileSync(path.join(dir, f), "utf8").includes(needle); } catch { return false; }
+    });
+  } catch { return false; }
+}
+const grantFor = (ch) => mintApprovalGrant({ policyHash: ch.approval?.policy_hash, requestHash: ch.approval?.request_hash });
+
+// A full ladder → held lease → open sealed session over the given endpoint. Returns ids.
+async function buildChain(tag, endpoint, kind, connId, cleanup) {
+  const track = (k, id) => { if (id) cleanup.push(["DELETE", `/v1/hypervisor/odk/${k}/${id}`]); };
+  const ds = (await jd("POST", "/v1/hypervisor/data-sources", { name: `${tag}-src`, kind, endpoint, credential_posture: "wallet_credential_lease" })).j.data_source?.source_id;
+  cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${ds}`]);
+  const ont = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: `${tag}-domain`, canonical_object_model: {
+    value_types: [{ id: "money", name: "Money", base: "double" }],
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" },
+      { id: "amount", name: "Amount", value_type: "money" } ] }],
+    action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }],
+  } })).j.ontology;
+  track("domain-ontologies", ont?.id);
+  const map = (await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: `${tag}-map`, data_source_id: ds, ontology_ref: ont.ref, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" },
+    field_mappings: [{ source_field: "amt", property_id: "amount", source_type: "double" }] })).j.connector_mapping?.id;
+  track("connector-mappings", map);
+  const view = (await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: map, name: `${tag}-gate`, authority_subjects: ["agent://materializer"],
+    allowed_operations: ["read", "transform"], purpose: "analysis", property_scope: ["loan_id", "title", "amount"], retention_posture: "bounded" })).j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", view);
+  const trun = (await jd("POST", "/v1/hypervisor/odk/transformation-runs", { connector_mapping_id: map, policy_view_id: view, name: `${tag}-trun` })).j.transformation_run?.id;
+  track("transformation-runs", trun);
+  await jd("POST", `/v1/hypervisor/odk/transformation-runs/${trun}/dry-run`);
+  const proj = (await jd("POST", "/v1/hypervisor/odk/ontology-projections", { connector_mapping_id: map, policy_view_id: view, name: `${tag}-explorer`, visible_properties: ["loan_id", "title", "amount"] })).j.ontology_projection?.id;
+  track("ontology-projections", proj);
+  const plan = (await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", { data_source_id: ds, connector_mapping_id: map, policy_view_id: view,
+    transformation_run_id: trun, ontology_projection_id: proj, name: `${tag}-plan`, subject: "agent://materializer", ttl_seconds: 900 })).j.capability_lease_plan?.id;
+  track("capability-lease-plans", plan);
+  const mrun = (await jd("POST", "/v1/hypervisor/odk/materializing-runs", { capability_lease_plan_id: plan, name: `${tag}-mrun` })).j.materializing_run?.id;
+  track("materializing-runs", mrun);
+  const ch = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, {});
+  await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, { wallet_approval_grant: grantFor(ch.j) });
+  let session = null;
+  if (kind === "rest_api") {
+    session = (await jd("POST", "/v1/hypervisor/odk/connector-sessions", { materializing_run_id: mrun, connector_id: connId, name: `${tag}-session` })).j.connector_session?.id;
+    track("connector-sessions", session);
+    const ch2 = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${session}/open`, {});
+    await jd("POST", `/v1/hypervisor/odk/connector-sessions/${session}/open`, { wallet_approval_grant: grantFor(ch2.j) });
+  }
+  return { ds, ontId: ont?.id, map, view, trun, proj, plan, mrun, session };
+}
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/materialized-object-sets/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon execution plane not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+
+  // Fixture row server — auth-checked; records exactly what the adapter sent.
+  const rows = [{ id: "L-1", disp: "First Loan", amt: 1250.5 }, { id: "L-2", disp: "Second Loan", amt: 90000 }, { id: "L-3", disp: "Third Loan", amt: 42.0 }];
+  const bad = [{ id: "L-1", disp: "ok", amt: 1.0 }, { disp: "missing key", amt: "not-a-number" }];
+  let hits = 0; let authedHits = 0;
+  const srv = http.createServer((req, res) => {
+    hits++;
+    if (req.headers.authorization !== `Bearer ${SENTINEL}`) { res.writeHead(401); return res.end("unauthorized"); }
+    authedHits++;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(req.url === "/bad-rows" ? bad : rows));
+  });
+  await new Promise((r) => srv.listen(0, "127.0.0.1", r));
+  const port = srv.address().port;
+
+  // Connector holding the sealed sentinel bearer.
+  const connR = await jd("POST", "/v1/hypervisor/connectors", { service: "odk-exec-verify", base_url: `http://127.0.0.1:${port}`, name: "Exec Verify Fixture" });
+  const connId = connR.j.connector?.connector_id || connR.j.connector_id;
+  await jd("POST", `/v1/hypervisor/connectors/${connId}/credential`, { token: SENTINEL });
+
+  try {
+    // Chain A: the happy path.
+    const A = await buildChain("execA", `http://127.0.0.1:${port}/rows`, "rest_api", connId, cleanup);
+    const before = await jd("GET", `/v1/hypervisor/odk/ontology-projections/${A.proj}`);
+    ok("BEFORE execution the tied projection reports 0 instances", before.j.ontology_projection?.health?.object_instances === 0);
+
+    // Guard lanes before the real execution.
+    const noSess = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${A.mrun}/execute`, { connector_session_id: "csn_nope", limit: 10 });
+    ok("fail-closed: unknown session", noSess.j.error?.code === "execution_session_unknown");
+    const rawQ = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${A.mrun}/execute`, { connector_session_id: A.session, limit: 10, sql: "SELECT 1" });
+    ok("fail-closed: raw query path does not exist", rawQ.j.error?.code === "execution_raw_query_rejected");
+    const envF = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${A.mrun}/execute`, { connector_session_id: A.session, limit: 10, from_env: "PG" });
+    ok("fail-closed: env-credential fallback", envF.j.error?.code === "execution_env_fallback_rejected");
+    const badLimit = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${A.mrun}/execute`, { connector_session_id: A.session, limit: 99999 });
+    ok("fail-closed: unbounded limit", badLimit.j.error?.code === "execution_limit_unbounded");
+
+    // THE EXECUTION.
+    const hitsBefore = hits;
+    const ex = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${A.mrun}/execute`, { connector_session_id: A.session, limit: 10 });
+    const set = ex.j.materialized_object_set;
+    if (set?.id) cleanup.unshift(["DELETE", `/v1/hypervisor/odk/materialized-object-sets/__SKIP__`]); // placeholder; real delete below
+    ok("execution succeeds: run executed, 3 objects registered all-or-nothing", ex.status === 200 && ex.j.materializing_run?.status === "executed" && set?.count === 3);
+    ok("source-contact evidence (daemon side): endpoint + http 200 + elapsed recorded", set?.source_contact?.http_status === 200 && typeof set?.source_contact?.elapsed_ms === "number" && String(set?.source_contact?.endpoint || "").endsWith("/rows"));
+    ok("source-contact evidence (source side): the fixture received EXACTLY the adapter's authed GET", hits === hitsBefore + 1 && authedHits >= 1, `hits ${hitsBefore}→${hits}`);
+    ok("objects carry key/title/typed properties + source hash + provenance", set?.objects?.[0]?.object_key === "L-1" && set?.objects?.[0]?.title === "First Loan" && set?.objects?.[0]?.properties?.amount === 1250.5 && String(set?.objects?.[0]?.source_hash || "").startsWith("sha256:") && set?.objects?.[0]?.provenance?.mapped_from?.amount === "amt");
+
+    // FIRST NONZERO — and only after the pre-output receipt (history order is append-ordered).
+    const after = await jd("GET", `/v1/hypervisor/odk/ontology-projections/${A.proj}`);
+    ok("the tied projection went 0 → 3 (row count matches the materialized output)", after.j.ontology_projection?.health?.object_instances === 3 && after.j.ontology_projection?.health?.materialized === true && after.j.ontology_projection?.materialized?.set_ref === set?.ref);
+    const hist = await jd("GET", `/v1/hypervisor/odk/materializing-runs/${A.mrun}/history`);
+    const opsInOrder = (hist.j.history || []).map((h) => h.op);
+    const iPre = opsInOrder.indexOf("pre_output_receipt");
+    const iReg = opsInOrder.indexOf("materialized_output_registered");
+    ok("receipt story complete and ORDERED: requested → contact started/completed → validation → PRE-OUTPUT → registered", ["execution_requested", "source_contact_started", "source_contact_completed", "validation_result", "pre_output_receipt", "materialized_output_registered"].every((o) => opsInOrder.includes(o)) && iPre !== -1 && iReg !== -1 && iPre < iReg, opsInOrder.join("→"));
+    ok("set records the pre-output receipt it was registered behind", String(set?.pre_output_receipt_ref || "").startsWith("agentgres://materializing-run-receipt/"));
+
+    // Sentinel sweep — the bearer was USED for the read yet exists NOWHERE in truth.
+    ok("SENTINEL absent from the execute response", !JSON.stringify(ex.j).includes(SENTINEL));
+    ok("SENTINEL absent from set records on disk", !dirContains(path.join(DATA, "odk-materialized-object-sets"), SENTINEL));
+    ok("SENTINEL absent from run records on disk", !dirContains(path.join(DATA, "odk-materializing-runs"), SENTINEL));
+    ok("SENTINEL absent from run receipts on disk", !dirContains(path.join(DATA, "odk-materializing-run-receipts"), SENTINEL));
+
+    // Rerun/idempotency is explicit.
+    const rerun = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${A.mrun}/execute`, { connector_session_id: A.session, limit: 10 });
+    ok("rerun explicitly refused — one bounded batch per run (v1)", rerun.j.error?.code === "execution_already_registered");
+
+    // Chain B: unsupported connector kind (postgres) refused before any contact.
+    const B = await buildChain("execB", "postgres://unreachable.invalid:5432/db", "postgres", connId, cleanup);
+    const exB = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${B.mrun}/execute`, { connector_session_id: "irrelevant", limit: 10 });
+    ok("fail-closed: unsupported connector kind (no allowlisted adapter)", exB.j.error?.code === "execution_connector_kind_unsupported");
+
+    // Chain C: malformed batch → ZERO objects, projection stays 0.
+    const C = await buildChain("execC", `http://127.0.0.1:${port}/bad-rows`, "rest_api", connId, cleanup);
+    const exC = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${C.mrun}/execute`, { connector_session_id: C.session, limit: 10 });
+    const projC = await jd("GET", `/v1/hypervisor/odk/ontology-projections/${C.proj}`);
+    ok("malformed batch rejected all-or-nothing (422, named row errors)", exC.status === 422 && exC.j.error?.code === "execution_batch_invalid" && (exC.j.error?.errors || []).length >= 2);
+    ok("ZERO objects registered from the malformed batch; projection stays 0", projC.j.ontology_projection?.health?.object_instances === 0 && projC.j.ontology_projection?.health?.materialized === false);
+    const setsNow = await jd("GET", "/v1/hypervisor/odk/materialized-object-sets");
+    ok("no set exists for the malformed chain", !(setsNow.j.materialized_object_sets || []).some((m) => m.ontology_projection_id === C.proj));
+    const histC = await jd("GET", `/v1/hypervisor/odk/materializing-runs/${C.mrun}/history`);
+    ok("malformed batch left a validation_result refusal in the receipt story", (histC.j.receipts || []).some((r) => r.op === "validation_result" && r.outcome === "execution_batch_invalid"));
+
+    // Chain D: unreachable rest endpoint → source_contact_failed receipted.
+    const Dc = await buildChain("execD", "http://127.0.0.1:9/rows", "rest_api", connId, cleanup);
+    const exD = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${Dc.mrun}/execute`, { connector_session_id: Dc.session, limit: 10 });
+    const histD = await jd("GET", `/v1/hypervisor/odk/materializing-runs/${Dc.mrun}/history`);
+    ok("unreachable source → 502 + source_contact_failed receipted (no output)", exD.status === 502 && exD.j.error?.code === "execution_source_unreachable" && (histD.j.receipts || []).some((r) => r.op === "source_contact_failed"));
+
+    // Surface: first bounded rows + the complete ladder; fresh chains stay honest.
+    const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(A.ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+    const t = page.text;
+    ok("Explorer shows the first bounded rows for the tied projection", page.status === 200 && />L-1</.test(t) && />First Loan</.test(t) && /3 objects · materialized/.test(t));
+    ok("ladder complete: 5 declared + 4 live rungs (all nine)", (t.match(/(ConnectorMapping|PolicyBoundDataView|TransformationRun \+ receipts|OntologyProjection|CapabilityLease plan)<\/code> <span class="pill ok">declared/g) || []).length === 5 && (t.match(/(CapabilityLease obtained|Sealed connector session|Connector execution|Materialized rows)<\/code> <span class="pill ok">live/g) || []).length === 4);
+    ok("object-type counts are real (3 objects)", /<b>3<\/b> objects/.test(t) && /3 objects<\/b> materialized across 1 receipted set/.test(t));
+    const freshPage = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(C.ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+    ok("a chain that never materialized keeps honest zeros + missing rungs", /0 objects<\/b> across all types/.test(freshPage.text) && (freshPage.text.match(/(Connector execution|Materialized rows)<\/code> <span class="pill muted">missing/g) || []).length === 2);
+    ok("brand-clean (no Palantir/Foundry leak)", !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
+    ok("SENTINEL absent from the rendered surface", !t.includes(SENTINEL));
+
+    // Set deletion resets the projection — no dangling counts.
+    const setId = set?.id;
+    const del = await jd("DELETE", `/v1/hypervisor/odk/materialized-object-sets/${setId}`);
+    const afterDel = await jd("GET", `/v1/hypervisor/odk/ontology-projections/${A.proj}`);
+    ok("set deletion is receipted and RESETS the tied projection to 0", del.j.removed === true && afterDel.j.ontology_projection?.health?.object_instances === 0 && afterDel.j.ontology_projection?.health?.materialized === false);
+  } finally {
+    for (const [method, p] of cleanup.reverse()) {
+      if (!p.includes("__SKIP__")) await jd(method, p);
+    }
+    await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}/credential`, { method: "DELETE" }).catch(() => {});
+    await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}`, { method: "DELETE" }).catch(() => {});
+    srv.close();
+  }
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`connector-execution readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/apps/hypervisor/scripts/verify-hypervisor-connector-execution.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-connector-execution.mjs
@@ -51,7 +51,7 @@ function dirContains(dir, needle) {
 const grantFor = (ch) => mintApprovalGrant({ policyHash: ch.approval?.policy_hash, requestHash: ch.approval?.request_hash });
 
 // A full ladder → held lease → open sealed session over the given endpoint. Returns ids.
-async function buildChain(tag, endpoint, kind, connId, cleanup) {
+async function buildChain(tag, endpoint, kind, connId, cleanup, opts = {}) {
   const track = (k, id) => { if (id) cleanup.push(["DELETE", `/v1/hypervisor/odk/${k}/${id}`]); };
   const ds = (await jd("POST", "/v1/hypervisor/data-sources", { name: `${tag}-src`, kind, endpoint, credential_posture: "wallet_credential_lease" })).j.data_source?.source_id;
   cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${ds}`]);
@@ -85,7 +85,7 @@ async function buildChain(tag, endpoint, kind, connId, cleanup) {
   const ch = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, {});
   await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, { wallet_approval_grant: grantFor(ch.j) });
   let session = null;
-  if (kind === "rest_api") {
+  if (kind === "rest_api" && !opts.skipSession) {
     session = (await jd("POST", "/v1/hypervisor/odk/connector-sessions", { materializing_run_id: mrun, connector_id: connId, name: `${tag}-session` })).j.connector_session?.id;
     track("connector-sessions", session);
     const ch2 = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${session}/open`, {});
@@ -119,6 +119,9 @@ async function run() {
   const connR = await jd("POST", "/v1/hypervisor/connectors", { service: "odk-exec-verify", base_url: `http://127.0.0.1:${port}`, name: "Exec Verify Fixture" });
   const connId = connR.j.connector?.connector_id || connR.j.connector_id;
   await jd("POST", `/v1/hypervisor/connectors/${connId}/credential`, { token: SENTINEL });
+  const connUnreachR = await jd("POST", "/v1/hypervisor/connectors", { service: "odk-exec-unreachable", base_url: "http://127.0.0.1:9", name: "Exec Unreachable Fixture" });
+  const connUnreachId = connUnreachR.j.connector?.connector_id || connUnreachR.j.connector_id;
+  await jd("POST", `/v1/hypervisor/connectors/${connUnreachId}/credential`, { token: SENTINEL });
 
   try {
     // Chain A: the happy path.
@@ -183,7 +186,7 @@ async function run() {
     ok("malformed batch left a validation_result refusal in the receipt story", (histC.j.receipts || []).some((r) => r.op === "validation_result" && r.outcome === "execution_batch_invalid"));
 
     // Chain D: unreachable rest endpoint → source_contact_failed receipted.
-    const Dc = await buildChain("execD", "http://127.0.0.1:9/rows", "rest_api", connId, cleanup);
+    const Dc = await buildChain("execD", "http://127.0.0.1:9/rows", "rest_api", connUnreachId, cleanup);
     const exD = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${Dc.mrun}/execute`, { connector_session_id: Dc.session, limit: 10 });
     const histD = await jd("GET", `/v1/hypervisor/odk/materializing-runs/${Dc.mrun}/history`);
     ok("unreachable source → 502 + source_contact_failed receipted (no output)", exD.status === 502 && exD.j.error?.code === "execution_source_unreachable" && (histD.j.receipts || []).some((r) => r.op === "source_contact_failed"));
@@ -200,6 +203,17 @@ async function run() {
     const exF = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${F.mrun}/execute`, { connector_session_id: F.session, limit: 10 });
     const projF = await jd("GET", `/v1/hypervisor/odk/ontology-projections/${F.proj}`);
     ok("fail-closed: duplicate object_key rejects the whole batch (zero registered)", exF.status === 422 && exF.j.error?.code === "execution_batch_invalid" && (exF.j.error?.errors || []).some((e) => /duplicate object key/.test(e)) && projF.j.ontology_projection?.health?.object_instances === 0);
+
+    // Chain G — CONFUSED-DEPUTY: connector A holds the sentinel for the fixture origin, but the
+    // session is opened with the UNREACHABLE-origin connector against the fixture data source. The
+    // credential↔endpoint binding must refuse the session, and the fixture must receive ZERO requests.
+    const G = await buildChain("execG", `http://127.0.0.1:${port}/rows`, "rest_api", connId, cleanup, { skipSession: true });
+    const hitsBeforeG = hits;
+    const badSession = await jd("POST", "/v1/hypervisor/odk/connector-sessions", { materializing_run_id: G.mrun, connector_id: connUnreachId, name: "confused-deputy-session" });
+    ok("fail-closed: session refused when the connector is not the source's origin authority", badSession.status === 400 && badSession.j.error?.code === "session_connector_source_mismatch");
+    // The matching connector opens a legit session; then re-point is impossible (endpoints immutable),
+    // so the execution re-check is proven at the unit level — here we assert the source stayed silent.
+    ok("the confused-deputy attempt contacted the source ZERO times", hits === hitsBeforeG, `hits ${hitsBeforeG}→${hits}`);
 
     // Credentialed endpoints are refused at DECLARATION (never enter declared truth).
     const credEp = await jd("POST", "/v1/hypervisor/data-sources", { name: "cred-ep", kind: "rest_api", endpoint: `http://127.0.0.1:${port}/rows?api_key=${SENTINEL}`, credential_posture: "wallet_credential_lease" });
@@ -229,6 +243,8 @@ async function run() {
     }
     await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}/credential`, { method: "DELETE" }).catch(() => {});
     await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}`, { method: "DELETE" }).catch(() => {});
+    await fetch(`${DAEMON}/v1/hypervisor/connectors/${connUnreachId}/credential`, { method: "DELETE" }).catch(() => {});
+    await fetch(`${DAEMON}/v1/hypervisor/connectors/${connUnreachId}`, { method: "DELETE" }).catch(() => {});
     srv.close();
   }
 }

--- a/apps/hypervisor/scripts/verify-hypervisor-connector-execution.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-connector-execution.mjs
@@ -103,12 +103,14 @@ async function run() {
   const rows = [{ id: "L-1", disp: "First Loan", amt: 1250.5 }, { id: "L-2", disp: "Second Loan", amt: 90000 }, { id: "L-3", disp: "Third Loan", amt: 42.0 }];
   const bad = [{ id: "L-1", disp: "ok", amt: 1.0 }, { disp: "missing key", amt: "not-a-number" }];
   let hits = 0; let authedHits = 0;
+  const dup = [{ id: "L-1", disp: "First", amt: 1.0 }, { id: "L-1", disp: "Same key again", amt: 2.0 }];
   const srv = http.createServer((req, res) => {
     hits++;
     if (req.headers.authorization !== `Bearer ${SENTINEL}`) { res.writeHead(401); return res.end("unauthorized"); }
     authedHits++;
+    if (req.url === "/redirect") { res.writeHead(302, { Location: "/rows" }); return res.end(); }
     res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify(req.url === "/bad-rows" ? bad : rows));
+    res.end(JSON.stringify(req.url === "/bad-rows" ? bad : req.url === "/dup-rows" ? dup : rows));
   });
   await new Promise((r) => srv.listen(0, "127.0.0.1", r));
   const port = srv.address().port;
@@ -185,6 +187,25 @@ async function run() {
     const exD = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${Dc.mrun}/execute`, { connector_session_id: Dc.session, limit: 10 });
     const histD = await jd("GET", `/v1/hypervisor/odk/materializing-runs/${Dc.mrun}/history`);
     ok("unreachable source → 502 + source_contact_failed receipted (no output)", exD.status === 502 && exD.j.error?.code === "execution_source_unreachable" && (histD.j.receipts || []).some((r) => r.op === "source_contact_failed"));
+
+    // Chain E: redirect refused — the adapter never follows a redirect to an undeclared URL.
+    const E = await buildChain("execE", `http://127.0.0.1:${port}/redirect`, "rest_api", connId, cleanup);
+    const exE = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${E.mrun}/execute`, { connector_session_id: E.session, limit: 10 });
+    const histE = await jd("GET", `/v1/hypervisor/odk/materializing-runs/${E.mrun}/history`);
+    const projE = await jd("GET", `/v1/hypervisor/odk/ontology-projections/${E.proj}`);
+    ok("fail-closed: 302 redirect REFUSED (declared endpoint verbatim; receipted; zero output)", exE.status === 502 && exE.j.error?.code === "execution_source_redirect_rejected" && (histE.j.receipts || []).some((r) => r.outcome === "execution_source_redirect_rejected") && projE.j.ontology_projection?.health?.object_instances === 0);
+
+    // Chain F: duplicate object keys in one batch — semantic identity must be unique.
+    const F = await buildChain("execF", `http://127.0.0.1:${port}/dup-rows`, "rest_api", connId, cleanup);
+    const exF = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${F.mrun}/execute`, { connector_session_id: F.session, limit: 10 });
+    const projF = await jd("GET", `/v1/hypervisor/odk/ontology-projections/${F.proj}`);
+    ok("fail-closed: duplicate object_key rejects the whole batch (zero registered)", exF.status === 422 && exF.j.error?.code === "execution_batch_invalid" && (exF.j.error?.errors || []).some((e) => /duplicate object key/.test(e)) && projF.j.ontology_projection?.health?.object_instances === 0);
+
+    // Credentialed endpoints are refused at DECLARATION (never enter declared truth).
+    const credEp = await jd("POST", "/v1/hypervisor/data-sources", { name: "cred-ep", kind: "rest_api", endpoint: `http://127.0.0.1:${port}/rows?api_key=${SENTINEL}`, credential_posture: "wallet_credential_lease" });
+    ok("fail-closed: endpoint embedding a credential is refused at declaration", credEp.status === 400 && credEp.j.error?.code === "data_source_endpoint_credentialed");
+    const userinfoEp = await jd("POST", "/v1/hypervisor/data-sources", { name: "cred-ep2", kind: "rest_api", endpoint: `http://user:${SENTINEL}@127.0.0.1:${port}/rows`, credential_posture: "wallet_credential_lease" });
+    ok("fail-closed: endpoint with URL userinfo is refused at declaration", userinfoEp.status === 400 && userinfoEp.j.error?.code === "data_source_endpoint_credentialed");
 
     // Surface: first bounded rows + the complete ladder; fresh chains stay honest.
     const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(A.ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));

--- a/apps/hypervisor/scripts/verify-hypervisor-connector-session.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-connector-session.mjs
@@ -100,7 +100,8 @@ async function run() {
   const mrun2Id = mrun2R.j.materializing_run?.id;
   track("materializing-runs", mrun2Id);
   // Connector fixture (NO credential yet).
-  const connR = await jd("POST", "/v1/hypervisor/connectors", { service: "odk-csn-fixture", base_url: "https://db.invalid", name: "ODK Session Fixture" });
+  // The connector's base_url must be the ORIGIN AUTHORITY for the source endpoint (credential↔source binding).
+  const connR = await jd("POST", "/v1/hypervisor/connectors", { service: "odk-csn-fixture", base_url: "postgres://unreachable.invalid:5432", name: "ODK Session Fixture" });
   const connId = connR.j.connector?.connector_id || connR.j.connector_id;
   if (!dataSourceId || !mapId || !viewId || !trunId || !projId || !planId || !mrunId || !connId) { console.error("BLOCKED: fixtures failed"); process.exit(2); }
 
@@ -155,6 +156,11 @@ async function run() {
   await reject("unknown run", { materializing_run_id: "mrun_nope", connector_id: connId, name: "x" }, "session_run_unknown");
   await reject("run does not HOLD its lease", { materializing_run_id: mrun2Id, connector_id: connId, name: "x" }, "session_lease_not_obtained");
   await reject("unknown connector", { materializing_run_id: mrunId, connector_id: "conn_nope", name: "x" }, "session_connector_unknown");
+  // A connector that is NOT the origin authority for the source endpoint cannot bind its credential.
+  const wrongConn = await jd("POST", "/v1/hypervisor/connectors", { service: "csn-wrong-origin", base_url: "https://elsewhere.invalid", name: "Wrong Origin" });
+  const wrongConnId = wrongConn.j.connector?.connector_id || wrongConn.j.connector_id;
+  await reject("connector not the source's origin authority (confused-deputy)", { materializing_run_id: mrunId, connector_id: wrongConnId, name: "x" }, "session_connector_source_mismatch");
+  await fetch(`${DAEMON}/v1/hypervisor/connectors/${wrongConnId}`, { method: "DELETE" }).catch(() => {});
   await reject("TTL widening (9999 > run's 900)", { materializing_run_id: mrunId, connector_id: connId, name: "x", ttl_seconds: 9999 }, "session_ttl_widening_rejected");
 
   // 6. Release + receipts tell the whole story, credential-free.

--- a/apps/hypervisor/scripts/verify-hypervisor-materializing-run.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-materializing-run.mjs
@@ -146,9 +146,9 @@ async function run() {
   ok("receipts record request, refusal, decision, release (the full crossing story)", ["created", "lease_requested", "lease_refused", "lease_obtained", "lease_released"].every((o) => opsSeen.includes(o)), opsSeen.join(","));
   ok("no credential material in any receipt", !JSON.stringify(hist.j.receipts || []).match(/"token"|hunter2|secret_key/i));
   const ov = await jd("GET", "/v1/hypervisor/odk/materializing-runs/overview");
-  ok("overview: lifecycle + lease-acquisition-only governance gaps", JSON.stringify(ov.j.lifecycle_states) === JSON.stringify(["planned", "lease_obtained", "lease_released", "cancelled"]) && (ov.j.governance_gaps || []).some((g) => /never contacts the source/i.test(g)));
+  ok("overview: lifecycle + lease-acquisition-only governance gaps", JSON.stringify(ov.j.lifecycle_states) === JSON.stringify(["planned", "lease_obtained", "executed", "lease_released", "cancelled"]) && (ov.j.governance_gaps || []).some((g) => /never contacts the source/i.test(g)));
   const allRuns = await jd("GET", "/v1/hypervisor/odk/materializing-runs");
-  ok("no run anywhere reports execution or object instances", (allRuns.j.materializing_runs || []).every((r) => r.execution?.source_contacted === false && r.execution?.object_instances === 0));
+  ok("no non-executed run reports execution or object instances", (allRuns.j.materializing_runs || []).filter((r) => r.status !== "executed").every((r) => r.execution?.source_contacted === false && r.execution?.object_instances === 0));
 
   // 8. UX ladder — the crossing rendered honestly.
   const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-projection.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-projection.mjs
@@ -163,7 +163,7 @@ async function run() {
   const ov = await jd("GET", "/v1/hypervisor/odk/ontology-projections/overview");
   ok("overview: declarative lifecycle + missing live authority + no-rows governance gaps", JSON.stringify(ov.j.lifecycle_states) === JSON.stringify(["draft", "ready", "blocked", "retired"]) && /credential authority/.test(ov.j.missing_authority || "") && (ov.j.governance_gaps || []).some((g) => /never rows|no materialized/i.test(g)));
   const all = await jd("GET", "/v1/hypervisor/odk/ontology-projections");
-  ok("no projection anywhere reports instances or materialization", (all.j.ontology_projections || []).every((p) => p.health?.object_instances === 0 && p.health?.materialized === false));
+  ok("no unmaterialized projection reports instances (materialization is set-backed only)", (all.j.ontology_projections || []).every((p) => (p.health?.materialized === true && !!p.materialized?.set_ref) || (p.health?.object_instances === 0 && p.health?.materialized === false)));
 
   // 6. ODK Manager UX — declared explorer shape + contract-complete ladder.
   const page = await fetch(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(ontId)}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -102,6 +102,8 @@ mod capability_lease_plan_routes;
 mod materializing_run_routes;
 #[path = "hypervisor_daemon_routes/connector_session_routes.rs"]
 mod connector_session_routes;
+#[path = "hypervisor_daemon_routes/connector_execution_routes.rs"]
+mod connector_execution_routes;
 #[path = "hypervisor_daemon_routes/harness_routes.rs"]
 mod harness_routes;
 #[path = "hypervisor_daemon_routes/model_routes.rs"]
@@ -1313,6 +1315,26 @@ async fn async_main() -> anyhow::Result<()> {
         .route(
             "/v1/hypervisor/odk/connector-sessions/:id/cancel",
             post(connector_session_routes::handle_session_cancel),
+        )
+        // Connector execution + materialized rows — the FINAL rung: one bounded read-only batch
+        // through the landed ladder, receipted before output, all-or-nothing. The first cut where a
+        // projection's object_instances may become nonzero.
+        .route(
+            "/v1/hypervisor/odk/materializing-runs/:id/execute",
+            post(connector_execution_routes::handle_run_execute),
+        )
+        .route(
+            "/v1/hypervisor/odk/materialized-object-sets",
+            get(connector_execution_routes::handle_sets_list),
+        )
+        .route(
+            "/v1/hypervisor/odk/materialized-object-sets/overview",
+            get(connector_execution_routes::handle_sets_overview),
+        )
+        .route(
+            "/v1/hypervisor/odk/materialized-object-sets/:id",
+            get(connector_execution_routes::handle_set_get)
+                .delete(connector_execution_routes::handle_set_delete),
         )
         .route(
             "/v1/hypervisor/odk/data-recipes",

--- a/crates/node/src/bin/hypervisor_daemon_routes/connector_execution_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/connector_execution_routes.rs
@@ -64,6 +64,21 @@ fn find_by_key(data_dir: &str, dir: &str, key: &str, id: &str) -> Option<Value> 
 fn expired(expires_at: &Value, now_millis: i64) -> bool {
     expires_at.as_i64().map(|e| e < now_millis).unwrap_or(false)
 }
+/// Endpoint form for receipts/provenance/records: userinfo and query are stripped — declared truth
+/// and audit trails carry host + path only (the GET itself uses the declared endpoint verbatim).
+fn redacted_endpoint(endpoint: &str) -> String {
+    let (scheme, rest) = match endpoint.split_once("://") {
+        Some((sc, r)) => (sc, r),
+        None => return endpoint.split(['?', '#']).next().unwrap_or(endpoint).to_string(),
+    };
+    let had_query = rest.contains('?');
+    let no_q = rest.split(['?', '#']).next().unwrap_or(rest);
+    let no_user = match no_q.rsplit_once('@') {
+        Some((_, host)) => host,
+        None => no_q,
+    };
+    format!("{scheme}://{no_user}{}", if had_query { "?…redacted" } else { "" })
+}
 fn sha256_hex(input: &str) -> String {
     let mut h = Sha256::new();
     h.update(input.as_bytes());
@@ -234,10 +249,20 @@ pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumP
 
     // THE READ — one GET of the DECLARED endpoint, verbatim. Read-only by construction.
     let endpoint = s(&source, "endpoint", "");
-    let receipt = run_receipt(&data_dir, &run_ref, "source_contact_started", "ok", &format!("GET {endpoint} (declared endpoint, verbatim; bearer attached, never recorded)"));
-    push_history(&mut run, "source_contact_started", &format!("GET {endpoint}"), &receipt);
+    let display_endpoint = redacted_endpoint(&endpoint);
+    let receipt = run_receipt(&data_dir, &run_ref, "source_contact_started", "ok", &format!("GET {display_endpoint} (declared endpoint, verbatim; bearer attached, never recorded)"));
+    push_history(&mut run, "source_contact_started", &format!("GET {display_endpoint}"), &receipt);
     let started = now_ms();
-    let resp = reqwest::Client::new()
+    let client = match reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "ok": false, "error": { "code": "execution_adapter_unavailable", "message": format!("adapter client could not initialize: {e}") } })));
+        }
+    };
+    let resp = client
         .get(&endpoint)
         .header("Authorization", format!("Bearer {bearer}"))
         .header("User-Agent", "ioi-hypervisor-odk-adapter")
@@ -251,15 +276,21 @@ pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumP
             (st_, r.text().await.unwrap_or_default())
         }
         Err(e) => {
-            let receipt = run_receipt(&data_dir, &run_ref, "source_contact_failed", "execution_source_unreachable", &format!("GET {endpoint} failed: {e}"));
+            let receipt = run_receipt(&data_dir, &run_ref, "source_contact_failed", "execution_source_unreachable", &format!("GET {display_endpoint} failed: {e}"));
             push_history(&mut run, "source_contact_failed", "source unreachable", &receipt);
             let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
             return (StatusCode::BAD_GATEWAY, Json(json!({ "ok": false, "error": { "code": "execution_source_unreachable", "message": format!("the declared endpoint did not answer: {e}") } })));
         }
     };
     let elapsed_ms = now_ms() - started;
+    if (300..400).contains(&(http_status as i32)) {
+        let receipt = run_receipt(&data_dir, &run_ref, "source_contact_failed", "execution_source_redirect_rejected", &format!("GET {display_endpoint} → http {http_status} redirect REFUSED — the adapter reads the DECLARED endpoint verbatim and never follows a redirect to an undeclared URL"));
+        push_history(&mut run, "source_contact_failed", &format!("redirect refused (http {http_status})"), &receipt);
+        let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+        return (StatusCode::BAD_GATEWAY, Json(json!({ "ok": false, "error": { "code": "execution_source_redirect_rejected", "message": "the declared endpoint answered with a redirect — refused; the adapter never follows redirects to undeclared URLs" } })));
+    }
     if !(200..300).contains(&(http_status as i32)) {
-        let receipt = run_receipt(&data_dir, &run_ref, "source_contact_failed", "execution_source_error", &format!("GET {endpoint} → http {http_status}"));
+        let receipt = run_receipt(&data_dir, &run_ref, "source_contact_failed", "execution_source_error", &format!("GET {display_endpoint} → http {http_status}"));
         push_history(&mut run, "source_contact_failed", &format!("http {http_status}"), &receipt);
         let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
         return (StatusCode::BAD_GATEWAY, Json(json!({ "ok": false, "error": { "code": "execution_source_error", "message": format!("the declared endpoint answered http {http_status}") } })));
@@ -276,7 +307,7 @@ pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumP
     let fetched = rows.len();
     let truncated = fetched as u64 > limit;
     let rows: Vec<Value> = rows.into_iter().take(limit as usize).collect();
-    let receipt = run_receipt(&data_dir, &run_ref, "source_contact_completed", "ok", &format!("GET {endpoint} → http {http_status} · {fetched} rows fetched · {} accepted (limit {limit}) · {elapsed_ms}ms", rows.len()));
+    let receipt = run_receipt(&data_dir, &run_ref, "source_contact_completed", "ok", &format!("GET {display_endpoint} → http {http_status} · {fetched} rows fetched · {} accepted (limit {limit}) · {elapsed_ms}ms", rows.len()));
     push_history(&mut run, "source_contact_completed", &format!("{fetched} rows fetched"), &receipt);
 
     // TRANSFORM + VALIDATE through the landed ladder — all-or-nothing, no partial truth.
@@ -284,6 +315,7 @@ pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumP
     let bindings = run_bindings(&mapping, &requested);
     let mut objects: Vec<Value> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
+    let mut seen_keys: Vec<String> = Vec::new();
     for (i, row) in rows.iter().enumerate() {
         let mut properties = serde_json::Map::new();
         let mut provenance = serde_json::Map::new();
@@ -310,6 +342,10 @@ pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumP
         }
         if object_key.trim().is_empty() {
             errors.push(format!("row {i}: empty object key"));
+        } else if seen_keys.iter().any(|k| k == &object_key) {
+            errors.push(format!("row {i}: duplicate object key '{object_key}' — semantic identity must be unique within a batch"));
+        } else {
+            seen_keys.push(object_key.clone());
         }
         if title.trim().is_empty() {
             errors.push(format!("row {i}: empty title"));
@@ -320,7 +356,7 @@ pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumP
             "object_type_id": s(&mapping, "object_type_id", ""),
             "properties": properties,
             "source_hash": sha256_hex(&row.to_string()),
-            "provenance": { "mapped_from": provenance, "connector_id": connector_id, "endpoint": endpoint, "session_ref": session.pointer("/session/session_ref").cloned().unwrap_or(Value::Null) }
+            "provenance": { "mapped_from": provenance, "connector_id": connector_id, "endpoint": display_endpoint, "session_ref": session.pointer("/session/session_ref").cloned().unwrap_or(Value::Null) }
         }));
     }
     if !errors.is_empty() {
@@ -361,7 +397,7 @@ pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumP
         "count": count,
         "rows_fetched": fetched,
         "truncated_to_limit": truncated,
-        "source_contact": { "endpoint": endpoint, "http_status": http_status, "elapsed_ms": elapsed_ms, "at": iso_now() },
+        "source_contact": { "endpoint": display_endpoint, "http_status": http_status, "elapsed_ms": elapsed_ms, "at": iso_now() },
         "pre_output_receipt_ref": pre.get("receipt_ref").cloned().unwrap_or(Value::Null),
         "registered_at": iso_now(),
         "runtimeTruthSource": "daemon-runtime"
@@ -372,23 +408,44 @@ pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumP
         let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
         return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "ok": false, "error": { "code": "execution_output_persist_failed", "message": "output could not persist" } })));
     }
+    // FINALIZATION IS ATOMIC-OR-ROLLED-BACK: every write after the set is CHECKED; any failure
+    // removes the set (and restores the projection) so no partial truth ever remains — a set never
+    // exists without its projection flip, and a run never stays executable beside a live set.
+    let rollback_set = |why: &str| {
+        let _ = remove_record(&data_dir, SET_DIR, &set_id);
+        let _ = run_receipt(&data_dir, &run_ref, "execution_refused", "execution_finalize_failed", &format!("finalization failed ({why}) — the set was ROLLED BACK; no partial truth remains"));
+    };
+    let prior_projection = projection.clone();
     projection["health"]["object_instances"] = json!(count);
     projection["health"]["materialized"] = json!(true);
     projection["health"]["note"] = json!("materialized — a bounded, receipted object set is registered for this projection");
     projection["materialized"] = json!({ "set_ref": set_ref, "count": count, "at": iso_now(), "materializing_run_ref": run_ref });
     projection["updated_at"] = json!(iso_now());
-    let _ = persist_record(&data_dir, crate::ontology_projection_routes::RECORD_DIR, &projection_id, &projection);
-
+    if let Err(e) = persist_record(&data_dir, crate::ontology_projection_routes::RECORD_DIR, &projection_id, &projection) {
+        rollback_set(&format!("projection persist: {e}"));
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "ok": false, "error": { "code": "execution_finalize_failed", "message": "the projection flip could not persist — the set was rolled back; no partial truth remains" } })));
+    }
     run["status"] = json!("executed");
     run["execution"] = json!({
         "source_contacted": true, "data_moved": true, "rows_extracted": count, "object_instances": count,
-        "endpoint": endpoint, "materialized_set_ref": set_ref, "completed_at": iso_now(),
+        "endpoint": display_endpoint, "materialized_set_ref": set_ref, "completed_at": iso_now(),
         "note": "one bounded read-only batch, registered all-or-nothing under the held lease + sealed session"
     });
     run["updated_at"] = json!(iso_now());
-    let receipt = run_receipt(&data_dir, &run_ref, "materialized_output_registered", "ok", &format!("{count} ontology-bound objects registered as {set_ref}; projection {projection_id} object_instances 0 → {count}"));
+    let receipt = match run_receipt_checked(&data_dir, &run_ref, "materialized_output_registered", "ok", &format!("{count} ontology-bound objects registered as {set_ref}; projection {projection_id} object_instances 0 → {count}")) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = persist_record(&data_dir, crate::ontology_projection_routes::RECORD_DIR, &projection_id, &prior_projection);
+            rollback_set(&format!("registration receipt: {e}"));
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "ok": false, "error": { "code": "execution_finalize_failed", "message": "the registration receipt could not persist — projection restored, set rolled back" } })));
+        }
+    };
     push_history(&mut run, "materialized_output_registered", &format!("{count} objects registered"), &receipt);
-    let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+    if let Err(e) = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run) {
+        let _ = persist_record(&data_dir, crate::ontology_projection_routes::RECORD_DIR, &projection_id, &prior_projection);
+        rollback_set(&format!("run persist: {e}"));
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "ok": false, "error": { "code": "execution_finalize_failed", "message": "the run state could not persist — projection restored, set rolled back (the run stays re-executable with no live set beside it)" } })));
+    }
     (StatusCode::OK, Json(json!({ "ok": true, "materializing_run": run, "materialized_object_set": set })))
 }
 
@@ -483,6 +540,14 @@ mod connector_execution_tests {
         let pids: Vec<&str> = b.iter().map(|(p, _, _, _)| p.as_str()).collect();
         assert!(pids.contains(&"loan_id") && pids.contains(&"title") && pids.contains(&"amount"));
         assert!(!pids.contains(&"extra")); // unrequested field excluded
+    }
+
+    #[test]
+    fn endpoint_redaction_strips_userinfo_and_query() {
+        assert_eq!(redacted_endpoint("https://host/rows"), "https://host/rows");
+        assert_eq!(redacted_endpoint("https://host/rows?api_key=X"), "https://host/rows?…redacted");
+        assert_eq!(redacted_endpoint("https://u:p@host/rows"), "https://host/rows");
+        assert_eq!(redacted_endpoint("https://u:p@host/rows?t=1"), "https://host/rows?…redacted");
     }
 
     #[test]

--- a/crates/node/src/bin/hypervisor_daemon_routes/connector_execution_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/connector_execution_routes.rs
@@ -234,8 +234,23 @@ pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumP
     let receipt = run_receipt(&data_dir, &run_ref, "execution_requested", "ok", &format!("read-only execution requested: kind {kind} · limit {limit} · session {}", s(&session, "id", "")));
     push_history(&mut run, "execution_requested", "read-only execution requested", &receipt);
 
-    // Resolve the sealed credential IN-MEMORY for the read — used for the header, then dropped.
     let connector_id = s(&session, "connector_id", "");
+    // RE-CHECK the credential↔endpoint binding at execution (never cached): the session's connector
+    // must STILL be the origin authority for the declared endpoint. Endpoints are immutable, but a
+    // connector's base_url can change (its /policy route) — so this is re-proven at the crossing,
+    // BEFORE the sealed credential is ever resolved. A stale binding sends the bearer nowhere.
+    let source_endpoint = s(&source, "endpoint", "");
+    match find_by_key(&data_dir, "connectors", "connector_id", &connector_id) {
+        Some(c) if crate::connector_session_routes::connector_covers_endpoint(&s(&c, "base_url", ""), &source_endpoint) => {}
+        _ => {
+            let receipt = run_receipt(&data_dir, &run_ref, "execution_refused", "execution_connector_source_mismatch", "the session's connector is no longer the origin authority for the declared source endpoint — refused before any credential resolution or source contact");
+            push_history(&mut run, "execution_refused", "connector↔source binding stale", &receipt);
+            let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+            return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "execution_connector_source_mismatch", "message": "the session's connector is not the origin authority for the declared source endpoint" } })));
+        }
+    }
+
+    // Resolve the sealed credential IN-MEMORY for the read — used for the header, then dropped.
     let bearer: Option<String> = match find_by_key(&data_dir, "connector-credentials", "connector_id", &connector_id) {
         Some(cred_rec) => resolve_sealed_credential(&cred_rec).await.0,
         None => None,

--- a/crates/node/src/bin/hypervisor_daemon_routes/connector_execution_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/connector_execution_routes.rs
@@ -1,0 +1,494 @@
+//! Connector execution + materialized rows — the FINAL rung of the ODK ratchet: the first cut where
+//! a projection's `object_instances` may become NONZERO. One narrow read-only adapter path, not a
+//! generic ingestion engine:
+//!
+//!   * a MaterializingRun that HOLDS its lease (#18) and has an OPENED sealed session (#19) may
+//!     execute ONE bounded read-only batch against an ALLOWLISTED connector kind (v1: `rest_api`);
+//!   * the adapter reads the DECLARED source shape only — a single GET of the data source's declared
+//!     endpoint; never caller SQL, never caller-shaped URLs;
+//!   * the sealed credential is resolved IN-MEMORY at read time, used for the Authorization header,
+//!     and dropped — never stored, logged, returned, or receipted;
+//!   * every fetched row transforms through the landed ladder (ConnectorMapping fields → typed
+//!     properties, scoped by the run's lease scope) and validates fully: valid key + title on every
+//!     row, every typed value validates — ONE malformed row rejects the WHOLE batch (all-or-nothing,
+//!     no partial truth);
+//!   * the PRE-OUTPUT receipt must persist BEFORE any materialized output record exists — a receipt
+//!     write failure aborts the registration;
+//!   * the materialized set stores ontology-bound object records + source hashes + provenance, and
+//!     updates ONLY the tied projection's materialized state;
+//!   * no actions, writeback, export, train, evaluate, publish, or route — read → validate → register.
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState};
+use crate::lifecycle_routes::resolve_sealed_credential;
+
+const SET_SCHEMA: &str = "ioi.hypervisor.odk.materialized-object-set.v1";
+const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.materialized-object-sets-overview.v1";
+pub(crate) const SET_DIR: &str = "odk-materialized-object-sets";
+/// Receipts land on the RUN's stream — execution is an act of the run.
+const RUN_RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.materializing-run-receipt.v1";
+const RUN_RECEIPT_DIR: &str = "odk-materializing-run-receipts";
+
+/// v1 allowlist: exactly one read-only adapter path.
+const SUPPORTED_EXECUTION_KINDS: &[&str] = &["rest_api"];
+const MAX_BATCH_LIMIT: u64 = 500;
+const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
+const RAW_QUERY_KEYS: &[&str] = &["query", "sql", "raw_query", "statement", "command"];
+const ENV_FALLBACK_KEYS: &[&str] = &["env", "env_var", "env_credential", "credential_env", "from_env"];
+
+fn nanos() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0)
+}
+fn now_ms() -> i64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as i64).unwrap_or(0)
+}
+fn s(v: &Value, k: &str, d: &str) -> String {
+    v.get(k).and_then(|x| x.as_str()).unwrap_or(d).to_string()
+}
+fn str_list(v: &Value, k: &str) -> Vec<String> {
+    v.get(k)
+        .and_then(|x| x.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str()).map(str::to_string).collect())
+        .unwrap_or_default()
+}
+fn find_by_key(data_dir: &str, dir: &str, key: &str, id: &str) -> Option<Value> {
+    read_record_dir(data_dir, dir).into_iter().find(|r| r.get(key).and_then(|v| v.as_str()) == Some(id))
+}
+fn expired(expires_at: &Value, now_millis: i64) -> bool {
+    expires_at.as_i64().map(|e| e < now_millis).unwrap_or(false)
+}
+fn sha256_hex(input: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(input.as_bytes());
+    format!("sha256:{:x}", h.finalize())
+}
+/// A fetched source value must match the mapping's DECLARED source_type (conservative, no coercion).
+fn value_matches_source_type(v: &Value, source_type: &str) -> bool {
+    match source_type {
+        "string" | "timestamp" | "date" => v.is_string(),
+        "integer" => v.as_i64().is_some(),
+        "double" => v.is_number(),
+        "boolean" => v.is_boolean(),
+        "json" => !v.is_null(),
+        _ => false,
+    }
+}
+/// The mapping bindings relevant to this run: (property_id, source_field, source_type, role).
+fn run_bindings(mapping: &Value, requested: &[String]) -> Vec<(String, String, String, &'static str)> {
+    let mut out: Vec<(String, String, String, &'static str)> = Vec::new();
+    let mut push = |m: &Value, role: &'static str| {
+        let pid = s(m, "property_id", "");
+        if !pid.is_empty() {
+            out.push((pid, s(m, "source_field", ""), s(m, "source_type", "string"), role));
+        }
+    };
+    if let Some(m) = mapping.get("key_mapping") {
+        push(m, "key");
+    }
+    if let Some(m) = mapping.get("title_mapping") {
+        push(m, "title");
+    }
+    if let Some(fs) = mapping.get("field_mappings").and_then(|v| v.as_array()) {
+        for f in fs {
+            push(f, "field");
+        }
+    }
+    // Key + title always participate (identity is never optional); other fields only when requested.
+    out.retain(|(pid, _, _, role)| *role != "field" || requested.iter().any(|r| r == pid));
+    out
+}
+
+/// Receipt on the RUN's stream. Returns Err when the receipt itself cannot persist — callers that
+/// are about to register OUTPUT must abort on that (receipts land BEFORE output, or nothing does).
+fn run_receipt_checked(data_dir: &str, run_ref: &str, op: &str, outcome: &str, summary: &str) -> Result<Value, String> {
+    let id = format!("mrr_{:x}", nanos());
+    let receipt_ref = format!("agentgres://materializing-run-receipt/{id}");
+    let rec = json!({
+        "schema_version": RUN_RECEIPT_SCHEMA, "receipt_id": id, "receipt_ref": receipt_ref,
+        "materializing_run_ref": run_ref, "op": op, "outcome": outcome, "summary": summary, "at": iso_now()
+    });
+    persist_record(data_dir, RUN_RECEIPT_DIR, &id, &rec).map_err(|e| e.to_string())?;
+    Ok(rec)
+}
+fn run_receipt(data_dir: &str, run_ref: &str, op: &str, outcome: &str, summary: &str) -> Value {
+    run_receipt_checked(data_dir, run_ref, op, outcome, summary).unwrap_or(Value::Null)
+}
+fn push_history(record: &mut Value, op: &str, summary: &str, receipt: &Value) {
+    let rev = record.get("revision").and_then(|v| v.as_u64()).unwrap_or(1);
+    let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
+    let mut hist = record.get("history").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    hist.push(json!({ "revision": rev, "op": op, "at": iso_now(), "summary": summary, "receipt_ref": receipt_ref.clone() }));
+    let len = hist.len();
+    if len > 20 {
+        hist = hist[len - 20..].to_vec();
+    }
+    record["history"] = json!(hist);
+    let mut refs = record.get("receipt_refs").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    refs.push(receipt_ref);
+    record["receipt_refs"] = json!(refs);
+}
+fn refuse(data_dir: &str, run_ref: &str, status: StatusCode, code: &str, msg: &str) -> (StatusCode, Json<Value>) {
+    let _ = run_receipt(data_dir, run_ref, "execution_refused", code, msg);
+    (status, Json(json!({ "ok": false, "error": { "code": code, "message": msg } })))
+}
+
+/// POST /v1/hypervisor/odk/materializing-runs/:id/execute — THE materialization. One bounded
+/// read-only batch through the landed ladder, receipted before output, all-or-nothing.
+pub(crate) async fn handle_run_execute(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(body): Json<Value>) -> (StatusCode, Json<Value>) {
+    let data_dir = st.data_dir.clone();
+    let Some(mut run) = find_by_key(&data_dir, crate::materializing_run_routes::RECORD_DIR, "id", &id) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "materializing run not found" })));
+    };
+    let run_ref = s(&run, "ref", "");
+    // Bypass guards — an execution request carries NO query shape and NO credential material.
+    if let Some(obj) = body.as_object() {
+        if PLAINTEXT_SECRET_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_plaintext_secret_rejected", "an execution request never carries credential material");
+        }
+        if RAW_QUERY_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_raw_query_rejected", "the adapter reads the DECLARED source shape only — caller queries never exist");
+        }
+        if ENV_FALLBACK_KEYS.iter().any(|k| obj.contains_key(*k) && !obj[*k].is_null()) {
+            return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_env_fallback_rejected", "environment-credential fallback is an authority bypass");
+        }
+    }
+    // Lifecycle: exactly one bounded batch per run (idempotency is explicit).
+    let status = s(&run, "status", "");
+    if status == "executed" {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "ok": false, "error": { "code": "execution_already_registered", "message": "this run already registered its batch — one bounded batch per run (v1); plan a new run for another batch" } })));
+    }
+    if status != "lease_obtained" {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_lease_not_obtained", &format!("run is '{status}' — execution requires a HELD lease"));
+    }
+    if expired(run.pointer("/lease/expires_at").unwrap_or(&Value::Null), now_ms()) {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_lease_expired", "the run's lease has expired");
+    }
+    // Bounded batch.
+    let limit = body.get("limit").and_then(|v| v.as_u64()).unwrap_or(100);
+    if limit == 0 || limit > MAX_BATCH_LIMIT {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_limit_unbounded", &format!("limit must be 1..={MAX_BATCH_LIMIT}"));
+    }
+    // Ladder re-check at the moment of execution — never cached.
+    let plan_id = s(&run, "capability_lease_plan_id", "");
+    let Some(plan) = find_by_key(&data_dir, crate::capability_lease_plan_routes::RECORD_DIR, "id", &plan_id) else {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_ladder_drift", "the run's plan no longer resolves");
+    };
+    if let Err(drift) = crate::materializing_run_routes::check_plan_against_truth(&data_dir, &plan) {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_ladder_drift", &format!("the ladder no longer matches: {drift}"));
+    }
+    // Allowlisted connector kind — checked from the DECLARED source, before any session lookup.
+    let source_id = s(&plan, "data_source_id", "");
+    let Some(source) = find_by_key(&data_dir, crate::data_source_routes::RECORD_DIR, "source_id", &source_id) else {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_ladder_drift", "the data source no longer resolves");
+    };
+    let kind = s(&source, "kind", "");
+    if !SUPPORTED_EXECUTION_KINDS.contains(&kind.as_str()) {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_connector_kind_unsupported", &format!("source kind '{kind}' has no allowlisted adapter in v1 (supported: {SUPPORTED_EXECUTION_KINDS:?})"));
+    }
+    // The sealed session: opened, unexpired, and tied to THIS run.
+    let session_id = s(&body, "connector_session_id", "");
+    let Some(session) = find_by_key(&data_dir, crate::connector_session_routes::RECORD_DIR, "id", &session_id) else {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_session_unknown", "connector_session_id does not resolve");
+    };
+    if session.get("materializing_run_id").and_then(|v| v.as_str()) != Some(id.as_str()) {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_session_mismatch", "the session is not tied to this run");
+    }
+    if s(&session, "status", "") != "session_obtained" {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_session_not_open", &format!("session is '{}' — execution requires an OPEN sealed session", s(&session, "status", "")));
+    }
+    if expired(session.pointer("/session/expires_at").unwrap_or(&Value::Null), now_ms()) {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_session_expired", "the sealed session has expired");
+    }
+    // The tied projection (the ONLY thing whose materialized state may change).
+    let projection_id = s(&plan, "ontology_projection_id", "");
+    let Some(mut projection) = find_by_key(&data_dir, crate::ontology_projection_routes::RECORD_DIR, "id", &projection_id) else {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_ladder_drift", "the tied projection no longer resolves");
+    };
+    let mapping_id = s(&plan, "connector_mapping_id", "");
+    let Some(mapping) = find_by_key(&data_dir, crate::connector_mapping_routes::RECORD_DIR, "id", &mapping_id) else {
+        return refuse(&data_dir, &run_ref, StatusCode::BAD_REQUEST, "execution_ladder_drift", "the mapping no longer resolves");
+    };
+
+    let receipt = run_receipt(&data_dir, &run_ref, "execution_requested", "ok", &format!("read-only execution requested: kind {kind} · limit {limit} · session {}", s(&session, "id", "")));
+    push_history(&mut run, "execution_requested", "read-only execution requested", &receipt);
+
+    // Resolve the sealed credential IN-MEMORY for the read — used for the header, then dropped.
+    let connector_id = s(&session, "connector_id", "");
+    let bearer: Option<String> = match find_by_key(&data_dir, "connector-credentials", "connector_id", &connector_id) {
+        Some(cred_rec) => resolve_sealed_credential(&cred_rec).await.0,
+        None => None,
+    };
+    let Some(bearer) = bearer else {
+        let receipt = run_receipt(&data_dir, &run_ref, "execution_refused", "execution_credential_unresolved", "the sealed credential no longer resolves — the session's authority is stale");
+        push_history(&mut run, "execution_refused", "sealed credential unresolved", &receipt);
+        let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+        return (StatusCode::PRECONDITION_REQUIRED, Json(json!({ "ok": false, "error": { "code": "execution_credential_unresolved", "message": "the sealed credential no longer resolves" } })));
+    };
+
+    // THE READ — one GET of the DECLARED endpoint, verbatim. Read-only by construction.
+    let endpoint = s(&source, "endpoint", "");
+    let receipt = run_receipt(&data_dir, &run_ref, "source_contact_started", "ok", &format!("GET {endpoint} (declared endpoint, verbatim; bearer attached, never recorded)"));
+    push_history(&mut run, "source_contact_started", &format!("GET {endpoint}"), &receipt);
+    let started = now_ms();
+    let resp = reqwest::Client::new()
+        .get(&endpoint)
+        .header("Authorization", format!("Bearer {bearer}"))
+        .header("User-Agent", "ioi-hypervisor-odk-adapter")
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await;
+    drop(bearer);
+    let (http_status, body_text) = match resp {
+        Ok(r) => {
+            let st_ = r.status().as_u16();
+            (st_, r.text().await.unwrap_or_default())
+        }
+        Err(e) => {
+            let receipt = run_receipt(&data_dir, &run_ref, "source_contact_failed", "execution_source_unreachable", &format!("GET {endpoint} failed: {e}"));
+            push_history(&mut run, "source_contact_failed", "source unreachable", &receipt);
+            let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+            return (StatusCode::BAD_GATEWAY, Json(json!({ "ok": false, "error": { "code": "execution_source_unreachable", "message": format!("the declared endpoint did not answer: {e}") } })));
+        }
+    };
+    let elapsed_ms = now_ms() - started;
+    if !(200..300).contains(&(http_status as i32)) {
+        let receipt = run_receipt(&data_dir, &run_ref, "source_contact_failed", "execution_source_error", &format!("GET {endpoint} → http {http_status}"));
+        push_history(&mut run, "source_contact_failed", &format!("http {http_status}"), &receipt);
+        let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+        return (StatusCode::BAD_GATEWAY, Json(json!({ "ok": false, "error": { "code": "execution_source_error", "message": format!("the declared endpoint answered http {http_status}") } })));
+    }
+    let rows: Vec<Value> = match serde_json::from_str::<Value>(&body_text) {
+        Ok(Value::Array(a)) => a,
+        _ => {
+            let receipt = run_receipt(&data_dir, &run_ref, "validation_result", "execution_source_shape_invalid", "the declared endpoint did not return a JSON array of rows");
+            push_history(&mut run, "validation_result", "source shape invalid", &receipt);
+            let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+            return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({ "ok": false, "error": { "code": "execution_source_shape_invalid", "message": "expected a JSON array of row objects" } })));
+        }
+    };
+    let fetched = rows.len();
+    let truncated = fetched as u64 > limit;
+    let rows: Vec<Value> = rows.into_iter().take(limit as usize).collect();
+    let receipt = run_receipt(&data_dir, &run_ref, "source_contact_completed", "ok", &format!("GET {endpoint} → http {http_status} · {fetched} rows fetched · {} accepted (limit {limit}) · {elapsed_ms}ms", rows.len()));
+    push_history(&mut run, "source_contact_completed", &format!("{fetched} rows fetched"), &receipt);
+
+    // TRANSFORM + VALIDATE through the landed ladder — all-or-nothing, no partial truth.
+    let requested = str_list(&run, "requested_properties");
+    let bindings = run_bindings(&mapping, &requested);
+    let mut objects: Vec<Value> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    for (i, row) in rows.iter().enumerate() {
+        let mut properties = serde_json::Map::new();
+        let mut provenance = serde_json::Map::new();
+        let mut object_key = String::new();
+        let mut title = String::new();
+        for (pid, sf, st_, role) in &bindings {
+            let v = row.get(sf.as_str()).cloned().unwrap_or(Value::Null);
+            if v.is_null() {
+                errors.push(format!("row {i}: source field '{sf}' (→ {pid}) is missing"));
+                continue;
+            }
+            if !value_matches_source_type(&v, st_) {
+                errors.push(format!("row {i}: source field '{sf}' (→ {pid}) does not match declared type '{st_}'"));
+                continue;
+            }
+            if *role == "key" {
+                object_key = v.as_str().map(str::to_string).unwrap_or_else(|| v.to_string());
+            }
+            if *role == "title" {
+                title = v.as_str().map(str::to_string).unwrap_or_else(|| v.to_string());
+            }
+            properties.insert(pid.clone(), v);
+            provenance.insert(pid.clone(), json!(sf));
+        }
+        if object_key.trim().is_empty() {
+            errors.push(format!("row {i}: empty object key"));
+        }
+        if title.trim().is_empty() {
+            errors.push(format!("row {i}: empty title"));
+        }
+        objects.push(json!({
+            "object_key": object_key,
+            "title": title,
+            "object_type_id": s(&mapping, "object_type_id", ""),
+            "properties": properties,
+            "source_hash": sha256_hex(&row.to_string()),
+            "provenance": { "mapped_from": provenance, "connector_id": connector_id, "endpoint": endpoint, "session_ref": session.pointer("/session/session_ref").cloned().unwrap_or(Value::Null) }
+        }));
+    }
+    if !errors.is_empty() {
+        errors.truncate(8);
+        let receipt = run_receipt(&data_dir, &run_ref, "validation_result", "execution_batch_invalid", &format!("batch REJECTED all-or-nothing: {} error(s), zero objects registered — {}", errors.len(), errors.join("; ")));
+        push_history(&mut run, "validation_result", "batch rejected — no partial truth", &receipt);
+        let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+        return (StatusCode::UNPROCESSABLE_ENTITY, Json(json!({ "ok": false, "error": { "code": "execution_batch_invalid", "message": "one or more rows failed validation — the whole batch is rejected (no partial truth)", "errors": errors } })));
+    }
+    let receipt = run_receipt(&data_dir, &run_ref, "validation_result", "ok", &format!("all {} rows validated against the typed ladder", objects.len()));
+    push_history(&mut run, "validation_result", "batch validated", &receipt);
+
+    // PRE-OUTPUT RECEIPT — must land BEFORE any output record. Persist failure ABORTS registration.
+    let set_id = format!("mset_{:x}", nanos());
+    let set_ref = format!("materialized-object-set://{set_id}");
+    let pre = match run_receipt_checked(&data_dir, &run_ref, "pre_output_receipt", "ok", &format!("about to register {} objects as {set_ref} for projection {projection_id} — receipt lands before output, or nothing does", objects.len())) {
+        Ok(r) => r,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "ok": false, "error": { "code": "execution_receipt_failed", "message": format!("the pre-output receipt could not persist — registration ABORTED before any output: {e}") } })));
+        }
+    };
+    push_history(&mut run, "pre_output_receipt", "pre-output receipt landed", &pre);
+
+    // REGISTER — all-or-nothing, one bounded set; then flip ONLY the tied projection.
+    let count = objects.len();
+    let set = json!({
+        "schema_version": SET_SCHEMA,
+        "object": "ioi.hypervisor.odk.materialized_object_set",
+        "id": set_id,
+        "ref": set_ref,
+        "materializing_run_ref": run_ref,
+        "connector_session_ref": session.get("ref").cloned().unwrap_or(Value::Null),
+        "capability_lease_plan_ref": plan.get("ref").cloned().unwrap_or(Value::Null),
+        "ontology_projection_id": projection_id,
+        "ontology_ref": run.get("ontology_ref").cloned().unwrap_or(Value::Null),
+        "object_type_id": run.get("object_type_id").cloned().unwrap_or(Value::Null),
+        "objects": objects,
+        "count": count,
+        "rows_fetched": fetched,
+        "truncated_to_limit": truncated,
+        "source_contact": { "endpoint": endpoint, "http_status": http_status, "elapsed_ms": elapsed_ms, "at": iso_now() },
+        "pre_output_receipt_ref": pre.get("receipt_ref").cloned().unwrap_or(Value::Null),
+        "registered_at": iso_now(),
+        "runtimeTruthSource": "daemon-runtime"
+    });
+    if let Err(e) = persist_record(&data_dir, SET_DIR, &set_id, &set) {
+        let receipt = run_receipt(&data_dir, &run_ref, "execution_refused", "execution_output_persist_failed", &format!("output persist failed after the pre-output receipt: {e}"));
+        push_history(&mut run, "execution_refused", "output persist failed", &receipt);
+        let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "ok": false, "error": { "code": "execution_output_persist_failed", "message": "output could not persist" } })));
+    }
+    projection["health"]["object_instances"] = json!(count);
+    projection["health"]["materialized"] = json!(true);
+    projection["health"]["note"] = json!("materialized — a bounded, receipted object set is registered for this projection");
+    projection["materialized"] = json!({ "set_ref": set_ref, "count": count, "at": iso_now(), "materializing_run_ref": run_ref });
+    projection["updated_at"] = json!(iso_now());
+    let _ = persist_record(&data_dir, crate::ontology_projection_routes::RECORD_DIR, &projection_id, &projection);
+
+    run["status"] = json!("executed");
+    run["execution"] = json!({
+        "source_contacted": true, "data_moved": true, "rows_extracted": count, "object_instances": count,
+        "endpoint": endpoint, "materialized_set_ref": set_ref, "completed_at": iso_now(),
+        "note": "one bounded read-only batch, registered all-or-nothing under the held lease + sealed session"
+    });
+    run["updated_at"] = json!(iso_now());
+    let receipt = run_receipt(&data_dir, &run_ref, "materialized_output_registered", "ok", &format!("{count} ontology-bound objects registered as {set_ref}; projection {projection_id} object_instances 0 → {count}"));
+    push_history(&mut run, "materialized_output_registered", &format!("{count} objects registered"), &receipt);
+    let _ = persist_record(&data_dir, crate::materializing_run_routes::RECORD_DIR, &id, &run);
+    (StatusCode::OK, Json(json!({ "ok": true, "materializing_run": run, "materialized_object_set": set })))
+}
+
+/// GET /v1/hypervisor/odk/materialized-object-sets.
+pub(crate) async fn handle_sets_list(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let mut items = read_record_dir(&st.data_dir, SET_DIR);
+    items.sort_by(|a, b| s(b, "registered_at", "").cmp(&s(a, "registered_at", "")));
+    Json(json!({ "ok": true, "schema_version": SET_SCHEMA, "materialized_object_sets": items, "runtimeTruthSource": "daemon-runtime" }))
+}
+
+/// GET /v1/hypervisor/odk/materialized-object-sets/overview.
+pub(crate) async fn handle_sets_overview(State(st): State<Arc<DaemonState>>) -> Json<Value> {
+    let items = read_record_dir(&st.data_dir, SET_DIR);
+    let objects: u64 = items.iter().map(|r| r.get("count").and_then(|v| v.as_u64()).unwrap_or(0)).sum();
+    Json(json!({
+        "ok": true,
+        "schema_version": OVERVIEW_SCHEMA,
+        "materialized_object_sets": items.len(),
+        "object_instances": objects,
+        "supported_execution_kinds": SUPPORTED_EXECUTION_KINDS,
+        "max_batch_limit": MAX_BATCH_LIMIT,
+        "governance_gaps": [
+            "one narrow read-only adapter path (rest_api GET of the declared endpoint) — not a generic ingestion engine",
+            "every set was registered all-or-nothing behind a pre-output receipt under a held lease + opened sealed session",
+            "object records carry source hashes + provenance — never credential or raw source secrets",
+            "no actions, writeback, export, train, evaluate, publish, or route exist on this path"
+        ],
+        "runtimeTruthSource": "daemon-runtime"
+    }))
+}
+
+/// GET /v1/hypervisor/odk/materialized-object-sets/:id.
+pub(crate) async fn handle_set_get(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> (StatusCode, Json<Value>) {
+    match find_by_key(&st.data_dir, SET_DIR, "id", &id) {
+        Some(r) => (StatusCode::OK, Json(json!({ "ok": true, "materialized_object_set": r }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "ok": false, "reason": "materialized object set not found" }))),
+    }
+}
+
+/// DELETE — receipted removal that RESETS the tied projection's materialized state (no dangling counts).
+pub(crate) async fn handle_set_delete(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> Json<Value> {
+    let Some(set) = find_by_key(&st.data_dir, SET_DIR, "id", &id) else {
+        return Json(json!({ "ok": false, "removed": false, "id": id }));
+    };
+    let projection_id = s(&set, "ontology_projection_id", "");
+    if let Some(mut projection) = find_by_key(&st.data_dir, crate::ontology_projection_routes::RECORD_DIR, "id", &projection_id) {
+        projection["health"]["object_instances"] = json!(0);
+        projection["health"]["materialized"] = json!(false);
+        projection["materialized"] = Value::Null;
+        projection["updated_at"] = json!(iso_now());
+        let _ = persist_record(&st.data_dir, crate::ontology_projection_routes::RECORD_DIR, &projection_id, &projection);
+    }
+    let removed = remove_record(&st.data_dir, SET_DIR, &id);
+    if removed {
+        let _ = run_receipt(&st.data_dir, &s(&set, "materializing_run_ref", ""), "materialized_output_removed", "ok", &format!("materialized set {} removed; projection {projection_id} reset to 0", s(&set, "ref", "")));
+    }
+    Json(json!({ "ok": removed, "removed": removed, "id": id }))
+}
+
+#[cfg(test)]
+mod connector_execution_tests {
+    use super::*;
+
+    #[test]
+    fn allowlist_and_bounds_are_narrow() {
+        assert_eq!(SUPPORTED_EXECUTION_KINDS, &["rest_api"]);
+        assert_eq!(MAX_BATCH_LIMIT, 500);
+    }
+
+    #[test]
+    fn source_type_validation_is_conservative() {
+        assert!(value_matches_source_type(&json!("x"), "string"));
+        assert!(value_matches_source_type(&json!(3), "integer"));
+        assert!(value_matches_source_type(&json!(3.5), "double"));
+        assert!(value_matches_source_type(&json!(3), "double"));
+        assert!(!value_matches_source_type(&json!("3"), "double"));
+        assert!(!value_matches_source_type(&json!(3.5), "integer"));
+        assert!(!value_matches_source_type(&json!(null), "json"));
+    }
+
+    #[test]
+    fn run_bindings_always_include_key_and_title() {
+        let mapping = json!({
+            "key_mapping": { "property_id": "loan_id", "source_field": "id", "source_type": "string" },
+            "title_mapping": { "property_id": "title", "source_field": "disp", "source_type": "string" },
+            "field_mappings": [
+                { "property_id": "amount", "source_field": "amt", "source_type": "double" },
+                { "property_id": "extra", "source_field": "x", "source_type": "string" }
+            ]
+        });
+        let b = run_bindings(&mapping, &vec!["loan_id".into(), "title".into(), "amount".into()]);
+        let pids: Vec<&str> = b.iter().map(|(p, _, _, _)| p.as_str()).collect();
+        assert!(pids.contains(&"loan_id") && pids.contains(&"title") && pids.contains(&"amount"));
+        assert!(!pids.contains(&"extra")); // unrequested field excluded
+    }
+
+    #[test]
+    fn source_hash_is_stable_and_prefixed() {
+        let h = sha256_hex("row");
+        assert!(h.starts_with("sha256:"));
+        assert_eq!(h, sha256_hex("row"));
+    }
+}

--- a/crates/node/src/bin/hypervisor_daemon_routes/connector_session_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/connector_session_routes.rs
@@ -29,7 +29,7 @@ use crate::lifecycle_routes::{authorize_capability_lease, CapabilityLeaseRequest
 const SESSION_SCHEMA: &str = "ioi.hypervisor.odk.connector-session.v1";
 const RECEIPT_SCHEMA: &str = "ioi.hypervisor.odk.connector-session-receipt.v1";
 const OVERVIEW_SCHEMA: &str = "ioi.hypervisor.odk.connector-sessions-overview.v1";
-const RECORD_DIR: &str = "odk-connector-sessions";
+pub(crate) const RECORD_DIR: &str = "odk-connector-sessions";
 const RECEIPT_DIR: &str = "odk-connector-session-receipts";
 
 /// Lifecycle: a session request exists, may be opened (the crossing), and released — nothing reads.

--- a/crates/node/src/bin/hypervisor_daemon_routes/connector_session_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/connector_session_routes.rs
@@ -76,6 +76,39 @@ fn source_kind_networked(kind: &str) -> bool {
     !matches!(kind, "file_drop" | "local_folder")
 }
 
+/// Split a URL into (scheme, authority, path) — authority lowercased; path defaults to "/".
+fn url_parts(u: &str) -> Option<(String, String, String)> {
+    let (scheme, rest) = u.split_once("://")?;
+    if scheme.is_empty() || rest.is_empty() {
+        return None;
+    }
+    let (authority, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, "/"),
+    };
+    let authority = authority.split(['?', '#']).next().unwrap_or(authority);
+    if authority.is_empty() {
+        return None;
+    }
+    let path = path.split(['?', '#']).next().unwrap_or(path);
+    Some((scheme.to_ascii_lowercase(), authority.to_ascii_lowercase(), path.to_string()))
+}
+/// Does the connector's `base_url` cover the data-source endpoint? A sealed credential may only be
+/// sent to the endpoint its connector is the ORIGIN AUTHORITY for: same scheme + host:port, and the
+/// endpoint path AT OR UNDER the base_url path. This binds the credential to the exact source it
+/// authorizes — connector A's bearer can never reach data-source B's endpoint. Fail-closed on any
+/// unparseable URL.
+pub(crate) fn connector_covers_endpoint(base_url: &str, endpoint: &str) -> bool {
+    let (Some((bs, ba, bp)), Some((es, ea, ep))) = (url_parts(base_url), url_parts(endpoint)) else {
+        return false;
+    };
+    if bs != es || ba != ea {
+        return false;
+    }
+    let base_path = bp.trim_end_matches('/'); // "" (root) covers all paths
+    base_path.is_empty() || ep == base_path || ep.starts_with(&format!("{base_path}/"))
+}
+
 /// Everything a session needs, resolved fresh: the run (holding its lease), its plan, the connector.
 struct SessionInputs {
     run: Value,
@@ -129,10 +162,18 @@ fn validate_inputs(data_dir: &str, body: &Value) -> Result<SessionInputs, VErr> 
     if !source_kind_networked(&kind) {
         return Err(verr("session_source_kind_unsupported", format!("source kind '{kind}' has no connector session to open (local kinds are read in-place by a future execution cut)")));
     }
-    // The connector that HOLDS the sealed credential must be registered in the connector estate.
+    // The connector that HOLDS the sealed credential must be registered in the connector estate AND
+    // be the ORIGIN AUTHORITY for the declared source endpoint — the credential is bound to the
+    // exact source it may reach, never a different endpoint.
     let connector_id = opt_s(body, "connector_id").unwrap_or_default();
-    if find_by_key(data_dir, "connectors", "connector_id", &connector_id).is_none() {
-        return Err(verr("session_connector_unknown", format!("connector_id '{connector_id}' is not registered in the connector estate")));
+    let connector = find_by_key(data_dir, "connectors", "connector_id", &connector_id)
+        .ok_or_else(|| verr("session_connector_unknown", format!("connector_id '{connector_id}' is not registered in the connector estate")))?;
+    let source_endpoint = s(&source, "endpoint", "");
+    if !connector_covers_endpoint(&s(&connector, "base_url", ""), &source_endpoint) {
+        return Err(verr(
+            "session_connector_source_mismatch",
+            format!("connector '{connector_id}' (base_url '{}') is not the origin authority for the source endpoint '{}' — a session cannot bind a credential to an endpoint it does not authorize", s(&connector, "base_url", ""), s(&source, "endpoint", "")),
+        ));
     }
     // TTL: bounded by the run's (which was bounded by the plan's).
     let run_ttl = run.get("ttl_seconds").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -455,6 +496,21 @@ mod connector_session_tests {
         assert!(lease_expired(&json!(1000), 2000));
         assert!(!lease_expired(&json!(3000), 2000));
         assert!(!lease_expired(&Value::Null, 2000));
+    }
+
+    #[test]
+    fn connector_authority_binds_credential_to_endpoint() {
+        // same origin, endpoint under (or at) the base_url path → covered
+        assert!(connector_covers_endpoint("http://127.0.0.1:18099", "http://127.0.0.1:18099/rows"));
+        assert!(connector_covers_endpoint("https://db.invalid", "https://db.invalid/rows?limit=5"));
+        assert!(connector_covers_endpoint("https://host/api", "https://host/api/loans"));
+        // different host:port → the confused-deputy case → refused
+        assert!(!connector_covers_endpoint("http://127.0.0.1:18099", "http://127.0.0.1:9/rows"));
+        assert!(!connector_covers_endpoint("https://a.host", "https://b.host/rows"));
+        // scheme mismatch, path sibling (not under), and unparseable → refused
+        assert!(!connector_covers_endpoint("http://host", "https://host/rows"));
+        assert!(!connector_covers_endpoint("https://host/api", "https://host/apiv2/x"));
+        assert!(!connector_covers_endpoint("not-a-url", "https://host/rows"));
     }
 
     #[test]

--- a/crates/node/src/bin/hypervisor_daemon_routes/data_source_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/data_source_routes.rs
@@ -48,6 +48,31 @@ const CREDENTIAL_POSTURES: &[&str] = &[
     "provider_vault_token",
     "customer_boundary",
 ];
+/// Query keys in an endpoint URL that would smuggle a credential into declared truth.
+const SENSITIVE_ENDPOINT_QUERY_KEYS: &[&str] = &[
+    "api_key", "apikey", "token", "secret", "password", "key", "access_token", "credential",
+];
+
+/// An endpoint that embeds credentials (userinfo or a sensitive query param) is rejected — the
+/// credential planes hold secrets; declared truth never does.
+fn endpoint_carries_credentials(endpoint: &str) -> bool {
+    if let Some((_, rest)) = endpoint.split_once("://") {
+        let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+        if authority.contains('@') {
+            return true;
+        }
+    }
+    if let Some((_, query)) = endpoint.split_once('?') {
+        for pair in query.split('&') {
+            let k = pair.split('=').next().unwrap_or("").to_ascii_lowercase();
+            if SENSITIVE_ENDPOINT_QUERY_KEYS.contains(&k.as_str()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Body keys that would be a plaintext secret — rejected outright (no secret ever enters the plane).
 const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
 
@@ -201,6 +226,14 @@ pub(crate) async fn handle_data_source_create(
             "A network data source kind requires an endpoint.",
         );
     }
+    if let Some(e) = &endpoint {
+        if endpoint_carries_credentials(e) {
+            return err(
+                "data_source_endpoint_credentialed",
+                "The endpoint embeds credential material (userinfo or a sensitive query param) — declare credential_posture instead; secrets never enter declared truth.",
+            );
+        }
+    }
     let credential_posture = s(&body, "credential_posture", "no_credentials_required");
     if !CREDENTIAL_POSTURES.contains(&credential_posture.as_str()) {
         return err(
@@ -241,6 +274,16 @@ mod data_source_tests {
         assert_eq!(kind_requires_endpoint("postgres"), Some(true));
         assert_eq!(kind_requires_endpoint("local_folder"), Some(false));
         assert_eq!(kind_requires_endpoint("nonsense"), None);
+    }
+
+    #[test]
+    fn credentialed_endpoints_are_detected() {
+        assert!(endpoint_carries_credentials("https://user:pass@host/rows"));
+        assert!(endpoint_carries_credentials("https://host/rows?api_key=x"));
+        assert!(endpoint_carries_credentials("https://host/rows?limit=5&TOKEN=x"));
+        assert!(!endpoint_carries_credentials("https://host/rows"));
+        assert!(!endpoint_carries_credentials("https://host/rows?limit=5&cursor=abc"));
+        assert!(!endpoint_carries_credentials("postgres://host:5432/db"));
     }
 
     #[test]

--- a/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
@@ -8915,7 +8915,7 @@ fn capability_lease_request_hash(req: &CapabilityLeaseRequest) -> String {
 /// Resolve a sealed credential record into a usable token + (source, key_source). Two kinds:
 /// a github-app record MINTS a fresh installation token (RS256 JWT → exchange); any other record
 /// opens its sealed PAT. The secret material (pem / sealed token) never leaves the daemon.
-async fn resolve_sealed_credential(
+pub(crate) async fn resolve_sealed_credential(
     rec: &Value,
 ) -> (Option<String>, Option<String>, Option<String>) {
     let key_source = rec["key_source"].as_str().map(str::to_string);

--- a/crates/node/src/bin/hypervisor_daemon_routes/materializing_run_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/materializing_run_routes.rs
@@ -36,7 +36,7 @@ pub(crate) const RECORD_DIR: &str = "odk-materializing-runs";
 const RECEIPT_DIR: &str = "odk-materializing-run-receipts";
 
 /// Lifecycle: a run exists, may obtain its lease, and may release it — nothing executes.
-const LIFECYCLE_STATES: &[&str] = &["planned", "lease_obtained", "lease_released", "cancelled"];
+const LIFECYCLE_STATES: &[&str] = &["planned", "lease_obtained", "executed", "lease_released", "cancelled"];
 /// What still does not exist after this rung — the two remaining cuts, named.
 const MISSING_AUTHORITY: &[&str] = &["ConnectorExecution", "MaterializedRows"];
 const PLAINTEXT_SECRET_KEYS: &[&str] = &["secret", "password", "api_key", "apikey", "token", "credential"];
@@ -262,7 +262,7 @@ pub(crate) async fn handle_mruns_overview(State(st): State<Arc<DaemonState>>) ->
         "ok": true,
         "schema_version": OVERVIEW_SCHEMA,
         "materializing_runs": items.len(),
-        "lifecycle": { "planned": by("planned"), "lease_obtained": by("lease_obtained"), "lease_released": by("lease_released"), "cancelled": by("cancelled") },
+        "lifecycle": { "planned": by("planned"), "lease_obtained": by("lease_obtained"), "executed": by("executed"), "lease_released": by("lease_released"), "cancelled": by("cancelled") },
         "lifecycle_states": LIFECYCLE_STATES,
         "missing_authority": MISSING_AUTHORITY,
         "governance_gaps": [
@@ -478,7 +478,7 @@ pub(crate) async fn handle_mrun_patch(State(st): State<Arc<DaemonState>>, AxumPa
     }
     let scope_keys = ["capability_lease_plan_id", "subject", "purpose", "requested_operations", "requested_properties", "ttl_seconds"];
     let scope_affecting = scope_keys.iter().any(|k| patch.get(*k).is_some());
-    if scope_affecting && status == "lease_obtained" {
+    if scope_affecting && (status == "lease_obtained" || status == "executed") {
         let _ = run_receipt(&st.data_dir, &s(&existing, "ref", ""), "patch_rejected", "materializing_run_scope_frozen", "scope-affecting patch refused — the obtained lease's scope is frozen");
         return Json(json!({ "ok": false, "error": { "code": "materializing_run_scope_frozen", "message": "the lease is obtained — its scope is frozen; release it to re-plan" } }));
     }
@@ -529,7 +529,7 @@ mod materializing_run_tests {
 
     #[test]
     fn lifecycle_and_missing_authority_are_explicit() {
-        assert_eq!(LIFECYCLE_STATES, &["planned", "lease_obtained", "lease_released", "cancelled"]);
+        assert_eq!(LIFECYCLE_STATES, &["planned", "lease_obtained", "executed", "lease_released", "cancelled"]);
         assert_eq!(MISSING_AUTHORITY, &["ConnectorExecution", "MaterializedRows"]);
     }
 

--- a/crates/node/src/bin/hypervisor_daemon_routes/ontology_projection_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/ontology_projection_routes.rs
@@ -321,7 +321,13 @@ fn push_history(record: &mut Value, op: &str, summary: &str, receipt_ref: Value)
 }
 /// Merge validated inputs onto a record (shared by create + patch + recheck).
 fn apply_inputs(record: &mut Value, inputs: &ProjInputs) {
-    let health = project_health(inputs);
+    let mut health = project_health(inputs);
+    // Materialized state survives re-validation: a registered, receipted object set is truth until
+    // its set is removed — a shape edit never silently zeroes real instances.
+    if record.pointer("/health/materialized").and_then(|v| v.as_bool()).unwrap_or(false) {
+        health["object_instances"] = record.pointer("/health/object_instances").cloned().unwrap_or(json!(0));
+        health["materialized"] = json!(true);
+    }
     let status = if health["status"] == "ready" { "ready" } else { "draft" };
     record["connector_mapping_id"] = inputs.mapping.get("id").cloned().unwrap_or(Value::Null);
     record["connector_mapping_ref"] = inputs.mapping.get("ref").cloned().unwrap_or(Value::Null);


### PR DESCRIPTION
**Base: master** (#19 merged). The final cut of the ODK ratchet, scoped exactly as directed: **one real read, one sealed session, one receipted batch, one projection goes nonzero** — one narrow read-only adapter path, not a generic ingestion engine.

## The execution
`POST /v1/hypervisor/odk/materializing-runs/:id/execute` — requires a **held** lease (#18) + an **open** sealed session (#19) tied to the same run, ladder re-checked at the moment of execution:
- **Allowlisted kind only** (v1: `rest_api`); the adapter GETs the **declared endpoint verbatim** — no caller SQL, no caller-shaped URLs.
- The sealed credential resolves **in-memory** for the Authorization header and is dropped.
- Rows transform through the landed ladder and validate **all-or-nothing** — one malformed row rejects the whole batch, zero objects registered.
- The **pre-output receipt must persist before any output** — a receipt write failure aborts registration.
- The set stores objects + **sha256 source hashes + provenance** (mapped_from per property · connector · endpoint · session ref) — never secrets.
- Only the **tied** projection's `object_instances` changes; set deletion resets it; rerun explicitly refused (one bounded batch per run).

## Proven, not asserted
| proof | result |
|---|---|
| projection **0 → 3**, count == set count | ✔ |
| first nonzero only **after** `pre_output_receipt` (append-ordered history) | `…→ validation_result → pre_output_receipt → materialized_output_registered` |
| source-contact evidence **both sides** — the fixture received exactly the adapter's authed GET | hits 0→1, authed |
| sentinel sweep: the bearer **used for the read** exists nowhere (response · run records · set records · receipts · rendered surface) | 5/5 clean |
| malformed batch → 422, named row errors, **zero registered**, projection stays 0 | ✔ |
| unsupported kind refused · unreachable source receipted · raw-query/env-fallback rejected · rerun refused · set-delete resets | ✔ |

## The ladder — complete
`ConnectorMapping ✓ · PolicyBoundDataView ✓ · TransformationRun dry-run ✓ · OntologyProjection ✓ · CapabilityLease plan ✓ · CapabilityLease obtained ✓ · Sealed connector session ✓ · Connector execution ✓ · Materialized rows ✓`

The Explorer pane renders the **first bounded rows** (declared columns only, set ref shown); object-type counts are real; and everything is **conditionally honest** — ontologies that never materialized keep their zeros and missing rungs. The Object Explorer seed stays secondary.

## Done bar — green
connector-execution **30/30** · cargo **105/105** (+4) · all 16 prior verifiers green (materializing-run/projection asserts evolved for `executed` lifecycle + set-backed materialization) · source-neutral PASSED · fallthrough empty · diff clean.

**The ODK ratchet is complete**: nine rungs from declared source to materialized, receipted, provenanced rows — every authority crossing separate, wallet-gated, and auditable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)