### PR TITLE
feat(hypervisor): estate reference data-clean sweep — the authoritative next-port map (#44)

### DIFF
--- a/apps/hypervisor/harvest-app-parity-matrix.json
+++ b/apps/hypervisor/harvest-app-parity-matrix.json
@@ -43,6 +43,9 @@
       "reference_capture": "/__apps/designer",
       "reference_workspace": "/workspace/solution-design/",
       "note": "read-only design map; owner surface stays /__ioi/agent-studio (no route rename); honest empty when an ontology has no concepts/components/resources; in-canvas authoring / save-open / drag-to-reference / load-lineage / machinery process-graph execution / workshop+module builders = named gaps",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane shows a failure (\"Failed to load favorites\") with CORS-blocked session lanes, but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 64 · lines 690) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "substrate_surface": "/__ioi/studio/designer",
       "surface_name": "Studio",
       "binding": "the system-design canvas — a read-only typed concept/component/resource map over real ODK composition (an ontology's object/value/action/link types = concepts; connector mappings + policy views + projections = components; materialized object sets + domain-app surface descriptors = resources)",
@@ -61,6 +64,9 @@
       "reference_capture": "/__apps/machinery",
       "reference_workspace": "/workspace/machinery-app/",
       "note": "DEFINITION-ONLY, read-only surface; a new inert daemon contract with fail-closed writes; owner surface stays /__ioi/agent-studio; honest empty/incomplete when a machine is under-declared; execution / stepping a running instance / scheduling / Automations-Missions-ODK binding / in-canvas graph authoring / simulation / versioning = named gaps (a later authority-crossing cut)",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane shows a failure (\"Failed to load Machinery Marketplace examples.\"), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 3 · lines 49) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "substrate_surface": "/__ioi/studio/machinery",
       "surface_name": "Studio",
       "binding": "the process/state-machine definition view — a read-only rendering of the inert daemon state-machine plane (declared states initial/normal/final, transitions from→to with event + guard, declared guards, inputs/outputs, owners, health empty|incomplete|ready, and edit history)",
@@ -78,7 +84,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/workshop",
       "reference_workspace": "/workspace/workshop/",
-      "note": "application/module builder; unbound"
+      "note": "application/module builder; unbound",
+      "reference_clean_state": "errored_reference",
+      "reference_clean_reason": "navigation failed on every lane (navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane) · navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane))",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Studio",
@@ -91,7 +100,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/module",
       "reference_workspace": "/workspace/module/",
-      "note": "compute-module builder; unbound"
+      "note": "compute-module builder; unbound",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane shows a failure (\"Page not found\"), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 9 · lines 54) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Automations",
@@ -104,7 +116,10 @@
       "capture_state": "boots_graph",
       "reference_capture": "/__apps/monitors",
       "reference_workspace": "/workspace/object-monitoring/",
-      "note": "condition→effect monitor wizard; unbound"
+      "note": "condition→effect monitor wizard; unbound",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane shows a failure (\"Failed to load favorites\") with CORS-blocked session lanes, but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 18/0 · nodes 0 · cards 17 · lines 87) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Automations",
@@ -117,7 +132,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/scheduler",
       "reference_workspace": "/workspace/scheduler/",
-      "note": "schedule table; unbound"
+      "note": "schedule table; unbound",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell regions [rail, header, body] render clean but the body carries no real data (rows 0/0 · nodes 0 · cards 0)",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Provenance",
@@ -131,6 +149,9 @@
       "reference_capture": "/__apps/lineage",
       "reference_workspace": "/workspace/monocle/",
       "note": "Monocle lineage grammar over real provenance; upstream ladder refs resolved to live records; no fake nodes for unmaterialized ontologies; freeform resource-search / graph-expansion / cross-tenant catalog = named gaps",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell renders a WELCOME/empty landing (cards 3 · lines 20, no row/node data) — clean chrome, no real data to port against",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "substrate_surface": "/__ioi/lineage",
       "binding": "ODK materialization provenance (MaterializedObjectSet → run → session → lease → projection → mapping → datasource, resolved to live ladder refs; per-object source hashes + mapped_from; pre-output + registration receipts; Provenance proof-stream edges where available)",
       "candidate_surface": "/__ioi/lineage",
@@ -147,7 +168,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/ingest",
       "reference_workspace": "/workspace/hyperauto/",
-      "note": "source-first pipeline wizard; unbound"
+      "note": "source-first pipeline wizard; unbound",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell regions [rail, header, body] render clean but the body carries no real data (rows 0/0 · nodes 0 · cards 2)",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Data",
@@ -160,7 +184,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/sources",
       "reference_workspace": "/workspace/data-ingestion-app/",
-      "note": "Sources/Syncs/Listeners IA; unbound"
+      "note": "Sources/Syncs/Listeners IA; unbound",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 9 · lines 60) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Data",
@@ -174,6 +201,9 @@
       "reference_capture": "/__apps/pipeline",
       "reference_workspace": "/workspace/builder/",
       "note": "TRUE parity (#39) under the HARDENED gate: /__ioi/pipeline REBUILT as a faithful LIGHT Pipeline Builder (dark global rail + light header w/ build state + light tool cluster [Tools/Select/Remove/Layout/Text · Add data · Reusables · Transform/AIP/Edit] + light central graph canvas with the ODK-ladder node cards + a Legend panel + a right 'Pipeline outputs' panel w/ Output settings/Edit output settings + a bottom Selection preview / Suggestions / Pipeline warnings tray), NOT the earlier dark native shell (which #34's theme gate correctly refused); passes the hardened Playwright harness (theme light/light + landmarks 10/10 + regions 1.0) against the ORIGIN-ALIGNED data-clean reference canvas (reference_url_override localhost:9225 …/sandbox/…, the What's-new modal dismissed via a reference-only preCapture hook), whose data completeness is the precondition proven by verify-pipeline-reference-data-clean.mjs (reference_data_complete=true, #38); Build+Preview wired to the real ODK ladder; Schedule/Deploy + freeform canvas authoring (drag-connect / transform code editor / scheduling / deploy) = named gaps disabled in place; no new daemon semantics",
+      "reference_clean_state": "data_clean",
+      "reference_clean_reason": "shell regions [rail, header, toolbar, body] + data evidence (rows 0/4 · nodes 18 · cards 1 · lists 0 · lines 30)",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "port_surface": "/__ioi/pipeline",
       "surface_name": "Data",
       "reference_url_override": "http://localhost:9225/workspace/builder/ri.eddie.main.pipeline.e73d6ae7-f6fe-4ac5-82a2-320d9f188590/sandbox/a082bef2-8826-4e6c-8925-871bcdb56c44",
@@ -205,7 +235,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/dataset",
       "reference_workspace": "/workspace/dataset/",
-      "note": "dataset preview/table; unbound"
+      "note": "dataset preview/table; unbound",
+      "reference_clean_state": "data_failed",
+      "reference_clean_reason": "shell boots but the body reports a data failure (\"__apps is not a dataset\") with captured (non-404) lanes",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Ontology",
@@ -219,6 +252,9 @@
       "reference_capture": "/__apps/schema",
       "reference_workspace": "/workspace/ontology/",
       "note": "TRUE parity (#34) under the HARDENED gate: light two-rail reference-faithful shell (matches the reference theme + IA landmarks + card-first body), NOT a native redesign; passes the hardened Playwright harness (theme + landmarks + geometry) against the VALID /__apps/schema reference; READ-ONLY over daemon truth — authoring/create-edit + object materialization stay in the /__ioi/odk substrate (linked first-class); in-canvas schema editing / Proposals / Shared properties / Groups / Interfaces / Cleanup / action+function execution = named gaps in place; Object Explorer is the sibling #35 cut",
+      "reference_clean_state": "data_clean",
+      "reference_clean_reason": "shell regions [rail, header, body] + data evidence (rows 0/6 · nodes 0 · cards 7 · lists 0 · lines 31)",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "port_surface": "/__ioi/ontology/manager",
       "surface_name": "Ontology",
       "reference_landmarks": [
@@ -250,6 +286,9 @@
       "reference_capture": "/__apps/explorer",
       "reference_workspace": "/workspace/hubble/",
       "note": "reference_ported (#35): faithful light Object-Explorer shell (global rail + search header + Shortcuts + object-type catalog + object-set catalog), wired to real object types + materialized sets, first-class linked to /__ioi/ontology/manager; READ-ONLY; object-instance full-text search / faceted Filter-by / Recents / Favorites / sort / type-group+application tabs / Created-by-me+Shared-with-me = named gaps disabled in place; NOT daemon_wired — the local Hubble reference is blank/failed, so the hardened harness cannot certify parity",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 23/6 · nodes 0 · cards 5 · lines 55) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "port_surface": "/__ioi/ontology/explorer",
       "surface_name": "Ontology",
       "parity_blocked": "local /workspace/hubble reference does not cleanly boot — the /__apps/explorer proxy renders a blank body and the mirror's data lanes render 'Failed to load' (no backend); no valid reference to certify visual_parity until a re-harvest",
@@ -268,7 +307,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/objectview",
       "reference_workspace": "/workspace/object-view/",
-      "note": "object view; unbound"
+      "note": "object view; unbound",
+      "reference_clean_state": "errored_reference",
+      "reference_clean_reason": "navigation failed on every lane (navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane) · navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane))",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Ontology",
@@ -281,7 +323,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/objecteditor",
       "reference_workspace": "/workspace/object-view-editor/",
-      "note": "object-view editor; unbound"
+      "note": "object-view editor; unbound",
+      "reference_clean_state": "errored_reference",
+      "reference_clean_reason": "navigation failed on every lane (navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane) · navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane))",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Evaluations",
@@ -295,6 +340,9 @@
       "reference_capture": "/__apps/evalsuites",
       "reference_workspace": "/workspace/evals/",
       "note": "declaration-only owner surface; /__ioi/feedback kept as a compatibility sublane; honest empty when no suites; EvalRun execution / scoring / verdicts / judge / scorecards / auto-mining / analysis+quiver canvases / promotion = named gaps",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 2 · lines 50) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "substrate_surface": "/__ioi/evaluations",
       "surface_name": "Evaluations",
       "binding": "the eval-suite library — the inert daemon eval-suite contract (a suite declares subject_scope + evidence/consent requirements + named candidate handoffs) over real assessment subjects (Missions runs/failures/blockers) + the consent ladder + feedback candidate source, table/list grammar over daemon truth",
@@ -312,7 +360,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/analysis",
       "reference_workspace": "/workspace/insight/",
-      "note": "object-set-first analysis canvas; unbound"
+      "note": "object-set-first analysis canvas; unbound",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell renders a WELCOME/empty landing (cards 4 · lines 19, no row/node data) — clean chrome, no real data to port against (proxy lane renders no data (score 0); the origin lane is the readable one)",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Evaluations",
@@ -325,7 +376,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/quiver",
       "reference_workspace": "/workspace/quiver/",
-      "note": "time-series analysis canvas; unbound"
+      "note": "time-series analysis canvas; unbound",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell renders a WELCOME/empty landing (cards 5 · lines 23, no row/node data) — clean chrome, no real data to port against (proxy lane renders no data (score 0); the origin lane is the readable one)",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Foundry",
@@ -339,6 +393,9 @@
       "reference_capture": "/__apps/models",
       "reference_workspace": "/workspace/model-catalog/",
       "note": "catalog grammar over real model-route truth; route administration lives in Agent Studio (linked); honest empty when no routes; fine-tuning / prompt playground / live inference evals / deployment automation / training runs / unbacked model cards = named gaps",
+      "reference_clean_state": "data_clean",
+      "reference_clean_reason": "shell regions [rail, header, body] + data evidence (rows 0/0 · nodes 0 · cards 4 · lists 0 · lines 18)",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "substrate_surface": "/__ioi/foundry",
       "surface_name": "Foundry",
       "binding": "the model registry — the Foundry Model Catalog over the real daemon model-route registry (per-route honest availability from probe evidence + staleness, weight custody, credential posture, admission trail, and admitted session-binding usage), plus the substrate stats and the draft Foundry specs/run-plans where they connect",
@@ -356,7 +413,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/modelstudio",
       "reference_workspace": "/workspace/model-studio/",
-      "note": "model studio; unbound"
+      "note": "model studio; unbound",
+      "reference_clean_state": "data_failed",
+      "reference_clean_reason": "shell boots but the body reports a data failure (\"Page not found\") with captured (non-404) lanes",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Foundry",
@@ -369,7 +429,10 @@
       "capture_state": "boots_wizard",
       "reference_capture": "/__apps/inference",
       "reference_workspace": "/workspace/foundry-inference-app/",
-      "note": "inference app; unbound"
+      "note": "inference app; unbound",
+      "reference_clean_state": "data_failed",
+      "reference_clean_reason": "shell boots but the body reports a data failure (\"Failed to load current space\") with captured (non-404) lanes",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Marketplace",
@@ -382,7 +445,10 @@
       "capture_state": "boots_graph",
       "reference_capture": "/__apps/listings",
       "reference_workspace": "/workspace/marketplace/",
-      "note": "store browse + install wizard; drill-down = named gap"
+      "note": "store browse + install wizard; drill-down = named gap",
+      "reference_clean_state": "data_clean",
+      "reference_clean_reason": "shell regions [rail, header, body] + data evidence (rows 1/0 · nodes 0 · cards 3 · lists 0 · lines 20)",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Marketplace",
@@ -395,7 +461,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/registry",
       "reference_workspace": "/workspace/artifacts/",
-      "note": "versioned artifact registry; unbound"
+      "note": "versioned artifact registry; unbound",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell renders a WELCOME/empty landing (cards 4 · lines 18, no row/node data) — clean chrome, no real data to port against (proxy lane shows a failure (\"Invalid resource identifier\"); the origin lane is the readable one)",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Developer Console",
@@ -408,7 +477,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/devconsole",
       "reference_workspace": "/workspace/developer-console/",
-      "note": "OAuth app registration + SDK on-ramps (self-bootstrapped)"
+      "note": "OAuth app registration + SDK on-ramps (self-bootstrapped)",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell renders a WELCOME/empty landing (cards 5 · lines 23, no row/node data) — clean chrome, no real data to port against (proxy lane renders no data (score 0); the origin lane is the readable one)",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Developer Console",
@@ -421,7 +493,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/widgets",
       "reference_workspace": "/workspace/custom-widgets/",
-      "note": "widget-set authoring (self-bootstrapped)"
+      "note": "widget-set authoring (self-bootstrapped)",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 0 · lines 47) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Developer Console",
@@ -434,7 +509,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/developer",
       "reference_workspace": "/workspace/developer/",
-      "note": "developer home; unbound"
+      "note": "developer home; unbound",
+      "reference_clean_state": "errored_reference",
+      "reference_clean_reason": "reference renders an error page (\"You don't have permissions to view this page\") without a usable shell",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Workbench",
@@ -447,7 +525,10 @@
       "capture_state": "boots_landing",
       "reference_capture": "/__apps/workspaces",
       "reference_workspace": "/workspace/code-workspaces/",
-      "note": "code workspace IDE; unbound"
+      "note": "code workspace IDE; unbound",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane renders no data (score 1), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 3/4 · nodes 0 · cards 5 · lines 26) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Workbench",
@@ -460,7 +541,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/repositories",
       "reference_workspace": "/workspace/code-repositories/",
-      "note": "code repositories; unbound"
+      "note": "code repositories; unbound",
+      "reference_clean_state": "errored_reference",
+      "reference_clean_reason": "navigation failed on every lane (navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane) · navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane))",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Workbench",
@@ -473,7 +557,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/notepad",
       "reference_workspace": "/workspace/notepad/",
-      "note": "notepad document; unbound"
+      "note": "notepad document; unbound",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane shows a failure (\"An error occurred\"), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 2/0 · nodes 0 · cards 11 · lines 28) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Provenance",
@@ -487,6 +574,9 @@
       "reference_capture": "/__apps/vertex",
       "reference_workspace": "/workspace/vertex/",
       "note": "Vertex graph grammar (nodes · relations · neighborhood) over real cross-plane materialized truth; no fake nodes for unmaterialized ontologies; freeform graph canvas / arbitrary path-finding / cross-tenant object search / saved explorations = named gaps",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell renders a WELCOME/empty landing (cards 6 · lines 21, no row/node data) — clean chrome, no real data to port against (proxy lane shows a failure (\"An error occurred\"); the origin lane is the readable one)",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "substrate_surface": "/__ioi/vertex",
       "surface_name": "Provenance",
       "binding": "a Provenance graph/exploration lens over materialized object sets, projections, objects, and the threaded proof-stream odk_materialization edges (cross-plane: ODK ↔ Provenance)",
@@ -504,7 +594,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/map",
       "reference_workspace": "/workspace/map/",
-      "note": "geospatial map canvas; unbound"
+      "note": "geospatial map canvas; unbound",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell renders a WELCOME/empty landing (cards 4 · lines 15, no row/node data) — clean chrome, no real data to port against (proxy lane renders no data (score 0); the origin lane is the readable one)",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Domain Apps",
@@ -517,7 +610,10 @@
       "capture_state": "blocked_missing_capture",
       "reference_capture": "/__apps/slate",
       "reference_workspace": "/workspace/slate/",
-      "note": "Slate app builder; unbound"
+      "note": "Slate app builder; unbound",
+      "reference_clean_state": "errored_reference",
+      "reference_clean_reason": "the app never mounts — uncaught page error (\"Workspace context path not found\")",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Domain Apps",
@@ -530,7 +626,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/logic",
       "reference_workspace": "/workspace/logic-app/",
-      "note": "Logic builder; unbound"
+      "note": "Logic builder; unbound",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/4 · nodes 0 · cards 2 · lines 51) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Domain Apps",
@@ -543,7 +642,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/contour",
       "reference_workspace": "/workspace/contour-app/",
-      "note": "Contour analysis; unbound"
+      "note": "Contour analysis; unbound",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane shows a failure (\"404: Page Not Found\"), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 2 · lines 50) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Domain Apps",
@@ -556,7 +658,10 @@
       "capture_state": "shell_only",
       "reference_capture": "/__apps/fusion",
       "reference_workspace": "/workspace/fusion/",
-      "note": "Fusion spreadsheet; unbound"
+      "note": "Fusion spreadsheet; unbound",
+      "reference_clean_state": "data_failed",
+      "reference_clean_reason": "shell boots but the body reports a data failure (\"Not Found\") with captured (non-404) lanes",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     },
     {
       "owner": "Missions",
@@ -570,6 +675,9 @@
       "reference_capture": "/__apps/jobs",
       "reference_workspace": "/workspace/job-tracker/",
       "note": "run-queue lane of the Missions owner surface; honest empty when no runs; freeform job-definition editing / board views / arbitrary filtering = named gaps; substrate/infra scheduler health stays in Operations",
+      "reference_clean_state": "shell_clean_only",
+      "reference_clean_reason": "shell regions [rail, header, body] render clean but the body carries no real data (rows 0/0 · nodes 0 · cards 0)",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "substrate_surface": "/__ioi/missions",
       "surface_name": "Missions",
       "binding": "the Missions run/job queue — the real operations run queue (recent runs, statuses, run counts) + scheduled missions, table/list grammar over daemon truth",
@@ -588,6 +696,9 @@
       "reference_capture": "/__apps/incidents",
       "reference_workspace": "/workspace/issues-app/",
       "note": "incident lane of the Missions owner surface; honest empty when no failures/blockers; create/assign incidents / SLA / comments = named gaps; substrate/infra incidents (storage repair, provider failover) stay in Operations",
+      "reference_clean_state": "data_clean",
+      "reference_clean_reason": "shell regions [rail, header, body] + data evidence (rows 5/0 · nodes 0 · cards 0 · lists 0 · lines 25) — clicked the 'Closed' status lane (the default Open lane is honestly empty; the capture carries 5 real closed incidents)",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "substrate_surface": "/__ioi/missions",
       "surface_name": "Missions",
       "binding": "the Missions incident/remediation inbox — real run failures + GoalRun blockers, each linking to its own proof/timeline, status-lane grammar over daemon truth",
@@ -606,6 +717,9 @@
       "reference_capture": "/__apps/approvals",
       "reference_workspace": "/workspace/approvals-app/",
       "note": "TRUE parity (#36) under the HARDENED gate: light faceted-inbox reference-faithful shell (matches the reference theme + IA landmarks + faceted layout), NOT the earlier dark native shell; passes the hardened Playwright harness against the VALID data-clean /__apps/approvals reference; decisions are the existing daemon transitions (no new governance semantics); reviewer-assignment / delegation / comments / SLA / audit-export + the unwired facets = named gaps disabled in place; substrate table stays at /__ioi/governance?tab=approvals",
+      "reference_clean_state": "data_clean",
+      "reference_clean_reason": "shell regions [rail, header, body] + data evidence (rows 0/9 · nodes 0 · cards 0 · lists 0 · lines 45)",
+      "reference_clean_artifact": "reference-clean-sweep.json",
       "port_surface": "/__ioi/governance/approvals",
       "surface_name": "Governance",
       "reference_landmarks": [
@@ -634,7 +748,10 @@
       "capture_state": "boots_editor_canvas",
       "reference_capture": "/__apps/changes",
       "reference_workspace": "/workspace/upgrade-assistant/",
-      "note": "change inbox"
+      "note": "change inbox",
+      "reference_clean_state": "needs_origin_alignment",
+      "reference_clean_reason": "proxy lane renders no data (score 3), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 4/4 · nodes 0 · cards 6 · lines 32) — align the reference URL like pipeline #38/#39",
+      "reference_clean_artifact": "reference-clean-sweep.json"
     }
   ],
   "_doc": "Generated by build-app-parity-matrix.mjs. Do not hand-edit; change the inventory / the SUBSTRATE_BOUND + REFERENCE_PORT_PENDING/REFERENCE_PORTED/DAEMON_WIRED overlays and regenerate. Run with --check to fail on staleness."

--- a/apps/hypervisor/reference-clean-sweep.json
+++ b/apps/hypervisor/reference-clean-sweep.json
@@ -1,0 +1,3910 @@
+{
+ "schema": "ioi.hypervisor.reference-clean-sweep.v1",
+ "swept_at": "2026-07-10T15:45:41.079Z",
+ "serve": "http://127.0.0.1:4173",
+ "mirror": "http://127.0.0.1:9225",
+ "total_seeds": 39,
+ "by_state": {
+  "needs_origin_alignment": 13,
+  "errored_reference": 6,
+  "shell_clean_only": 10,
+  "data_clean": 6,
+  "data_failed": 4
+ },
+ "doctrine": "reference cleanliness only — no ports, no promotions, parity_class untouched; local mirror lanes only (no live dependency); screenshots corroborate, DOM/text/network classify",
+ "ranked_next": [
+  {
+   "rank": 1,
+   "slug": "incidents",
+   "owner": "Missions",
+   "score": 27,
+   "why": {
+    "data_clean_reference": true,
+    "daemon_truth_bindable": "/__ioi/missions",
+    "owner_value": "Missions (4)",
+    "fabrication_risk": "low (table_list)",
+    "ia_landmarks": [
+     "Home",
+     "Search…",
+     "ctrl + J",
+     "Notifications",
+     "Gift Icon",
+     "What's New",
+     "Recent",
+     "Files"
+    ],
+    "live_palantir_dependency": "none (local mirror lanes only)"
+   }
+  },
+  {
+   "rank": 2,
+   "slug": "models",
+   "owner": "Foundry",
+   "score": 26,
+   "why": {
+    "data_clean_reference": true,
+    "daemon_truth_bindable": "/__ioi/foundry",
+    "owner_value": "Foundry (3)",
+    "fabrication_risk": "low (catalog)",
+    "ia_landmarks": [
+     "Home",
+     "Search…",
+     "ctrl + J",
+     "Notifications",
+     "Gift Icon",
+     "What's New",
+     "Recent",
+     "Files"
+    ],
+    "live_palantir_dependency": "none (local mirror lanes only)"
+   }
+  },
+  {
+   "rank": 3,
+   "slug": "listings",
+   "owner": "Marketplace",
+   "score": 19,
+   "why": {
+    "data_clean_reference": true,
+    "daemon_truth_bindable": "no existing surface — new binding work",
+    "owner_value": "Marketplace (2)",
+    "fabrication_risk": "low (catalog)",
+    "ia_landmarks": [
+     "Home",
+     "Search…",
+     "ctrl + J",
+     "Notifications",
+     "Gift Icon",
+     "What's New",
+     "Recent",
+     "Files"
+    ],
+    "live_palantir_dependency": "none (local mirror lanes only)"
+   }
+  }
+ ],
+ "seeds": [
+  {
+   "slug": "designer",
+   "owner": "Studio",
+   "parity_class": "substrate_bound",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/solution-design/",
+   "candidate_surface": "/__ioi/studio/designer",
+   "substrate_surface": "/__ioi/studio/designer",
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane shows a failure (\"Failed to load favorites\") with CORS-blocked session lanes, but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 64 · lines 690) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Training",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nTraining\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nSolution Designer\nNew Diagram\nHelp\nSolution Designer\nSolution Designer helps you to transform business problems into Foundry solutions using a graph-based interface, with examples, editing tools, and resource links for collaborative and iterative design.\nHave a workflow in mind? Use AIP Architect to help you plan it.\nAnswer a few questions to get AIP suggestions on how to implement your workflow in Foundry.\nStart plannin",
+   "data_evidence": {
+    "table_rows": 12,
+    "graph_nodes": 0,
+    "cards": 64,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 35310,
+    "meaningful_lines": 690
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 160653
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/designer",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "toolbar",
+      "body"
+     ],
+     "data_score": 3,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 19,
+     "cors_signals": 8,
+     "console_errors": 20,
+     "screenshot": ".artifacts/reference-clean-sweep/designer-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/solution-design/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 7,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/designer-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/designer-origin.png"
+  },
+  {
+   "slug": "machinery",
+   "owner": "Studio",
+   "parity_class": "substrate_bound",
+   "grammar": "graph",
+   "reference_path": "http://localhost:9225/workspace/machinery-app/",
+   "candidate_surface": "/__ioi/studio/machinery",
+   "substrate_surface": "/__ioi/studio/machinery",
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane shows a failure (\"Failed to load Machinery Marketplace examples.\"), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 3 · lines 49) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Training",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nTraining\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nMachinery\nNew graph\nHelp\nMachinery\nBuild, manage and monitor your business processes with precision. Streamline operations and drive efficiency through strategic automations.\nView\nRecents\nFavorites\nFILES\nCREATOR\nLAST EDITED BY\nLAST VIEWED\nUse AIP Logic to classify and edit objects Walkthrough\n/test-ab81f6/test4/AIP Chatbot with transcribed video context (2026-04-26 22:22:24)/logic/Use AIP Logic to classify and edit objec",
+   "data_evidence": {
+    "table_rows": 12,
+    "graph_nodes": 0,
+    "cards": 3,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 4973,
+    "meaningful_lines": 49
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 1143077
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/machinery",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 5,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/machinery-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/machinery-app/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 7,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/machinery-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/machinery-origin.png"
+  },
+  {
+   "slug": "workshop",
+   "owner": "Studio",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "/__apps/workshop",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "errored_reference",
+   "reason": "navigation failed on every lane (navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane) · navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane))",
+   "lane_used": "proxy",
+   "shell_regions": [],
+   "landmarks_observed": [],
+   "matrix_landmarks_present": [],
+   "body_sample": "",
+   "data_evidence": null,
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": null,
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 27
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/workshop",
+     "loaded": false,
+     "nav_error": "navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane)",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ""
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/workshop/",
+     "loaded": false,
+     "nav_error": "navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane)",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ""
+    }
+   ],
+   "screenshot": ""
+  },
+  {
+   "slug": "module",
+   "owner": "Studio",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/module/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane shows a failure (\"Page not found\"), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 9 · lines 54) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Workshop",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nWorkshop\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nWorkshop\nNew module\nHelp\nWorkshop\nCreate high-quality, easy-to-maintain operational applications using native object components in a point-and-click environment.\nCreate new module\nBlank module\nInbox template\nMap template\nMetrics template\nView\nRecents\nFavorites\nMODULE\nCREATOR\nLAST EDITED BY\nLAST VIEWED\nUse AIP Logic to classify and edit objects Walkthrough\n/test-ab81f6/test4/AIP Chatbot with transcribed video context (202",
+   "data_evidence": {
+    "table_rows": 12,
+    "graph_nodes": 0,
+    "cards": 9,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 5036,
+    "meaningful_lines": 54
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 36,
+    "deep_route_dirs": [
+     "splash",
+     "view"
+    ],
+    "bytes": 14689495
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/module",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/module-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/module/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 7,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/module-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/module-origin.png"
+  },
+  {
+   "slug": "monitors",
+   "owner": "Automations",
+   "parity_class": "reference_capture",
+   "grammar": "wizard",
+   "reference_path": "http://localhost:9225/workspace/object-monitoring/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane shows a failure (\"Failed to load favorites\") with CORS-blocked session lanes, but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 18/0 · nodes 0 · cards 17 · lines 87) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Automate",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nAutomate\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nAutomate\nOverview\nAutomations\nNew automation\nHelp\nCreate and manage automations\nBuild business automation by defining conditions that trigger automatic effects.\nGetting started\nView all automations\nCreate your first automation\nGet started by creating a new automation or adding yourself to existing automations.\nNew automation\nConfigure conditions\nE.g. time, objects added to a set, metric increased, etc.\nConfigure effects\n",
+   "data_evidence": {
+    "table_rows": 18,
+    "graph_nodes": 0,
+    "cards": 17,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 6240,
+    "meaningful_lines": 87
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 1189282
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/monitors",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 4,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 23,
+     "cors_signals": 8,
+     "console_errors": 20,
+     "screenshot": ".artifacts/reference-clean-sweep/monitors-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/object-monitoring/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 7,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/monitors-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/monitors-origin.png"
+  },
+  {
+   "slug": "scheduler",
+   "owner": "Automations",
+   "parity_class": "reference_capture",
+   "grammar": "table_list",
+   "reference_path": "http://localhost:9225/workspace/scheduler/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "shell_clean_only",
+   "reason": "shell regions [rail, header, body] render clean but the body carries no real data (rows 0/0 · nodes 0 · cards 0)",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nYour favorited apps will appear here\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nBuild schedules\nCreate schedule\n0\n0\n0\n0 schedules\nResults matching\nJohn Doe\nSet search parameters\nSorted by most recently updated\nSelect schedules…\nNo schedules found. Add search criteria to find more schedules.",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 415,
+    "meaningful_lines": 13
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 152264
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/scheduler",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/scheduler-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/scheduler/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 1,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/scheduler-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/scheduler-origin.png"
+  },
+  {
+   "slug": "lineage",
+   "owner": "Provenance",
+   "parity_class": "substrate_bound",
+   "grammar": "graph",
+   "reference_path": "/__apps/lineage",
+   "candidate_surface": "/__ioi/lineage",
+   "substrate_surface": "/__ioi/lineage",
+   "clean_state": "shell_clean_only",
+   "reason": "shell renders a WELCOME/empty landing (cards 3 · lines 20, no row/node data) — clean chrome, no real data to port against",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "header",
+    "toolbar",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Training",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nTraining\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nData Lineage\nWorkflow Lineage\nMain\n0\n0\n0\nSave as\nWelcome to Data Lineage\nExplore how data flows through your resources and applications\nRead documentation\nAdd resources\nSearch for resources to add to graph\nor\nOpen graph\nFind and explore existing graphs\nTools\nLayout\nUndo/redo\nClean\nSelect\nExpand\nColor\nFind\nRemove\nAlign\nText\nFlow\nLayout by color\nGroup by color\nLegend\nNode color options\nNo resources on graph\n0 nodes selecte",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 3,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 664,
+    "meaningful_lines": 20
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 205634
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/lineage",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "toolbar",
+      "body"
+     ],
+     "data_score": 3,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/lineage-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/monocle/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "toolbar",
+      "body"
+     ],
+     "data_score": 3,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/lineage-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/lineage-proxy.png"
+  },
+  {
+   "slug": "ingest",
+   "owner": "Data",
+   "parity_class": "reference_capture",
+   "grammar": "wizard",
+   "reference_path": "http://localhost:9225/workspace/hyperauto/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "shell_clean_only",
+   "reason": "shell regions [rail, header, body] render clean but the body carries no real data (rows 0/0 · nodes 0 · cards 2)",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Training",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nTraining\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nHyperAuto\nHyperAuto Pipelines\nCreate pipeline\nThere is no existing HyperAuto pipelines. Please create a HyperAuto pipeline on one of your supported sources via Data Connection Application.\nGo to Data Connection Application",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 2,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 398,
+    "meaningful_lines": 9
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 159298
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/ingest",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/ingest-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/hyperauto/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/ingest-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/ingest-origin.png"
+  },
+  {
+   "slug": "sources",
+   "owner": "Data",
+   "parity_class": "reference_capture",
+   "grammar": "table_list",
+   "reference_path": "http://localhost:9225/workspace/data-ingestion-app/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 9 · lines 60) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Data Connection",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account",
+    "Sources",
+    "Syncs",
+    "Agents",
+    "Listeners",
+    "External stacks",
+    "New source"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nData Connection\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nData Connection\nSources\nSyncs\nAgents\nListeners\nExternal stacks\nNew source\nHelp\n0\n0\n0\nData Connection\nSynchronize and manage data flows between Foundry and external systems.\nSet up new connections\nConnect to external system\nRecommended\nConfigure a live connection from Foundry to your production system.\nUpload static data\nManually upload a one-off extract from your production system.\nInput or generate data\nSynthesiz",
+   "data_evidence": {
+    "table_rows": 12,
+    "graph_nodes": 0,
+    "cards": 9,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 5320,
+    "meaningful_lines": 60
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": true,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 21,
+    "deep_route_dirs": [
+     "agents",
+     "listeners",
+     "sources",
+     "splash",
+     "syncs"
+    ],
+    "bytes": 1602522
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/sources",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/sources-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/data-ingestion-app/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 7,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/sources-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/sources-origin.png"
+  },
+  {
+   "slug": "pipeline",
+   "owner": "Data",
+   "parity_class": "daemon_wired",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/builder/ri.eddie.main.pipeline.e73d6ae7-f6fe-4ac5-82a2-320d9f188590/sandbox/a082bef2-8826-4e6c-8925-871bcdb56c44",
+   "candidate_surface": "/__ioi/pipeline",
+   "substrate_surface": null,
+   "clean_state": "data_clean",
+   "reason": "shell regions [rail, header, toolbar, body] + data evidence (rows 0/4 · nodes 18 · cards 1 · lists 0 · lines 30)",
+   "lane_used": "override",
+   "shell_regions": [
+    "rail",
+    "header",
+    "toolbar",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Pipeline Builder",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account",
+    "test4"
+   ],
+   "matrix_landmarks_present": [
+    "Add data",
+    "Reusables",
+    "Transform",
+    "Legend",
+    "Pipeline outputs",
+    "Selection preview",
+    "Suggestions",
+    "Pipeline warnings",
+    "Edit output settings",
+    "Tools"
+   ],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nPipeline Builder\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\ntest4\nPipeline Builder - Calculate Flight Data with Reusable Custom Functions\nFile\nSettings\nHelp\n1\nBatch\nTabs\nMain\n0\nActions\nShare\nFlights\n51 columns\nMarketplace transform…\n51 columns\nCalculate actual, sche…\n11 columns\nCalculate departure, a…\n9 columns\nRemove unnecessary …\n7 columns\n[Example] Flights (Cle…\nDeployed and built\nTools\nSelect\nRemove\nLayout\nText\nAdd data\nReusables\nTransform\nAIP\nEdit\nLegend\nInput Data\n(",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 18,
+    "cards": 1,
+    "list_items": 0,
+    "repeated_rows": 4,
+    "body_text_chars": 1153,
+    "meaningful_lines": 30
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": true,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 15,
+    "deep_route_dirs": [
+     "create-pipeline"
+    ],
+    "bytes": 1008862
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/pipeline",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 4,
+     "screenshot": ".artifacts/reference-clean-sweep/pipeline-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/builder/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body",
+      "tray"
+     ],
+     "data_score": 1,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/pipeline-origin.png"
+    },
+    {
+     "lane": "override",
+     "url": "http://localhost:9225/workspace/builder/ri.eddie.main.pipeline.e73d6ae7-f6fe-4ac5-82a2-320d9f188590/sandbox/a082bef2-8826-4e6c-8925-871bcdb56c44",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "toolbar",
+      "body"
+     ],
+     "data_score": 7,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/pipeline-override.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/pipeline-override.png"
+  },
+  {
+   "slug": "dataset",
+   "owner": "Data",
+   "parity_class": "reference_capture",
+   "grammar": "table_list",
+   "reference_path": "/__apps/dataset",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "data_failed",
+   "reason": "shell boots but the body reports a data failure (\"__apps is not a dataset\") with captured (non-404) lanes",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Training",
+    "Add to favorites",
+    "Walkthroughs",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nTraining\nWalkthroughs\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\n__apps\nNot a dataset\n__apps is not a dataset",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 233,
+    "meaningful_lines": 8
+   },
+   "error_text": "__apps is not a dataset",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 181382
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/dataset",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/dataset-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/dataset/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/dataset-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/dataset-proxy.png"
+  },
+  {
+   "slug": "schema",
+   "owner": "Ontology",
+   "parity_class": "daemon_wired",
+   "grammar": "editor_canvas",
+   "reference_path": "/__apps/schema",
+   "candidate_surface": "/__ioi/ontology/manager",
+   "substrate_surface": null,
+   "clean_state": "data_clean",
+   "reason": "shell regions [rail, header, body] + data evidence (rows 0/6 · nodes 0 · cards 7 · lists 0 · lines 31)",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Ontology Manager",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account",
+    "Resources",
+    "575"
+   ],
+   "matrix_landmarks_present": [
+    "Ontology Manager",
+    "Discover",
+    "Resources",
+    "Object types",
+    "Properties",
+    "Link types",
+    "Action types",
+    "Value types",
+    "Functions",
+    "Health"
+   ],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nOntology Manager\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nOntology Manager\nctrl + K\nMain\nNew\nDiscover\nProposals\nHistory\nResources\nObject types\n22\nProperties\nShared properties\n0\nLink types\n17\nAction types\n11\nGroups\n0\nInterfaces\n0\nValue types\n0\nFunctions\n575\nHealth issues\nCleanup\nOntology configuration\nObject types recently modified in test Ontology\nConfigure\n[Example jj74] [AR] PDF\n0 objects\n0 dependents\nNo description\n[Example jj74] [AR] Page\n0 objects\n0 dependents\nNo d",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 7,
+    "list_items": 0,
+    "repeated_rows": 6,
+    "body_text_chars": 862,
+    "meaningful_lines": 31
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 18,
+    "deep_route_dirs": [
+     "object-type",
+     "object-type-rid"
+    ],
+    "bytes": 7587502
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/schema",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 6,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/schema-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/ontology/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 6,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/schema-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/schema-proxy.png"
+  },
+  {
+   "slug": "explorer",
+   "owner": "Ontology",
+   "parity_class": "reference_ported",
+   "grammar": "table_list",
+   "reference_path": "http://localhost:9225/workspace/hubble/",
+   "candidate_surface": "/__ioi/ontology/explorer",
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 23/6 · nodes 0 · cards 5 · lines 55) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Object Explorer",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nObject Explorer\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nNew exploration\nAll Ontologies\nObject Explorer search\nFilter by...\nShortcuts\nRecents\nFavorites\nYour object sets\n[Example rk46] Email Claims\nObject Type\n2 objects\n[Example] Airport\nObject Type\n178 objects\n[Example ep72] Tasks\nObject Type\n9 objects\n[Example tx76] Video\nObject Type\n3 objects\nObject type catalog\nTYPE GROUP\nNo type groups\n55 of 55\nRelevancy\nAll\nType group\nApplication\nOBJECT TYPE NAME\nSTATUS\nOBJECT COUN",
+   "data_evidence": {
+    "table_rows": 23,
+    "graph_nodes": 0,
+    "cards": 5,
+    "list_items": 0,
+    "repeated_rows": 6,
+    "body_text_chars": 3346,
+    "meaningful_lines": 55
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 1400225
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/explorer",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/explorer-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/hubble/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 10,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/explorer-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/explorer-origin.png"
+  },
+  {
+   "slug": "objectview",
+   "owner": "Ontology",
+   "parity_class": "reference_capture",
+   "grammar": "document",
+   "reference_path": "/__apps/objectview",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "errored_reference",
+   "reason": "navigation failed on every lane (navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane) · navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane))",
+   "lane_used": "proxy",
+   "shell_regions": [],
+   "landmarks_observed": [],
+   "matrix_landmarks_present": [],
+   "body_sample": "",
+   "data_evidence": null,
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": null,
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 27
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/objectview",
+     "loaded": false,
+     "nav_error": "navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane)",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ""
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/object-view/",
+     "loaded": false,
+     "nav_error": "navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane)",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ""
+    }
+   ],
+   "screenshot": ""
+  },
+  {
+   "slug": "objecteditor",
+   "owner": "Ontology",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "/__apps/objecteditor",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "errored_reference",
+   "reason": "navigation failed on every lane (navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane) · navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane))",
+   "lane_used": "proxy",
+   "shell_regions": [],
+   "landmarks_observed": [],
+   "matrix_landmarks_present": [],
+   "body_sample": "",
+   "data_evidence": null,
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": null,
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 27
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/objecteditor",
+     "loaded": false,
+     "nav_error": "navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane)",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ""
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/object-view-editor/",
+     "loaded": false,
+     "nav_error": "navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane)",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ""
+    }
+   ],
+   "screenshot": ""
+  },
+  {
+   "slug": "evalsuites",
+   "owner": "Evaluations",
+   "parity_class": "substrate_bound",
+   "grammar": "table_list",
+   "reference_path": "http://localhost:9225/workspace/evals/",
+   "candidate_surface": "/__ioi/evaluations",
+   "substrate_surface": "/__ioi/evaluations",
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 2 · lines 50) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "AIP Evals",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nAIP Evals\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nAIP Evals\nNew evaluation suite\nHelp\nAIP Evals\nCreate evaluation suites for LLM-backed use-cases.\nView\nRecents\nFavorites\nFILES\nCREATOR\nLAST EDITED BY\nLAST VIEWED\nUse AIP Logic to classify and edit objects Walkthrough\n/test-ab81f6/test4/AIP Chatbot with transcribed video context (2026-04-26 22:22:24)/logic/Use AIP Logic to classify and edit objects (2026-06-23 20:26:32)\naip-assist\naip-assist\nJun 24, 2026\nLeverage feedback",
+   "data_evidence": {
+    "table_rows": 12,
+    "graph_nodes": 0,
+    "cards": 2,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 4871,
+    "meaningful_lines": 50
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": true,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 181008
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/evalsuites",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/evalsuites-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/evals/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 5,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/evalsuites-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/evalsuites-origin.png"
+  },
+  {
+   "slug": "analysis",
+   "owner": "Evaluations",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/insight/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "shell_clean_only",
+   "reason": "shell renders a WELCOME/empty landing (cards 4 · lines 19, no row/node data) — clean chrome, no real data to port against (proxy lane renders no data (score 0); the origin lane is the readable one)",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Insight",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nInsight\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nInsight\nAll namespaces\nStart analysis\nWhat's New\nHelp\nInsight\nSearch, analyze and view data in your ontology.\nView analyses\nWorkbooks\nObject sets\nRecents\nFavorites\nAll\nNAME\nCREATOR\nPATHS\nNo workbooks found\nQuick start\nObject types\nInterfaces\nAll\nChoose data\n[Example] Airport\nObject type • 0 objects\n[Example rk46] Email Claims\nObject type • 0 objects\n[Example ep72] Tasks\nObject type • 0 objects\n[Example tx76] Video\nObject ",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 4,
+    "list_items": 0,
+    "repeated_rows": 4,
+    "body_text_chars": 616,
+    "meaningful_lines": 19
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": true,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 1310154
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/analysis",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/analysis-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/insight/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 6,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/analysis-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/analysis-origin.png"
+  },
+  {
+   "slug": "quiver",
+   "owner": "Evaluations",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/quiver/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "shell_clean_only",
+   "reason": "shell renders a WELCOME/empty landing (cards 5 · lines 23, no row/node data) — clean chrome, no real data to port against (proxy lane renders no data (score 0); the origin lane is the readable one)",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body",
+    "tray"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Quiver",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nQuiver\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nCreate new analysis\nGet started on analyzing your object and time series data\nName and location\nFile name\nLocation\nBrowse\nAll\nAll projects\nShow hidden\nThere are no projects.\nCreate new project\nSelect analysis type\nCompare types\nQuiver Analysis\nFlexible, ad-hoc analysis and dashboard building across any Foundry data type\nRecommended for most use-cases\nTime Series Analysis\nStreamlined interface for ad-hoc analysis on time se",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 5,
+    "list_items": 2,
+    "repeated_rows": 0,
+    "body_text_chars": 816,
+    "meaningful_lines": 23
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 6,
+    "deep_route_dirs": [
+     "splash"
+    ],
+    "bytes": 2366926
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/quiver",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/quiver-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/quiver/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body",
+      "tray"
+     ],
+     "data_score": 3,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/quiver-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/quiver-origin.png"
+  },
+  {
+   "slug": "models",
+   "owner": "Foundry",
+   "parity_class": "substrate_bound",
+   "grammar": "catalog",
+   "reference_path": "/__apps/models",
+   "candidate_surface": "/__ioi/foundry",
+   "substrate_surface": "/__ioi/foundry",
+   "clean_state": "data_clean",
+   "reason": "shell regions [rail, header, body] + data evidence (rows 0/0 · nodes 0 · cards 4 · lists 0 · lines 18)",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Model Catalog",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nModel Catalog\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nModel Catalog\nIOI-provided models\nRegistered models\nIOI-provided models\nBrowse large language models in Foundry\nCompare models\nFilters\nLIFECYCLE STATUS\nClear\nStable\n1\nTYPE\nClear\nText Completion\n1\nVision\n1\nMODEL CREATOR\nClear\nAdditional Models\nLocal default (env) (default)\nText Completion\nVision",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 4,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 476,
+    "meaningful_lines": 18
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 155064
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/models",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 3,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/models-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/model-catalog/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 7,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/models-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/models-proxy.png"
+  },
+  {
+   "slug": "modelstudio",
+   "owner": "Foundry",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "/__apps/modelstudio",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "data_failed",
+   "reason": "shell boots but the body reports a data failure (\"Page not found\") with captured (non-404) lanes",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Model Studio",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nModel Studio\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nPage not found",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 194,
+    "meaningful_lines": 7
+   },
+   "error_text": "Page not found",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 179560
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/modelstudio",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/modelstudio-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/model-studio/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/modelstudio-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/modelstudio-proxy.png"
+  },
+  {
+   "slug": "inference",
+   "owner": "Foundry",
+   "parity_class": "reference_capture",
+   "grammar": "wizard",
+   "reference_path": "/__apps/inference",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "data_failed",
+   "reason": "shell boots but the body reports a data failure (\"Failed to load current space\") with captured (non-404) lanes",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Sensitive Data Scanner",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nSensitive Data Scanner\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nSensitive Data Scanner\nFailed to load current space\nYou do not have access to this space\nPermission to discover a space is required to view its scans.\nFailed to load current space",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 369,
+    "meaningful_lines": 11
+   },
+   "error_text": "Failed to load current space",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": true,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 154414
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/inference",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 1,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/inference-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/foundry-inference-app/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/inference-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/inference-proxy.png"
+  },
+  {
+   "slug": "listings",
+   "owner": "Marketplace",
+   "parity_class": "reference_capture",
+   "grammar": "catalog",
+   "reference_path": "/__apps/listings",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "data_clean",
+   "reason": "shell regions [rail, header, body] + data evidence (rows 1/0 · nodes 0 · cards 3 · lists 0 · lines 20)",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Marketplace",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nMarketplace\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nMarketplace\nInstallations\nHelp\nMarketplace\nDiscover and install Foundry products\nStores\nFound 1 store\nName\nProducts\nEstate Marketplace — governed listing plane\nListings drafted over real substrate. Publish is the governed path: admitted review + open release control + serving runtime, receipted.\n0 products\nInstall your first product\nA store holds a collection of products. Select a store to browse or search for a produ",
+   "data_evidence": {
+    "table_rows": 1,
+    "graph_nodes": 0,
+    "cards": 3,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 888,
+    "meaningful_lines": 20
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": true,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 6,
+    "deep_route_dirs": [
+     "installed-product"
+    ],
+    "bytes": 332257
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/listings",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 3,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/listings-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/marketplace/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 10,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/listings-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/listings-proxy.png"
+  },
+  {
+   "slug": "registry",
+   "owner": "Marketplace",
+   "parity_class": "reference_capture",
+   "grammar": "table_list",
+   "reference_path": "http://localhost:9225/workspace/artifacts/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "shell_clean_only",
+   "reason": "shell renders a WELCOME/empty landing (cards 4 · lines 18, no row/node data) — clean chrome, no real data to port against (proxy lane shows a failure (\"Invalid resource identifier\"); the origin lane is the readable one)",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Artifacts",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nArtifacts\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nArtifacts\nCreate artifact repository\nHelp\n0\n0\n0\nExplore artifacts\nArtifact repositories enable users to publish and manage artifacts. Explore and search through all your artifact repositories in one place.\nConda\nLearn about artifacts\nGo to documentation\nCore concepts\nLearn the core concepts used by artifacts.\nPublish an artifact\nLearn the different types of artifacts, and how to publish them.\nSearch an artifact\nLearn ho",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 4,
+    "list_items": 0,
+    "repeated_rows": 4,
+    "body_text_chars": 735,
+    "meaningful_lines": 18
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 159678
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/registry",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 1,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/registry-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/artifacts/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 6,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/registry-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/registry-origin.png"
+  },
+  {
+   "slug": "devconsole",
+   "owner": "Developer Console",
+   "parity_class": "reference_capture",
+   "grammar": "wizard",
+   "reference_path": "http://localhost:9225/workspace/developer-console/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "shell_clean_only",
+   "reason": "shell renders a WELCOME/empty landing (cards 5 · lines 23, no row/node data) — clean chrome, no real data to port against (proxy lane renders no data (score 0); the origin lane is the readable one)",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Developer Console",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nDeveloper Console\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nDeveloper Console\nNew application\nWelcome to Developer Console\n\nBuild applications on top of APIs generated from your Ontology.\n\nView documentation\nApplications\nStandalone OAuth clients\nLegacy\nRecents (0)\nFavorites (0)\nAll (0)\nCreated by me\nAPPLICATION\nCREATOR\nLAST EDITED BY\nLAST MODIFIED\nNo applications\nExamples and templates\nOntology SDK reference examples\nGet started with a ready-to-use Ontology and learn wha",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 5,
+    "list_items": 0,
+    "repeated_rows": 5,
+    "body_text_chars": 757,
+    "meaningful_lines": 23
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 167089
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/devconsole",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 1,
+     "cors_signals": 1,
+     "console_errors": 3,
+     "screenshot": ".artifacts/reference-clean-sweep/devconsole-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/developer-console/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 6,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/devconsole-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/devconsole-origin.png"
+  },
+  {
+   "slug": "widgets",
+   "owner": "Developer Console",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/custom-widgets/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 0 · lines 47) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Custom Widgets",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nCustom Widgets\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nCustom Widgets\nNew widget set\nHelp\nCustom Widgets\nDevelop custom frontend widgets for use within Foundry applications.\nView\nRecents\nFavorites\nFILES\nCREATOR\nLAST EDITED BY\nLAST VIEWED\nUse AIP Logic to classify and edit objects Walkthrough\n/test-ab81f6/test4/AIP Chatbot with transcribed video context (2026-04-26 22:22:24)/logic/Use AIP Logic to classify and edit objects (2026-06-23 20:26:32)\naip-assist\naip-assist\nJun",
+   "data_evidence": {
+    "table_rows": 12,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 4484,
+    "meaningful_lines": 47
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 159979
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/widgets",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 1,
+     "cors_signals": 1,
+     "console_errors": 3,
+     "screenshot": ".artifacts/reference-clean-sweep/widgets-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/custom-widgets/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 5,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/widgets-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/widgets-origin.png"
+  },
+  {
+   "slug": "developer",
+   "owner": "Developer Console",
+   "parity_class": "reference_capture",
+   "grammar": "table_list",
+   "reference_path": "http://localhost:9225/workspace/developer/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "errored_reference",
+   "reason": "reference renders an error page (\"You don't have permissions to view this page\") without a usable shell",
+   "lane_used": "origin",
+   "shell_regions": [
+    "body"
+   ],
+   "landmarks_observed": [],
+   "matrix_landmarks_present": [],
+   "body_sample": "You don't have permissions to view this page",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 44,
+    "meaningful_lines": 1
+   },
+   "error_text": "You don't have permissions to view this page",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 82667
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/developer",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/developer-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/developer/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/developer-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/developer-origin.png"
+  },
+  {
+   "slug": "workspaces",
+   "owner": "Workbench",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/code-workspaces/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane renders no data (score 1), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 3/4 · nodes 0 · cards 5 · lines 26) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Code Workspaces",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nCode Workspaces\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nCode Workspaces\nNew workspace\nHelp\nCode Workspaces\nLaunch code workspaces that run open-source IDEs and notebooks.\nRunning workspaces\nYou have no running workspaces. Create or open a workspace to get started.\nView\nRecents\nFavorites\nAll\nCreated by me\nVS Code\nJupyter\nRStudio\nWORKSPACES\nCREATOR\nLAST EDITED BY\nLAST EDITED\n[Template] Dash App\n/test-ab81f6/test4/AIP Chatbot with transcribed video context (2026-04-26 22:",
+   "data_evidence": {
+    "table_rows": 3,
+    "graph_nodes": 0,
+    "cards": 5,
+    "list_items": 0,
+    "repeated_rows": 4,
+    "body_text_chars": 1733,
+    "meaningful_lines": 26
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 9,
+    "deep_route_dirs": [
+     "splash"
+    ],
+    "bytes": 593907
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/workspaces",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 1,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/workspaces-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/code-workspaces/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 10,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/workspaces-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/workspaces-origin.png"
+  },
+  {
+   "slug": "repositories",
+   "owner": "Workbench",
+   "parity_class": "reference_capture",
+   "grammar": "table_list",
+   "reference_path": "/__apps/repositories",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "errored_reference",
+   "reason": "navigation failed on every lane (navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane) · navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane))",
+   "lane_used": "proxy",
+   "shell_regions": [],
+   "landmarks_observed": [],
+   "matrix_landmarks_present": [],
+   "body_sample": "",
+   "data_evidence": null,
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": null,
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 27
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/repositories",
+     "loaded": false,
+     "nav_error": "navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane)",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ""
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/code-repositories/",
+     "loaded": false,
+     "nav_error": "navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane)",
+     "regions": [],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ""
+    }
+   ],
+   "screenshot": ""
+  },
+  {
+   "slug": "notepad",
+   "owner": "Workbench",
+   "parity_class": "reference_capture",
+   "grammar": "document",
+   "reference_path": "http://localhost:9225/workspace/notepad/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane shows a failure (\"An error occurred\"), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 2/0 · nodes 0 · cards 11 · lines 28) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Notepad",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nNotepad\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nNotepad\nNew document\nHelp\nNotepad\nCreate, share and export object-aware documents and reports.\nCreate a new document\nBlank document\nCreate an object-aware collaborative rich-text document with widgets and other embedded content from Foundry applications\nNew from template\nCreate a document from a template to efficiently populate it with relevant data and content tailored to the specific use case\nDocument template\nCreate a ",
+   "data_evidence": {
+    "table_rows": 2,
+    "graph_nodes": 0,
+    "cards": 11,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 1602,
+    "meaningful_lines": 28
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 6,
+    "deep_route_dirs": [
+     "view-template"
+    ],
+    "bytes": 2664226
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/notepad",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 4,
+     "screenshot": ".artifacts/reference-clean-sweep/notepad-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/notepad/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 4,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/notepad-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/notepad-origin.png"
+  },
+  {
+   "slug": "vertex",
+   "owner": "Provenance",
+   "parity_class": "substrate_bound",
+   "grammar": "graph",
+   "reference_path": "http://localhost:9225/workspace/vertex/",
+   "candidate_surface": "/__ioi/vertex",
+   "substrate_surface": "/__ioi/vertex",
+   "clean_state": "shell_clean_only",
+   "reason": "shell renders a WELCOME/empty landing (cards 6 · lines 21, no row/node data) — clean chrome, no real data to port against (proxy lane shows a failure (\"An error occurred\"); the origin lane is the readable one)",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Vertex",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nVertex\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nWelcome to Vertex\nExplore your organization's digital twin\nOR\nNew exploration\nNone available\nGraphs\n\nA graph is a collection of nodes and edges with associated styling. It helps you visualize practically any aspect of your digital twin and evaluate what-if analyses visually.\n\nExplore\n2 available\nTemplates\n\nA graph template constructs a graph given inputs to its parameters. Design templates to quickly generate visualization",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 6,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 1362,
+    "meaningful_lines": 21
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 1243753
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/vertex",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 4,
+     "screenshot": ".artifacts/reference-clean-sweep/vertex-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/vertex/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 4,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/vertex-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/vertex-origin.png"
+  },
+  {
+   "slug": "map",
+   "owner": "Environments",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/map/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "shell_clean_only",
+   "reason": "shell renders a WELCOME/empty landing (cards 4 · lines 15, no row/node data) — clean chrome, no real data to port against (proxy lane renders no data (score 0); the origin lane is the readable one)",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "toolbar",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Map",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nMap\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nUnsaved Map\nSave as…\n© Mapbox © OpenStreetMap Improve this map\nLayers\nLegend\nHistogram\nAdd to map\nNo layers\nAdd data to your map to get started\nMapbox Light\nTimeline\nSelect\nSearch Around\nSelection\nExplore reference examples\nLearn how to build your use case using example Map modules from Marketplace\nObfuscate sensitive data with Cipher\nLearn how to use Cipher to obfuscate sensitive data by default while still allowing authoriz",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 4,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 800,
+    "meaningful_lines": 15
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": true,
+    "overlay_post": true,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 1234217
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/map",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 3,
+     "screenshot": ".artifacts/reference-clean-sweep/map-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/map/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "toolbar",
+      "body"
+     ],
+     "data_score": 3,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/map-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/map-origin.png"
+  },
+  {
+   "slug": "slate",
+   "owner": "Domain Apps",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/slate/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "errored_reference",
+   "reason": "the app never mounts — uncaught page error (\"Workspace context path not found\")",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Slate",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nSlate\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 172,
+    "meaningful_lines": 5
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 6,
+    "deep_route_dirs": [
+     "splash"
+    ],
+    "bytes": 2298976
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/slate",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/slate-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/slate/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/slate-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/slate-origin.png"
+  },
+  {
+   "slug": "logic",
+   "owner": "Domain Apps",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/logic-app/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane renders no data (score 0), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/4 · nodes 0 · cards 2 · lines 51) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "AIP Logic",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nAIP Logic\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nAIP Logic\nNew logic\nHelp\nBuild no-code Ontology functions\nUse Logic to build composable no-code functions that can parse, modify, and expand your Ontology.\nView functions\nRecents\nFavorites\nAll\nLOGIC FILE\nCREATOR\nLAST EDITED BY\nLAST VIEWED\nUse AIP Logic to classify and edit objects Walkthrough\n/test-ab81f6/test4/AIP Chatbot with transcribed video context (2026-04-26 22:22:24)/logic/Use AIP Logic to classify and edit obje",
+   "data_evidence": {
+    "table_rows": 12,
+    "graph_nodes": 0,
+    "cards": 2,
+    "list_items": 0,
+    "repeated_rows": 4,
+    "body_text_chars": 4980,
+    "meaningful_lines": 51
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 9,
+    "deep_route_dirs": [
+     "create-new"
+    ],
+    "bytes": 562000
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/logic",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/logic-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/logic-app/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 8,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/logic-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/logic-origin.png"
+  },
+  {
+   "slug": "contour",
+   "owner": "Domain Apps",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "http://localhost:9225/workspace/contour-app/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane shows a failure (\"404: Page Not Found\"), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 12/0 · nodes 0 · cards 2 · lines 50) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Contour",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nContour\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nContour\nNew analysis\nHelp\nContour\nAnalyze large datasets with filters, joins, and visualizations. Export the result to contribute back to the Foundry pipeline.\nView\nRecents\nFavorites\nFILES\nCREATOR\nLAST EDITED BY\nLAST VIEWED\nUse AIP Logic to classify and edit objects Walkthrough\n/test-ab81f6/test4/AIP Chatbot with transcribed video context (2026-04-26 22:22:24)/logic/Use AIP Logic to classify and edit objects (2026-06-23 2",
+   "data_evidence": {
+    "table_rows": 12,
+    "graph_nodes": 0,
+    "cards": 2,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 4960,
+    "meaningful_lines": 50
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 12,
+    "deep_route_dirs": [
+     "overview",
+     "splash"
+    ],
+    "bytes": 1067164
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/contour",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/contour-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/contour-app/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 5,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/contour-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/contour-origin.png"
+  },
+  {
+   "slug": "fusion",
+   "owner": "Domain Apps",
+   "parity_class": "reference_capture",
+   "grammar": "editor_canvas",
+   "reference_path": "/__apps/fusion",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "data_failed",
+   "reason": "shell boots but the body reports a data failure (\"Not Found\") with captured (non-404) lanes",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Training",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nTraining\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nNot Found\n\nCouldn't find this path. Please check the URL for typos.\n\nReturn to files",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 260,
+    "meaningful_lines": 7
+   },
+   "error_text": "Not Found",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 6,
+    "deep_route_dirs": [
+     "create"
+    ],
+    "bytes": 2316799
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/fusion",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/fusion-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/fusion/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "body"
+     ],
+     "data_score": 0,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/fusion-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/fusion-proxy.png"
+  },
+  {
+   "slug": "jobs",
+   "owner": "Missions",
+   "parity_class": "substrate_bound",
+   "grammar": "table_list",
+   "reference_path": "/__apps/jobs",
+   "candidate_surface": "/__ioi/missions",
+   "substrate_surface": "/__ioi/missions",
+   "clean_state": "shell_clean_only",
+   "reason": "shell regions [rail, header, body] render clean but the body carries no real data (rows 0/0 · nodes 0 · cards 0)",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Builds",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nBuilds\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nBuilds\n0\n0\n0\nSearch by…\nResource\nAll\nInclude intermediate job resources\nObject type\nFilter by…\nMy builds\nShow only my builds\nBranch\nAll branches\nOnly master branch\nAll branches excluding master\nStarted by\nlevi.josman\nYou\nJob type\nStart date\nFinish date\nClear all filters\nYour builds\nAll\nRunning\nFinished\nOutputs\nStarted by\nStart time\nDuration\nStatus\nActions\nNo visible builds",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 549,
+    "meaningful_lines": 12
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 6,
+    "deep_route_dirs": [
+     "splash"
+    ],
+    "bytes": 314836
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/jobs",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 1,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/jobs-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/job-tracker/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 1,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/jobs-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/jobs-proxy.png"
+  },
+  {
+   "slug": "incidents",
+   "owner": "Missions",
+   "parity_class": "substrate_bound",
+   "grammar": "table_list",
+   "reference_path": "/__apps/incidents",
+   "candidate_surface": "/__ioi/missions",
+   "substrate_surface": "/__ioi/missions",
+   "clean_state": "data_clean",
+   "reason": "shell regions [rail, header, body] + data evidence (rows 5/0 · nodes 0 · cards 0 · lists 0 · lines 25) — clicked the 'Closed' status lane (the default Open lane is honestly empty; the capture carries 5 real closed incidents)",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Issues",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nIssues\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nIssues\nNew\nOpen\n0\nClosed\n5\nAll\n5\nFILTERS\nClear filters\nPriority\nHigh\nMedium\nLow\nAssignees\ninclude\nReporters\ninclude\nMentions\ninclude\nLabels\ninclude\nSupport types\ninclude\nReported on\nReported on MM-DD-YYYY\nReported on MM-DD-YYYY\nLast updated\nLast updated MM-DD-YYYY\nLast updated MM-DD-YYYY\n5 closed issues\nfiltered by\nselect filter\nSort by\nMost recently updated\n\t\nvm_lost · env_18bceb4d757a82be\nCreated 13 days ago\n\t\t\nHigh\nPrio",
+   "data_evidence": {
+    "table_rows": 5,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 0,
+    "body_text_chars": 898,
+    "meaningful_lines": 25
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 162247
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/incidents",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 4,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 1,
+     "screenshot": ".artifacts/reference-clean-sweep/incidents-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/issues-app/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 1,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/incidents-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/incidents-proxy.png"
+  },
+  {
+   "slug": "approvals",
+   "owner": "Governance",
+   "parity_class": "daemon_wired",
+   "grammar": "table_list",
+   "reference_path": "/__apps/approvals",
+   "candidate_surface": "/__ioi/governance/approvals",
+   "substrate_surface": null,
+   "clean_state": "data_clean",
+   "reason": "shell regions [rail, header, body] + data evidence (rows 0/9 · nodes 0 · cards 0 · lists 0 · lines 45)",
+   "lane_used": "proxy",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Approvals",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account",
+    "Quick filters",
+    "Additional filters",
+    "Clear",
+    "Request type",
+    "Access requests",
+    "Status"
+   ],
+   "matrix_landmarks_present": [
+    "Approvals",
+    "Quick filters",
+    "Your inbox",
+    "Created by you",
+    "All requests",
+    "Additional filters",
+    "Request type",
+    "Status"
+   ],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nApprovals\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nApprovals\nQuick filters\nYour inbox\n9\nCreated by you\n0\nAll requests\n9\nAdditional filters\nClear\nRequest type\nAccess requests\nStatus\nApproved +3\nCreated by\nSelect user\nAssigned to you\nProject requested to\nUsers or groups in request\nSelect user or group\nGroups requested to\nSelect group\nYour inbox(9)\nSort: Recently created\nverify_rebind · verify-approvals-rebind mr9k9qeb\nCreated by an unknown user on Jul 6, 2026, 2:36 PM\nPen",
+   "data_evidence": {
+    "table_rows": 0,
+    "graph_nodes": 0,
+    "cards": 0,
+    "list_items": 0,
+    "repeated_rows": 9,
+    "body_text_chars": 1514,
+    "meaningful_lines": 45
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": false,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 154980
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/approvals",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 5,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/approvals-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/approvals-app/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 1,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/approvals-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/approvals-proxy.png"
+  },
+  {
+   "slug": "changes",
+   "owner": "Improvement",
+   "parity_class": "reference_capture",
+   "grammar": "table_list",
+   "reference_path": "http://localhost:9225/workspace/upgrade-assistant/",
+   "candidate_surface": null,
+   "substrate_surface": null,
+   "clean_state": "needs_origin_alignment",
+   "reason": "proxy lane renders no data (score 3), but the capture-origin lane (http://localhost:9225) renders the app failure-free WITH data (rows 4/4 · nodes 0 · cards 6 · lines 32) — align the reference URL like pipeline #38/#39",
+   "lane_used": "origin",
+   "shell_regions": [
+    "rail",
+    "header",
+    "body"
+   ],
+   "landmarks_observed": [
+    "Home",
+    "Search…",
+    "ctrl + J",
+    "Notifications",
+    "Gift Icon",
+    "What's New",
+    "Recent",
+    "Files",
+    "Ontology",
+    "Applications",
+    "View all",
+    "Upgrade Assistant",
+    "Add to favorites",
+    "AIP logo icon",
+    "AIP Assist",
+    "ctrl + shift + U",
+    "Support",
+    "Account",
+    "Filters",
+    "UPGRADE PROGRESS",
+    "All upgrades",
+    "Upgrades requiring my action",
+    "UPGRADE TYPE",
+    "Admin action"
+   ],
+   "matrix_landmarks_present": [],
+   "body_sample": "Skip to content\nHome\nSearch…\nctrl + J\nNotifications\nWhat's New\nRecent\nFiles\nOntology\nApplications\nAPPLICATIONS\nView all\nUpgrade Assistant\nAIP Assist\nctrl + shift + U\nSupport\nLJ\nAccount\nUpgrade Assistant\n1 organization\nAdmin view\nAssignee view\nHelp\nYou are viewing resources for which you are personally assigned actions. Enable Admin view to help manage upgrades for organizations where you are a Maintenance Operator.\nActive\nPast due\nArchived\nFilters\nUPGRADE PROGRESS\nAll upgrades\n13\nUpgrades requiring my action\n1\nUPGRADE TYPE\nAdmin action\n1\nModel migration\n0\nPlatform change\n0\nRemediation\n0\nSecuri",
+   "data_evidence": {
+    "table_rows": 4,
+    "graph_nodes": 0,
+    "cards": 6,
+    "list_items": 0,
+    "repeated_rows": 4,
+    "body_text_chars": 1213,
+    "meaningful_lines": 32
+   },
+   "error_text": "",
+   "missing_chunks": [],
+   "cors_evidence": [],
+   "modal_evidence": {
+    "overlay_pre": true,
+    "overlay_post": false,
+    "dismissed_reveals_data": false
+   },
+   "capture_store": {
+    "present": true,
+    "file_count": 3,
+    "deep_route_dirs": [],
+    "bytes": 153494
+   },
+   "lanes_summary": [
+    {
+     "lane": "proxy",
+     "url": "http://127.0.0.1:4173/__apps/changes",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 3,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/changes-proxy.png"
+    },
+    {
+     "lane": "origin",
+     "url": "http://localhost:9225/workspace/upgrade-assistant/",
+     "loaded": true,
+     "nav_error": "",
+     "regions": [
+      "rail",
+      "header",
+      "body"
+     ],
+     "data_score": 10,
+     "chunk_404s": 0,
+     "api_failures": 0,
+     "cross_origin_9225": 0,
+     "cors_signals": 0,
+     "console_errors": 0,
+     "screenshot": ".artifacts/reference-clean-sweep/changes-origin.png"
+    }
+   ],
+   "screenshot": ".artifacts/reference-clean-sweep/changes-origin.png"
+  }
+ ],
+ "evidence_dir": ".artifacts/reference-clean-sweep"
+}

--- a/apps/hypervisor/scripts/build-app-parity-matrix.mjs
+++ b/apps/hypervisor/scripts/build-app-parity-matrix.mjs
@@ -182,6 +182,20 @@ const SHELL_PIXEL_CERTIFIED = {
   pipeline: "pixel-certifications/pipeline.json",
 };
 
+// ---- PR #44: the ESTATE REFERENCE CLEAN SWEEP (committed evidence written by
+// harness-reference-clean-sweep.mjs from real Playwright renders over the LOCAL
+// mirror lanes). Stamps reference_clean_state / _reason / _artifact on every
+// seed. parity_class is NEVER derived from it — cleanliness describes the
+// REFERENCE, not the port.
+const CLEAN_SWEEP_STATES = new Set([
+  "data_clean", "shell_clean_only", "blank_reference", "errored_reference",
+  "cors_origin_mismatch", "missing_chunk", "modal_blocked", "data_failed",
+  "needs_backend_reharvest", "needs_origin_alignment", "unknown_blocked",
+]);
+let CLEAN_SWEEP = null;
+try { CLEAN_SWEEP = JSON.parse(readFileSync(path.join(appRoot, "reference-clean-sweep.json"), "utf8")); } catch { /* pre-sweep generation stays valid */ }
+const cleanRowOf = (slug) => (CLEAN_SWEEP && Array.isArray(CLEAN_SWEEP.seeds) ? CLEAN_SWEEP.seeds.find((x) => x.slug === slug) : null);
+
 const rows = SEED_INVENTORY.map((e) => {
   const cls = parityClass(e.slug);
   const row = {
@@ -197,6 +211,12 @@ const rows = SEED_INVENTORY.map((e) => {
     reference_workspace: e.captureBase,
     note: e.note,
   };
+  const clean = cleanRowOf(e.slug);
+  if (clean) {
+    row.reference_clean_state = clean.clean_state;
+    row.reference_clean_reason = clean.reason;
+    row.reference_clean_artifact = "reference-clean-sweep.json";
+  }
   const overlay = OVERLAY_FOR(e.slug);
   if (overlay) {
     Object.assign(row, overlay);
@@ -212,6 +232,31 @@ const rows = SEED_INVENTORY.map((e) => {
   }
   return row;
 });
+
+// INVARIANT (PR #44): the clean sweep may only carry known states; daemon_wired
+// seeds must be data_clean CERTIFIED CONTROLS (their references are the calibration
+// standard — a daemon_wired row whose reference is not clean means either the sweep
+// heuristics or the certification is wrong, and generation must not paper over it);
+// reference_ported rows may stay blocked but must NAME the blocker. The sweep never
+// changes parity_class (cleanliness describes the reference, not the port).
+if (CLEAN_SWEEP) {
+  if (!Array.isArray(CLEAN_SWEEP.seeds) || CLEAN_SWEEP.seeds.length !== rows.length) {
+    console.error(`FATAL: reference-clean-sweep.json covers ${(CLEAN_SWEEP.seeds || []).length} seeds but the inventory has ${rows.length} — re-run the sweep (node scripts/harness-reference-clean-sweep.mjs).`);
+    process.exit(2);
+  }
+  for (const r of rows) {
+    if (!r.reference_clean_state) { console.error(`FATAL: seed '${r.slug}' missing from reference-clean-sweep.json — the sweep must cover every seed.`); process.exit(2); }
+    if (!CLEAN_SWEEP_STATES.has(r.reference_clean_state)) { console.error(`FATAL: seed '${r.slug}' carries unknown reference_clean_state '${r.reference_clean_state}'.`); process.exit(2); }
+    if (!r.reference_clean_reason) { console.error(`FATAL: seed '${r.slug}' reference_clean_state has no reference_clean_reason — every classification must be evidence-backed prose.`); process.exit(2); }
+    if (r.parity_class === "daemon_wired" && (r.reference_clean_state !== "data_clean" || !r.shell_pixel_certified)) {
+      console.error(`FATAL: daemon_wired seed '${r.slug}' must be a data_clean certified control (state=${r.reference_clean_state}, certified=${r.shell_pixel_certified}).`);
+      process.exit(2);
+    }
+    // reference_ported rows may stay clean-blocked or port-pending — the global
+    // reason check above already forces them to NAME why (explorer: the origin-
+    // alignment finding). No stronger constraint: promotion is a port PR's job.
+  }
+}
 
 // INVARIANT: shell_pixel_certified is a layer ON TOP of daemon_wired — a row may not claim it without
 // first being a certified faithful port, and its evidence file must EXIST, PARSE, and actually certify

--- a/apps/hypervisor/scripts/harness-reference-clean-sweep.mjs
+++ b/apps/hypervisor/scripts/harness-reference-clean-sweep.mjs
@@ -1,0 +1,515 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// PR #44 — ESTATE REFERENCE DATA-CLEAN SWEEP (infrastructure only; no ports,
+// no promotions, no parity_class changes, no shell-pixel certification changes).
+//
+// The authoritative estate-wide answer to: "which references are actually clean
+// enough to port/certify next?" Sweeps ALL 39 seeds with real Playwright
+// renders over the LOCAL lanes only:
+//   proxy lane  — SERVE /__apps/<slug>          (token-injected estate proxy)
+//   origin lane — MIRROR <capture_base>          (the capture's own origin path;
+//                 the lane that unblocked pipeline in #38/#39)
+// plus the per-seed reference_url_override when the matrix carries one.
+//
+// Classification (one state per seed, evidence-backed, fail-first precedence):
+//   errored_reference · missing_chunk · cors_origin_mismatch · blank_reference
+//   · modal_blocked · data_failed · needs_backend_reharvest
+//   · needs_origin_alignment · data_clean · shell_clean_only · unknown_blocked
+//
+// Evidence per seed: shell regions (geometry-gated, same predicates as the
+// visual harness) · observed landmarks · data evidence (table rows / graph
+// nodes / cards / list items / meaningful text) · console+page errors ·
+// failed/4xx network requests (missing chunk hashes, API-lane failures) ·
+// CORS/origin signals · capture-store fs facts (file count, deep routes) ·
+// screenshot per lane. Screenshots are never the sole evidence — every state
+// is derived from DOM/text/network signals; the png is corroboration.
+//
+// Outputs:
+//   .artifacts/reference-clean-sweep/result.json        (full evidence)
+//   .artifacts/reference-clean-sweep/contact-sheet.html (all seeds, both lanes)
+//   .artifacts/reference-clean-sweep/<slug>-<lane>.png  (screenshots)
+//   .artifacts/reference-clean-sweep/<slug>-network.json(per-seed request log)
+//   reference-clean-sweep.json (COMMITTED compact evidence — the matrix's
+//   reference_clean_* source of truth; parity_class is never touched)
+//
+// Controls: schema / approvals / pipeline must classify data_clean (they are
+// certified surfaces over VALID references — if a control misclassifies, the
+// sweep's heuristics are wrong, not the reference). An errored reference must
+// never classify clean even when the global rail renders.
+// ---------------------------------------------------------------------------
+import { chromium } from "playwright";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { REFERENCE_PRE_CAPTURE, ERROR_PAGE_RE } from "./harness-reference-parity.mjs";
+
+// The sweep reads a WIDER error vocabulary than the visual harness (audit pass:
+// permission-denied captures, invalid-resource-id proxy routes, context-path
+// failures all masqueraded as blank/clean).
+const SWEEP_ERROR_RE = new RegExp(ERROR_PAGE_RE.source + "|don'?t have permission|no permission|not authorized|invalid resource identifier|is not a dataset|context path not found|couldn'?t find this path", "i");
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(here, "..");
+const repoRoot = path.resolve(appRoot, "..", "..");
+const SERVE = process.env.IOI_SERVE_URL || "http://127.0.0.1:4173";
+const MIRROR = process.env.IOI_HARVEST_MIRROR_URL || "http://127.0.0.1:9225";
+// The capture ORIGIN the seed documents hardcode (localhost, NOT 127.0.0.1 — the
+// hostname mismatch alone manufactures CORS noise; pipeline's #39 override uses
+// localhost for exactly this reason). Origin-lane probes run here.
+const CAPTURE_ORIGIN = process.env.IOI_SWEEP_ORIGIN || MIRROR.replace("127.0.0.1", "localhost");
+const OUT = process.env.IOI_SWEEP_ARTIFACT_DIR || path.join(appRoot, ".artifacts", "reference-clean-sweep");
+const COMMITTED = path.join(appRoot, "reference-clean-sweep.json");
+const MIRROR_PUBLIC = path.join(repoRoot, "internal-docs", "reverse-engineering", "palantir", "public");
+const ONLY = (process.env.IOI_SWEEP_SEEDS || "").split(",").map((s) => s.trim()).filter(Boolean);
+const CONCURRENCY = Number(process.env.IOI_SWEEP_CONCURRENCY || 4);
+
+export const CLEAN_STATES = [
+  "data_clean", "shell_clean_only", "blank_reference", "errored_reference",
+  "cors_origin_mismatch", "missing_chunk", "modal_blocked", "data_failed",
+  "needs_backend_reharvest", "needs_origin_alignment", "unknown_blocked",
+];
+
+// The reference chrome region predicates — the SAME geometry discipline as the
+// visual harness (selector match alone never counts; layout must agree).
+const REGION_SELECTORS = {
+  rail: '[class*="rail"],[class*="sidebar"],[class*="side-nav"],nav,aside',
+  header: 'header,[class*="header"],[class*="navbar"],[class*="topbar"],[class*="app-bar"]',
+  toolbar: '[role="toolbar"],[class*="toolbar"],[class*="tool-bar"],[class*="actions-bar"]',
+  body: 'main,[class*="content"],[class*="canvas"],[class*="workspace"],[class*="body"]',
+  right: '[class*="right-panel"],[class*="rightPanel"],[class*="side-panel"],[class*="inspector"],[class*="details-panel"]',
+  tray: 'footer,[class*="tray"],[class*="bottom-panel"],[class*="footer"]',
+};
+
+// Data-lane API families the capture serves (mirrors the serve proxy's list) —
+// a 4xx/5xx on these is a DATA-LANE failure, not a chrome asset problem.
+const API_FAMILY_RE = /\/(multipass|graphql-gateway|compass|monocle|approvals|workspace\/api|interventions|ontology-metadata|magritte-coordinator|issues|foundry-search|marketplace|object-set-service|phonograph2|language-model-service|foundry-ml|artifacts|foundry-catalog|models|build2|foundry-stemma|third-party-applications|developer-console|aip-assist|documentation|log-receiver)\//;
+const CHUNK_RE = /\.(js|mjs|css)(\?|$)|content-addressable-storage/;
+
+// Post-boot interactions (no auth/origin change — a single in-app click, like a
+// user switching a status lane). Applied to EVERY lane after modal handling;
+// recorded on the lane so the classification names it.
+const SWEEP_INTERACTIONS = {
+  incidents: { note: "clicked the 'Closed' status lane (the default Open lane is honestly empty; the capture carries 5 real closed incidents)", run: async (page) => {
+    await page.getByText("Closed", { exact: true }).first().click({ timeout: 3000 });
+    await page.waitForTimeout(900);
+  } },
+};
+
+function seedRows() {
+  const m = JSON.parse(readFileSync(path.join(appRoot, "harvest-app-parity-matrix.json"), "utf8"));
+  return (m.seeds || []).filter((s) => !ONLY.length || ONLY.includes(s.slug));
+}
+
+// Capture-store fs facts: how much of this seed's workspace was actually
+// captured (index-only shells cannot carry deep data routes).
+function captureStoreFacts(captureBase) {
+  const dir = path.join(MIRROR_PUBLIC, ...(captureBase || "").split("/").filter(Boolean));
+  const facts = { present: false, file_count: 0, deep_route_dirs: [], bytes: 0 };
+  if (!captureBase || !existsSync(dir)) return facts;
+  facts.present = true;
+  const walk = (d, depth) => {
+    let entries = [];
+    try { entries = readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) {
+        if (depth === 0) facts.deep_route_dirs.push(e.name);
+        if (depth < 3) walk(p, depth + 1);
+      } else {
+        facts.file_count += 1;
+        try { facts.bytes += statSync(p).size; } catch { /* */ }
+      }
+    }
+  };
+  walk(dir, 0);
+  facts.deep_route_dirs = facts.deep_route_dirs.slice(0, 12);
+  return facts;
+}
+
+// ---- one lane render: full network/console/DOM evidence -------------------
+async function sweepLane(browser, url, slug, laneName, preCapture, matrixLandmarks) {
+  const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const page = await ctx.newPage();
+  const net = { failed: [], http_errors: [], cross_origin_9225: 0, total: 0 };
+  const consoleErrors = [], pageErrors = [];
+  const pageOrigin = new URL(url).origin;
+  page.on("requestfailed", (r) => {
+    const f = r.failure();
+    net.failed.push({ url: r.url().slice(0, 220), error: (f && f.errorText) || "", type: r.resourceType() });
+  });
+  page.on("response", (r) => {
+    net.total += 1;
+    const st = r.status();
+    if (st >= 400) net.http_errors.push({ url: r.url().slice(0, 220), status: st, type: r.request().resourceType() });
+  });
+  page.on("request", (r) => {
+    try { if (new URL(r.url()).origin !== pageOrigin && /:9225$/.test(new URL(r.url()).host)) net.cross_origin_9225 += 1; } catch { /* */ }
+  });
+  page.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text().slice(0, 260)); });
+  page.on("pageerror", (e) => pageErrors.push(String(e.message || e).slice(0, 260)));
+
+  const lane = { lane: laneName, url, loaded: true, nav_error: "", evidence: null, evidence_pre_modal: null, modal: null, screenshot: "" };
+  try {
+    await page.emulateMedia({ reducedMotion: "reduce" }).catch(() => {});
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 25000 });
+    await page.addStyleTag({ content: "*,*::before,*::after{animation-duration:.001s !important;transition-duration:.001s !important;caret-color:transparent !important}" }).catch(() => {});
+    await page.evaluate(() => Promise.race([
+      document.fonts && document.fonts.ready ? document.fonts.ready.then(() => true).catch(() => true) : Promise.resolve(true),
+      new Promise((r) => setTimeout(() => r(true), 3000)),
+    ])).catch(() => {});
+    await page.waitForTimeout(3200); // reference SPA hydrate
+  } catch (e) {
+    lane.loaded = false;
+    const msg = String(e.message || e);
+    lane.nav_error = /Download is starting/i.test(msg)
+      ? "navigation triggered a content-type download — the captured app document is an empty 307 + application/octet-stream response (broken capture, cannot boot on any lane)"
+      : msg.split("\n")[0].slice(0, 160);
+  }
+
+  const snapshot = async () => page.evaluate(({ sel, ERR, ML }) => {
+    const VW = innerWidth, VH = innerHeight;
+    const vis = (el) => { const r = el.getBoundingClientRect(); const s = getComputedStyle(el); return r.width > 24 && r.height > 24 && s.visibility !== "hidden" && s.display !== "none" && s.opacity !== "0" ? r : null; };
+    const geom = {
+      rail: (b) => b.left < VW * 0.15 && b.height > VH * 0.4,
+      header: (b) => b.top < VH * 0.15 && b.width > VW * 0.5 && b.height < VH * 0.28,
+      toolbar: (b) => b.top < VH * 0.4 && b.width > VW * 0.25 && b.height < VH * 0.22,
+      body: (b) => b.width > VW * 0.4 && b.height > VH * 0.35,
+      right: (b) => b.right > VW * 0.8 && b.height > VH * 0.3 && b.width < VW * 0.6,
+      tray: (b) => b.bottom > VH * 0.8 && b.width > VW * 0.4 && b.height < VH * 0.4,
+    };
+    const regions = [];
+    for (const [k, q] of Object.entries(sel)) {
+      let hit = false;
+      for (const el of document.querySelectorAll(q)) { const b = vis(el); if (b && geom[k](b)) { hit = true; break; } }
+      if (hit) regions.push(k);
+    }
+    // data evidence — DOM signals, never pixels
+    let tableRows = 0;
+    for (const tb of document.querySelectorAll("table tbody")) tableRows = Math.max(tableRows, tb.querySelectorAll("tr").length);
+    const ariaRows = document.querySelectorAll('[role="row"]').length;
+    tableRows = Math.max(tableRows, Math.max(0, ariaRows - 1));
+    const nodeEls = document.querySelectorAll('[data-node-id],[class*="node-card"],[class*="graph-node"],[class*="nodeCard"],svg [class*="node"]');
+    let graphNodes = 0; for (const el of nodeEls) if (vis(el) || el.ownerSVGElement) graphNodes += 1;
+    let cards = 0; for (const el of document.querySelectorAll('[class*="card"]')) { const b = vis(el); if (b && b.width > 80 && b.height > 48) cards += 1; }
+    let listItems = 0; for (const el of document.querySelectorAll('li,[role="listitem"],[role="option"],[role="menuitem"]')) if (vis(el)) listItems += 1;
+    // repeated-structure rows: custom-DOM lists/tables (>=4 same-class visible
+    // siblings, uniform height, textual) — the approvals reference renders its
+    // request list this way (co-table-rows > approvals-components__row-container).
+    let repeatedRows = 0;
+    for (const el of document.querySelectorAll("div,ul,ol,section")) {
+      // CONTENT-AREA guard: the global rail / app sidebars are themselves uniform
+      // repeated structures (8x nav rows) — chrome must never count as data.
+      const pb = el.getBoundingClientRect();
+      if (pb.left < VW * 0.16 && pb.width < VW * 0.5) continue;
+      if (el.closest("nav,aside,[class*='sidebar'],[class*='side-nav'],[class*='rail']")) continue;
+      const kids = []; for (const k of el.children) { const b = vis(k); if (b && b.width > 60) kids.push({ k, h: b.height }); }
+      if (kids.length < 4) continue;
+      const cls = (k) => (String(k.className || "").split(/\s+/)[0] || k.tagName);
+      const first = cls(kids[0].k);
+      const same = kids.filter((x) => cls(x.k) === first);
+      if (same.length < 4) continue;
+      const avg = same.reduce((a, c) => a + c.h, 0) / same.length;
+      if (!same.every((x) => Math.abs(x.h - avg) < Math.max(8, avg * 0.35))) continue;
+      const texty = same.filter((x) => ((x.k.textContent || "").trim().length > 8)).length;
+      if (texty >= 3 && avg >= 18 && avg <= 160) repeatedRows = Math.max(repeatedRows, same.length);
+    }
+    const text = (document.body && document.body.innerText) || "";
+    const lines = text.split("\n").map((l) => l.trim()).filter((l) => l.length > 2);
+    const meaningful = lines.filter((l) => l.length >= 12).length;
+    const errLine = (() => { const re = new RegExp(ERR, "i"); for (const l of lines) if (re.test(l)) return l.slice(0, 160); return ""; })();
+    // landmark-ish labels: short distinct texts in nav/header/aside chrome
+    const lm = new Set();
+    for (const el of document.querySelectorAll("nav *,aside *,header *,[class*='sidebar'] *,[class*='rail'] *")) {
+      if (el.children.length) continue;
+      const t = (el.textContent || "").trim();
+      if (t && t.length >= 3 && t.length <= 32) lm.add(t);
+      if (lm.size >= 24) break;
+    }
+    const overlays = [];
+    for (const el of document.querySelectorAll('[class*="overlay"],[class*="portal"],[class*="dialog"],[class*="modal"],[role="dialog"]')) {
+      const b = vis(el); if (b && b.width > 200 && b.height > 120) overlays.push(((el.className && String(el.className)) || el.tagName).slice(0, 60));
+    }
+    let spinners = 0; for (const el of document.querySelectorAll('[class*="spinner"],[class*="loading"],[class*="skeleton"],[class*="progress"]')) if (vis(el)) spinners += 1;
+    const matrixLm = ML.filter((l) => text.includes(l));
+    const welcome = /welcome to |get started|getting started|create your first|no .{0,24} yet\b|there (are|is) no |no [^\n]{0,28}(found|available)\b|all [^\n]{0,24}completed|add [^\n]{0,24}to get started|learn about\b/i.test(text);
+    return {
+      title: document.title || "", regions, landmarks: [...lm], matrix_landmarks: matrixLm,
+      data: { table_rows: tableRows, graph_nodes: graphNodes, cards, list_items: listItems, repeated_rows: repeatedRows, body_text_chars: text.length, meaningful_lines: meaningful },
+      error_text: errLine, overlays, spinners, welcome_state: welcome, body_sample: text.slice(0, 600),
+    };
+  }, { sel: REGION_SELECTORS, ERR: SWEEP_ERROR_RE.source, ML: Array.isArray(matrixLandmarks) ? matrixLandmarks : [] }).catch((e) => ({ snapshot_error: String(e.message || e).slice(0, 120) }));
+
+  if (lane.loaded) {
+    lane.evidence_pre_modal = await snapshot();
+    // Modal probe: if a blocking overlay is up, dismiss THE SAME WAY the pipeline
+    // pre-capture does (Escape + hide portal layers — no auth/origin change) and
+    // re-measure. The delta is the modal_blocked evidence.
+    const hadOverlay = (lane.evidence_pre_modal.overlays || []).length > 0;
+    if (preCapture) { try { await preCapture(page); } catch { /* best effort */ } await page.waitForTimeout(400); }
+    else if (hadOverlay) {
+      await page.keyboard.press("Escape").catch(() => {});
+      await page.addStyleTag({ content: '.bp6-portal,.bp6-overlay,.bp6-overlay-backdrop,[class*="whats-new"],[data-portal]{display:none !important}' }).catch(() => {});
+      await page.waitForTimeout(700);
+    }
+    const inter = SWEEP_INTERACTIONS[slug];
+    if (inter) { try { await inter.run(page); lane.interaction = inter.note; } catch { /* lane may not render the control */ } }
+    lane.evidence = await snapshot();
+    lane.modal = {
+      overlay_pre: hadOverlay,
+      overlay_post: (lane.evidence.overlays || []).length > 0,
+      dismissed_reveals_data: hadOverlay && dataScore(lane.evidence.data) > dataScore(lane.evidence_pre_modal.data),
+    };
+    const png = path.join(OUT, `${slug}-${laneName}.png`);
+    try { await page.screenshot({ path: png }); lane.screenshot = path.relative(appRoot, png); } catch { /* */ }
+  }
+  lane.network = {
+    total: net.total,
+    failed: net.failed.slice(0, 24),
+    http_errors: net.http_errors.slice(0, 40),
+    cross_origin_9225: net.cross_origin_9225,
+    chunk_404s: net.http_errors.filter((e) => CHUNK_RE.test(e.url)).slice(0, 16),
+    api_failures: net.http_errors.filter((e) => API_FAMILY_RE.test(e.url)).slice(0, 24),
+  };
+  lane.console_errors = consoleErrors.slice(0, 20);
+  lane.page_errors = pageErrors.slice(0, 10);
+  lane.cors_signals = consoleErrors.filter((t) => /CORS|Cross-Origin|blocked by CORS|Access-Control-Allow/i.test(t)).slice(0, 8);
+  await ctx.close();
+  return lane;
+}
+
+function dataScore(d) {
+  if (!d) return 0;
+  return (d.table_rows >= 3 ? 3 : 0) + (d.repeated_rows >= 4 ? 3 : 0) + (d.graph_nodes >= 3 ? 3 : 0) + (d.cards >= 3 ? 2 : 0)
+    + (d.list_items >= 8 ? 1 : 0) + (d.meaningful_lines >= 10 ? 1 : 0) + (d.body_text_chars >= 1200 ? 1 : 0);
+}
+const hasData = (d) => dataScore(d) >= 3;
+// REAL data: strong signals that are not a welcome/empty landing masquerading as
+// content (audit pass: quick-start pickers, doc-link cards, empty-counter chrome).
+// Welcome-landing override (audit-calibrated): real user tables run 6+ repeated
+// rows or ANY nonzero table rows (notepad's 2 real resources count); onboarding
+// card-lists run 4-5 uniform items with zero rows (analysis/registry/devconsole).
+const realData = (ev) => !!ev && hasData(ev.data)
+  && !(ev.welcome_state && (ev.data.table_rows | 0) === 0 && (ev.data.repeated_rows | 0) < 6 && (ev.data.graph_nodes | 0) < 3);
+const shellOk = (ev) => ev && Array.isArray(ev.regions) && ev.regions.length >= 2;
+const isBlank = (ev) => !ev || ((ev.data?.body_text_chars || 0) < 60 && (ev.regions || []).length <= 1);
+
+// ---- classification: one state, fail-first, evidence named -----------------
+function classify(seed, lanes, storeFacts) {
+  const proxyReal = lanes.proxy && lanes.proxy.loaded && realData(lanes.proxy.evidence) && !lanes.proxy.evidence?.error_text;
+  const linesOf = (l) => (l && l.loaded && l.evidence && l.evidence.data && l.evidence.data.meaningful_lines) || 0;
+  const pick = lanes.override
+    || (proxyReal ? lanes.proxy : null)
+    || ((lanes.origin && lanes.origin.loaded && dataScore(lanes.origin.evidence?.data) > dataScore(lanes.proxy?.evidence?.data)) ? lanes.origin : null)
+    || ((lanes.origin && lanes.origin.loaded && linesOf(lanes.origin) > linesOf(lanes.proxy)) ? lanes.origin : null)
+    || lanes.proxy || lanes.origin;
+  const alt = pick === lanes.proxy ? lanes.origin : lanes.proxy;
+  const ev = pick && pick.evidence;
+  const R = (state, reason, extra = {}) => ({ state, reason, lane_used: pick ? pick.lane : "none", ...extra });
+
+  // 0. nothing loaded anywhere
+  if ((!lanes.proxy || !lanes.proxy.loaded) && (!lanes.origin || !lanes.origin.loaded) && (!lanes.override || !lanes.override.loaded)) {
+    return R("errored_reference", `navigation failed on every lane (${[lanes.proxy?.nav_error, lanes.origin?.nav_error].filter(Boolean).join(" · ") || "no lane loaded"})`);
+  }
+  if (!pick || !pick.loaded) return R("errored_reference", `primary lane failed to load: ${pick ? pick.nav_error : "missing"}`);
+
+  const errText = ev?.error_text || "";
+  const chunk404 = pick.network.chunk_404s.length;
+  const apiFail = pick.network.api_failures.length;
+  const cors = pick.cors_signals.length > 0;
+
+  // 1. hard error page with no usable shell — never clean even if the rail renders
+  if (errText && !shellOk(ev) && !hasData(ev?.data)) {
+    return R("errored_reference", `reference renders an error page ("${errText}") without a usable shell`);
+  }
+  // 2. boot-killing missing chunks (js/css 404) with a broken/blank result
+  if (chunk404 > 0 && (!shellOk(ev) || isBlank(ev))) {
+    return R("missing_chunk", `${chunk404} chunk asset(s) 404 at the mirror and the app fails to boot`, { missing_chunks: pick.network.chunk_404s.map((c) => c.url.split("/").pop()) });
+  }
+  // 3. ORIGIN ALIGNMENT (the pipeline #38/#39 pattern): the standard /__apps proxy
+  // lane carries no data while the capture-origin lane renders it — the reference
+  // needs a reference_url_override onto the origin lane, nothing else is wrong.
+  const proxyDefect = lanes.proxy && (!lanes.proxy.loaded
+    ? `proxy lane fails to load (${lanes.proxy.nav_error})`
+    : lanes.proxy.evidence?.error_text
+      ? `proxy lane shows a failure ("${lanes.proxy.evidence.error_text}")${lanes.proxy.cors_signals.length ? " with CORS-blocked session lanes" : ""}`
+      : !realData(lanes.proxy.evidence)
+        ? `proxy lane renders no data (score ${dataScore(lanes.proxy?.evidence?.data)})`
+        : "");
+  const originBetter = !lanes.override && lanes.origin && lanes.origin.loaded
+    && realData(lanes.origin.evidence) && !lanes.origin.evidence?.error_text && !!proxyDefect;
+  if (originBetter) {
+    const od = lanes.origin.evidence.data;
+    return R("needs_origin_alignment", `${proxyDefect}, but the capture-origin lane (${CAPTURE_ORIGIN}) renders the app failure-free WITH data (rows ${od.table_rows}/${od.repeated_rows} · nodes ${od.graph_nodes} · cards ${od.cards} · lines ${od.meaningful_lines}) — align the reference URL like pipeline #38/#39`, { origin_lane_evidence: od, origin_lane_url: lanes.origin.url });
+  }
+  if (cors && !hasData(ev?.data) && !shellOk(ev)) {
+    return R("cors_origin_mismatch", `CORS/origin failures block boot (${pick.cors_signals[0] || "cross-origin request failures"}) and no lane renders data`, { cors_evidence: pick.cors_signals });
+  }
+  // 3b. an app that never mounts with an uncaught page error is ERRORED, not blank/clean
+  const pageErr = (pick.page_errors && pick.page_errors[0]) || (lanes.proxy && lanes.proxy.page_errors && lanes.proxy.page_errors[0]) || "";
+  if (!realData(ev) && pageErr && ((ev?.data?.meaningful_lines | 0) < 8)) {
+    return R("errored_reference", `the app never mounts — uncaught page error ("${pageErr.slice(0, 120)}")`, { page_error: pageErr.slice(0, 200) });
+  }
+  // 4. blank
+  if (isBlank(ev)) {
+    const why = chunk404 ? `blank body + ${chunk404} chunk 404s` : apiFail ? `blank body + ${apiFail} data-lane failures` : "blank body (no regions, no text)";
+    return R(chunk404 ? "missing_chunk" : "blank_reference", why, chunk404 ? { missing_chunks: pick.network.chunk_404s.map((c) => c.url.split("/").pop()) } : {});
+  }
+  // 5. modal-only blocker: dismissing reveals real data without auth/origin change
+  if (pick.modal && pick.modal.dismissed_reveals_data && hasData(ev?.data)) {
+    return R("modal_blocked", "a blocking modal hides real data; dismissing it (Escape/portal-hide, no auth/origin change) reveals the data — wire a pre-capture hook like pipeline's", { modal_evidence: pick.modal });
+  }
+  // 6a. welcome/landing state masquerading as data: landing copy + card chrome but
+  // ZERO row/node/repeated evidence is an EMPTY app home, not a data-clean reference.
+  if (shellOk(ev) && hasData(ev?.data) && !realData(ev) && !errText) {
+    return R("shell_clean_only", `shell renders a WELCOME/empty landing (cards ${ev.data.cards} · lines ${ev.data.meaningful_lines}, no row/node data) — clean chrome, no real data to port against${pick.lane === "origin" && proxyDefect ? ` (${proxyDefect}; the origin lane is the readable one)` : ""}`);
+  }
+  // 6. clean: shell + REAL data evidence (post any pre-capture/interaction)
+  if (shellOk(ev) && realData(ev) && !errText) {
+    return R("data_clean", `shell regions [${ev.regions.join(", ")}] + data evidence (rows ${ev.data.table_rows}/${ev.data.repeated_rows} · nodes ${ev.data.graph_nodes} · cards ${ev.data.cards} · lists ${ev.data.list_items} · lines ${ev.data.meaningful_lines})${pick.interaction ? ` — ${pick.interaction}` : ""}`);
+  }
+  // 7. shell renders but the body says the data failed
+  if (shellOk(ev) && errText) {
+    if (apiFail > 0) return R("needs_backend_reharvest", `shell boots but ${apiFail} data-lane request(s) fail at the capture ("${errText}") — the backend payloads were not harvested`, { api_failures: pick.network.api_failures.slice(0, 6) });
+    return R("data_failed", `shell boots ${hasData(ev?.data) ? `with PARTIAL data (rows ${ev.data.table_rows}/${ev.data.repeated_rows} · nodes ${ev.data.graph_nodes} · cards ${ev.data.cards}) ` : ""}but the body reports a data failure ("${errText}") with captured (non-404) lanes`, {});
+  }
+  // 8. shell renders, no data, data lanes 404 → capture lacks backend payloads
+  if (shellOk(ev) && !hasData(ev?.data)) {
+    if (apiFail > 0) return R("needs_backend_reharvest", `shell boots empty and ${apiFail} data-lane request(s) 404/5xx at the capture — backend payloads missing`, { api_failures: pick.network.api_failures.slice(0, 6) });
+    if ((ev.spinners || 0) > 0) return R("data_failed", `shell boots but data never arrives (${ev.spinners} live loading indicator(s), no failing lane recorded)`);
+    return R("shell_clean_only", `shell regions [${ev.regions.join(", ")}] render clean but the body carries no real data (rows ${ev.data.table_rows}/${ev.data.repeated_rows} · nodes ${ev.data.graph_nodes} · cards ${ev.data.cards})`);
+  }
+  return R("unknown_blocked", `no classification rule matched (regions ${(ev?.regions || []).length}, dataScore ${dataScore(ev?.data)}, chunk404 ${chunk404}, apiFail ${apiFail}) — needs a human read`);
+}
+
+// ---- ranking: the directive's preference order ------------------------------
+function rankNext(records) {
+  const PORTED = new Set(["daemon_wired", "reference_ported"]);
+  const candidates = records.filter((r) => !PORTED.has(r.parity_class) && r.clean_state === "data_clean");
+  const OWNER_VALUE = { Data: 5, Ontology: 5, Governance: 5, Missions: 4, Automations: 4, Provenance: 4, Evaluations: 3, Foundry: 3, Studio: 3, Marketplace: 2, "Developer Console": 2, Workbench: 2, "Domain Apps": 2, Improvement: 3, Environments: 1 };
+  const scored = candidates.map((r) => {
+    const bindable = r.candidate_surface || r.substrate_surface ? 2 : 0; // daemon truth already wired/easy to bind
+    const owner = OWNER_VALUE[r.owner] || 1;
+    const grammarRisk = /table|list|catalog|inbox|registry|queue|wizard/i.test(r.grammar || "") ? 2 : /graph|canvas|map|spreadsheet|ide/i.test(r.grammar || "") ? 0 : 1; // low fabrication risk
+    const ia = Math.min(2, Math.floor((r.landmarks_observed || []).length / 6)); // stable IA landmarks
+    const noLive = 1; // local lanes only — the sweep never leaves the mirror
+    const score = 10 + bindable * 3 + owner + grammarRisk * 2 + ia + noLive;
+    return { slug: r.slug, owner: r.owner, score, why: {
+      data_clean_reference: true,
+      daemon_truth_bindable: bindable > 0 ? (r.candidate_surface || r.substrate_surface) : "no existing surface — new binding work",
+      owner_value: `${r.owner} (${owner})`,
+      fabrication_risk: grammarRisk === 2 ? `low (${r.grammar})` : grammarRisk === 0 ? `high (${r.grammar})` : `medium (${r.grammar})`,
+      ia_landmarks: (r.landmarks_observed || []).slice(0, 8),
+      live_palantir_dependency: "none (local mirror lanes only)",
+    } };
+  }).sort((a, b) => b.score - a.score);
+  return scored.slice(0, 3).map((s, i) => ({ rank: i + 1, ...s }));
+}
+
+function contactSheet(records) {
+  const cell = (r) => {
+    const shots = (r.lanes_summary || []).filter((l) => l.screenshot).map((l) => `<figure><img src="${path.basename(l.screenshot)}" loading="lazy"><figcaption>${l.lane}</figcaption></figure>`).join("");
+    return `<section class="${r.clean_state}"><h2>${r.slug} <small>${r.owner} · ${r.parity_class}</small></h2>
+      <p class="state">${r.clean_state}</p><p class="why">${r.reason}</p>
+      <p class="ev">rows ${r.data_evidence?.table_rows ?? "—"} · nodes ${r.data_evidence?.graph_nodes ?? "—"} · cards ${r.data_evidence?.cards ?? "—"} · lists ${r.data_evidence?.list_items ?? "—"} · lines ${r.data_evidence?.meaningful_lines ?? "—"}${r.error_text ? ` · <b>err:</b> ${r.error_text}` : ""}</p>
+      <div class="shots">${shots}</div></section>`;
+  };
+  return `<!doctype html><meta charset="utf-8"><title>Reference clean sweep — 39 seeds</title><style>
+  body{font:13px/1.45 system-ui;margin:16px;background:#14171b;color:#e8eaed}
+  section{border:1px solid #2a2f36;border-radius:8px;padding:10px 12px;margin:0 0 12px;background:#1b1f24}
+  h2{margin:0;font-size:15px} small{color:#8b93a0;font-weight:400}
+  .state{font-weight:700;margin:4px 0} .why{color:#aeb6c2;margin:2px 0} .ev{color:#8b93a0;margin:2px 0}
+  .data_clean .state{color:#43d17a}.shell_clean_only .state{color:#8ab4f8}
+  .errored_reference .state,.data_failed .state{color:#f28b82}
+  .blank_reference .state,.unknown_blocked .state{color:#9aa0a6}
+  .missing_chunk .state,.needs_backend_reharvest .state{color:#fbbc04}
+  .cors_origin_mismatch .state,.needs_origin_alignment .state{color:#d7aefb}.modal_blocked .state{color:#78d9ec}
+  .shots{display:flex;gap:8px;margin-top:6px} figure{margin:0} img{width:420px;border:1px solid #2a2f36;border-radius:4px}
+  figcaption{color:#8b93a0;font-size:11px;text-align:center}</style>
+  <h1>Estate reference data-clean sweep — ${records.length} seeds</h1>${records.map(cell).join("\n")}`;
+}
+
+async function run() {
+  mkdirSync(OUT, { recursive: true });
+  const seeds = seedRows();
+  const browser = await chromium.launch({ headless: true });
+  const records = [];
+  let cursor = 0;
+  const worker = async () => {
+    for (;;) {
+      const i = cursor++; if (i >= seeds.length) return;
+      const s = seeds[i];
+      const pre = REFERENCE_PRE_CAPTURE[s.slug] || null;
+      const lanes = {};
+      lanes.proxy = await sweepLane(browser, `${SERVE}/__apps/${s.slug}`, s.slug, "proxy", pre, s.reference_landmarks);
+      if (s.capture_base) lanes.origin = await sweepLane(browser, `${CAPTURE_ORIGIN}${s.capture_base}`, s.slug, "origin", pre, s.reference_landmarks);
+      if (s.reference_url_override) lanes.override = await sweepLane(browser, s.reference_url_override, s.slug, "override", pre, s.reference_landmarks);
+      const storeFacts = captureStoreFacts(s.capture_base);
+      const cls = classify(s, lanes, storeFacts);
+      const laneUsed = lanes[cls.lane_used === "proxy" ? "proxy" : cls.lane_used === "origin" ? "origin" : cls.lane_used === "override" ? "override" : "proxy"] || lanes.proxy;
+      const ev = laneUsed && laneUsed.evidence;
+      const rec = {
+        slug: s.slug, owner: s.owner, parity_class: s.parity_class, grammar: s.grammar || "",
+        reference_path: laneUsed ? laneUsed.url.replace(SERVE, "").replace(MIRROR, "") : `/__apps/${s.slug}`,
+        candidate_surface: s.candidate_surface || null, substrate_surface: s.substrate_surface || null,
+        clean_state: cls.state, reason: cls.reason, lane_used: cls.lane_used,
+        shell_regions: (ev && ev.regions) || [],
+        landmarks_observed: (ev && ev.landmarks) || [],
+        matrix_landmarks_present: [], body_sample: "",
+        data_evidence: (ev && ev.data) || null,
+        error_text: (ev && ev.error_text) || "",
+        missing_chunks: cls.missing_chunks || [],
+        cors_evidence: cls.cors_evidence || (laneUsed ? laneUsed.cors_signals : []),
+        modal_evidence: cls.modal_evidence || (laneUsed && laneUsed.modal) || null,
+        capture_store: storeFacts,
+        lanes_summary: Object.values(lanes).map((l) => ({
+          lane: l.lane, url: l.url, loaded: l.loaded, nav_error: l.nav_error || "",
+          regions: (l.evidence && l.evidence.regions) || [], data_score: dataScore(l.evidence && l.evidence.data),
+          chunk_404s: l.network.chunk_404s.length, api_failures: l.network.api_failures.length,
+          cross_origin_9225: l.network.cross_origin_9225, cors_signals: l.cors_signals.length,
+          console_errors: l.console_errors.length, screenshot: l.screenshot,
+        })),
+        screenshot: (laneUsed && laneUsed.screenshot) || "",
+      };
+      if (laneUsed && laneUsed.evidence) {
+        rec.matrix_landmarks_present = laneUsed.evidence.matrix_landmarks || [];
+        rec.body_sample = laneUsed.evidence.body_sample || "";
+      }
+      writeFileSync(path.join(OUT, `${s.slug}-network.json`), JSON.stringify(Object.fromEntries(Object.entries(lanes).map(([k, l]) => [k, { url: l.url, network: l.network, console_errors: l.console_errors, page_errors: l.page_errors }])), null, 1));
+      records.push(rec);
+      console.log(`  ${String(records.length).padStart(2)}/${seeds.length}  ${s.slug.padEnd(14)} → ${cls.state.padEnd(24)} ${cls.reason.slice(0, 90)}`);
+    }
+  };
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  await browser.close();
+  records.sort((a, b) => seeds.findIndex((s) => s.slug === a.slug) - seeds.findIndex((s) => s.slug === b.slug));
+
+  const ranked = rankNext(records);
+  const byState = {};
+  for (const r of records) byState[r.clean_state] = (byState[r.clean_state] || 0) + 1;
+  const result = {
+    schema: "ioi.hypervisor.reference-clean-sweep.v1",
+    swept_at: new Date().toISOString(),
+    serve: SERVE, mirror: MIRROR,
+    total_seeds: records.length,
+    by_state: byState,
+    doctrine: "reference cleanliness only — no ports, no promotions, parity_class untouched; local mirror lanes only (no live dependency); screenshots corroborate, DOM/text/network classify",
+    ranked_next: ranked,
+    seeds: records,
+    evidence_dir: path.relative(appRoot, OUT),
+  };
+  writeFileSync(path.join(OUT, "result.json"), JSON.stringify(result, null, 1));
+  writeFileSync(path.join(OUT, "contact-sheet.html"), contactSheet(records));
+  if (!ONLY.length) {
+    // the COMMITTED compact evidence (screenshots stay in .artifacts)
+    const compact = { ...result, seeds: records.map((r) => ({ ...r, lanes_summary: r.lanes_summary, capture_store: { ...r.capture_store, deep_route_dirs: r.capture_store.deep_route_dirs.slice(0, 6) } })) };
+    writeFileSync(COMMITTED, JSON.stringify(compact, null, 1));
+    console.log(`\n★ wrote reference-clean-sweep.json (committed evidence) + ${path.relative(appRoot, OUT)}/{result.json,contact-sheet.html}`);
+  } else {
+    console.log(`\n(partial sweep — committed file NOT written; artifact at ${path.relative(appRoot, OUT)}/result.json)`);
+  }
+  console.log(`states: ${JSON.stringify(byState)}`);
+  console.log(`ranked next: ${ranked.map((r) => `#${r.rank} ${r.slug} (${r.score})`).join(" · ") || "(none data_clean among unported seeds)"}`);
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) run().catch((e) => { console.error("sweep crashed:", e); process.exit(1); });

--- a/apps/hypervisor/scripts/verify-hypervisor-reference-clean-sweep.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-reference-clean-sweep.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// PR #44 — REFERENCE CLEAN-SWEEP VERIFIER.
+// Asserts the committed estate sweep (reference-clean-sweep.json) is complete,
+// internally coherent (every state agrees with its own recorded evidence — a
+// screenshot is never the evidence, the DOM/text/network record is), agrees
+// with the matrix stamping, keeps the certified controls clean, covers the
+// explorer/pipeline special cases, and ranks a justified next-3 WITHOUT any
+// parity promotion. Infrastructure-only: no ports, no daemon_wired changes.
+// ---------------------------------------------------------------------------
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(here, "..");
+const results = [];
+const ok = (name, pass, detail = "") => results.push({ name, pass: !!pass, detail });
+
+const CLEAN_STATES = new Set([
+  "data_clean", "shell_clean_only", "blank_reference", "errored_reference",
+  "cors_origin_mismatch", "missing_chunk", "modal_blocked", "data_failed",
+  "needs_backend_reharvest", "needs_origin_alignment", "unknown_blocked",
+]);
+
+let sweep = null, matrix = null;
+try { sweep = JSON.parse(readFileSync(path.join(appRoot, "reference-clean-sweep.json"), "utf8")); } catch { /* */ }
+try { matrix = JSON.parse(readFileSync(path.join(appRoot, "harvest-app-parity-matrix.json"), "utf8")); } catch { /* */ }
+
+// 1. The committed sweep exists and is the sweep the harness writes.
+ok("committed sweep evidence exists and parses (reference-clean-sweep.json)", !!sweep && sweep.schema === "ioi.hypervisor.reference-clean-sweep.v1");
+ok("the sweep is estate-COMPLETE: all 39 seeds, unique slugs, local lanes only", !!sweep && sweep.total_seeds === 39 && Array.isArray(sweep.seeds) && sweep.seeds.length === 39
+  && new Set(sweep.seeds.map((s) => s.slug)).size === 39
+  && /^http:\/\/(127\.0\.0\.1|localhost):\d+/.test(sweep.serve || "") && /^http:\/\/(127\.0\.0\.1|localhost):\d+/.test(sweep.mirror || ""));
+const seeds = (sweep && sweep.seeds) || [];
+const bySlug = Object.fromEntries(seeds.map((s) => [s.slug, s]));
+
+// 2. Every seed: exactly one KNOWN state, an evidence-backed reason, a screenshot pointer.
+ok("every seed carries exactly one known clean state + a non-empty reason", seeds.length === 39 && seeds.every((s) => CLEAN_STATES.has(s.clean_state) && typeof s.reason === "string" && s.reason.length >= 12));
+ok("every seed records its lanes (url, load, data score, network failure counts) — DOM/network evidence, not screenshots alone", seeds.every((s) => Array.isArray(s.lanes_summary) && s.lanes_summary.length >= 1 && s.lanes_summary.every((l) => l.url && typeof l.data_score === "number" && typeof l.chunk_404s === "number" && typeof l.api_failures === "number")));
+ok("every seed records shell regions + data evidence + capture-store facts", seeds.every((s) => Array.isArray(s.shell_regions) && (s.data_evidence === null || typeof s.data_evidence.body_text_chars === "number") && s.capture_store && typeof s.capture_store.file_count === "number"));
+
+// 3. STATE ↔ EVIDENCE coherence (the sweep's own record must justify its verdict).
+const d = (s) => s.data_evidence || {};
+const strongData = (s) => (d(s).table_rows >= 3 || d(s).repeated_rows >= 4 || d(s).graph_nodes >= 3 || d(s).cards >= 3);
+const coherent = [];
+for (const s of seeds) {
+  let c = true;
+  switch (s.clean_state) {
+    case "data_clean": c = strongData(s) && s.shell_regions.length >= 2 && !s.error_text; break;
+    case "shell_clean_only": c = s.shell_regions.length >= 2 && !s.error_text; break;
+    case "blank_reference": c = (d(s).body_text_chars || 0) < 60 && s.shell_regions.length <= 1; break;
+    case "errored_reference": c = !!s.error_text || /navigation|download|error/i.test(s.reason); break;
+    case "missing_chunk": c = Array.isArray(s.missing_chunks) && s.missing_chunks.length > 0; break;
+    case "cors_origin_mismatch": c = Array.isArray(s.cors_evidence) && s.cors_evidence.length > 0; break;
+    case "modal_blocked": c = !!(s.modal_evidence && s.modal_evidence.dismissed_reveals_data); break;
+    case "data_failed": c = !!s.error_text || /loading indicator/.test(s.reason); break;
+    case "needs_backend_reharvest": c = /data-lane|backend payloads/.test(s.reason); break;
+    case "needs_origin_alignment": {
+      // the ORIGIN lane must carry the data; the proxy defect is named in the reason
+      // (it may be a failure/CORS artifact even when chrome scores nonzero).
+      const origin = s.lanes_summary.find((l) => l.lane === "origin");
+      c = !!origin && origin.data_score >= 3 && /origin lane/.test(s.reason); break;
+    }
+    case "unknown_blocked": c = true; break;
+  }
+  if (!c) coherent.push(`${s.slug}:${s.clean_state}`);
+}
+ok("every state agrees with its own recorded evidence (data_clean⇒rows/nodes/cards; errored⇒error; chunk⇒hashes; cors⇒signals; modal⇒reveal delta; origin-alignment⇒origin-lane data with a data-poor proxy)", coherent.length === 0, coherent.join(", ") || "all coherent");
+ok("no errored/blank reference is classified clean (rail rendering alone never counts)", seeds.every((s) => !(["errored_reference", "blank_reference"].includes(s.clean_state) && strongData(s) && s.shell_regions.length >= 2)));
+
+// 4. Calibration controls: the three certified daemon_wired surfaces read data_clean.
+for (const slug of ["schema", "approvals", "pipeline"]) {
+  const s = bySlug[slug];
+  ok(`control '${slug}' is data_clean (certified surface over a VALID reference — heuristics calibrate on it)`, s && s.clean_state === "data_clean" && strongData(s), s ? `${s.clean_state} · ${s.reason.slice(0, 80)}` : "missing");
+}
+ok("control 'pipeline' evidences the ORIGIN-ALIGNMENT pattern (classified on its origin-aligned override lane)", bySlug.pipeline && bySlug.pipeline.lane_used === "override");
+
+// 5. Explorer special case: the pipeline origin-trick explicitly tested with a verdict.
+{
+  const e = bySlug.explorer;
+  const origin = e && e.lanes_summary.find((l) => l.lane === "origin");
+  ok("explorer: the origin-alignment trick was explicitly TESTED (origin lane rendered + recorded)", !!origin && typeof origin.data_score === "number");
+  ok("explorer: verdict is explicit — needs_origin_alignment/data_clean with origin-lane data evidence, or a blocked state NAMING the exact blocker", e && (["needs_origin_alignment", "data_clean"].includes(e.clean_state) ? (origin && origin.data_score >= 3) : e.reason.length > 24), e ? `${e.clean_state} · origin data_score=${origin ? origin.data_score : "n/a"}` : "missing");
+}
+
+// 6. Ranked next-3: present, justified on the directive's axes, and NOT promotions.
+{
+  const r = (sweep && sweep.ranked_next) || [];
+  ok("ranked next-3 present (3 candidates, ranks 1..3)", r.length === 3 && r.map((x) => x.rank).join(",") === "1,2,3");
+  ok("every ranked candidate is a data_clean reference (preference #1 is a hard gate)", r.every((x) => bySlug[x.slug] && bySlug[x.slug].clean_state === "data_clean"));
+  ok("no ranked candidate is already ported (daemon_wired/reference_ported are not 'next')", r.every((x) => !["daemon_wired", "reference_ported"].includes(bySlug[x.slug]?.parity_class)));
+  ok("every ranked candidate is JUSTIFIED on the directive's axes (daemon-truth bindability, owner value, fabrication risk, IA landmarks, live-dependency)", r.every((x) => x.why && x.why.data_clean_reference === true && x.why.daemon_truth_bindable && x.why.owner_value && x.why.fabrication_risk && x.why.live_palantir_dependency));
+}
+
+// 7. Matrix agreement: stamped fields match the sweep; parity_class UNTOUCHED by the sweep.
+{
+  const rows = (matrix && matrix.seeds) || [];
+  ok("matrix rows carry reference_clean_state/_reason/_artifact for all 39 seeds", rows.length === 39 && rows.every((m) => CLEAN_STATES.has(m.reference_clean_state) && m.reference_clean_reason && m.reference_clean_artifact === "reference-clean-sweep.json"));
+  const mismatch = rows.filter((m) => bySlug[m.slug] && (m.reference_clean_state !== bySlug[m.slug].clean_state || m.reference_clean_reason !== bySlug[m.slug].reason));
+  ok("matrix stamping AGREES with the sweep evidence (state + reason verbatim)", mismatch.length === 0, mismatch.map((m) => m.slug).join(", ") || "all agree");
+  const parityDrift = rows.filter((m) => bySlug[m.slug] && m.parity_class !== bySlug[m.slug].parity_class);
+  ok("NO PROMOTIONS: every parity_class is exactly what the sweep observed (cleanliness describes the reference, not the port)", parityDrift.length === 0, parityDrift.map((m) => `${m.slug}: ${bySlug[m.slug].parity_class}→${m.parity_class}`).join(", ") || "untouched");
+  ok("parity distribution unchanged (daemon_wired 3 · reference_ported 1 · substrate_bound 8 · reference_capture 27)", JSON.stringify(matrix && matrix.by_parity_class) === JSON.stringify({ substrate_bound: 8, reference_capture: 27, daemon_wired: 3, reference_ported: 1 }), JSON.stringify(matrix && matrix.by_parity_class));
+  ok("daemon_wired seeds are clean CERTIFIED controls in the matrix (data_clean + shell_pixel_certified)", rows.filter((m) => m.parity_class === "daemon_wired").every((m) => m.reference_clean_state === "data_clean" && m.shell_pixel_certified === true));
+  ok("reference_ported (explorer) names its blocker in the matrix", rows.filter((m) => m.parity_class === "reference_ported").every((m) => m.reference_clean_reason && m.reference_clean_reason.length > 24));
+}
+
+// 8. The matrix is CURRENT (generator idempotence over the committed inputs).
+{
+  const chk = spawnSync(process.execPath, [path.join(appRoot, "scripts", "build-app-parity-matrix.mjs"), "--check"], { encoding: "utf8", timeout: 60000 });
+  ok("matrix --check green (generation is current over the committed sweep)", chk.status === 0, (chk.stdout || chk.stderr || "").trim().split("\n").pop());
+}
+
+// 9. Hygiene: the committed evidence is text-clean.
+{
+  const raw = readFileSync(path.join(appRoot, "reference-clean-sweep.json"), "utf8");
+  ok("no NUL/control characters in the committed sweep evidence", !/[\x00-\x08\x0b\x0c\x0e-\x1f]/.test(raw));
+}
+
+let fail = 0;
+for (const r of results) { console.log(`  ${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`); if (!r.pass) fail++; }
+console.log(`\n${results.length - fail}/${results.length} passed`);
+console.log(`reference-clean-sweep readiness: ${fail ? "FAIL" : "OK"}`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## PR #44 — Estate reference data-clean sweep

**Stacked on #43** (`feat/pixel-certify-pipeline`). **Infrastructure only**: no ports, no promotions, no `parity_class` changes, no shell-pixel certification changes. This PR makes the estate map answer: *which references are actually clean enough to port/certify next?*

### The sweep
`harness-reference-clean-sweep.mjs` renders **all 39 seeds** with real Playwright over local lanes only — the `/__apps` proxy lane **and** the capture-origin lane (`localhost:9225<capture_base>`; the hostname matters — `127.0.0.1` vs `localhost` is itself a cross-origin mismatch, which is why pipeline's #39 override uses localhost). Classification is DOM/text/network-driven; screenshots corroborate, never decide.

### Final states (11-state taxonomy; 5 observed)
| state | n | seeds |
|---|---|---|
| `data_clean` | 6 | schema · approvals · pipeline (certified **calibration controls**) + models · listings · incidents (5 real closed incidents one *recorded* status-lane click deep) |
| `needs_origin_alignment` | 13 | designer, machinery, module, monitors, sources, **explorer**, evalsuites, widgets, workspaces, notepad, logic, contour, changes — proxy lane defective (CORS-blocked session lanes / no data) while the **origin lane renders the app failure-free with data**: the pipeline #38/#39 pattern generalizes |
| `shell_clean_only` | 10 | clean chrome, welcome/empty landings (incl. lineage's "Welcome to Data Lineage" downgraded from a naive data read) |
| `errored_reference` | 6 | 4× broken captures (empty 307 + `application/octet-stream` download documents: workshop, objectview, objecteditor, repositories) · developer (permission-denied capture) · slate (uncaught "Workspace context path not found") |
| `data_failed` | 4 | dataset (the proxy injects `__apps` as a resource id; origin route 404s in-app), modelstudio, inference, fusion |

### Explorer special case — PROVEN
`localhost:9225/workspace/hubble/` renders the object-type catalog (**55 types with real object counts**, a 178-object Airport set, 24 aria rows) while `/__apps/explorer` stays shell-only. The same origin-alignment that unblocked pipeline applies; the exact blocker is named in the matrix row.

### Adversarial audit
A 6-bucket agent panel re-probed **every** classification against the live lanes (40 verdicts). **15 refutations** were reconciled into the classifier (welcome-vocabulary, realData discipline on both lanes, proxy-CORS artifacts reattributed to alignment, page-error blanks reclassified as errors, zero-row onboarding lists vs real tables) and the final run matches the audited expectations **39/39**.

### Ranked next-3
1. **incidents** — data_clean, Missions, `/__ioi/missions` substrate already wired, table/inbox grammar (low fabrication risk)
2. **models** — data_clean, Foundry, `/__ioi/foundry` substrate already wired, catalog grammar
3. **listings** — data_clean, Marketplace store browse

### Matrix + verifier
- Every seed row now carries `reference_clean_state` / `reference_clean_reason` / `reference_clean_artifact` (source of truth: the committed `reference-clean-sweep.json`, written by the sweep itself). Generation-time invariants: full coverage, known states only, evidence-backed reasons, **daemon_wired ⇒ data_clean certified controls**, reference_ported must name its blocker. Parity distribution **unchanged** (3 · 1 · 8 · 27).
- `verify-hypervisor-reference-clean-sweep.mjs` — **25/25**: coverage, per-state evidence coherence, no errored/blank-as-clean, certified controls, explorer/pipeline special cases, justified next-3, matrix agreement + currency, NUL hygiene.

### Done bar
clean-sweep **25/25** · reset **23/23** · pixel **36/36** · schema **38/38** · approvals **23/23** · pipeline **31/31** · explorer **24/24** · matrix `--check` green · NUL-clean · no Rust.

**Held for review — do not merge without sign-off.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)