### PR TITLE
feat(hypervisor): Vertex — the cross-plane Provenance graph/exploration lens (#24)

### DIFF
--- a/apps/hypervisor/harvest-app-parity-matrix.json
+++ b/apps/hypervisor/harvest-app-parity-matrix.json
@@ -9,8 +9,7 @@
   "total_seeds": 39,
   "by_parity_class": {
     "reference_capture": 36,
-    "daemon_bound": 2,
-    "queued": 1
+    "daemon_bound": 3
   },
   "legend": {
     "reference_capture": "the /__apps/<slug> reference baseline serves; not yet bound to daemon truth",
@@ -378,13 +377,13 @@
       "capture_base": "/workspace/vertex/",
       "grammar": "graph",
       "tier": "high_value",
-      "parity_class": "queued",
+      "parity_class": "daemon_bound",
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/vertex",
-      "note": "the first materialized objects need a graph/exploration lens; queued as a Provenance surface, not a Work Ledger app",
-      "target_surface": "/__ioi/work-ledger",
+      "note": "Vertex graph grammar (nodes · relations · neighborhood) over real cross-plane materialized truth; no fake nodes for unmaterialized ontologies; freeform graph canvas / arbitrary path-finding / cross-tenant object search / saved explorations = named gaps",
+      "daemon_surface": "/__ioi/vertex",
       "surface_name": "Provenance",
-      "binding": "a Provenance graph/exploration lens over materialized object sets, projections, and Provenance proof-stream edges"
+      "binding": "a Provenance graph/exploration lens over materialized object sets, projections, objects, and the threaded proof-stream odk_materialization edges (cross-plane: ODK ↔ Provenance)"
     },
     {
       "owner": "Environments",

--- a/apps/hypervisor/scripts/build-app-parity-matrix.mjs
+++ b/apps/hypervisor/scripts/build-app-parity-matrix.mjs
@@ -33,13 +33,11 @@ const captureState = Object.fromEntries((startingPoints.seeds || []).map((s) => 
 const DAEMON_BOUND = {
   pipeline: { daemon_surface: "/__ioi/pipeline", binding: "ODK authority ladder (DataSource → ConnectorMapping → PolicyBoundDataView → TransformationRun → OntologyProjection → CapabilityLease → ConnectorSession → MaterializedObjectSet)", note: "the ODK ladder rendered as a datasource→transform→output pipeline; supported lanes = daemon truth, freeform authoring/schedule/deploy = named gaps" },
   lineage: { daemon_surface: "/__ioi/lineage", binding: "ODK materialization provenance (MaterializedObjectSet → run → session → lease → projection → mapping → datasource, resolved to live ladder refs; per-object source hashes + mapped_from; pre-output + registration receipts; Provenance proof-stream edges where available)", note: "Monocle lineage grammar over real provenance; upstream ladder refs resolved to live records; no fake nodes for unmaterialized ontologies; freeform resource-search / graph-expansion / cross-tenant catalog = named gaps" },
+  // Canon: Work Ledger evolves into Provenance — Vertex is a Provenance graph/exploration lens.
+  vertex: { daemon_surface: "/__ioi/vertex", surface_name: "Provenance", binding: "a Provenance graph/exploration lens over materialized object sets, projections, objects, and the threaded proof-stream odk_materialization edges (cross-plane: ODK ↔ Provenance)", note: "Vertex graph grammar (nodes · relations · neighborhood) over real cross-plane materialized truth; no fake nodes for unmaterialized ontologies; freeform graph canvas / arbitrary path-finding / cross-tenant object search / saved explorations = named gaps" },
 };
-// Named-next targets (owner binding declared; surface not built yet). Canon: Work Ledger evolves
-// into Provenance — the /__ioi/work-ledger route is the Provenance surface; vertex is a Provenance
-// graph/exploration lens (not a "Work Ledger app").
-const QUEUED = {
-  vertex: { target_surface: "/__ioi/work-ledger", surface_name: "Provenance", binding: "a Provenance graph/exploration lens over materialized object sets, projections, and Provenance proof-stream edges", note: "the first materialized objects need a graph/exploration lens; queued as a Provenance surface, not a Work Ledger app" },
-};
+// Named-next targets (owner binding declared; surface not built yet).
+const QUEUED = {};
 
 function parityClass(slug) {
   if (DAEMON_BOUND[slug]) return "daemon_bound";

--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -1087,7 +1087,7 @@ function renderWorkLedger(entries, scopedProject) {
   const scope = scopedProject
     ? `<p class="sub" style="margin:-10px 0 16px"><span class="pill ok">project: ${CX_ESC(scopedProject)}</span> · <a href="/__ioi/work-ledger">view all projects →</a></p>`
     : "";
-  const head = `<h1>Provenance</h1><p class="sub"><a href="/__apps/lineage">Lineage canvas seed (adopting) →</a> · The proof plane — one chronological stream of admitted work — runs and trigger receipts across every project and automation, each with its state root and a link to the full timeline.</p>${scope}`;
+  const head = `<h1>Provenance</h1><p class="sub"><a href="/__apps/lineage">Lineage canvas seed (adopting) →</a> · The proof plane — one chronological stream of admitted work — runs and trigger receipts across every project and automation, each with its state root and a link to the full timeline.</p><p class="sub" style="margin:-8px 0 0">Graph lenses over materialized truth: <a href="/__ioi/lineage">Data lineage →</a> · <a href="/__ioi/vertex">Vertex graph →</a></p>${scope}`;
   if (!entries.length) {
     const msg = scopedProject
       ? "No admitted work yet for this project. Run one of its automations to create ledger evidence."
@@ -1190,7 +1190,7 @@ function renderWorkLedger(entries, scopedProject) {
       if(e.listing_id){links+=bl('Listing',e.listing_id,'/__ioi/marketplace');}
       if(e.kind==='provider_crossing'){links+=bl('Provider health',e.account_ref||'provider accounts','/__ioi/operations')+bl('Provider accounts',e.account_ref||'environments','/__ioi/environments');if(e.exposure_ref){links+=bl('Spend reconciliation',e.exposure_ref,e.spend_reconciliation_ref||'/__ioi/operations');}}
       if(e.kind==='storage_custody'){links+=bl('Storage backend health',e.backend_ref||'storage backends',e.storage_health_ref||'/__ioi/operations')+bl('Archive custody',e.archive_ref||'environments','/__ioi/environments');}
-      if(e.kind==='odk_materialization'){var oid=String(e.ontology_ref||'').replace('ontology://','');var q=oid?('?ontology='+oid):'';links+=bl('Lineage graph',e.materialized_set_ref,'/__ioi/lineage'+q)+bl('Pipeline',e.ontology_ref,'/__ioi/pipeline'+q)+bl('Object set',e.materialized_set_ref,'/__ioi/odk'+q+'#pane-explorer')+bl('Materializing run',e.materializing_run_ref,'/__ioi/odk'+q+'#pane-resources')+bl('Sealed session',e.connector_session_ref,'/__ioi/odk'+q+'#pane-resources')+bl('Lease plan',e.capability_lease_plan_ref,'/__ioi/odk'+q+'#pane-resources');}
+      if(e.kind==='odk_materialization'){var oid=String(e.ontology_ref||'').replace('ontology://','');var q=oid?('?ontology='+oid):'';links+=bl('Lineage graph',e.materialized_set_ref,'/__ioi/lineage'+q)+bl('Vertex graph',e.materialized_set_ref,'/__ioi/vertex'+q)+bl('Pipeline',e.ontology_ref,'/__ioi/pipeline'+q)+bl('Object set',e.materialized_set_ref,'/__ioi/odk'+q+'#pane-explorer')+bl('Materializing run',e.materializing_run_ref,'/__ioi/odk'+q+'#pane-resources')+bl('Sealed session',e.connector_session_ref,'/__ioi/odk'+q+'#pane-resources')+bl('Lease plan',e.capability_lease_plan_ref,'/__ioi/odk'+q+'#pane-resources');}
       if(e.release_control_ref){links+=bl('Release control',e.release_control_ref,'/__ioi/governance');}
       if(e.approval_request_ref){links+=bl('Approval request',e.approval_request_ref,'/__ioi/governance');}
       if(e.kill_switch_ref){links+=bl('Kill switch',e.kill_switch_ref,'/__ioi/governance');}

--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -3117,6 +3117,89 @@ function lineageLegend() {
   return `<div class="chips" style="margin:0 0 10px"><span class="chiplabel">Nodes</span>${LINEAGE_NODE_KINDS.map(([, ic, l]) => `<span class="pill muted" style="margin:0">${ic} ${CX_ESC(l)}</span>`).join(" ")}</div>`
     + `<div class="chips" style="margin:0 0 12px"><span class="chiplabel">Edges</span>${["mapped_by", "gated_by", "planned_by", "projected_as", "read_under", "produced_by", "receipted_by", "contains", "hashed_as", "mapped_from"].map((e) => `<span class="pill muted" style="margin:0"><code>${e}</code></span>`).join(" ")}</div>`;
 }
+// ============================ VERTEX (Provenance graph/exploration lens over real materialized truth)
+// The Application UX Parity Baseline phase, applied to Vertex. The reference capture (/__apps/vertex,
+// /workspace/vertex/) is the familiar baseline; this IOI-owned surface renders the SAME graph
+// exploration grammar — a node/relation graph you explore by neighborhood — but every node/edge is
+// REAL and CROSS-PLANE: materialized object sets, their projections + runs, the objects themselves,
+// AND the threaded Provenance proof-stream `odk_materialization` edges (the #23 payoff) that connect
+// ODK materialization to the Provenance plane. Vertex is the GRAPH (nodes · relations · expand a
+// node's neighborhood); lineage is the PATH. No graph data is invented: an ontology with no
+// materialized objects shows an empty graph. Unsupported Vertex lanes (freeform graph canvas,
+// arbitrary path-finding, cross-tenant object search, saved explorations) are named gaps.
+const VERTEX_NODE_KINDS = [
+  ["set", "📦", "Object set"], ["projection", "🔭", "Projection"], ["run", "⚙", "Materializing run"],
+  ["object", "▪", "Object"], ["proof", "🧾", "Proof-stream edge"],
+];
+function renderVertex(lists, selectedId) {
+  const ontologies = Array.isArray(lists.ontologies) ? lists.ontologies : [];
+  const allSets = Array.isArray(lists.materialized_sets) ? lists.materialized_sets : [];
+  const has = new Set(allSets.map((s) => s.ontology_ref));
+  const selected = ontologies.find((x) => x.id === selectedId) || ontologies.find((x) => has.has(x.ref)) || ontologies[0] || null;
+  const oref = selected ? selected.ref : "__none__";
+  const oid = selected ? selected.id : "";
+  const sets = allSets.filter((s) => s.ontology_ref === oref);
+  const projs = (lists.ontology_projections || []).filter((p) => p.ontology_ref === oref);
+  const runs = (lists.materializing_runs || []).filter((r) => r.ontology_ref === oref);
+  const provStream = Array.isArray(lists.provenance_stream) ? lists.provenance_stream : [];
+  const setRefs = new Set(sets.map((s) => s.ref));
+  const proofEdges = provStream.filter((e) => e.kind === "odk_materialization" && setRefs.has(e.materialized_set_ref));
+  const objectCount = sets.reduce((a, s) => a + (s.count || 0), 0);
+
+  const switcher = ontologies.length
+    ? `<div class="chips" style="margin:0 0 14px">${ontologies.map((x) => {
+        const on = selected && x.id === selected.id;
+        return `<a href="/__ioi/vertex?ontology=${encodeURIComponent(x.id)}" class="pill ${on ? "ok" : "muted"}" style="text-decoration:none;margin:0">${CX_ESC(x.domain || x.id)}${has.has(x.ref) ? ` <span class="pill ok" style="margin-left:4px">graph</span>` : ""}</a>`;
+      }).join(" ")}</div>`
+    : `<div class="empty">No ontologies yet.</div>`;
+
+  const head = `<div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap"><div><h1 style="margin:0">Vertex</h1><p class="sub" style="margin:4px 0 0">Explore the materialized object graph — object sets, projections, objects, and the cross-plane Provenance proof-stream edges as a navigable node/relation graph, over IOI daemon truth. Reference grammar: <a href="/__apps/vertex">Vertex ↗</a> (secondary capture).</p></div><div class="row" style="gap:8px"><a class="act ghost" href="/__ioi/lineage?ontology=${encodeURIComponent(oid)}">Lineage path</a><a class="act ghost" href="/__ioi/pipeline?ontology=${encodeURIComponent(oid)}">Pipeline</a></div></div>`;
+
+  // HONEST EMPTY — no materialized objects ⇒ no graph. Never fabricate nodes.
+  if (!sets.length) {
+    const note = omBoundaryNote(`This ontology has materialized <b>no objects</b>, so there is <b>no graph to explore</b> — Vertex renders the real materialized object graph (sets · projections · objects · proof-stream edges), which appears only once a pipeline is built. Build one from the <a href="/__ioi/pipeline?ontology=${encodeURIComponent(oid)}">Pipeline Builder</a>. The <a href="/__apps/vertex">Vertex reference capture ↗</a> is the familiar baseline, never a rebound surface.`);
+    return automationsShell("Vertex", head + switcher + `<div class="chips" style="margin:10px 0 12px"><span class="pill muted">empty graph</span> <span class="sub" style="margin:0">${selected ? `No materialized objects for <b>${CX_ESC(selected.domain || selected.id)}</b>.` : "Select or create an ontology."}</span></div>` + note);
+  }
+
+  // Graph catalog — node-type counts (the exploration summary).
+  const counts = { set: sets.length, projection: projs.length, run: runs.length, object: objectCount, proof: proofEdges.length };
+  const catalog = `<div class="row" style="gap:10px;align-items:stretch;margin:0 0 14px;flex-wrap:wrap">${VERTEX_NODE_KINDS.map(([k, ic, l]) => `<div style="flex:1;min-width:118px;padding:11px 13px;border:1px solid #24262d;border-radius:10px;background:#15171c"><div style="font-size:20px;font-weight:700;color:#fff">${ic} ${counts[k]}</div><div style="color:#878a93;font-size:12px;margin-top:2px">${CX_ESC(l)}${k === "proof" ? " <span class=\"pill ok\" style=\"margin:0\">cross-plane</span>" : ""}</div></div>`).join("")}</div>`;
+
+  // Node inventory (grouped) — the graph's nodes, real refs.
+  const nodeChip = (ic, label, ref) => `<span class="pill muted" style="margin:0" title="${CX_ESC(ref || "")}">${ic} ${CX_ESC(label)}</span>`;
+  const inv = `<h2 id="vertex-nodes">Nodes <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">(${counts.set + counts.projection + counts.run + counts.object + counts.proof})</span></h2>`
+    + `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Object sets</span>${sets.map((s) => nodeChip("📦", `${s.count || 0} obj`, s.ref)).join(" ")}</div>`
+    + `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Projections</span>${projs.map((p) => nodeChip("🔭", p.name || p.id, p.ref)).join(" ")}</div>`
+    + `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Runs</span>${runs.filter((r) => r.status === "executed").map((r) => nodeChip("⚙", r.name || r.id, r.ref)).join(" ") || `<span class="sub" style="margin:0">—</span>`}</div>`
+    + `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Proof edges</span>${proofEdges.length ? proofEdges.map((e) => nodeChip("🧾", e.kind, e.receipt_ref)).join(" ") : `<span class="sub" style="margin:0">none</span>`}</div>`;
+
+  // Neighborhood — expand the primary set: its projection, run, cross-plane proof edge, and objects.
+  const primary = sets.slice().sort((a, b) => String(b.registered_at || "").localeCompare(String(a.registered_at || "")))[0];
+  const projById = new Map(projs.map((p) => [p.id, p]));
+  const proj = projById.get(primary.ontology_projection_id) || null;
+  const proofEdge = proofEdges.find((e) => e.materialized_set_ref === primary.ref) || null;
+  const rel = (from, type, to, toRef) => `<tr><td><code style="font-size:10.5px">${CX_ESC(from)}</code></td><td><span class="pill muted" style="margin:0">${CX_ESC(type)}</span></td><td>${CX_ESC(to)}${toRef ? ` <code style="font-size:10px;opacity:.7">${CX_ESC(String(toRef).slice(0, 26))}…</code>` : ""}</td></tr>`;
+  const objs = (primary.objects || []).slice(0, 6);
+  const relRows = [
+    proj ? rel(primary.ref, "projected_by", "Projection", proj.ref) : "",
+    primary.materializing_run_ref ? rel(primary.ref, "produced_by", "Materializing run", primary.materializing_run_ref) : "",
+    proofEdge ? rel(primary.ref, "proven_by", "Proof-stream edge (Provenance)", proofEdge.receipt_ref) : "",
+    ...objs.map((o) => rel(primary.ref, "contains", `Object ${o.object_key || ""}`, o.source_hash)),
+  ].filter(Boolean).join("");
+  const neighborhood = `<h2 id="vertex-neighborhood">Neighborhood <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— expand <code>${CX_ESC(primary.ref || "")}</code> (${primary.count || 0} objects)</span></h2>`
+    + `<table><thead><tr><th>From</th><th>Relation</th><th>To</th></tr></thead><tbody>${relRows}</tbody></table>`;
+
+  // Cross-plane highlight — the proof-stream edge is what makes this a cross-plane graph.
+  const crossPlane = proofEdge
+    ? omBoundaryNote(`<b>Cross-plane:</b> this object set is connected to the <a href="/__ioi/work-ledger">Provenance proof stream</a> by a threaded <code>odk_materialization</code> edge (proof <code>${CX_ESC(String(proofEdge.receipt_ref || "").slice(0, 40))}…</code>) — the materialized objects and their receipt are reachable as one graph, not isolated ODK records.`)
+    : omBoundaryNote(`This set has no threaded Provenance proof-stream edge yet — the graph is ODK-local until the materialization receipt is threaded.`);
+
+  const gaps = omBoundaryNote(`This is <b>real cross-plane graph truth</b> in the Vertex grammar. Unsupported Vertex lanes — freeform graph canvas, arbitrary path-finding, cross-tenant object search, saved explorations — are <b>reference-only</b>, not bound. The <a href="/__apps/vertex">Vertex reference capture ↗</a> is the familiar baseline, never a rebound surface.`);
+
+  const banner = `<div class="chips" style="margin:10px 0 12px"><span class="pill ok">graph</span> <span class="sub" style="margin:0">${counts.set} object set${counts.set === 1 ? "" : "s"} · ${objectCount} object${objectCount === 1 ? "" : "s"} · ${counts.proof} cross-plane proof edge${counts.proof === 1 ? "" : "s"} for <b>${CX_ESC(selected.domain || selected.id)}</b></span></div>`;
+  return automationsShell("Vertex", head + switcher + banner + catalog + inv + neighborhood + crossPlane + gaps);
+}
+
 function renderDataLineage(lists, selectedId) {
   const ontologies = Array.isArray(lists.ontologies) ? lists.ontologies : [];
   const allSets = Array.isArray(lists.materialized_sets) ? lists.materialized_sets : [];
@@ -3144,7 +3227,7 @@ function renderDataLineage(lists, selectedId) {
       }).join(" ")}</div>`
     : `<div class="empty">No ontologies yet.</div>`;
 
-  const head = `<div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap"><div><h1 style="margin:0">Data lineage</h1><p class="sub" style="margin:4px 0 0">Where materialized objects came from — the ODK provenance graph as a Monocle-familiar lineage of typed nodes + edges, over IOI daemon truth. Reference grammar: <a href="/__apps/lineage">Monocle lineage ↗</a> (secondary capture).</p></div><a class="act ghost" href="/__ioi/pipeline?ontology=${encodeURIComponent(oid)}">Open pipeline</a></div>`;
+  const head = `<div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap"><div><h1 style="margin:0">Data lineage</h1><p class="sub" style="margin:4px 0 0">Where materialized objects came from — the ODK provenance graph as a Monocle-familiar lineage of typed nodes + edges, over IOI daemon truth. Reference grammar: <a href="/__apps/lineage">Monocle lineage ↗</a> (secondary capture).</p></div><div class="row" style="gap:8px"><a class="act ghost" href="/__ioi/vertex?ontology=${encodeURIComponent(oid)}">Explore graph</a><a class="act ghost" href="/__ioi/pipeline?ontology=${encodeURIComponent(oid)}">Open pipeline</a></div></div>`;
 
   // HONEST EMPTY — no materialized objects ⇒ no lineage. Never fabricate nodes.
   if (!sets.length) {
@@ -6985,6 +7068,26 @@ const server = http.createServer((req, res) => {
       }
     }
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
+    if (pathname === "/__ioi/vertex" && req.method === "GET") {
+      const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
+      const [o, ms, op, mr, wl] = await Promise.all([
+        J("/v1/hypervisor/odk/domain-ontologies"),
+        J("/v1/hypervisor/odk/materialized-object-sets"),
+        J("/v1/hypervisor/odk/ontology-projections"),
+        J("/v1/hypervisor/odk/materializing-runs"),
+        J("/v1/hypervisor/work-ledger"),
+      ]);
+      const selectedOntology = new URL(req.url, "http://x").searchParams.get("ontology") || "";
+      res.writeHead(200, HTMLH);
+      res.end(renderVertex({
+        ontologies: o.ontologies || [],
+        materialized_sets: ms.materialized_object_sets || [],
+        ontology_projections: op.ontology_projections || [],
+        materializing_runs: mr.materializing_runs || [],
+        provenance_stream: Array.isArray(wl) ? wl : (wl.entries || wl.work_ledger || []),
+      }, selectedOntology));
+      return;
+    }
     if (pathname === "/__ioi/lineage" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
       const [o, mr, ms, wl, cm, pv, op, lp, dsr] = await Promise.all([

--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-lineage.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-lineage.mjs
@@ -17,7 +17,7 @@
 //     and zero source hashes (the legend grammar remains, but no data is fabricated).
 //   - HONEST GAPS: Work Ledger edges shown "where available" (0 for the ODK chain today, named);
 //     unsupported Monocle lanes (resource search / graph expansion / cross-tenant catalog) named.
-//   - MATRIX current + honest: lineage=daemon_bound → /__ioi/lineage; vertex stays queued.
+//   - MATRIX current + honest: lineage=daemon_bound → /__ioi/lineage; vertex=daemon_bound → /__ioi/vertex.
 //   - Brand-clean; the pipeline surface (#21) still renders (regression hold).
 //
 // Usage: node apps/hypervisor/scripts/verify-hypervisor-app-parity-lineage.mjs
@@ -54,8 +54,8 @@ async function run() {
   const matrix = JSON.parse(spawnSync("node", ["-e", `import(${JSON.stringify(path.join(here, "..", "harvest-app-parity-matrix.json"))}, { with: { type: "json" } }).then(m => console.log(JSON.stringify(m.default)))`], { encoding: "utf8" }).stdout || "{}");
   const bySlug = Object.fromEntries((matrix.seeds || []).map((s) => [s.slug, s]));
   ok("matrix classifies lineage as daemon_bound → /__ioi/lineage", bySlug.lineage?.parity_class === "daemon_bound" && bySlug.lineage?.daemon_surface === "/__ioi/lineage");
-  ok("matrix keeps vertex queued (not claimed covered); pipeline still daemon_bound", bySlug.vertex?.parity_class === "queued" && bySlug.pipeline?.parity_class === "daemon_bound");
-  ok("matrix queues vertex as a Provenance lens (canon: Work Ledger evolves into Provenance)", bySlug.vertex?.surface_name === "Provenance" && /Provenance graph\/exploration lens/.test(bySlug.vertex?.binding || ""));
+  ok("matrix binds vertex as daemon_bound → /__ioi/vertex (its own cut, #24); pipeline still daemon_bound", bySlug.vertex?.parity_class === "daemon_bound" && bySlug.vertex?.daemon_surface === "/__ioi/vertex" && bySlug.pipeline?.parity_class === "daemon_bound");
+  ok("matrix keeps vertex a Provenance lens (canon: Work Ledger evolves into Provenance)", bySlug.vertex?.surface_name === "Provenance" && /Provenance graph\/exploration lens/.test(bySlug.vertex?.binding || ""));
 
   // 1. Reference baseline.
   const ref = await page(`${SERVE}/__apps/lineage`);

--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-pipeline.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-pipeline.mjs
@@ -16,7 +16,7 @@
 //   - UNSUPPORTED LANES = NAMED GAPS: Schedule + Deploy shown unavailable; freeform authoring is a
 //     reference-only lane; the capture is linked as the secondary baseline, never rebound.
 //   - CONDITIONALLY HONEST: a fresh ontology's pipeline is "not built" with 0/7 stages live.
-//   - PARITY MATRIX current + honest: pipeline=daemon_bound, vertex+lineage=queued, rest
+//   - PARITY MATRIX current + honest: pipeline=daemon_bound, vertex+lineage=daemon_bound, rest
 //     reference_capture; no false "covered".
 //   - No brand/reference leak; the ODK ladder itself remains intact (Ontology Manager still renders).
 //
@@ -54,7 +54,7 @@ async function run() {
   const matrix = JSON.parse(spawnSync("node", ["-e", `import(${JSON.stringify(path.join(here, "..", "harvest-app-parity-matrix.json"))}, { with: { type: "json" } }).then(m => console.log(JSON.stringify(m.default)))`], { encoding: "utf8" }).stdout || "{}");
   const bySlug = Object.fromEntries((matrix.seeds || []).map((s) => [s.slug, s]));
   ok("matrix classifies pipeline as daemon_bound → /__ioi/pipeline", bySlug.pipeline?.parity_class === "daemon_bound" && bySlug.pipeline?.daemon_surface === "/__ioi/pipeline");
-  ok("matrix queues the next graph surface (vertex) — named, not claimed covered", bySlug.vertex?.parity_class === "queued");
+  ok("matrix binds the sibling graph surfaces (lineage + vertex) as daemon_bound — their own cuts, not claimed by pipeline", bySlug.lineage?.parity_class === "daemon_bound" && bySlug.vertex?.parity_class === "daemon_bound" && bySlug.vertex?.daemon_surface === "/__ioi/vertex");
   ok("matrix is honest estate-wide: most seeds are reference_capture only, none over-claimed", (matrix.by_parity_class?.reference_capture || 0) >= 30 && !(matrix.seeds || []).some((s) => s.parity_class === "covered"));
 
   // 1. Reference baseline boots the familiar grammar, brand-clean.

--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-vertex.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-vertex.mjs
@@ -140,6 +140,10 @@ async function run() {
   ok("unsupported Vertex lanes named (freeform canvas / path-finding / cross-tenant / saved explorations)", /freeform graph canvas, arbitrary path-finding, cross-tenant object search, saved explorations/.test(t));
   ok("cross-links to the Lineage path + Pipeline; reference capture linked as secondary", t.includes("/__ioi/lineage") && t.includes("/__ioi/pipeline") && t.includes("/__apps/vertex"));
   ok("terminology: no 'Work Ledger' UI prose leaks; brand-clean (no Palantir/Foundry)", !/Work Ledger app/.test(t) && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
+  // DISCOVERABILITY: Vertex is a daemon_bound PROVENANCE lens, so the owning Provenance surface
+  // (/__ioi/work-ledger) must link to it first-class — not only via Lineage/Pipeline deep links.
+  const prov = await page(`${SERVE}/__ioi/work-ledger`);
+  ok("the owning Provenance surface (/__ioi/work-ledger) links to Vertex first-class", prov.status === 200 && prov.text.includes("/__ioi/vertex"));
 
   // 7. NO FAKE NODES for an unmaterialized ontology.
   const fresh = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "vtx-parity-fresh", canonical_object_model: { object_types: [{ id: "a", name: "A", title_property: "t", properties: [{ id: "t", name: "T", value_type: "string" }] }], action_types: [{ id: "x", name: "X", kind: "modify_object", applies_to: "a" }] } })).j.ontology?.id;

--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-vertex.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-vertex.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// Application UX Parity Baseline — Vertex (Provenance graph/exploration lens) done-bar.
+//
+// The parity phase's fourth surface, and the cross-plane one. /__apps/vertex is the reference
+// baseline; the IOI-owned /__ioi/vertex renders the SAME graph-exploration grammar (node-type
+// catalog + node inventory + neighborhood expansion + relations) but over REAL materialized truth:
+// object sets, projections, materializing runs, objects, and — crucially — the THREADED Provenance
+// proof-stream `odk_materialization` edges (#23), which make this a CROSS-PLANE graph (ODK ↔
+// Provenance) rather than another isolated view over ODK records. No graph is invented: an ontology
+// with no materialized objects shows NO graph; freeform Vertex lanes are named gaps.
+//
+// Asserts:
+//   - REFERENCE BASELINE: /__apps/vertex boots the Vertex graph grammar, brand-clean.
+//   - IOI SURFACE = SAME GRAMMAR OVER REAL TRUTH: for a freshly materialized fixture object set,
+//     /__ioi/vertex renders the node-type catalog (real counts), the node inventory (real ladder
+//     refs), and a neighborhood expansion of the newest set with typed relations (projected_by /
+//     produced_by / proven_by / contains) carrying real projection · run · proof · object refs.
+//   - CROSS-PLANE: the neighborhood's `proven_by` relation is the threaded proof-stream
+//     odk_materialization edge, and the cross-plane note links to the Provenance proof stream.
+//   - NO FAKE NODES: a fresh/unmaterialized ontology shows "no graph to explore" — empty graph, zero
+//     catalog, zero source hashes (the grammar remains, but no data is fabricated).
+//   - HONEST GAPS: unsupported Vertex lanes named (freeform canvas / path-finding / cross-tenant /
+//     saved explorations). Reference capture linked as secondary; brand-clean.
+//   - MATRIX current + honest: vertex=daemon_bound → /__ioi/vertex, Provenance lens.
+//   - Regression: the lineage surface (#22/#23) still renders and now links back to Vertex.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-app-parity-vertex.mjs
+// Exit 2 = BLOCKED.
+
+import http from "node:http";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { mintApprovalGrant } from "../../../scripts/lib/mint-approval-grant.mjs";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+const grantFor = (ch) => mintApprovalGrant({ policyHash: ch.approval?.policy_hash, requestHash: ch.approval?.request_hash });
+const page = (url) => fetch(url).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/materialized-object-sets/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon ODK plane not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+  const SENTINEL = "vertex-parity-bearer";
+
+  // 0. Matrix current + honest.
+  const check = spawnSync("node", [path.join(here, "build-app-parity-matrix.mjs"), "--check"], { encoding: "utf8" });
+  ok("parity matrix is current (regenerated == committed)", check.status === 0, (check.stderr || "").trim().slice(0, 80));
+  const matrix = JSON.parse(spawnSync("node", ["-e", `import(${JSON.stringify(path.join(here, "..", "harvest-app-parity-matrix.json"))}, { with: { type: "json" } }).then(m => console.log(JSON.stringify(m.default)))`], { encoding: "utf8" }).stdout || "{}");
+  const bySlug = Object.fromEntries((matrix.seeds || []).map((s) => [s.slug, s]));
+  ok("matrix classifies vertex as daemon_bound → /__ioi/vertex", bySlug.vertex?.parity_class === "daemon_bound" && bySlug.vertex?.daemon_surface === "/__ioi/vertex");
+  ok("matrix keeps vertex a Provenance lens (canon: Work Ledger evolves into Provenance)", bySlug.vertex?.surface_name === "Provenance" && /Provenance graph\/exploration lens/.test(bySlug.vertex?.binding || ""));
+  ok("matrix declares vertex cross-plane (ODK ↔ Provenance proof-stream edges)", /cross-plane/.test(bySlug.vertex?.binding || "") && /odk_materialization/.test(bySlug.vertex?.binding || ""));
+
+  // 1. Reference baseline. (The /__apps/ capture is the raw familiar original; brand-clean is
+  // enforced on the IOI-owned /__ioi/vertex surface below, not on the captured baseline.)
+  const ref = await page(`${SERVE}/__apps/vertex`);
+  ok("reference baseline /__apps/vertex boots the Vertex graph grammar", ref.status === 200 && /<title>[^<]*[Vv]ertex/.test(ref.text));
+
+  // Build a REAL materialized object set (fixture) → the graph Vertex explores.
+  const rows = [{ id: "V-1", disp: "First Loan", amt: 1250.5 }, { id: "V-2", disp: "Second Loan", amt: 90000 }];
+  const srv = http.createServer((req, res) => {
+    if (req.headers.authorization !== `Bearer ${SENTINEL}`) { res.writeHead(401); return res.end(); }
+    res.writeHead(200, { "content-type": "application/json" }); res.end(JSON.stringify(rows));
+  });
+  await new Promise((r) => srv.listen(0, "127.0.0.1", r));
+  const port = srv.address().port;
+  const conn = (await jd("POST", "/v1/hypervisor/connectors", { service: "vtx-parity", base_url: `http://127.0.0.1:${port}`, name: "Vtx Parity" })).j;
+  const connId = conn.connector?.connector_id || conn.connector_id;
+  await jd("POST", `/v1/hypervisor/connectors/${connId}/credential`, { token: SENTINEL });
+  const track = (k, id) => { if (id) cleanup.push(["DELETE", `/v1/hypervisor/odk/${k}/${id}`]); };
+  const ds = (await jd("POST", "/v1/hypervisor/data-sources", { name: "vtx-parity-src", kind: "rest_api", endpoint: `http://127.0.0.1:${port}/rows`, credential_posture: "wallet_credential_lease" })).j.data_source?.source_id;
+  cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${ds}`]);
+  const ont = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "vtx-parity", canonical_object_model: {
+    value_types: [{ id: "money", name: "Money", base: "double" }],
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" }, { id: "amount", name: "Amount", value_type: "money" } ] }],
+    action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }] } })).j.ontology;
+  track("domain-ontologies", ont?.id);
+  const map = (await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "vtx-parity-map", data_source_id: ds, ontology_ref: ont.ref, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" },
+    field_mappings: [{ source_field: "amt", property_id: "amount", source_type: "double" }] })).j.connector_mapping?.id;
+  track("connector-mappings", map);
+  const view = (await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: map, name: "vtx-parity-gate", authority_subjects: ["agent://m"], allowed_operations: ["read", "transform"], purpose: "a", property_scope: ["loan_id", "title", "amount"], retention_posture: "bounded" })).j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", view);
+  const trun = (await jd("POST", "/v1/hypervisor/odk/transformation-runs", { connector_mapping_id: map, policy_view_id: view, name: "vtx-parity-trun" })).j.transformation_run?.id;
+  track("transformation-runs", trun);
+  await jd("POST", `/v1/hypervisor/odk/transformation-runs/${trun}/dry-run`);
+  const proj = (await jd("POST", "/v1/hypervisor/odk/ontology-projections", { connector_mapping_id: map, policy_view_id: view, name: "vtx-parity-proj", visible_properties: ["loan_id", "title", "amount"] })).j.ontology_projection?.id;
+  track("ontology-projections", proj);
+  const plan = (await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", { data_source_id: ds, connector_mapping_id: map, policy_view_id: view, transformation_run_id: trun, ontology_projection_id: proj, name: "vtx-parity-plan", subject: "agent://m", ttl_seconds: 900 })).j.capability_lease_plan?.id;
+  track("capability-lease-plans", plan);
+  const mrun = (await jd("POST", "/v1/hypervisor/odk/materializing-runs", { capability_lease_plan_id: plan, name: "vtx-parity-mrun" })).j.materializing_run?.id;
+  track("materializing-runs", mrun);
+  const ch = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, {});
+  await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, { wallet_approval_grant: grantFor(ch.j) });
+  const sess = (await jd("POST", "/v1/hypervisor/odk/connector-sessions", { materializing_run_id: mrun, connector_id: connId, name: "vtx-parity-sess" })).j.connector_session?.id;
+  track("connector-sessions", sess);
+  const ch2 = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${sess}/open`, {});
+  await jd("POST", `/v1/hypervisor/odk/connector-sessions/${sess}/open`, { wallet_approval_grant: grantFor(ch2.j) });
+  const ex = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/execute`, { connector_session_id: sess, limit: 10 });
+  const setRec = ex.j.materialized_object_set;
+  const setId = setRec?.id;
+  if (setId) cleanup.unshift(["DELETE", `/v1/hypervisor/odk/materialized-object-sets/${setId}`]);
+  if (!ont?.id || ex.j.materializing_run?.status !== "executed") { console.error("BLOCKED: could not build the vertex fixture"); srv.close(); process.exit(2); }
+
+  // Resolve the real ladder refs the graph should carry.
+  const projRec = (await jd("GET", `/v1/hypervisor/odk/ontology-projections/${proj}`)).j.ontology_projection;
+
+  // 2. IOI Vertex = graph grammar over real truth.
+  const vtx = await page(`${SERVE}/__ioi/vertex?ontology=${encodeURIComponent(ont.id)}`);
+  const t = vtx.text;
+  ok("IOI /__ioi/vertex renders the Vertex graph grammar (title + node catalog + neighborhood)", vtx.status === 200 && /<h1[^>]*>Vertex/.test(t) && /id="vertex-nodes"/.test(t) && /id="vertex-neighborhood"/.test(t));
+  ok("node-type catalog present (Object set · Projection · Materializing run · Object · Proof-stream edge)", ["Object set", "Projection", "Materializing run", "Object", "Proof-stream edge"].every((l) => t.includes(l)));
+  ok("catalog counts are REAL (≥1 set, 2 objects, 1 cross-plane proof edge)", /📦 1/.test(t) && /▪ 2/.test(t) && /🧾 1/.test(t) && /cross-plane/.test(t));
+
+  // 3. Node inventory carries the real resolved refs.
+  ok("node inventory carries the REAL set + projection refs (not fabricated labels)", setRec?.ref && projRec?.ref && t.includes(String(setRec.ref).slice(0, 26)) && t.includes(String(projRec.ref).slice(0, 26)));
+
+  // 4. Neighborhood expansion = typed relations over the newest set.
+  ok("neighborhood expands the newest set with typed relations (projected_by · produced_by · proven_by · contains)", ["projected_by", "produced_by", "proven_by", "contains"].every((r) => t.includes(`>${r}<`)));
+  ok("relations carry real targets — the set's materializing_run_ref + a real object (V-1) with source hash (sha256)", setRec?.materializing_run_ref && t.includes(String(setRec.materializing_run_ref).slice(0, 20)) && /Object V-1/.test(t) && /sha256:/.test(t));
+
+  // 5. CROSS-PLANE — the proof-stream edge makes this a cross-plane graph.
+  ok("cross-plane: a threaded odk_materialization proof edge connects the set to the Provenance proof stream", /Cross-plane:/.test(t) && />odk_materialization</.test(t) && t.includes("/__ioi/work-ledger") && /threaded/.test(t));
+  ok("proof edge is a first-class graph node (proven_by relation → Provenance), not an isolated ODK record", /proven_by/.test(t) && /Proof-stream edge \(Provenance\)/.test(t));
+
+  // 6. Honest gaps + cross-links + brand-clean.
+  ok("unsupported Vertex lanes named (freeform canvas / path-finding / cross-tenant / saved explorations)", /freeform graph canvas, arbitrary path-finding, cross-tenant object search, saved explorations/.test(t));
+  ok("cross-links to the Lineage path + Pipeline; reference capture linked as secondary", t.includes("/__ioi/lineage") && t.includes("/__ioi/pipeline") && t.includes("/__apps/vertex"));
+  ok("terminology: no 'Work Ledger' UI prose leaks; brand-clean (no Palantir/Foundry)", !/Work Ledger app/.test(t) && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
+
+  // 7. NO FAKE NODES for an unmaterialized ontology.
+  const fresh = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "vtx-parity-fresh", canonical_object_model: { object_types: [{ id: "a", name: "A", title_property: "t", properties: [{ id: "t", name: "T", value_type: "string" }] }], action_types: [{ id: "x", name: "X", kind: "modify_object", applies_to: "a" }] } })).j.ontology?.id;
+  track("domain-ontologies", fresh);
+  const freshPage = await page(`${SERVE}/__ioi/vertex?ontology=${encodeURIComponent(fresh)}`);
+  const ft = freshPage.text;
+  ok("fresh ontology shows 'no graph to explore' — empty graph, ZERO catalog, ZERO source hashes (no fabrication)", /no graph to explore/.test(ft) && /empty graph/.test(ft) && !/id="vertex-nodes"/.test(ft) && !/sha256:/.test(ft));
+  ok("fresh ontology keeps the grammar (title + reference baseline) but invents no data", /<h1[^>]*>Vertex/.test(ft) && ft.includes("/__apps/vertex"));
+
+  // 8. Regression: the lineage surface still renders and now links back to Vertex.
+  const lin = await page(`${SERVE}/__ioi/lineage?ontology=${encodeURIComponent(ont.id)}`);
+  ok("regression: the #22/#23 lineage surface still renders and links back to Vertex (Explore graph)", /Data lineage/.test(lin.text) && lin.text.includes("/__ioi/vertex") && />Explore graph</.test(lin.text));
+
+  srv.close();
+  for (const [method, p] of cleanup) await jd(method, p);
+  await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}/credential`, { method: "DELETE" }).catch(() => {});
+  await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}`, { method: "DELETE" }).catch(() => {});
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`app-parity-vertex readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/apps/hypervisor/scripts/verify-hypervisor-provenance-proof-stream-threading.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-provenance-proof-stream-threading.mjs
@@ -136,6 +136,7 @@ async function run() {
   const prov = await page(`${SERVE}/__ioi/work-ledger`);
   const pt = prov.text;
   ok("Provenance surface renders + is brand-clean", prov.status === 200 && /Provenance/.test(pt) && !/\bPalantir\b/.test(pt));
+  ok("Provenance surface links its daemon-bound graph lenses first-class (Data lineage + Vertex graph)", pt.includes("/__ioi/lineage") && pt.includes("/__ioi/vertex"));
   ok("odk_materialization is a first-class facet chip ('Materializations')", /data-val="odk_materialization"/.test(pt) && />Materializations</.test(pt));
   ok("the materialization row has its own title (not the generic '—' fallback)", new RegExp(`data-kind="odk_materialization"[^>]*>[\\s\\S]*?materialized 2 objects → loan`).test(pt));
   ok("the row carries the kind for filtering + a 'registered' status pill", new RegExp(`data-kind="odk_materialization" data-status="registered"`).test(pt));


### PR DESCRIPTION
## Vertex — Application UX Parity Baseline, fourth surface (the cross-plane one)

`/__apps/vertex` is the familiar reference capture. The IOI-owned **`/__ioi/vertex`** renders the SAME graph-exploration grammar — node-type catalog · node inventory · neighborhood expansion · typed relations — over **REAL materialized truth**: object sets, projections, materializing runs, objects, and (the point of this cut) the **threaded Provenance proof-stream `odk_materialization` edges** from #23.

That proof edge is what makes this a **cross-plane graph (ODK ↔ Provenance)**: the materialized objects and their *existing* receipt are reachable as one graph, not isolated ODK records. Vertex mints nothing and duplicates no receipt authority — it projects the same threaded read-time stream the Provenance surface does.

### Doctrine held
- **Reference parity first**: `/__apps/vertex` is the untouched familiar baseline (secondary link), never a rebound surface.
- **IOI substrate underneath**: supported lanes bind to daemon truth; **no fake nodes** — a fresh/unmaterialized ontology shows *"no graph to explore"* (empty graph, zero catalog, zero source hashes).
- **Honest named gaps**: freeform graph canvas / arbitrary path-finding / cross-tenant object search / saved explorations are reference-only, named.
- Brand-clean on the IOI surface; no "Work Ledger app" prose leak (canon: Work Ledger evolves into Provenance — Vertex is a Provenance lens).

### Changes
- **serve**: `renderVertex(lists, selectedId)` + `GET /__ioi/vertex`; honest-empty guard; reciprocal **Explore graph ↔ Lineage path** links between `/__ioi/lineage` and `/__ioi/vertex`.
- **matrix**: vertex `reference_capture` → `daemon_bound` (`/__ioi/vertex`, Provenance lens, cross-plane binding); `queued` class now empty. `reference_capture 36 / daemon_bound 3`.
- **verifier**: `verify-hypervisor-app-parity-vertex.mjs` (**19/19**) — builds a real materialized fixture via an in-verifier auth-checked HTTP fixture server, then asserts real catalog counts, resolved ladder refs, typed neighborhood relations (`projected_by · produced_by · proven_by · contains`), the cross-plane proof edge, no-fake-nodes on a fresh ontology, and a brand-clean IOI surface.
- lineage + pipeline verifiers: stale *"vertex queued"* asserts evolved to `daemon_bound`.

### Verification
| verifier | result |
|---|---|
| app-parity-vertex | **19/19** |
| app-parity-pipeline (regression) | 16/16 |
| app-parity-lineage (regression) | 21/21 |
| provenance-proof-stream-threading (regression) | 18/18 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)