### PR TITLE
feat(hypervisor): Governance · Approvals — formalize the approvals decision queue (approvals → daemon_bound)

### DIFF
--- a/apps/hypervisor/harvest-app-parity-matrix.json
+++ b/apps/hypervisor/harvest-app-parity-matrix.json
@@ -8,8 +8,8 @@
   ],
   "total_seeds": 39,
   "by_parity_class": {
-    "daemon_bound": 7,
-    "reference_capture": 32
+    "daemon_bound": 8,
+    "reference_capture": 31
   },
   "legend": {
     "reference_capture": "the /__apps/<slug> reference baseline serves; not yet bound to daemon truth",
@@ -488,10 +488,13 @@
       "capture_base": "/workspace/approvals-app/",
       "grammar": "table_list",
       "tier": "high_value",
-      "parity_class": "reference_capture",
+      "parity_class": "daemon_bound",
       "capture_state": "boots_table_list",
       "reference_capture": "/__apps/approvals",
-      "note": "approvals inbox; per-row drilldown = named gap"
+      "note": "real decision queue on the Governance owner surface; honest empty when no requests; reviewer assignment / delegation / threaded comments / SLA-escalation / identity-team review workflows / audit exports = named gaps",
+      "daemon_surface": "/__ioi/governance?tab=approvals",
+      "surface_name": "Governance",
+      "binding": "the approvals decision queue — the review-inbox grammar over real daemon ApprovalRequest records (status-count inbox chips, blast radius from would_call/required_authority_refs, age, per-row inspector drawer, in-row approve/reject/revoke transitions); release controls, kill switches, cohorts, improvement gates render as supporting Governance context"
     },
     {
       "owner": "Improvement",

--- a/apps/hypervisor/scripts/build-app-parity-matrix.mjs
+++ b/apps/hypervisor/scripts/build-app-parity-matrix.mjs
@@ -45,6 +45,9 @@ const DAEMON_BOUND = {
   // Studio owner-family: only designer binds in this cut (machinery/workshop/module stay reference_capture).
   // A dedicated /__ioi/studio/designer surface; the /__ioi/agent-studio owner links to it (no rename).
   designer: { daemon_surface: "/__ioi/studio/designer", surface_name: "Studio", binding: "the system-design canvas — a read-only typed concept/component/resource map over real ODK composition (an ontology's object/value/action/link types = concepts; connector mappings + policy views + projections = components; materialized object sets + domain-app surface descriptors = resources)", note: "read-only design map; owner surface stays /__ioi/agent-studio (no route rename); honest empty when an ontology has no concepts/components/resources; in-canvas authoring / save-open / drag-to-reference / load-lineage / machinery process-graph execution / workshop+module builders = named gaps" },
+  // Governance owner-family: only approvals binds in this cut. The Governance owner surface already
+  // renders the review-inbox queue over real ApprovalRequest records; this formalizes it in the matrix.
+  approvals: { daemon_surface: "/__ioi/governance?tab=approvals", surface_name: "Governance", binding: "the approvals decision queue — the review-inbox grammar over real daemon ApprovalRequest records (status-count inbox chips, blast radius from would_call/required_authority_refs, age, per-row inspector drawer, in-row approve/reject/revoke transitions); release controls, kill switches, cohorts, improvement gates render as supporting Governance context", note: "real decision queue on the Governance owner surface; honest empty when no requests; reviewer assignment / delegation / threaded comments / SLA-escalation / identity-team review workflows / audit exports = named gaps" },
 };
 // Named-next targets (owner binding declared; surface not built yet).
 const QUEUED = {};

--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -4060,6 +4060,7 @@ function govApprovalsQueue(records) {
     ? `<div class="wlwrap"><div><table><thead><tr><th>Request</th><th>Target</th><th>Blast radius</th><th>Age</th><th>Status</th><th>Decide</th></tr></thead><tbody id="aq-body">${rows}</tbody></table><div class="empty" id="aq-empty" style="display:${byStatus.pending ? "none" : ""}">Nothing in this view — pick another inbox chip.</div></div>
        <div class="wldrawer" id="aq-drawer"><div class="sub" style="margin:0">Select a request to inspect its full record — blast radius, policy posture, decision history.</div></div></div>`
     : `<div class="empty">No approval requests yet — governed work creates them when it parks at a gate, or record one below.</div>`;
+  const gaps = omBoundaryNote(`This is the <b>real decision queue</b> over daemon ApprovalRequest records — status counts, blast radius, age, per-row inspector, and in-row decisions are daemon truth. Unsupported reference lanes — <b>reviewer assignment</b>, delegation, threaded comments, SLA/escalation timers, identity/team review workflows, audit exports — are <b>named gaps</b> (no authority contract yet), not hidden. The <a href="/__apps/approvals">approvals reference capture ↗</a> is the familiar baseline, never a rebound surface.`);
   const dataTag = `<script id="aq-data" type="application/json">${JSON.stringify(records).replace(/</g, "\\u003c")}</script>`;
   const script = `<script>
     var AQ=[];try{AQ=JSON.parse(document.getElementById('aq-data').textContent||'[]');}catch(e){}
@@ -4085,7 +4086,7 @@ function govApprovalsQueue(records) {
       document.getElementById('aq-drawer').innerHTML=h;
     }
   </script>`;
-  return inbox + table + dataTag + script;
+  return inbox + table + gaps + dataTag + script;
 }
 function govControlTab(fam, records, cohorts, joins) {
   const forms = {

--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-approvals.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-approvals.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Application UX Parity Baseline — Governance · Approvals done-bar (approvals seed only).
+//
+// The parity phase's eighth surface. The reference capture (/__apps/approvals = the approvals inbox)
+// is the familiar baseline; the IOI-owned Governance owner surface already renders the SAME
+// review-inbox grammar at /__ioi/governance?tab=approvals over REAL daemon ApprovalRequest records
+// (status-count inbox chips, blast radius, age, per-row inspector, in-row decisions). This cut
+// FORMALIZES that binding (matrix + verifier) and names the unsupported lanes.
+//
+// SCOPE (tight, by direction): only `approvals` binds. Release controls, kill switches, cohorts, and
+// improvement gates remain supporting Governance context (not separate parity claims).
+//
+// Because the queue is a read-only projection over existing ApprovalRequest truth, the guard is a
+// CROSS-CHECK: create one fixture request, then read the live daemon and assert the rendered queue's
+// total, status counts, and the oldest+newest pending requests match the daemon exactly.
+//
+// Asserts:
+//   - MATRIX: approvals = daemon_bound → /__ioi/governance?tab=approvals (Governance); not over-claimed.
+//   - REFERENCE BASELINE: /__apps/approvals boots the approvals-inbox grammar.
+//   - IOI SURFACE = SAME GRAMMAR OVER REAL TRUTH: the queue renders; total, pending/approved counts,
+//     and the oldest+newest pending requests all MATCH the live daemon; the fixture renders in-row.
+//   - NO FALSE COVERAGE: named gaps (reviewer assignment / delegation / comments / SLA / identity-team
+//     / audit exports); brand-clean; reference seed secondary.
+//   - DISCOVERABILITY: the Governance overview links the approvals lens first-class (tab + link).
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-app-parity-approvals.mjs
+// Exit 2 = BLOCKED.
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+async function jd(method, p, body) {
+  const r = await fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+  return { status: r.status, j: await r.json().catch(() => ({})) };
+}
+const page = (url) => fetch(url).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/governance/approval-requests`).then((r) => r.ok).catch(() => false);
+  if (!up) { console.error("BLOCKED: daemon governance plane not reachable at " + DAEMON); process.exit(2); }
+
+  // 0. Matrix current + honest.
+  const check = spawnSync("node", [path.join(here, "build-app-parity-matrix.mjs"), "--check"], { encoding: "utf8" });
+  ok("parity matrix is current (regenerated == committed)", check.status === 0, (check.stderr || "").trim().slice(0, 80));
+  const matrix = JSON.parse(spawnSync("node", ["-e", `import(${JSON.stringify(path.join(here, "..", "harvest-app-parity-matrix.json"))}, { with: { type: "json" } }).then(m => console.log(JSON.stringify(m.default)))`], { encoding: "utf8" }).stdout || "{}");
+  const bySlug = Object.fromEntries((matrix.seeds || []).map((s) => [s.slug, s]));
+  ok("matrix binds approvals as daemon_bound → /__ioi/governance?tab=approvals (Governance)", bySlug.approvals?.parity_class === "daemon_bound" && bySlug.approvals?.daemon_surface === "/__ioi/governance?tab=approvals" && bySlug.approvals?.surface_name === "Governance");
+  ok("no 'covered' anywhere; prior daemon_bound surfaces intact (pipeline/lineage/vertex/jobs/incidents/evalsuites/designer)", !(matrix.seeds || []).some((s) => s.parity_class === "covered") && ["pipeline", "lineage", "vertex", "jobs", "incidents", "evalsuites", "designer"].every((k) => bySlug[k]?.parity_class === "daemon_bound"));
+
+  // 1. Reference baseline.
+  const ref = await page(`${SERVE}/__apps/approvals`);
+  ok("reference baseline /__apps/approvals boots the approvals-inbox grammar", ref.status === 200 && /<title>[^<]*(Approval|Task|Request|Inbox)/i.test(ref.text));
+
+  // 2. Fixture: one real pending ApprovalRequest (named subject ref — allowed without resolution).
+  const KIND = "app_parity_fixture";
+  const created = await jd("POST", "/v1/hypervisor/governance/approval-requests", {
+    subject_ref: "authority-action://app-parity-approvals-fixture", request_kind: KIND,
+    reason: "app-parity-approvals verifier fixture", required_authority_refs: ["authority-action://parity-a"], would_call: ["tool://parity-x", "tool://parity-y"],
+  });
+  const fix = created.j.approval_request;
+  ok("fixture ApprovalRequest created (pending, real ref)", created.status === 201 && fix?.status === "pending" && fix?.ref?.startsWith("approval-request://"), fix?.id || "");
+
+  // 3. Live daemon truth — the projection the queue must reflect.
+  const all = (await jd("GET", "/v1/hypervisor/governance/approval-requests")).j.approval_requests || [];
+  const total = all.length;
+  const byStatus = { pending: 0, approved: 0, rejected: 0, revoked: 0 };
+  for (const a of all) if (byStatus[a.status] != null) byStatus[a.status]++;
+  const pend = all.filter((a) => a.status === "pending");
+  const sortedPend = pend.slice().sort((a, b) => String(a.created_at || "").localeCompare(String(b.created_at || "")));
+  const oldestPend = sortedPend[0];
+  const newestPend = sortedPend[sortedPend.length - 1];
+
+  // 4. IOI surface = the review-inbox queue over real truth (cross-checked).
+  const q = await page(`${SERVE}/__ioi/governance?tab=approvals`);
+  const t = q.text;
+  ok("IOI /__ioi/governance?tab=approvals renders the review-inbox queue (inbox chips + queue table)", q.status === 200 && /id="aq-inbox"/.test(t) && />Request<\/th>/.test(t) && />Blast radius<\/th>/.test(t) && />Decide<\/th>/.test(t));
+  ok("CROSS-CHECK: status-count inbox chips match the daemon (pending / approved / all)", new RegExp(`Needs decision ${byStatus.pending}\\b`).test(t) && new RegExp(`Approved ${byStatus.approved}\\b`).test(t) && new RegExp(`All ${total}\\b`).test(t), `pending ${byStatus.pending} · approved ${byStatus.approved} · all ${total}`);
+  ok("CROSS-CHECK: the family total matches the daemon record count", new RegExp(`Approval Requests \\(${total}\\)`).test(t));
+  ok("the fixture request renders in-row (kind + subject_ref + id)", fix && t.includes(KIND) && t.includes("authority-action://app-parity-approvals-fixture") && t.includes(fix.id));
+  ok("blast radius renders from the record's own would_call + required_authority_refs", />2 calls</.test(t) && /1 authority</.test(t));
+  ok("CROSS-CHECK: newest + oldest pending requests both render (queue spans the real range)", oldestPend && newestPend && t.includes(oldestPend.id) && t.includes(newestPend.id) && /oldest pending/.test(t), `${oldestPend?.id} … ${newestPend?.id}`);
+
+  // 5. No false coverage — named gaps + brand-clean + secondary reference.
+  ok("named gaps: reviewer assignment / delegation / comments / SLA / identity-team / audit exports", /reviewer assignment/.test(t) && /delegation/.test(t) && /threaded comments/.test(t) && /SLA/.test(t) && /identity\/team/.test(t) && /audit exports/.test(t));
+  ok("reference capture linked as secondary; IOI surface brand-clean (no Palantir)", t.includes("/__apps/approvals") && !/\bPalantir\b/.test(t));
+
+  // 6. Discoverability — the Governance overview links the approvals lens first-class.
+  const ov = await page(`${SERVE}/__ioi/governance`);
+  ok("Governance overview links the approvals lens first-class (tab + link)", ov.status === 200 && ov.text.includes("/__ioi/governance?tab=approvals") && />Approval Requests</.test(ov.text));
+
+  // 7. Cleanup — delete the fixture; the queue total drops back.
+  if (fix?.id) {
+    const del = await jd("DELETE", `/v1/hypervisor/governance/approval-requests/${fix.id}`);
+    const after = (await jd("GET", "/v1/hypervisor/governance/approval-requests")).j.approval_requests || [];
+    ok("fixture cleaned up (deleted; queue total returns to baseline)", (del.status === 200 || del.status === 204) && after.length === total - 1, `${total} → ${after.length}`);
+  }
+}
+
+run().then(() => {
+  let fail = 0;
+  for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+  console.log(`\n${results.length - fail}/${results.length} passed`);
+  console.log(`app-parity-approvals readiness: ${fail ? "FAIL" : "OK"}`);
+  process.exit(fail ? 1 : 0);
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });


### PR DESCRIPTION
## Governance · Approvals — Application UX Parity Baseline, eighth surface

The cheapest honest win, exactly as scoped: the Governance owner surface **already** renders the review-inbox queue over real `ApprovalRequest` records at **`/__ioi/governance?tab=approvals`** (`govApprovalsQueue` — status-count inbox chips, blast radius from `would_call`/`required_authority_refs`, age, per-row inspector drawer, in-row approve/reject/revoke). This cut **formalizes** that binding (matrix + verifier) and **names the gaps**. No route drift — `approvals`' `ownerUrl` already matched `/__ioi/governance`.

**Tight scope**: only `approvals` binds. Release controls, kill switches, cohorts, improvement gates stay supporting Governance context — not separate parity claims.

### Field audit (per the #27 lesson)
Every field the queue reads — `status`, `request_kind`, `subject_ref`, `reason`, `id`, `ref`, `created_at`, `reviewer_ref`, `decided_at`, `updated_at`, `required_authority_refs`, `would_call`, `enforcement_preview` — **matches the daemon record exactly** (probed live). No mismatch this time.

### Changes
- **serve**: added the explicit **named-gaps** note to `govApprovalsQueue` — reviewer assignment · delegation · threaded comments · SLA/escalation · identity-team review workflows · audit exports.
- **matrix**: `approvals` `reference_capture` → `daemon_bound` (`/__ioi/governance?tab=approvals`, Governance). **31 / 8**.

### The guard (read-only-projection cross-check)
`verify-hypervisor-app-parity-approvals.mjs` (**15/15**): creates one fixture request, then asserts the rendered queue's **total, pending/approved counts, and the oldest+newest pending requests all match the live daemon** (proven: pending 9, approved 1, all 10; fixture renders in-row with blast radius; oldest…newest span). Asserts the named gaps, the first-class lens link from the Governance overview, and the reference seed as secondary — then **deletes the fixture and confirms the total returns to baseline** (10 → 9).

### Verification
| check | result |
|---|---|
| app-parity-approvals | **15/15** |
| studio-designer / evaluations / missions / pipeline / lineage / vertex / threading | 17 / 23 / 19 / 16 / 21 / 20 / 19 |
| cargo test -p ioi-node | 112/112 (no Rust change) |

Matrix: **reference_capture 31 / daemon_bound 8** (pipeline · lineage · vertex · jobs · incidents · evalsuites · designer · approvals).

Held for review — not merging until blessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)