### PR TITLE
feat(hypervisor): Studio · Designer — system-design canvas over real composition (designer → /__ioi/studio/designer)

### DIFF
--- a/apps/hypervisor/harvest-app-parity-matrix.json
+++ b/apps/hypervisor/harvest-app-parity-matrix.json
@@ -8,8 +8,8 @@
   ],
   "total_seeds": 39,
   "by_parity_class": {
-    "reference_capture": 33,
-    "daemon_bound": 6
+    "daemon_bound": 7,
+    "reference_capture": 32
   },
   "legend": {
     "reference_capture": "the /__apps/<slug> reference baseline serves; not yet bound to daemon truth",
@@ -25,10 +25,13 @@
       "capture_base": "/workspace/solution-design/",
       "grammar": "editor_canvas",
       "tier": "high_value",
-      "parity_class": "reference_capture",
+      "parity_class": "daemon_bound",
       "capture_state": "boots_graph",
       "reference_capture": "/__apps/designer",
-      "note": "typed concept/component/resource canvas; in-canvas open/save/reference/load-lineage = named gaps"
+      "note": "read-only design map; owner surface stays /__ioi/agent-studio (no route rename); honest empty when an ontology has no concepts/components/resources; in-canvas authoring / save-open / drag-to-reference / load-lineage / machinery process-graph execution / workshop+module builders = named gaps",
+      "daemon_surface": "/__ioi/studio/designer",
+      "surface_name": "Studio",
+      "binding": "the system-design canvas — a read-only typed concept/component/resource map over real ODK composition (an ontology's object/value/action/link types = concepts; connector mappings + policy views + projections = components; materialized object sets + domain-app surface descriptors = resources)"
     },
     {
       "owner": "Studio",

--- a/apps/hypervisor/scripts/build-app-parity-matrix.mjs
+++ b/apps/hypervisor/scripts/build-app-parity-matrix.mjs
@@ -42,6 +42,9 @@ const DAEMON_BOUND = {
   // Evaluations owner-family: only evalsuites binds in this cut (analysis + quiver stay reference_capture).
   // The eval-suite library renders the INERT daemon eval-suite contract (a declaration; no scoring).
   evalsuites: { daemon_surface: "/__ioi/evaluations", surface_name: "Evaluations", binding: "the eval-suite library — the inert daemon eval-suite contract (a suite declares subject_scope + evidence/consent requirements + named candidate handoffs) over real assessment subjects (Missions runs/failures/blockers) + the consent ladder + feedback candidate source, table/list grammar over daemon truth", note: "declaration-only owner surface; /__ioi/feedback kept as a compatibility sublane; honest empty when no suites; EvalRun execution / scoring / verdicts / judge / scorecards / auto-mining / analysis+quiver canvases / promotion = named gaps" },
+  // Studio owner-family: only designer binds in this cut (machinery/workshop/module stay reference_capture).
+  // A dedicated /__ioi/studio/designer surface; the /__ioi/agent-studio owner links to it (no rename).
+  designer: { daemon_surface: "/__ioi/studio/designer", surface_name: "Studio", binding: "the system-design canvas — a read-only typed concept/component/resource map over real ODK composition (an ontology's object/value/action/link types = concepts; connector mappings + policy views + projections = components; materialized object sets + domain-app surface descriptors = resources)", note: "read-only design map; owner surface stays /__ioi/agent-studio (no route rename); honest empty when an ontology has no concepts/components/resources; in-canvas authoring / save-open / drag-to-reference / load-lineage / machinery process-graph execution / workshop+module builders = named gaps" },
 };
 // Named-next targets (owner binding declared; surface not built yet).
 const QUEUED = {};

--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -3385,7 +3385,9 @@ function renderStudioDesigner(lists, selectedId) {
   const myViews = policyViews.filter((v) => v.ontology_ref === oref);
   const myProjections = projections.filter((p) => p.ontology_ref === oref);
   const mySets = sets.filter((s) => s.ontology_ref === oref);
-  const myApps = domainApps.filter((a) => a.ontology_ref === oref || a.ontology_id === oid);
+  // DomainApps carry ontology_refs (an ARRAY, derived from the surface descriptor) — not a singular
+  // ontology_ref; filter on membership, and read domain_app_ref/domain_app_id (the real field names).
+  const myApps = domainApps.filter((a) => Array.isArray(a.ontology_refs) && a.ontology_refs.includes(oref));
   const conceptCount = objectTypes.length + valueTypes.length + actionTypes.length + linkTypes.length;
   const componentCount = myMappings.length + myViews.length + myProjections.length;
   const resourceCount = mySets.length + myApps.length;
@@ -3420,7 +3422,7 @@ function renderStudioDesigner(lists, selectedId) {
   const resourcesPane = `<h2 id="designer-resources">Resources ${sub(`— what this composition generates (${resourceCount})`)}</h2>`
     + (resourceCount
       ? `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Object sets</span>${mySets.map((s) => compChip("📦", `${s.count || 0} obj`, s.ref, s.object_type_id)).join("") || "<span class='sub' style='margin:0'>none</span>"}</div>`
-        + `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Surface descriptors</span>${myApps.length ? myApps.map((a) => compChip("🖥", a.name || a.id || a.domain_app_id, a.ref || a.surface_descriptor_ref, "")).join("") : "<span class='sub' style='margin:0'>none — no domain-app surfaces generated yet (named gap)</span>"}</div>`
+        + `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Surface descriptors</span>${myApps.length ? myApps.map((a) => compChip("🖥", a.name || a.domain_app_id, a.domain_app_ref, a.surface_descriptor_ref || "")).join("") : "<span class='sub' style='margin:0'>none — no domain-app surfaces generated yet (named gap)</span>"}</div>`
       : omBoundaryNote(`This composition has generated <b>no resources</b> yet — materialize a set from the <a href="/__ioi/pipeline?ontology=${enc(oid)}">pipeline</a> to see it here. Surface descriptors (domain-app surfaces) appear once a domain app is composed.`));
 
   const gaps = omBoundaryNote(`This is a <b>read-only design map</b> over real composition truth. Unsupported Designer lanes — in-canvas authoring, save/open, drag-to-reference, load-lineage into the canvas — are <b>named gaps</b> (no authority contract yet), not silently hidden. Sibling Studio seeds stay reference-only too: the <a href="/__apps/machinery">machinery</a> process/state-machine graph (data lanes unbound), the <a href="/__apps/workshop">workshop</a> and module builders. The <a href="/__apps/designer">Designer reference capture ↗</a> is the familiar baseline, never a rebound surface.`);

--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -2344,7 +2344,7 @@ function renderAgentStudio(agents, profiles, routes, providers, conversations, r
     ? agents.filter((a) => `${a.id || ""} ${pickv(a, "model_id", "modelId") || ""}`.toLowerCase().includes(qn))
     : agents;
   const activeCount = agents.filter((a) => (a.status || "") === "active").length;
-  const head = `<h1>Studio</h1><p class="sub"><a href="/__apps/designer">System canvas seed (adopting) →</a> · Compose systems &amp; agents. The agent lens is live — the agent estate — every configured agent, its model route and runtime posture, the platform's harness adapters, and recent activity. Author and operate agents here; <a href="/__ioi/automations">put one to work in an Automation →</a></p>`;
+  const head = `<h1>Studio</h1><p class="sub"><a href="/__ioi/studio/designer">System design canvas →</a> (the concept/component/resource map over real composition) · reference <a href="/__apps/designer">Designer seed ↗</a> · Compose systems &amp; agents. The agent lens is live — the agent estate — every configured agent, its model route and runtime posture, the platform's harness adapters, and recent activity. Author and operate agents here; <a href="/__ioi/automations">put one to work in an Automation →</a></p>`;
   const styles = `<style>.wrap{max-width:1180px}.asgrid{display:grid;grid-template-columns:248px 1fr;gap:20px;align-items:start}.aslist{position:sticky;top:16px;max-height:82vh;overflow:auto;display:flex;flex-direction:column;gap:6px}.asrow{display:block;padding:10px 12px;border:1px solid #24262d;border-radius:10px;background:#15171c;text-decoration:none;color:inherit}.asrow:hover{border-color:#3a82f6}.asrow.sel{border-color:#3a82f6;box-shadow:0 0 0 1px #3a82f6 inset}.asrow .nm{font-weight:600;color:#fff;font-size:12.5px}.asrow .ml{color:#878a93;font-size:11.5px;margin-top:2px;word-break:break-all}.asearch{width:100%;box-sizing:border-box;padding:9px 12px;border-radius:9px;border:1px solid #2a2c33;background:#0e0f13;color:#e6e7ea;font:inherit;margin-bottom:10px}</style>`;
   if (!agents.length) {
     // Registry truth still renders without agents — routes exist independently of the agent estate.
@@ -3337,6 +3337,96 @@ function renderVertex(lists, selectedId) {
 
   const banner = `<div class="chips" style="margin:10px 0 12px"><span class="pill ok">graph</span> <span class="sub" style="margin:0">${counts.set} object set${counts.set === 1 ? "" : "s"} · ${objectCount} object${objectCount === 1 ? "" : "s"} · ${counts.proof} cross-plane proof edge${counts.proof === 1 ? "" : "s"} for <b>${CX_ESC(selected.domain || selected.id)}</b></span></div>`;
   return automationsShell("Vertex", head + switcher + banner + catalog + inv + neighborhood + crossPlane + gaps);
+}
+
+// ============================ STUDIO · DESIGNER (system/solution-design canvas over real composition)
+// The Application UX Parity Baseline phase, applied to the Studio `designer` seed. The reference
+// capture (/__apps/designer, /workspace/solution-design/) is the familiar typed concept/component/
+// resource DESIGN canvas; this IOI-owned surface renders the SAME grammar as a READ-ONLY typed map
+// over REAL daemon composition truth: an ontology's canonical object model (object/value/action/link
+// types = CONCEPTS), the composition that shapes it (connector mappings · policy views · projections
+// = COMPONENTS), and what that composition generates (materialized object sets · domain-app surface
+// descriptors = RESOURCES). Nothing is authored/saved here — canvas authoring, save/open/reference/
+// load-lineage, process-graph execution (machinery), and the workshop/module builders are NAMED GAPS.
+// Owner: Studio (/__ioi/agent-studio); this is a dedicated daemon-bound surface, no route rename.
+function renderStudioDesigner(lists, selectedId) {
+  const enc = (s) => encodeURIComponent(String(s || ""));
+  const ontologies = Array.isArray(lists.ontologies) ? lists.ontologies : [];
+  const mappings = Array.isArray(lists.connector_mappings) ? lists.connector_mappings : [];
+  const policyViews = Array.isArray(lists.policy_views) ? lists.policy_views : [];
+  const projections = Array.isArray(lists.projections) ? lists.projections : [];
+  const sets = Array.isArray(lists.materialized_sets) ? lists.materialized_sets : [];
+  const domainApps = Array.isArray(lists.domain_apps) ? lists.domain_apps : [];
+  const sub = (txt) => `<span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">${txt}</span>`;
+  const composed = new Set(mappings.map((m) => m.ontology_ref));
+  const selected = ontologies.find((x) => x.id === selectedId) || ontologies.find((x) => composed.has(x.ref)) || ontologies[0] || null;
+  const oref = selected ? selected.ref : "__none__";
+  const oid = selected ? selected.id : "";
+
+  const switcher = ontologies.length
+    ? `<div class="chips" style="margin:0 0 14px">${ontologies.map((x) => {
+        const on = selected && x.id === selected.id;
+        return `<a href="/__ioi/studio/designer?ontology=${enc(x.id)}" class="pill ${on ? "ok" : "muted"}" style="text-decoration:none;margin:0">${CX_ESC(x.domain || x.id)}${composed.has(x.ref) ? ` <span class="pill ok" style="margin-left:4px">composed</span>` : ""}</a>`;
+      }).join(" ")}</div>`
+    : `<div class="empty">No ontologies yet.</div>`;
+
+  const head = `<div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap"><div><h1 style="margin:0">Designer</h1><p class="sub" style="margin:4px 0 0">The system-design canvas — an ontology's concepts, the components that compose them, and the resources they generate, as a typed read-only map over IOI daemon truth. Reference grammar: <a href="/__apps/designer">Designer ↗</a> (secondary capture). Owner: <a href="/__ioi/agent-studio">Agent Studio</a>.</p></div><div class="row" style="gap:8px"><a class="act ghost" href="/__ioi/odk?ontology=${enc(oid)}">Ontology Manager</a><a class="act ghost" href="/__ioi/pipeline?ontology=${enc(oid)}">Build pipeline</a></div></div>`;
+
+  if (!selected) {
+    return automationsShell("Designer", head + switcher + omBoundaryNote(`No ontologies to design over yet — create one in the <a href="/__ioi/odk">Ontology Manager</a>. This canvas renders real composition truth; it never fabricates concepts.`));
+  }
+
+  const model = selected.canonical_object_model || {};
+  const objectTypes = Array.isArray(model.object_types) ? model.object_types : [];
+  const valueTypes = Array.isArray(model.value_types) ? model.value_types : [];
+  const actionTypes = Array.isArray(model.action_types) ? model.action_types : [];
+  const linkTypes = Array.isArray(model.link_types) ? model.link_types : [];
+  const myMappings = mappings.filter((m) => m.ontology_ref === oref);
+  const myViews = policyViews.filter((v) => v.ontology_ref === oref);
+  const myProjections = projections.filter((p) => p.ontology_ref === oref);
+  const mySets = sets.filter((s) => s.ontology_ref === oref);
+  const myApps = domainApps.filter((a) => a.ontology_ref === oref || a.ontology_id === oid);
+  const conceptCount = objectTypes.length + valueTypes.length + actionTypes.length + linkTypes.length;
+  const componentCount = myMappings.length + myViews.length + myProjections.length;
+  const resourceCount = mySets.length + myApps.length;
+
+  const banner = `<div class="row" style="gap:10px;align-items:stretch;margin:12px 0 14px;flex-wrap:wrap">${[
+    ["Concepts", conceptCount, "🧩"], ["Components", componentCount, "🧱"], ["Resources", resourceCount, "📦"],
+  ].map(([l, n, ic]) => `<div style="flex:1;min-width:120px;padding:11px 13px;border:1px solid #24262d;border-radius:10px;background:#15171c"><div style="font-size:20px;font-weight:700;color:#fff">${ic} ${n}</div><div style="color:#878a93;font-size:12px;margin-top:2px">${CX_ESC(l)}</div></div>`).join("")}</div>`;
+
+  // CONCEPTS — the ontology's canonical object model (typed nodes; no authoring).
+  const actionsFor = (otId) => actionTypes.filter((a) => a.applies_to === otId);
+  const conceptRows = objectTypes.map((ot) => `<tr>
+    <td>🧩 <b>${CX_ESC(ot.name || ot.id)}</b> <code style="font-size:10px;opacity:.7">${CX_ESC(ot.id)}</code></td>
+    <td>${(ot.properties || []).length} <span class="sub" style="margin:0">props</span>${ot.title_property ? ` · title <code style="font-size:10px">${CX_ESC(ot.title_property)}</code>` : ""}</td>
+    <td>${actionsFor(ot.id).map((a) => `<span class="pill muted" style="margin:0 3px 3px 0">${CX_ESC(a.name || a.id)}</span>`).join("") || "<span class='sub' style='margin:0'>—</span>"}</td>
+  </tr>`).join("");
+  const conceptsPane = objectTypes.length
+    ? `<h2 id="designer-concepts">Concepts ${sub(`— object types + their properties/actions (${objectTypes.length} object · ${valueTypes.length} value · ${actionTypes.length} action · ${linkTypes.length} link types)`)}</h2>`
+      + `<table><thead><tr><th>Object type</th><th>Shape</th><th>Actions</th></tr></thead><tbody>${conceptRows}</tbody></table>`
+      + (valueTypes.length || linkTypes.length ? `<div class="chips" style="margin:8px 0 0">${valueTypes.map((v) => `<span class="pill muted" style="margin:0">◇ ${CX_ESC(v.name || v.id)}</span>`).join(" ")}${linkTypes.map((l) => `<span class="pill muted" style="margin:0">↔ ${CX_ESC(l.name || l.id)}</span>`).join(" ")}</div>` : "")
+    : `<h2 id="designer-concepts">Concepts</h2>` + omBoundaryNote(`This ontology declares <b>no object types</b> yet — there are no concepts to map. Define them in the <a href="/__ioi/odk?ontology=${enc(oid)}">Ontology Manager</a>; nothing is invented here.`);
+
+  // COMPONENTS — the composition that shapes concepts (real refs).
+  const compChip = (ic, label, ref, meta) => `<span class="pill muted" style="margin:0 4px 4px 0" title="${CX_ESC(ref || "")}">${ic} ${CX_ESC(label)}${meta ? ` <span style="opacity:.6">${CX_ESC(meta)}</span>` : ""}</span>`;
+  const componentsPane = `<h2 id="designer-components">Components ${sub(`— the composition that shapes these concepts (${componentCount})`)}</h2>`
+    + (componentCount
+      ? `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Mappings</span>${myMappings.map((m) => compChip("🔌", m.name || m.id, m.ref, `→ ${m.object_type_id || ""}`)).join("") || "<span class='sub' style='margin:0'>—</span>"}</div>`
+        + `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Policy views</span>${myViews.map((v) => compChip("🛡", v.name || v.id, v.ref, (v.allowed_operations || []).join("/"))).join("") || "<span class='sub' style='margin:0'>—</span>"}</div>`
+        + `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Projections</span>${myProjections.map((p) => compChip("🔭", p.name || p.id, p.ref, `${(p.visible_properties || []).length} props`)).join("") || "<span class='sub' style='margin:0'>—</span>"}</div>`
+      : omBoundaryNote(`No components compose this ontology yet — add a connector mapping + projection in the <a href="/__ioi/pipeline?ontology=${enc(oid)}">Pipeline Builder</a>. Components appear only once real composition exists.`));
+
+  // RESOURCES — what the composition generates (materialized sets + surface descriptors).
+  const resourcesPane = `<h2 id="designer-resources">Resources ${sub(`— what this composition generates (${resourceCount})`)}</h2>`
+    + (resourceCount
+      ? `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Object sets</span>${mySets.map((s) => compChip("📦", `${s.count || 0} obj`, s.ref, s.object_type_id)).join("") || "<span class='sub' style='margin:0'>none</span>"}</div>`
+        + `<div class="chips" style="margin:0 0 6px"><span class="chiplabel">Surface descriptors</span>${myApps.length ? myApps.map((a) => compChip("🖥", a.name || a.id || a.domain_app_id, a.ref || a.surface_descriptor_ref, "")).join("") : "<span class='sub' style='margin:0'>none — no domain-app surfaces generated yet (named gap)</span>"}</div>`
+      : omBoundaryNote(`This composition has generated <b>no resources</b> yet — materialize a set from the <a href="/__ioi/pipeline?ontology=${enc(oid)}">pipeline</a> to see it here. Surface descriptors (domain-app surfaces) appear once a domain app is composed.`));
+
+  const gaps = omBoundaryNote(`This is a <b>read-only design map</b> over real composition truth. Unsupported Designer lanes — in-canvas authoring, save/open, drag-to-reference, load-lineage into the canvas — are <b>named gaps</b> (no authority contract yet), not silently hidden. Sibling Studio seeds stay reference-only too: the <a href="/__apps/machinery">machinery</a> process/state-machine graph (data lanes unbound), the <a href="/__apps/workshop">workshop</a> and module builders. The <a href="/__apps/designer">Designer reference capture ↗</a> is the familiar baseline, never a rebound surface.`);
+
+  const summary = `<div class="chips" style="margin:10px 0 12px"><span class="pill ok">design map</span> <span class="sub" style="margin:0">${conceptCount} concept${conceptCount === 1 ? "" : "s"} · ${componentCount} component${componentCount === 1 ? "" : "s"} · ${resourceCount} resource${resourceCount === 1 ? "" : "s"} for <b>${CX_ESC(selected.domain || selected.id)}</b></span></div>`;
+  return automationsShell("Designer", head + switcher + summary + banner + conceptsPane + componentsPane + resourcesPane + gaps);
 }
 
 function renderDataLineage(lists, selectedId) {
@@ -7265,6 +7355,30 @@ const server = http.createServer((req, res) => {
       }
     }
     // ---- ODK — controlled builder over the daemon ODK object plane (estate surface #5).
+    // ---- Studio · Designer — the system-design canvas (designer seed). Read-only typed map over
+    // real ODK composition (concepts/components) + generated resources. Owner: /__ioi/agent-studio.
+    if (pathname === "/__ioi/studio/designer" && req.method === "GET") {
+      const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
+      const [o, cm, pv, op, ms, da] = await Promise.all([
+        J("/v1/hypervisor/odk/domain-ontologies"),
+        J("/v1/hypervisor/odk/connector-mappings"),
+        J("/v1/hypervisor/odk/policy-bound-data-views"),
+        J("/v1/hypervisor/odk/ontology-projections"),
+        J("/v1/hypervisor/odk/materialized-object-sets"),
+        J("/v1/hypervisor/domain-apps"),
+      ]);
+      const selectedOntology = new URL(req.url, "http://x").searchParams.get("ontology") || "";
+      res.writeHead(200, HTMLH);
+      res.end(renderStudioDesigner({
+        ontologies: o.ontologies || [],
+        connector_mappings: cm.connector_mappings || [],
+        policy_views: pv.policy_bound_data_views || [],
+        projections: op.ontology_projections || [],
+        materialized_sets: ms.materialized_object_sets || [],
+        domain_apps: da.domain_apps || da.apps || [],
+      }, selectedOntology));
+      return;
+    }
     if (pathname === "/__ioi/vertex" && req.method === "GET") {
       const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
       const [o, ms, op, mr, wl] = await Promise.all([

--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-studio-designer.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-studio-designer.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Application UX Parity Baseline — Studio · Designer done-bar (designer seed only).
+//
+// The parity phase's seventh surface, and the first of the Studio canvas family. The reference
+// capture (/__apps/designer = the solution-design canvas) is the familiar typed concept/component/
+// resource DESIGN canvas; the IOI-owned /__ioi/studio/designer renders the SAME grammar as a
+// READ-ONLY typed map over REAL daemon composition truth:
+//   * CONCEPTS   — an ontology's canonical object model (object / value / action / link types);
+//   * COMPONENTS — the composition that shapes them (connector mappings · policy views · projections);
+//   * RESOURCES  — what that composition generates (materialized object sets · domain-app descriptors).
+// Nothing is authored/saved here.
+//
+// SCOPE (tight, by direction): only `designer` binds. `machinery`, `workshop`, `module` stay
+// reference_capture. Owner surface stays /__ioi/agent-studio (no route rename); the designer gets a
+// dedicated /__ioi/studio/designer surface the owner links to.
+//
+// Because the map is a read-only projection over real ODK composition, the guard is a CROSS-CHECK:
+// build a real ontology + its full ladder (mapping → view → projection → materialized set), then
+// assert the map renders those exact concepts/components/resources — and an unbound ontology shows
+// honest-empty component/resource lanes (no fabrication).
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-app-parity-studio-designer.mjs
+// Exit 2 = BLOCKED.
+
+import http from "node:http";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { mintApprovalGrant } from "../../../scripts/lib/mint-approval-grant.mjs";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+const grantFor = (ch) => mintApprovalGrant({ policyHash: ch.approval?.policy_hash, requestHash: ch.approval?.request_hash });
+const page = (url) => fetch(url).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/odk/materialized-object-sets/overview`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon ODK plane not reachable at " + DAEMON); process.exit(2); }
+  const cleanup = [];
+  const SENTINEL = "designer-parity-bearer";
+
+  // 0. Matrix current + honest.
+  const check = spawnSync("node", [path.join(here, "build-app-parity-matrix.mjs"), "--check"], { encoding: "utf8" });
+  ok("parity matrix is current (regenerated == committed)", check.status === 0, (check.stderr || "").trim().slice(0, 80));
+  const matrix = JSON.parse(spawnSync("node", ["-e", `import(${JSON.stringify(path.join(here, "..", "harvest-app-parity-matrix.json"))}, { with: { type: "json" } }).then(m => console.log(JSON.stringify(m.default)))`], { encoding: "utf8" }).stdout || "{}");
+  const bySlug = Object.fromEntries((matrix.seeds || []).map((s) => [s.slug, s]));
+  ok("matrix binds designer as daemon_bound → /__ioi/studio/designer (Studio)", bySlug.designer?.parity_class === "daemon_bound" && bySlug.designer?.daemon_surface === "/__ioi/studio/designer" && bySlug.designer?.surface_name === "Studio");
+  ok("matrix keeps machinery + workshop + module reference_capture (NOT over-claimed in this cut)", ["machinery", "workshop", "module"].every((k) => bySlug[k]?.parity_class === "reference_capture"));
+  ok("no 'covered' anywhere; prior daemon_bound surfaces intact (pipeline/lineage/vertex/jobs/incidents/evalsuites)", !(matrix.seeds || []).some((s) => s.parity_class === "covered") && ["pipeline", "lineage", "vertex", "jobs", "incidents", "evalsuites"].every((k) => bySlug[k]?.parity_class === "daemon_bound"));
+
+  // 1. Reference baseline.
+  const ref = await page(`${SERVE}/__apps/designer`);
+  ok("reference baseline /__apps/designer boots the design-canvas grammar", ref.status === 200 && /<title>[^<]*(Design|Solution)/i.test(ref.text));
+
+  // 2. Build a real ontology + full ladder → the composition the map reflects.
+  const rows = [{ id: "D-1", disp: "First Loan", amt: 1250.5 }, { id: "D-2", disp: "Second Loan", amt: 90000 }];
+  const srv = http.createServer((req, res) => {
+    if (req.headers.authorization !== `Bearer ${SENTINEL}`) { res.writeHead(401); return res.end(); }
+    res.writeHead(200, { "content-type": "application/json" }); res.end(JSON.stringify(rows));
+  });
+  await new Promise((r) => srv.listen(0, "127.0.0.1", r));
+  const port = srv.address().port;
+  const conn = (await jd("POST", "/v1/hypervisor/connectors", { service: "dsg-parity", base_url: `http://127.0.0.1:${port}`, name: "Dsg Parity" })).j;
+  const connId = conn.connector?.connector_id || conn.connector_id;
+  await jd("POST", `/v1/hypervisor/connectors/${connId}/credential`, { token: SENTINEL });
+  const track = (k, id) => { if (id) cleanup.push(["DELETE", `/v1/hypervisor/odk/${k}/${id}`]); };
+  const ds = (await jd("POST", "/v1/hypervisor/data-sources", { name: "dsg-parity-src", kind: "rest_api", endpoint: `http://127.0.0.1:${port}/rows`, credential_posture: "wallet_credential_lease" })).j.data_source?.source_id;
+  cleanup.push(["DELETE", `/v1/hypervisor/data-sources/${ds}`]);
+  const ont = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "dsg-parity", canonical_object_model: {
+    value_types: [{ id: "money", name: "Money", base: "double" }],
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" }, { id: "amount", name: "Amount", value_type: "money" } ] }],
+    action_types: [{ id: "approve", name: "Approve", kind: "modify_object", applies_to: "loan" }] } })).j.ontology;
+  track("domain-ontologies", ont?.id);
+  const map = (await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: "dsg-parity-map", data_source_id: ds, ontology_ref: ont.ref, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" },
+    field_mappings: [{ source_field: "amt", property_id: "amount", source_type: "double" }] })).j.connector_mapping?.id;
+  track("connector-mappings", map);
+  const view = (await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: map, name: "dsg-parity-gate", authority_subjects: ["agent://m"], allowed_operations: ["read", "transform"], purpose: "a", property_scope: ["loan_id", "title", "amount"], retention_posture: "bounded" })).j.policy_bound_data_view?.id;
+  track("policy-bound-data-views", view);
+  const trun = (await jd("POST", "/v1/hypervisor/odk/transformation-runs", { connector_mapping_id: map, policy_view_id: view, name: "dsg-parity-trun" })).j.transformation_run?.id;
+  track("transformation-runs", trun);
+  await jd("POST", `/v1/hypervisor/odk/transformation-runs/${trun}/dry-run`);
+  const proj = (await jd("POST", "/v1/hypervisor/odk/ontology-projections", { connector_mapping_id: map, policy_view_id: view, name: "dsg-parity-proj", visible_properties: ["loan_id", "title", "amount"] })).j.ontology_projection?.id;
+  track("ontology-projections", proj);
+  const plan = (await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", { data_source_id: ds, connector_mapping_id: map, policy_view_id: view, transformation_run_id: trun, ontology_projection_id: proj, name: "dsg-parity-plan", subject: "agent://m", ttl_seconds: 900 })).j.capability_lease_plan?.id;
+  track("capability-lease-plans", plan);
+  const mrun = (await jd("POST", "/v1/hypervisor/odk/materializing-runs", { capability_lease_plan_id: plan, name: "dsg-parity-mrun" })).j.materializing_run?.id;
+  track("materializing-runs", mrun);
+  const ch = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, {});
+  await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, { wallet_approval_grant: grantFor(ch.j) });
+  const sess = (await jd("POST", "/v1/hypervisor/odk/connector-sessions", { materializing_run_id: mrun, connector_id: connId, name: "dsg-parity-sess" })).j.connector_session?.id;
+  track("connector-sessions", sess);
+  const ch2 = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${sess}/open`, {});
+  await jd("POST", `/v1/hypervisor/odk/connector-sessions/${sess}/open`, { wallet_approval_grant: grantFor(ch2.j) });
+  const ex = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/execute`, { connector_session_id: sess, limit: 10 });
+  const setRec = ex.j.materialized_object_set;
+  if (setRec?.id) cleanup.unshift(["DELETE", `/v1/hypervisor/odk/materialized-object-sets/${setRec.id}`]);
+  if (!ont?.id || ex.j.materializing_run?.status !== "executed") { console.error("BLOCKED: could not build the designer fixture"); srv.close(); process.exit(2); }
+  const mapRec = (await jd("GET", `/v1/hypervisor/odk/connector-mappings/${map}`)).j.connector_mapping;
+  const projRec = (await jd("GET", `/v1/hypervisor/odk/ontology-projections/${proj}`)).j.ontology_projection;
+  const viewRec = (await jd("GET", `/v1/hypervisor/odk/policy-bound-data-views/${view}`)).j.policy_bound_data_view;
+
+  // 3. IOI surface = the design-map grammar over real composition.
+  const dsg = await page(`${SERVE}/__ioi/studio/designer?ontology=${encodeURIComponent(ont.id)}`);
+  const t = dsg.text;
+  ok("IOI /__ioi/studio/designer renders the design-map grammar (title + concepts/components/resources lanes)", dsg.status === 200 && /<h1[^>]*>Designer/.test(t) && /id="designer-concepts"/.test(t) && /id="designer-components"/.test(t) && /id="designer-resources"/.test(t));
+  // CONCEPTS = the real object model.
+  ok("CONCEPTS render the real object model (object type Loan + Money value type + Approve action)", t.includes("Loan") && t.includes("Money") && t.includes("Approve") && /🧩 3/.test(t), "1 object + 1 value + 1 action + 0 link = 3 concepts");
+  // COMPONENTS = the real composition refs.
+  ok("COMPONENTS render the real mapping · policy view · projection refs (not fabricated labels)", mapRec?.ref && viewRec?.ref && projRec?.ref && t.includes(mapRec.ref) && t.includes(viewRec.ref) && t.includes(projRec.ref));
+  // RESOURCES = the real generated set.
+  ok("RESOURCES render the real materialized object set (ref + object count)", setRec?.ref && t.includes(setRec.ref) && new RegExp(`${setRec.count || 2} obj`).test(t));
+
+  // 4. NO AUTHORING — the map is read-only (no create/save form posting to the surface).
+  ok("the surface is READ-ONLY (no authoring form posts to /__ioi/studio/designer)", !/action="\/__ioi\/studio\/designer/.test(t));
+
+  // 5. Honest empty — a fresh ontology has concepts but NO components/resources (no fabrication).
+  const fresh = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "dsg-parity-fresh", canonical_object_model: { object_types: [{ id: "a", name: "Alpha", title_property: "t", properties: [{ id: "t", name: "T", value_type: "string" }] }], action_types: [{ id: "x", name: "X", kind: "modify_object", applies_to: "a" }] } })).j.ontology?.id;
+  track("domain-ontologies", fresh);
+  const ft = (await page(`${SERVE}/__ioi/studio/designer?ontology=${encodeURIComponent(fresh)}`)).text;
+  ok("fresh ontology: CONCEPTS render but COMPONENTS + RESOURCES are honest-empty (no fabrication)", /Alpha/.test(ft) && /No components compose this ontology yet/.test(ft) && /generated <b>no resources<\/b> yet/.test(ft));
+
+  // 6. Named gaps + owner discoverability + brand-clean.
+  ok("named gaps: in-canvas authoring / save-open / drag-to-reference / load-lineage", /in-canvas authoring/.test(t) && /save\/open/.test(t) && /load-lineage/.test(t));
+  ok("sibling Studio seeds named reference-only (machinery process graph, workshop/module builders)", t.includes("/__apps/machinery") && t.includes("/__apps/workshop") && /workshop<\/a> and module builders/.test(t));
+  ok("owner discoverability: Designer links back to /__ioi/agent-studio, and the owner links to the designer", t.includes("/__ioi/agent-studio") && (await page(`${SERVE}/__ioi/agent-studio`)).text.includes("/__ioi/studio/designer"));
+  ok("reference capture linked as secondary; IOI surface brand-clean (no Palantir)", t.includes("/__apps/designer") && !/\bPalantir\b/.test(t));
+
+  srv.close();
+  for (const [method, p] of cleanup) await jd(method, p);
+  await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}/credential`, { method: "DELETE" }).catch(() => {});
+  await fetch(`${DAEMON}/v1/hypervisor/connectors/${connId}`, { method: "DELETE" }).catch(() => {});
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`app-parity-studio-designer readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-studio-designer.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-studio-designer.mjs
@@ -111,6 +111,15 @@ async function run() {
   const projRec = (await jd("GET", `/v1/hypervisor/odk/ontology-projections/${proj}`)).j.ontology_projection;
   const viewRec = (await jd("GET", `/v1/hypervisor/odk/policy-bound-data-views/${view}`)).j.policy_bound_data_view;
 
+  // A real DomainApp RESOURCE: a domain_app surface descriptor carrying this ontology_ref → a DomainApp
+  // whose ontology_refs (an ARRAY, DERIVED from the descriptor) includes it. This is the resource the
+  // Resources lane must render — the regression the review caught (filter was on the singular field).
+  const sd = (await jd("POST", "/v1/hypervisor/odk/surface-descriptors", { name: "dsg-parity-sd", composition_pattern: "domain_app", ontology_ref: ont.ref, recipe_refs: [] })).j.surface_descriptor;
+  const dapp = (await jd("POST", "/v1/hypervisor/domain-apps", { name: "Dsg Parity App", description: "draft", surface_descriptor_ref: sd?.ref, visibility: "private" })).j.domain_app;
+  if (dapp?.domain_app_id) cleanup.unshift(["DELETE", `/v1/hypervisor/domain-apps/${dapp.domain_app_id}`]);
+  if (sd?.id) cleanup.unshift(["DELETE", `/v1/hypervisor/odk/surface-descriptors/${sd.id}`]);
+  ok("fixture sanity: the DomainApp derived ontology_refs (array) includes this ontology", Array.isArray(dapp?.ontology_refs) && dapp.ontology_refs.includes(ont.ref), JSON.stringify(dapp?.ontology_refs || null));
+
   // 3. IOI surface = the design-map grammar over real composition.
   const dsg = await page(`${SERVE}/__ioi/studio/designer?ontology=${encodeURIComponent(ont.id)}`);
   const t = dsg.text;
@@ -119,8 +128,9 @@ async function run() {
   ok("CONCEPTS render the real object model (object type Loan + Money value type + Approve action)", t.includes("Loan") && t.includes("Money") && t.includes("Approve") && /🧩 3/.test(t), "1 object + 1 value + 1 action + 0 link = 3 concepts");
   // COMPONENTS = the real composition refs.
   ok("COMPONENTS render the real mapping · policy view · projection refs (not fabricated labels)", mapRec?.ref && viewRec?.ref && projRec?.ref && t.includes(mapRec.ref) && t.includes(viewRec.ref) && t.includes(projRec.ref));
-  // RESOURCES = the real generated set.
+  // RESOURCES = the real generated set + the real DomainApp surface descriptor.
   ok("RESOURCES render the real materialized object set (ref + object count)", setRec?.ref && t.includes(setRec.ref) && new RegExp(`${setRec.count || 2} obj`).test(t));
+  ok("RESOURCES render the real DomainApp surface descriptor (domain-app ref + surface-descriptor ref)", dapp?.domain_app_ref && t.includes(dapp.domain_app_ref) && sd?.ref && t.includes(sd.ref), dapp?.domain_app_ref || "no domain app");
 
   // 4. NO AUTHORING — the map is read-only (no create/save form posting to the surface).
   ok("the surface is READ-ONLY (no authoring form posts to /__ioi/studio/designer)", !/action="\/__ioi\/studio\/designer/.test(t));


### PR DESCRIPTION
## Studio · Designer — Application UX Parity Baseline, seventh surface (first of the Studio canvas family)

`/__apps/designer` is the familiar typed concept/component/resource design canvas. The IOI-owned **`/__ioi/studio/designer`** renders the SAME grammar as a **read-only typed map** over REAL daemon composition truth.

**Tight scope, by direction**: only `designer` binds; `machinery`, `workshop`, `module` stay `reference_capture`. **No route rename** — the owner surface stays `/__ioi/agent-studio` and links to a dedicated `/__ioi/studio/designer` (per your call on both forks).

### The three lanes (real composition truth)
- **Concepts** — an ontology's canonical object model: object / value / action / link types (object types show property count, title, action badges).
- **Components** — the composition that shapes them: connector mappings · policy views · projections, rendered with their **real daemon refs**.
- **Resources** — what that composition generates: materialized object sets (with object counts) · domain-app surface descriptors.

### Doctrine held
- **Reference parity first**: `/__apps/designer` is the untouched baseline (secondary link).
- **Read-only, no fabrication**: nothing is authored/saved; a fresh ontology shows its concepts but **honest-empty** component/resource lanes.
- **Named gaps**: in-canvas authoring · save/open · drag-to-reference · load-lineage · machinery process-graph execution · workshop/module builders — all named, not hidden.
- **Owner discoverability**: `/__ioi/agent-studio` links the design canvas first-class; Designer links back to the owner.

### The guard (cross-check over real composition)
Because the map is a read-only projection, the verifier **builds a real ontology + full ODK ladder** (mapping → view → projection → materialized set), then asserts the map renders those **exact** concepts/components/resources — and that an unbound ontology shows honest-empty component/resource lanes.

### Verification
| check | result |
|---|---|
| app-parity-studio-designer | **15/15** |
| evaluations / missions / pipeline / lineage / vertex / threading | 23 / 19 / 16 / 21 / 20 / 19 |
| cargo test -p ioi-node | 112/112 (no Rust change this cut) |

Matrix: **reference_capture 32 / daemon_bound 7** (pipeline · lineage · vertex · jobs · incidents · evalsuites · designer).

Held for review — not merging until blessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)