### PR TITLE
Thread ODK materialization receipts into the Provenance proof stream (by reference)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -3203,14 +3203,21 @@ function renderDataLineage(lists, selectedId) {
   const receiptPane = `<h2 id="lineage-receipts">Receipt chain <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— the run's auditable acts (${receiptRefs.length})</span></h2>`
     + (run ? `<dl class="grid">${(run.history || []).slice().reverse().slice(0, 8).map((h) => `<dt>${CX_ESC(h.op || "")}</dt><dd>${CX_ESC(h.summary || "")}<br><span class="sub" style="margin:0"><code>${CX_ESC(h.receipt_ref || "")}</code></span></dd>`).join("")}</dl>` : `<div class="empty">The materializing run for this set is no longer resolvable.</div>`);
 
-  // Provenance proof-stream edges — WHERE AVAILABLE (honest; the ODK materialization receipts are not
-  // yet threaded into the Provenance proof stream, so today this is 0). Backing route unchanged.
+  // Provenance proof-stream edges — the ODK materialization receipts are THREADED into the Provenance
+  // proof stream (daemon-side, by reference — no receipt re-minted); each entry that references this
+  // chain is a real cross-plane edge. Backing route unchanged.
   const chainRefs = [primary.ref, primary.materializing_run_ref, primary.connector_session_ref, primary.capability_lease_plan_ref].filter(Boolean);
   const provEdges = provStream.filter((e) => chainRefs.some((r) => JSON.stringify(e).includes(r)));
-  const ledgerPane = `<h2 id="lineage-provenance-stream">Provenance proof-stream edges <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— where available</span></h2>`
+  const provEdgeRows = provEdges.slice(0, 8).map((e) => `<tr>
+    <td><span class="pill muted">${CX_ESC(e.kind || "—")}</span></td>
+    <td>${CX_ESC(e.status || "")}${e.object_count != null ? ` · ${CX_ESC(String(e.object_count))} objects` : ""}</td>
+    <td><code style="font-size:10.5px">${CX_ESC(e.receipt_ref || "—")}</code></td>
+    <td class="sub" style="margin:0">${CX_ESC(e.timestamp || "")}</td>
+  </tr>`).join("");
+  const ledgerPane = `<h2 id="lineage-provenance-stream">Provenance proof-stream edges <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— threaded from the ODK materialization receipts, by reference</span></h2>`
     + (provEdges.length
-      ? `<div class="sub">${provEdges.length} Provenance proof-stream entr${provEdges.length === 1 ? "y" : "ies"} reference this lineage chain.</div>`
-      : omBoundaryNote(`<b>0 Provenance proof-stream edges</b> for this chain — the ODK materialization receipts live on their own run stream and are <b>not yet threaded into the Provenance proof stream</b> (a named gap). The resolved ladder refs + object provenance above are the authoritative lineage today.`));
+      ? `<p class="sub" style="margin:0 0 8px">${provEdges.length} Provenance proof-stream entr${provEdges.length === 1 ? "y" : "ies"} reference this lineage chain — projected by reference from the existing materialization receipts (<b>no receipt authority is duplicated</b>).</p><table><thead><tr><th>Kind</th><th>Outcome</th><th>Receipt (existing)</th><th>When</th></tr></thead><tbody>${provEdgeRows}</tbody></table>`
+      : omBoundaryNote(`<b>0 Provenance proof-stream edges</b> for this chain — no materialization receipt references it yet. The resolved ladder refs + object provenance above are the authoritative lineage.`));
 
   const gaps = omBoundaryNote(`This is <b>real provenance</b> in the Monocle lineage grammar. Freeform Monocle lanes — resource search, arbitrary graph expansion, cross-tenant catalog search — are <b>reference-only</b>, not bound. The <a href="/__apps/lineage">Monocle reference capture ↗</a> is the familiar baseline, never a rebound surface.`);
 

--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -1097,11 +1097,11 @@ function renderWorkLedger(entries, scopedProject) {
   const projects = [...new Set(entries.map((e) => e.project_id).filter(Boolean))];
   const chip = (f, v, label) => `<button class="chip" data-facet="${f}" data-val="${v}" onclick="wlChip(this)">${label}</button>`;
   const filters = `<div class="chips">
-    <span class="chiplabel">kind</span>${chip("kind", "run", "Runs")}${chip("kind", "harness_execution", "Harness runs")}${chip("kind", "goal_run", "IOI Agent coordination")}${chip("kind", "goal_run_invocation", "Agent invocations")}${chip("kind", "goal_run_reconciliation", "Reconciliations")}${chip("kind", "memory_lifecycle", "Memory lifecycle")}${chip("kind", "simulation_report", "Simulations")}${chip("kind", "policy_rollout", "Rollouts")}${chip("kind", "rollout_enforcement", "Rollout enforcement")}${chip("kind", "provider_crossing", "Provider crossings")}${chip("kind", "storage_custody", "Storage custody")}${chip("kind", "trigger", "Trigger events")}${chip("kind", "marketplace_publish", "Publishes")}${chip("kind", "kill_enforcement", "Kill enforcements")}
-    <span class="chiplabel">status</span>${chip("status", "done", "Done")}${chip("status", "success", "Success")}${chip("status", "failed", "Failed")}${chip("status", "failure", "Failure")}${chip("status", "accepted", "Accepted")}${chip("status", "rejected", "Rejected")}
+    <span class="chiplabel">kind</span>${chip("kind", "run", "Runs")}${chip("kind", "harness_execution", "Harness runs")}${chip("kind", "goal_run", "IOI Agent coordination")}${chip("kind", "goal_run_invocation", "Agent invocations")}${chip("kind", "goal_run_reconciliation", "Reconciliations")}${chip("kind", "memory_lifecycle", "Memory lifecycle")}${chip("kind", "simulation_report", "Simulations")}${chip("kind", "policy_rollout", "Rollouts")}${chip("kind", "rollout_enforcement", "Rollout enforcement")}${chip("kind", "provider_crossing", "Provider crossings")}${chip("kind", "storage_custody", "Storage custody")}${chip("kind", "odk_materialization", "Materializations")}${chip("kind", "trigger", "Trigger events")}${chip("kind", "marketplace_publish", "Publishes")}${chip("kind", "kill_enforcement", "Kill enforcements")}
+    <span class="chiplabel">status</span>${chip("status", "done", "Done")}${chip("status", "success", "Success")}${chip("status", "registered", "Registered")}${chip("status", "failed", "Failed")}${chip("status", "failure", "Failure")}${chip("status", "accepted", "Accepted")}${chip("status", "rejected", "Rejected")}
     <span class="chiplabel">project</span><select id="wl-project" onchange="wlFilter()"><option value="">all</option>${projects.map((p) => `<option value="${CX_ESC(p)}">${CX_ESC(p)}</option>`).join("")}</select>
   </div>`;
-  const icon = (k) => (k === "run" ? "▶" : k === "harness_execution" ? "🤖" : k === "goal_run" ? "🎯" : k === "goal_run_invocation" ? "🤝" : k === "goal_run_reconciliation" ? "⚖" : k === "memory_lifecycle" ? "🧬" : k === "simulation_report" ? "🔮" : k === "policy_rollout" ? "🚦" : k === "rollout_enforcement" ? "🚫" : k === "improvement_applied" ? "📈" : k === "memory_projection" ? "🧠" : k === "marketplace_publish" ? "🛒" : k === "domain_app_runtime" ? "🧩" : k === "kill_enforcement" ? "🛑" : k === "provider_crossing" ? "🔌" : k === "storage_custody" ? "🗄" : "🪝");
+  const icon = (k) => (k === "run" ? "▶" : k === "harness_execution" ? "🤖" : k === "goal_run" ? "🎯" : k === "goal_run_invocation" ? "🤝" : k === "goal_run_reconciliation" ? "⚖" : k === "memory_lifecycle" ? "🧬" : k === "simulation_report" ? "🔮" : k === "policy_rollout" ? "🚦" : k === "rollout_enforcement" ? "🚫" : k === "improvement_applied" ? "📈" : k === "memory_projection" ? "🧠" : k === "marketplace_publish" ? "🛒" : k === "domain_app_runtime" ? "🧩" : k === "kill_enforcement" ? "🛑" : k === "provider_crossing" ? "🔌" : k === "storage_custody" ? "🗄" : k === "odk_materialization" ? "📦" : "🪝");
   // A ledger row's headline: automation name for runs, else the harness/session/subject it proves.
   const title = (e) => e.kind === "provider_crossing"
     ? `provider ${CX_ESC(e.op || "op")} · ${CX_ESC(e.provider || "")} ${CX_ESC(String(e.account_ref || e.environment_ref || "").slice(-22))}`
@@ -1117,10 +1117,11 @@ function renderWorkLedger(entries, scopedProject) {
     : e.kind === "marketplace_publish" ? `publish ${CX_ESC(e.listing_id || e.candidate_ref || "")}`
     : e.kind === "kill_enforcement" ? `kill ${CX_ESC(e.subject_ref || "")}`
     : e.kind === "domain_app_runtime" ? `${CX_ESC(e.action || "runtime")} ${CX_ESC(e.domain_app_ref || "")}`
+    : e.kind === "odk_materialization" ? `materialized ${CX_ESC(String(e.object_count == null ? "" : e.object_count))} object${e.object_count === 1 ? "" : "s"} → ${CX_ESC(e.object_type_id || "objects")}`
     : CX_ESC(e.automation_name || "—");
   const rows = entries.map((e, i) => {
     const st = e.status || "";
-    const pill = (st === "done" || st === "accepted" || st === "success" || st === "published") ? "ok" : (st === "failed" || st === "rejected" || st === "failure") ? "warn" : "muted";
+    const pill = (st === "done" || st === "accepted" || st === "success" || st === "published" || st === "registered") ? "ok" : (st === "failed" || st === "rejected" || st === "failure") ? "warn" : "muted";
     const proof = (e.state_root || "").slice(0, 20) || "—";
     return `<tr class="wlrow" data-kind="${CX_ESC(e.kind)}" data-status="${CX_ESC(st)}" data-project="${CX_ESC(e.project_id || "")}" data-i="${i}" onclick="wlOpen(${i})">
       <td>${icon(e.kind)} ${title(e)}</td>
@@ -1161,8 +1162,8 @@ function renderWorkLedger(entries, scopedProject) {
     function wlOpen(i){
       var e=WL[i];if(!e)return;
       function row(k,v){return (v===0||v)?('<div class="wlk">'+k+'</div><div class="wlv">'+wesc(v)+'</div>'):'';}
-      var titles={run:'▶',harness_execution:'🤖',marketplace_publish:'🛒',domain_app_runtime:'🧩',kill_enforcement:'🛑'};
-      var hd=e.kind==='harness_execution'?((e.harness||'harness')+' → '+(e.session_ref||'session')):(e.automation_name||e.listing_id||e.subject_ref||e.domain_app_ref||'—');
+      var titles={run:'▶',harness_execution:'🤖',marketplace_publish:'🛒',domain_app_runtime:'🧩',kill_enforcement:'🛑',odk_materialization:'📦'};
+      var hd=e.kind==='harness_execution'?((e.harness||'harness')+' → '+(e.session_ref||'session')):e.kind==='odk_materialization'?('materialized '+(e.object_count==null?'':e.object_count)+' → '+(e.object_type_id||'objects')):(e.automation_name||e.listing_id||e.subject_ref||e.domain_app_ref||'—');
       var h='<h3>'+(titles[e.kind]||'🪝')+' '+wesc(hd)+'</h3><div class="wlgrid">';
       h+=row('Kind',e.kind)+row('Project',e.project_id)+row('Status',e.status)+row('Trigger',e.trigger_kind||e.kind)+row('When',e.timestamp);
       if(e.kind==='run'){h+=row('Environment',e.environment_id)+row('Authority',e.authority?JSON.stringify(e.authority):'')+row('Steps',e.counts?JSON.stringify(e.counts):'');}
@@ -1171,6 +1172,7 @@ function renderWorkLedger(entries, scopedProject) {
       if(e.kind==='trigger'){h+=row('Reason',e.reason)+row('Request',e.request_id);}
       if(e.kind==='provider_crossing'){h+=row('Op',e.op)+row('Provider',e.provider)+row('Account',e.account_ref)+row('Environment',e.environment_ref)+row('Receipt',e.receipt_ref)+row('Grant',e.grant_ref)+row('Candidate',e.candidate_ref)+row('Quote',e.quote_ref)+row('Execution mode',e.execution_mode)+row('Teardown',e.teardown_state)+row('State root',e.state_root_evidence)+row('Cost estimate',e.cost_estimate?JSON.stringify(e.cost_estimate):'');}
       if(e.kind==='storage_custody'){h+=row('Op',e.op)+row('Backend',e.backend)+row('Backend ref',e.backend_ref)+row('Archive',e.archive_ref)+row('Material',e.material_ref)+row('Environment',e.environment_ref)+row('State root',e.state_root)+row('Commitment',e.commitment?(e.commitment.address||''):'')+row('Grant',e.grant_ref)+row('Incident',e.incident_ref)+row('Repair',e.repair_ref)+row('Custody rule',e.custody_rule);}
+      if(e.kind==='odk_materialization'){h+=row('Objects',e.object_count)+row('Ontology',e.ontology_ref)+row('Object type',e.object_type_id)+row('Object set',e.materialized_set_ref)+row('Materializing run',e.materializing_run_ref)+row('Sealed session',e.connector_session_ref)+row('Lease plan',e.capability_lease_plan_ref)+row('Projection',e.ontology_projection_id)+row('Pre-output receipt',e.pre_output_receipt_ref)+row('Source',e.source_contact?e.source_contact.endpoint:'')+row('Authority',e.authority_rule);}
       h+='</div><h4>Hashes</h4><div class="wlgrid">'+row('State root',e.state_root)+row('Payload hash',e.payload_hash)+row('Headers hash',e.headers_hash)+'</div>';
       // Backlinks — this ledger entry is an executable cross-reference map: every cross-object
       // ref it names is rendered as a navigable link into the surface that owns that object, so
@@ -1188,6 +1190,7 @@ function renderWorkLedger(entries, scopedProject) {
       if(e.listing_id){links+=bl('Listing',e.listing_id,'/__ioi/marketplace');}
       if(e.kind==='provider_crossing'){links+=bl('Provider health',e.account_ref||'provider accounts','/__ioi/operations')+bl('Provider accounts',e.account_ref||'environments','/__ioi/environments');if(e.exposure_ref){links+=bl('Spend reconciliation',e.exposure_ref,e.spend_reconciliation_ref||'/__ioi/operations');}}
       if(e.kind==='storage_custody'){links+=bl('Storage backend health',e.backend_ref||'storage backends',e.storage_health_ref||'/__ioi/operations')+bl('Archive custody',e.archive_ref||'environments','/__ioi/environments');}
+      if(e.kind==='odk_materialization'){var oid=String(e.ontology_ref||'').replace('ontology://','');var q=oid?('?ontology='+oid):'';links+=bl('Lineage graph',e.materialized_set_ref,'/__ioi/lineage'+q)+bl('Pipeline',e.ontology_ref,'/__ioi/pipeline'+q)+bl('Object set',e.materialized_set_ref,'/__ioi/odk'+q+'#pane-explorer')+bl('Materializing run',e.materializing_run_ref,'/__ioi/odk'+q+'#pane-resources')+bl('Sealed session',e.connector_session_ref,'/__ioi/odk'+q+'#pane-resources')+bl('Lease plan',e.capability_lease_plan_ref,'/__ioi/odk'+q+'#pane-resources');}
       if(e.release_control_ref){links+=bl('Release control',e.release_control_ref,'/__ioi/governance');}
       if(e.approval_request_ref){links+=bl('Approval request',e.approval_request_ref,'/__ioi/governance');}
       if(e.kill_switch_ref){links+=bl('Kill switch',e.kill_switch_ref,'/__ioi/governance');}

--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-lineage.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-lineage.mjs
@@ -131,7 +131,7 @@ async function run() {
   ok("receipt chain shows the run's registration act", /id="lineage-receipts"/.test(t) && /materialized_output_registered/.test(t));
 
   // 4. Honest gaps.
-  ok("Provenance proof-stream edges shown 'where available' — honest 0 for the ODK chain (named gap)", /0 Provenance proof-stream edges/.test(t) && /not yet threaded into the Provenance proof stream/.test(t));
+  ok("Provenance proof-stream edges are THREADED (a built chain shows ≥1 real edge, not the 0-gap)", /Provenance proof-stream entr(y|ies) reference this lineage chain/.test(t) && />odk_materialization</.test(t) && /no receipt authority is duplicated/.test(t));
   ok("terminology: no 'Work Ledger' UI prose leaks into the lineage surface", !/Work Ledger/.test(t));
   ok("unsupported Monocle lanes named (resource search / graph expansion / cross-tenant catalog)", /resource search, arbitrary graph expansion, cross-tenant catalog/.test(t));
   ok("reference capture linked as secondary baseline; brand-clean", t.includes("/__apps/lineage") && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));

--- a/apps/hypervisor/scripts/verify-hypervisor-provenance-proof-stream-threading.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-provenance-proof-stream-threading.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Provenance proof-stream threading done-bar.
+//
+// The ODK materialization receipts (each materialized object set registered behind a pre-output
+// receipt) are now THREADED into the Provenance proof stream (backing route /v1/hypervisor/work-
+// ledger; surface Provenance) — BY REFERENCE. The projection is read-time: it references the
+// EXISTING receipts and mints nothing, so receipt authority is not duplicated. This turns the
+// lineage surface's "0 Provenance proof-stream edges" into real cross-plane edges.
+//
+// Asserts:
+//   - A freshly materialized object set appears in the proof stream as an `odk_materialization`
+//     entry that references the full chain (set · run · session · plan) and whose proof pointer IS
+//     the set's EXISTING pre-output receipt (receipt_ref === the set's pre_output_receipt_ref).
+//   - NO DUPLICATE AUTHORITY: reading the proof stream mints nothing — the ODK receipt + set record
+//     counts on disk are unchanged across repeated reads, and the projection is idempotent (the
+//     odk_materialization entry count for our set stays exactly 1).
+//   - The lineage surface renders the real edge (kind + existing receipt + "no receipt authority is
+//     duplicated"), not the 0-edge gap.
+//   - HONEST STILL: an ontology that materialized nothing contributes NO odk_materialization entry
+//     and its lineage shows 0 edges.
+//   - The Provenance surface (/__ioi/work-ledger) still renders (regression).
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-provenance-proof-stream-threading.mjs
+// Exit 2 = BLOCKED.
+
+import http from "node:http";
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { mintApprovalGrant } from "../../../scripts/lib/mint-approval-grant.mjs";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+const DATA = process.env.IOI_HYPERVISOR_DATA_DIR || path.join(os.homedir(), ".ioi", "hypervisor", "data");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+const grantFor = (ch) => mintApprovalGrant({ policyHash: ch.approval?.policy_hash, requestHash: ch.approval?.request_hash });
+const page = (url) => fetch(url).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+const dirCount = (d) => { try { return readdirSync(path.join(DATA, d)).length; } catch { return -1; } };
+const stream = async () => (await jd("GET", "/v1/hypervisor/work-ledger")).j.entries || [];
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/work-ledger`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon proof stream not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+  const SENTINEL = "thread-parity-bearer";
+
+  // Build a real materialized object set (fixture) → the receipts to thread.
+  const rows = [{ id: "L-1", disp: "First Loan", amt: 1250.5 }, { id: "L-2", disp: "Second Loan", amt: 90000 }];
+  const srv = http.createServer((req, res) => {
+    if (req.headers.authorization !== `Bearer ${SENTINEL}`) { res.writeHead(401); return res.end(); }
+    res.writeHead(200, { "content-type": "application/json" }); res.end(JSON.stringify(rows));
+  });
+  await new Promise((r) => srv.listen(0, "127.0.0.1", r));
+  const port = srv.address().port;
+  const conn = (await jd("POST", "/v1/hypervisor/connectors", { service: "thread-parity", base_url: `http://127.0.0.1:${port}`, name: "Thread Parity" })).j;
+  const connId = conn.connector?.connector_id || conn.connector_id;
+  await jd("POST", `/v1/hypervisor/connectors/${connId}/credential`, { token: SENTINEL });
+  const track = (k, id) => { if (id) cleanup.push(["DELETE", `/v1/hypervisor/odk/${k}/${id}`]); };
+  const ds = (await jd("POST", "/v1/hypervisor/data-sources", { name: "thread-parity-src", kind: "rest_api", endpoint: `http://127.0.0.1:${port}/rows`, credential_posture: "wallet_credential_lease" })).j.data_source?.source_id;
+  cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${ds}`]);
+  const ont = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "thread-parity", canonical_object_model: {
+    value_types: [{ id: "money", name: "Money", base: "double" }],
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" }, { id: "amount", name: "Amount", value_type: "money" } ] }],
+    action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }] } })).j.ontology;
+  track("domain-ontologies", ont?.id);
+  const map = (await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "thread-parity-map", data_source_id: ds, ontology_ref: ont.ref, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" },
+    field_mappings: [{ source_field: "amt", property_id: "amount", source_type: "double" }] })).j.connector_mapping?.id;
+  track("connector-mappings", map);
+  const view = (await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: map, name: "thread-parity-gate", authority_subjects: ["agent://m"], allowed_operations: ["read", "transform"], purpose: "a", property_scope: ["loan_id", "title", "amount"], retention_posture: "bounded" })).j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", view);
+  const trun = (await jd("POST", "/v1/hypervisor/odk/transformation-runs", { connector_mapping_id: map, policy_view_id: view, name: "thread-parity-trun" })).j.transformation_run?.id;
+  track("transformation-runs", trun);
+  await jd("POST", `/v1/hypervisor/odk/transformation-runs/${trun}/dry-run`);
+  const proj = (await jd("POST", "/v1/hypervisor/odk/ontology-projections", { connector_mapping_id: map, policy_view_id: view, name: "thread-parity-proj", visible_properties: ["loan_id", "title", "amount"] })).j.ontology_projection?.id;
+  track("ontology-projections", proj);
+  const plan = (await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", { data_source_id: ds, connector_mapping_id: map, policy_view_id: view, transformation_run_id: trun, ontology_projection_id: proj, name: "thread-parity-plan", subject: "agent://m", ttl_seconds: 900 })).j.capability_lease_plan?.id;
+  track("capability-lease-plans", plan);
+  const mrun = (await jd("POST", "/v1/hypervisor/odk/materializing-runs", { capability_lease_plan_id: plan, name: "thread-parity-mrun" })).j.materializing_run?.id;
+  track("materializing-runs", mrun);
+  const ch = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, {});
+  await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, { wallet_approval_grant: grantFor(ch.j) });
+  const sess = (await jd("POST", "/v1/hypervisor/odk/connector-sessions", { materializing_run_id: mrun, connector_id: connId, name: "thread-parity-sess" })).j.connector_session?.id;
+  track("connector-sessions", sess);
+  const ch2 = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${sess}/open`, {});
+  await jd("POST", `/v1/hypervisor/odk/connector-sessions/${sess}/open`, { wallet_approval_grant: grantFor(ch2.j) });
+  const ex = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/execute`, { connector_session_id: sess, limit: 10 });
+  const set = ex.j.materialized_object_set;
+  if (set?.id) cleanup.unshift(["DELETE", `/v1/hypervisor/odk/materialized-object-sets/${set.id}`]);
+  if (!ont?.id || ex.j.materializing_run?.status !== "executed") { console.error("BLOCKED: could not build the fixture"); srv.close(); process.exit(2); }
+
+  // 1. The set is threaded into the proof stream, referencing the EXISTING pre-output receipt.
+  const entries = await stream();
+  const mine = entries.find((e) => e.kind === "odk_materialization" && e.materialized_set_ref === set.ref);
+  ok("a materialized set is threaded into the Provenance proof stream as odk_materialization", !!mine, mine ? "present" : "missing");
+  ok("the entry references the full chain (set · run · session · plan)", mine && mine.materializing_run_ref === set.materializing_run_ref && mine.connector_session_ref === set.connector_session_ref && mine.capability_lease_plan_ref === set.capability_lease_plan_ref);
+  ok("the proof pointer IS the set's EXISTING pre-output receipt (referenced, not re-minted)", mine && mine.receipt_ref === set.pre_output_receipt_ref && mine.pre_output_receipt_ref === set.pre_output_receipt_ref);
+  ok("the entry declares its authority rule: the stream mints no receipt here", /mints no receipt/.test(mine?.authority_rule || ""));
+  ok("the entry carries the outcome + object count (registered · 2)", mine?.status === "registered" && mine?.object_count === 2);
+
+  // 2. No duplicate authority: reading the stream mints nothing; the projection is idempotent.
+  const recBefore = dirCount("odk-materializing-run-receipts");
+  const setBefore = dirCount("odk-materialized-object-sets");
+  await stream(); await stream(); await stream();
+  const recAfter = dirCount("odk-materializing-run-receipts");
+  const setAfter = dirCount("odk-materialized-object-sets");
+  ok("NO DUPLICATE AUTHORITY: repeated proof-stream reads mint no ODK receipt", recBefore >= 0 && recBefore === recAfter, `${recBefore} → ${recAfter}`);
+  ok("NO DUPLICATE OUTPUT: repeated reads register no new object set", setBefore >= 0 && setBefore === setAfter, `${setBefore} → ${setAfter}`);
+  const again = await stream();
+  ok("idempotent projection: exactly ONE odk_materialization entry for our set (no accumulation)", again.filter((e) => e.kind === "odk_materialization" && e.materialized_set_ref === set.ref).length === 1);
+  ok("no work-ledger/proof-stream receipt FAMILY is written (read-time projection only)", dirCount("work-ledger-receipts") === -1 && dirCount("provenance-stream-receipts") === -1);
+
+  // 3. The lineage surface renders the real edge, not the gap.
+  const lin = await page(`${SERVE}/__ioi/lineage?ontology=${encodeURIComponent(ont.id)}`);
+  const t = lin.text;
+  ok("lineage surface shows the real threaded edge (odk_materialization + existing receipt)", />odk_materialization</.test(t) && t.includes(set.pre_output_receipt_ref) && /no receipt authority is duplicated/.test(t));
+  ok("lineage surface no longer shows the 0-edge 'not yet threaded' gap for a built chain", !/not yet threaded/.test(t) && !/0 Provenance proof-stream edges/.test(t));
+
+  // 4. Still honest — a fresh ontology contributes no entry and shows 0 edges.
+  const fresh = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "thread-parity-fresh", canonical_object_model: { object_types: [{ id: "a", name: "A", title_property: "t", properties: [{ id: "t", name: "T", value_type: "string" }] }], action_types: [{ id: "x", name: "X", kind: "modify_object", applies_to: "a" }] } })).j.ontology;
+  track("domain-ontologies", fresh?.id);
+  const s2 = await stream();
+  ok("a fresh (unmaterialized) ontology contributes NO odk_materialization entry", !s2.some((e) => e.kind === "odk_materialization" && e.ontology_ref === fresh.ref));
+
+  // 5. Regression: the Provenance surface still renders with the new kind present.
+  const prov = await page(`${SERVE}/__ioi/work-ledger`);
+  ok("regression: the Provenance surface (/__ioi/work-ledger) still renders", prov.status === 200 && /Provenance/.test(prov.text) && !/\bPalantir\b/.test(prov.text));
+
+  srv.close();
+  for (const [method, p] of cleanup) await jd(method, p);
+  await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}/credential`, { method: "DELETE" }).catch(() => {});
+  await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}`, { method: "DELETE" }).catch(() => {});
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`provenance-proof-stream-threading readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/apps/hypervisor/scripts/verify-hypervisor-provenance-proof-stream-threading.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-provenance-proof-stream-threading.mjs
@@ -131,9 +131,20 @@ async function run() {
   const s2 = await stream();
   ok("a fresh (unmaterialized) ontology contributes NO odk_materialization entry", !s2.some((e) => e.kind === "odk_materialization" && e.ontology_ref === fresh.ref));
 
-  // 5. Regression: the Provenance surface still renders with the new kind present.
+  // 5. The Provenance surface renders odk_materialization as a FIRST-CLASS kind (not a generic row):
+  //    facet chip, icon/title, and a drawer with the object-set/run/session/plan/receipt backlinks.
   const prov = await page(`${SERVE}/__ioi/work-ledger`);
-  ok("regression: the Provenance surface (/__ioi/work-ledger) still renders", prov.status === 200 && /Provenance/.test(prov.text) && !/\bPalantir\b/.test(prov.text));
+  const pt = prov.text;
+  ok("Provenance surface renders + is brand-clean", prov.status === 200 && /Provenance/.test(pt) && !/\bPalantir\b/.test(pt));
+  ok("odk_materialization is a first-class facet chip ('Materializations')", /data-val="odk_materialization"/.test(pt) && />Materializations</.test(pt));
+  ok("the materialization row has its own title (not the generic '—' fallback)", new RegExp(`data-kind="odk_materialization"[^>]*>[\\s\\S]*?materialized 2 objects → loan`).test(pt));
+  ok("the row carries the kind for filtering + a 'registered' status pill", new RegExp(`data-kind="odk_materialization" data-status="registered"`).test(pt));
+  // The drawer data is embedded as JSON in the page (wl-data); the drawer JS renders backlinks from
+  // it. Assert the embedded entry carries every backlink ref the drawer will render.
+  const wlData = JSON.parse((pt.match(/<script id="wl-data" type="application\/json">([\s\S]*?)<\/script>/) || [])[1]?.replace(/\\u003c/g, "<") || "[]");
+  const de = wlData.find((e) => e.kind === "odk_materialization" && e.materialized_set_ref === set.ref);
+  ok("drawer entry carries the full backlink set (set · run · session · plan · projection · existing receipt)", de && de.materialized_set_ref && de.materializing_run_ref && de.connector_session_ref && de.capability_lease_plan_ref && de.ontology_projection_id && de.receipt_ref === set.pre_output_receipt_ref);
+  ok("drawer will render Lineage + Pipeline backlinks (ontology resolvable from the entry)", de && String(de.ontology_ref || "").startsWith("ontology://"));
 
   srv.close();
   for (const [method, p] of cleanup) await jd(method, p);

--- a/crates/node/src/bin/hypervisor_daemon_routes/orchestration_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/orchestration_routes.rs
@@ -773,6 +773,31 @@ pub(crate) async fn handle_work_ledger(
             "affected_runtime_refs": g(&r, "affected_runtime_refs"), "receipt_ref": g(&r, "ref"),
         }));
     }
+    // ODK materialization crossings — each materialized object set is a governed act: a materializing
+    // run read a declared source under a held CapabilityLease + sealed connector session and
+    // registered a bounded, all-or-nothing object set BEHIND a pre-output receipt. Project each set
+    // into the one proof stream BY REFERENCE. The pre-output + registration receipts already exist on
+    // the ODK materializing-run receipt family; this projection MINTS NOTHING (it is a read-time view)
+    // — receipt authority is not duplicated, only surfaced. This turns the lineage surface's
+    // "0 Provenance proof-stream edges" into real cross-plane edges.
+    for r in read_record_dir(&st.data_dir, "odk-materialized-object-sets") {
+        entries.push(json!({
+            "id": g(&r, "id"), "kind": "odk_materialization", "timestamp": g(&r, "registered_at"),
+            "status": "registered", "object_count": g(&r, "count"),
+            "ontology_ref": g(&r, "ontology_ref"), "object_type_id": g(&r, "object_type_id"),
+            "materialized_set_ref": g(&r, "ref"),
+            "materializing_run_ref": g(&r, "materializing_run_ref"),
+            "connector_session_ref": g(&r, "connector_session_ref"),
+            "capability_lease_plan_ref": g(&r, "capability_lease_plan_ref"),
+            "ontology_projection_id": g(&r, "ontology_projection_id"),
+            // The proof pointer IS the existing pre-output receipt — referenced, never re-minted.
+            "receipt_ref": g(&r, "pre_output_receipt_ref"),
+            "pre_output_receipt_ref": g(&r, "pre_output_receipt_ref"),
+            "source_contact": g(&r, "source_contact"),
+            "lineage_ref": "/__ioi/lineage",
+            "authority_rule": "projected by reference from the existing ODK materialization receipts; the Provenance proof stream mints no receipt here",
+        }));
+    }
     entries.sort_by(|a, b| {
         b.get("timestamp").and_then(|v| v.as_str()).unwrap_or("")
             .cmp(a.get("timestamp").and_then(|v| v.as_str()).unwrap_or(""))


### PR DESCRIPTION
**Base: master** (`d95b1ae44`, #22 lineage landed). Closes the honest gap the lineage surface named — *"0 Provenance proof-stream edges; the ODK materialization receipts are not yet threaded"* — **without duplicating receipt authority.**

## The move: one more read-time projection
The Provenance proof stream (`handle_work_ledger`; backing route `/v1/hypervisor/work-ledger`, surface Provenance) is a **read-time projection** — it reads existing receipt families off disk (provider/storage receipts, automation-executions, placement-decisions, …) and maps each into a stream entry by `kind`. It **mints nothing.**

This adds one projection block over `odk-materialized-object-sets`: each materialized set becomes an **`odk_materialization`** entry that references the full chain (set · run · session · plan · projection) and whose **proof pointer *is* the set's existing `pre_output_receipt_ref`**. The receipts already exist on the ODK run stream; the projection references them — **receipt authority is surfaced, not duplicated.**

## No duplicate authority — proven
| guarantee | result |
|---|---|
| entry's `receipt_ref` === the set's existing `pre_output_receipt_ref` | ✔ (referenced, not re-minted) |
| repeated proof-stream reads mint **no** ODK receipt | receipt files **1194 → 1194** |
| repeated reads register **no** new object set | set files **1 → 1** |
| projection is idempotent | exactly **one** entry per set |
| no proof-stream receipt family is ever written | ✔ (read-time only) |

## Surface
The lineage "Provenance proof-stream edges" pane renders the real threaded edges (kind · outcome · **the existing receipt** · when) with *"no receipt authority is duplicated"*, instead of the 0-edge gap. An unmaterialized ontology still contributes nothing and shows 0 edges (honest).

## Done bar — green
| gate | result |
|---|---|
| provenance-proof-stream-threading | **13/13** |
| app-parity-lineage (edge assert evolved) | **21/21** |
| cargo test -p ioi-node | **108/108** |
| surface-parity (Playwright, Provenance surface) · harvest-provenance-lineage | 28/28 · 15/15 |
| all 11 ODK ladder verifiers · queue-seeds · legacy builders · matrix current | green |
| source-neutral · fallthrough · diff-check | PASSED · empty · clean |

This gives **Vertex** a real **cross-plane** graph substrate — materialized objects ↔ their receipts in the one Provenance proof stream, not isolated ODK records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)