### PR TITLE
feat(hypervisor): Pipeline module extraction + surface interaction kit — zero drift (#56)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -36,6 +36,8 @@ import { CHG_APP_TILE_URI } from "./changes-assets.mjs";
 import { EVL_APP_TILE_URI, EVL_HERO_URI } from "./evalsuites-assets.mjs";
 import { appCatalog } from "./app-catalog.mjs";
 import { bindSurface, boundSurface } from "./surface-registry.mjs";
+import { escHtml } from "../surfaces/kit.mjs";
+import { ioiGlobalRailHtml, IOI_GRAIL_CSS } from "../surfaces/chrome.mjs";
 import { mintApprovalGrant } from "../../../scripts/lib/mint-approval-grant.mjs";
 
 // Build the current conversation entries for a run, in the exact NDJSON shape the SPA's V1 pane
@@ -237,7 +239,7 @@ function publicBase(req) {
 // Doctrine: Connections owns every binding (MCP, communication, OAuth apps, bearer/PAT, cloud roles,
 // service accounts); Org/User Settings > Integrations are thin projections; MCP is one type inside.
 // Agents consume only scoped leases — credentials are sealed in the daemon, never exposed.
-const CX_ESC = (s) => String(s == null ? "" : s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+const CX_ESC = escHtml; // canonical escaper lives in surfaces/kit.mjs — one definition estate-wide
 function connectionCategory(c) {
   if (c.kind === "mcp") return "MCP servers";
   if (["slack", "discord", "teams", "email"].includes(c.service)) return "Communication channels";
@@ -4755,337 +4757,9 @@ function renderDataLineage(lists, selectedId) {
     + objPane + receiptPane + ledgerPane + gaps);
 }
 
-// ============================ PIPELINE BUILDER (reference-UX parity over the ODK ladder) =========
-// The Reference UX Port program (post-#31 reset), substrate for the Data Pipeline Builder. The reference
-// capture (/__apps/pipeline, /workspace/builder/) is the FAMILIAR STARTING POINT; this IOI-owned
-// surface renders the SAME builder grammar — a datasource → transform → output pipeline of nodes on
-// a canvas, with a Build / Preview / Schedule / Deploy toolbar — but every node is DAEMON TRUTH: the
-// landed ODK ladder for the selected ontology IS the pipeline. Supported lanes reflect real daemon
-// state; unsupported builder lanes (freeform canvas authoring, drag-connect, transform code editor,
-// schedule, deploy) are visible but honest named gaps. Reference-familiar UX; IOI truth underneath.
-function pipeStatusPill(cls, label) {
-  const c = cls === "live" ? "ok" : cls === "declared" ? "warn" : "muted";
-  return `<span class="pill ${c}" style="margin:0">${CX_ESC(label)}</span>`;
-}
-// ============================ PIPELINE BUILDER — reference UX PORT (#32, first reference_ported shell).
-// A PORTED reference builder shell, NOT the dark automationsShell: a source-neutral rebuild of the
-// /workspace/builder/ layout — a full-height left RAIL (pipelines + stage palette), a HEADER bar, a
-// graph TOOLBAR (Build/Preview/Schedule/Deploy — unsupported controls disabled IN PLACE, not hidden),
-// a central CANVAS rendering the ODK authority ladder as connected pipeline node cards, a right
-// OUTPUT PANEL (projection schema + output stats), and a bottom TRAY (preview rows + warnings). Every
-// cell is REAL daemon truth. This is `reference_ported`, NOT `daemon_wired`: the local /workspace/
-// builder/* reference currently ERRORS, so parity cannot yet be certified by the Playwright harness —
-// daemon_wired awaits a valid (non-errored) builder reference to compare against.
-function renderPipelineBuilder(lists, selectedId) {
-  const ontologies = Array.isArray(lists.ontologies) ? lists.ontologies : [];
-  const sets = Array.isArray(lists.materialized_sets) ? lists.materialized_sets : [];
-  const builtRefs = new Set(sets.map((s) => s.ontology_ref));
-  // Prefer an explicit selection; else a "built" pipeline (has a materialized set); else most recent.
-  const selected = ontologies.find((x) => x.id === selectedId)
-    || ontologies.find((x) => builtRefs.has(x.ref))
-    || ontologies[0] || null;
-  const oref = selected ? selected.ref : "__none__";
-  const oid = selected ? selected.id : "";
-  const F = (arr) => (Array.isArray(arr) ? arr : []).filter((x) => x.ontology_ref === oref);
-  const maps = F(lists.connector_mappings), views = F(lists.policy_views), truns = F(lists.transformation_runs);
-  const projs = F(lists.ontology_projections), plans = F(lists.capability_lease_plans), mruns = F(lists.materializing_runs);
-  const sessions = F(lists.connector_sessions), osets = F(lists.materialized_sets);
-  const dsIds = new Set(maps.map((m) => m.data_source_id).filter(Boolean));
-  const dsources = (lists.data_sources || []).filter((d) => dsIds.has(d.source_id));
-  const instances = osets.reduce((a, s) => a + (s.count || 0), 0);
-  const anyReady = (arr, pred) => arr.filter(pred).length;
-
-  // The pipeline nodes, in ODK-ladder order. Each node: real daemon state → live / declared / missing.
-  const mk = (icon, label, kind, n, live, declared, count, detail, pane) => ({ icon, label, kind, n, cls: n === 0 ? "missing" : live ? "live" : declared ? "declared" : "declared", count, detail, pane });
-  const nodes = [
-    mk("🌐", "Datasource", "input", dsources.length, dsources.length > 0, true, dsources.length, dsources.map((d) => d.name || d.source_id).slice(0, 2).join(", "), "data"),
-    mk("🔗", "Object mapping", "transform", maps.length, anyReady(maps, (m) => (m.health || {}).status === "ready") > 0, true, maps.length, "source fields → typed properties", "resources"),
-    mk("🛡", "Policy gate", "transform", views.length, anyReady(views, (v) => (v.health || {}).status === "ready") > 0, true, views.length, "capability envelope", "resources"),
-    mk("📋", "Transform plan", "transform", truns.length, anyReady(truns, (r) => r.status === "dry_run_ready") > 0, true, truns.length, "dry-run validated", "resources"),
-    mk("🔭", "Read projection", "transform", projs.length, anyReady(projs, (p) => p.status === "ready") > 0, true, projs.length, "explorer/search shape", "resources"),
-    mk("🎟", "Lease + session", "authority", plans.length, anyReady(mruns, (r) => ["lease_obtained", "executed"].includes(r.status)) > 0 && anyReady(sessions, (c) => c.status === "session_obtained") > 0, plans.length > 0, plans.length, `${anyReady(mruns, (r) => ["lease_obtained", "executed"].includes(r.status))} lease · ${anyReady(sessions, (c) => c.status === "session_obtained")} session`, "resources"),
-    mk("📦", "Materialized objects", "output", osets.length, instances > 0, osets.length > 0, instances, `${instances} object instance${instances === 1 ? "" : "s"}`, "explorer"),
-  ];
-  const enc = encodeURIComponent, esc = CX_ESC;
-  const oname = selected ? esc(selected.domain || selected.id) : "no pipeline";
-
-  // Preview + output projection (daemon truth) — feeds the bottom tray + right output panel.
-  const proj = projs.find((p) => p.status !== "retired") || projs[0] || null;
-  const mset = osets.find((s) => proj && s.ontology_projection_id === proj.id) || osets[0] || null;
-  const cols = proj ? (proj.visible_properties || []) : [];
-  const previewTable = proj
-    ? `<table class="pb-table"><thead><tr>${cols.map((c) => `<th>${esc(c)}</th>`).join("")}</tr></thead><tbody>${(mset && (mset.objects || []).length)
-        ? mset.objects.slice(0, 12).map((o) => `<tr>${cols.map((c) => `<td>${esc(String((o.properties || {})[c] ?? ""))}</td>`).join("")}</tr>`).join("")
-        : `<tr><td colspan="${cols.length || 1}" class="pb-empty-cell">No rows yet — Build a materializing run to populate this output (object_instances stays 0 until then).</td></tr>`}</tbody></table>`
-    : `<div class="pb-empty">No read projection on this pipeline yet — add one in the Ontology Manager.</div>`;
-
-  // ---- SHARED pixel-aligned GLOBAL RAIL (#43) — Pipeline Builder active. The live pipeline PICKER
-  // (no reference counterpart in the rail) lives in the canvas body (excluded region), keeping the rail
-  // pixel-faithful while the control keeps its function.
-  const globalRail = ioiGlobalRailHtml({ label: "Pipeline Builder", href: "/__ioi/pipeline", iconUri: PIPELINE_APP_ICON_URI, railVariant: "rv-pipe", viewAll: false, star: false, badges: true, aipGradient: true, acctMuted: true });
-  const railPipes = ontologies.length
-    ? ontologies.map((x) => { const on = selected && x.id === selected.id; const built = builtRefs.has(x.ref); return `<a class="pb-pipe ${on ? "on" : ""}" href="/__ioi/pipeline?ontology=${enc(x.id)}">${esc(x.domain || x.id)}${built ? `<span class="pb-tag">built</span>` : ""}</a>`; }).join("")
-    : `<div class="pb-empty">No pipelines yet. <a href="/__ioi/odk/ontologies/new">Create an ontology</a>.</div>`;
-  const nodeCard = (nd) => `<div class="pb-node pb-${nd.cls}"${selected ? ` onclick="location.href='/__ioi/odk?ontology=${enc(oid)}#pane-${nd.pane}'"` : ""}>
-    <div class="pb-nhead"><span class="pb-nicon">${nd.icon}</span><span class="pb-dot pb-${nd.cls}"></span></div>
-    <div class="pb-nlabel">${esc(nd.label)}</div>
-    <div class="pb-ncount"><b>${esc(String(nd.count))}</b> ${nd.kind === "output" ? "objects" : nd.kind === "input" ? "source" + (nd.count === 1 ? "" : "s") : "record" + (nd.count === 1 ? "" : "s")}</div>
-    <div class="pb-ndetail">${esc(nd.detail || "")}</div>
-  </div>`;
-  const legendGroups = [
-    ["Input Data", "#8f99a8", dsources.length],
-    ["Data Cleaning", "#238551", maps.length + views.length],
-    ["Calculations", "#d1980b", truns.length + projs.length + plans.length],
-    ["Output Dataset", "#147eb3", osets.length],
-  ];
-
-  // ---- HEADER (h51, white, hairline shadow) — the reference navbar: app chip · breadcrumb title row
-  // (live names → masked as dynamic data) + File/Settings/Help menu row (named gaps) + Batch tag · a
-  // FLUID MIDDLE zone that in the reference carries captured SESSION STATE (tabs/undo/branch/build
-  // state — masked as dynamic residue) and in the port carries the LIVE Build/Preview controls · right
-  // cluster Actions ▾ / Share / panel toggle (named gaps).
-  const header = `<header class="pb-header">
-    <span class="pb-hchip"></span>
-    <div class="pb-htitles">
-      <div class="pb-crumbrow"><span class="pb-crumb">${oname} <span class="pb-cx">›</span> <b>Pipeline Builder</b>${selected ? ` <span class="pb-cxt">— ${instances > 0 ? `<span class="pb-live">built</span>` : `<span class="pb-declared">not built</span>`} · ${nodes.filter((n) => n.cls === "live").length}/${nodes.length} stages live</span>` : ""}</span><span class="pb-star">${bpIcon("star-empty")}</span></div>
-      <div class="pb-menurow">
-        <span class="pb-menu gap" title="File menu is a reference-only lane (named gap)">File ${bpIcon("caret-down", 16)}</span>
-        <span class="pb-menu gap" title="named gap">Settings ${bpIcon("caret-down", 16)}</span>
-        <span class="pb-menu gap" title="named gap">Help ${bpIcon("caret-down", 16)}</span>
-        <span class="pb-menudiv"></span>
-        <span class="pb-batch">${bpIcon("office", 16)}<span class="pb-batchn">1</span></span>
-        <span class="pb-menudiv d2"></span>
-        <span class="pb-batchtag">Batch</span>
-      </div>
-    </div>
-    <div class="pb-hmid">
-      <a class="pb-btn primary" href="/__ioi/odk?ontology=${enc(oid)}">Build</a>
-      <a class="pb-btn ghost" href="#pb-preview">Preview</a>
-      <button class="pb-btn ghost" disabled title="No pipeline scheduler yet — a named gap (author + run via a materializing run).">Schedule</button>
-      <button class="pb-btn ghost" disabled title="No pipeline deploy yet — a named gap.">Deploy</button>
-      <a class="pb-btn link" href="/__ioi/lineage?ontology=${enc(oid)}">Lineage</a>
-      <a class="pb-btn link" href="/__ioi/odk?ontology=${enc(oid)}">Ontology Manager</a>
-    </div>
-    <div class="pb-hright">
-      <span class="pb-hbtn gap" title="Actions menu is a reference-only lane (named gap)">Actions ${bpIcon("caret-down")}</span>
-      <span class="pb-hdrdiv"></span>
-      <span class="pb-hbtn gap" title="Sharing is a reference-only lane (named gap)">${bpIcon("people")} Share</span>
-      <span class="pb-hico gap" title="Panel layout toggle — named gap">${bpIcon("properties")}</span>
-    </div>
-  </header>`;
-
-  // ---- FLOATING TOOL CARD (canvas top-left) — the reference's grouped canvas tools as GROUP UNITS in a
-  // wrapping flex card: at 1440 the groups wrap to three rows exactly like the reference; at 1920 they
-  // fit one row. All named gaps except Add data (routes to the real authoring ladder).
-  const tbtn = (icon, opts = {}) => `<${opts.href ? `a href="${opts.href}"` : "button disabled"} class="pb-ticon${opts.look ? " " + opts.look : ""}${opts.tint ? " pb-i-" + opts.tint : ""}" title="${esc(opts.title || "named gap")}">${icon === "@aip-grad" ? AIP_GRADIENT_SVG_TOOLBAR : bpIcon(icon)}${opts.href ? "</a>" : "</button>"}`;
-  const seg = (...btns) => `<span class="pb-seg">${btns.join("")}</span>`;
-  const toolcard = `<div class="pb-toolcard">
-    <div class="pb-tg">
-      <div class="pb-tgrow">${seg(tbtn("move", { look: "act" }), tbtn("select"))}${seg(tbtn("selection"))}${seg(tbtn("graph-remove", { look: "dim" }))}${seg(tbtn("layout-sorted-clusters"), tbtn("grid"))}${seg(tbtn("new-text-box"))}</div>
-      <div class="pb-tghints"><span style="left:15.5px">Tools</span><span style="left:72.3px">Select</span><span class="pb-hwrap" style="left:115px">Remove</span><span style="left:175.5px">Layout</span><span style="left:242px">Text</span></div>
-    </div>
-    <div class="pb-tg pb-tg2">
-      <a class="pb-twide" href="/__ioi/odk?ontology=${enc(oid)}" title="Add data — routes to the real ODK authoring ladder">${bpIcon("import")} Add data ${bpIcon("caret-down")}</a>
-      <button class="pb-twide" disabled title="Reusable transforms library — a named gap">${bpIcon("repeat")} Reusables ${bpIcon("caret-down")}</button>
-    </div>
-    <div class="pb-tg pb-tg3">
-      <div class="pb-tgrow">${seg(tbtn("path", { look: "dim", tint: "blue" }), tbtn("join-table", { look: "dim", tint: "cyan" }), tbtn("add-row-bottom", { look: "dim", tint: "rose" }), tbtn("split-columns", { look: "dim", tint: "green" }), tbtn("model", { look: "dim", tint: "violet" }))}${seg(tbtn("@aip-grad", { look: "dim" }), tbtn("clean", { tint: "violet" }), tbtn("lightbulb", { tint: "violet" }))}${seg(tbtn("edit", { look: "dim" }))}</div>
-      <div class="pb-tghints"><span style="left:45.9px">Transform</span><span style="left:195.3px">AIP</span><span style="left:268.7px">Edit</span></div>
-    </div>
-  </div>`;
-
-  // ---- FLOATING canvas buttons (search / fit) + ZOOM stack (bottom-left) — reference chrome, named gaps.
-  const floatbtns = `<div class="pb-floatbtns">${tbtn("search")}${tbtn("many-to-many")}</div>
-  <div class="pb-zoomstack">${tbtn("zoom-in")}${tbtn("zoom-out")}${tbtn("zoom-to-fit")}</div>`;
-
-  // ---- LEGEND card (canvas top-right, left of the outputs panel) — live category counts masked as data.
-  const legend = `<div class="pb-legend">
-    <div class="pb-legendhd">Legend <span class="pb-legcaret">${bpIcon("caret-up")}</span></div>
-    <div class="pb-leggrid">
-      ${legendGroups.map(([g, c, n]) => `<div class="pb-legrow"><span class="pb-legchip" style="background:${c}"></span><span class="pb-legname">${esc(g)}</span> <b>(${n})</b> <span class="pb-legeye">${bpIcon("eye-open", 14)}</span></div>`).join("")}
-    </div>
-    <button class="pb-addcolor" disabled title="Legend color authoring — a named gap">${bpIcon("plus")} Add color</button>
-  </div>`;
-
-  const canvasWrap = `<div class="pb-canvaszone">
-    <div class="pb-toolband" role="toolbar" aria-label="Canvas tools"></div>
-    ${toolcard}
-    ${floatbtns}
-    ${legend}
-    <div class="pb-canvas" id="pb-canvas">${selected
-      ? `<div class="pb-pickrow"><details class="pb-pick"><summary>Pipeline: ${oname} ▾</summary><div class="pb-picklist">${railPipes}</div></details></div><div class="pb-flow">${nodes.map((nd, i) => `${i ? `<div class="pb-arrow">→</div>` : ""}${nodeCard(nd)}`).join("")}</div>`
-      : `<div class="pb-empty" style="margin:120px auto;max-width:420px">Select or create a pipeline to see its datasource → transform → output graph. <a href="/__ioi/odk/ontologies/new">Create an ontology →</a></div>`}</div>
-    <div class="pb-tray" id="pb-preview">
-      <div class="pb-traytabs">
-        <span class="pb-tab on">${bpIcon("panel-table")} Selection preview</span>
-        <span class="pb-tab s2">${bpIcon("clean")} Suggestions<span class="pb-tabpill" title="suggestions count — reference-only lane"></span></span>
-        <span class="pb-tab warn">${bpIcon("warning-sign")} Pipeline warnings</span>
-        <span class="pb-traycollapse">${bpIcon("double-chevron-down")}</span>
-      </div>
-      <div class="pb-traybody">${previewTable}
-        <div class="pb-gapnote">Freeform canvas authoring — drag-connect nodes, transform code editor, scheduling, deploy — are <b>reference-only lanes disabled above</b>, not yet wired. Author stages in the <a href="/__ioi/odk?ontology=${enc(oid)}">Ontology Manager</a>; execute via a materializing run. Reference: <a href="/__apps/pipeline">Pipeline Builder capture ↗</a>.</div>
-      </div>
-    </div>
-  </div>`;
-
-  // ---- RIGHT "Pipeline outputs" PANEL (w386 = 336 content + 50 icon strip) — live projection values
-  // masked as data; Output settings block bottom-anchored like the reference.
-  const mapped = cols.length;
-  const stripIcons = ["circle-arrow-right", "search", "split-view", "build", "settings", "calendar", "folder-open", "form", "import"];
-  const rightPanel = `<aside class="pb-right">
-    <div class="pb-rmain">
-      <div class="pb-righthd"><span class="pb-righttitle">Pipeline outputs</span><span class="pb-rhdico gap">${bpIcon("cog")}</span><span class="pb-rhdico gap">${bpIcon("panel-table")}</span><button class="pb-addbtn" disabled title="Adding outputs is authored in the ODK substrate — a named gap here">${bpIcon("plus")} Add</button></div>
-      <div class="pb-rsearch">${bpIcon("search")}<input placeholder="Search outputs…" disabled aria-label="Search outputs (reference-only, not wired)"></div>
-      ${proj ? `<div class="pb-outcard"><div class="pb-outcode">${bpIcon("panel-table")} ${esc(proj.name || proj.id)}</div><div class="pb-outsub">${esc(selected ? (selected.domain || selected.id) : "")} · read projection</div><div class="pb-outmapped">✓ ${mapped}/${mapped} column${mapped === 1 ? "" : "s"} mapped</div></div>` : `<div class="pb-empty">No read projection on this pipeline yet.</div>`}
-      <div class="pb-outstat">${instances} object instance${instances === 1 ? "" : "s"} materialized · ${nodes.filter((n) => n.cls === "missing").length ? nodes.filter((n) => n.cls === "missing").map((n) => esc(n.label) + " not built").join(" · ") : "all ladder stages present"}</div>
-      <div class="pb-settings">
-        <div class="pb-outboxt">Output settings</div>
-        <div class="pb-setrow"><span class="pb-setk">Target ontology</span><span class="pb-setv">${selected ? esc(selected.domain || selected.id) : "No ontology selected"}</span></div>
-        <div class="pb-setrow"><span class="pb-setk">Output folder</span><span class="pb-setv">No location selected</span></div>
-        <div class="pb-editrow"><a class="pb-editbtn" href="/__ioi/odk?ontology=${enc(oid)}">Edit output settings</a><span class="pb-moreico gap">${bpIcon("more")}</span></div>
-      </div>
-    </div>
-    <div class="pb-rstrip">${stripIcons.map((ic, i) => `<span class="pb-stripico${i === 0 ? " on" : ""}${i && i % 3 === 0 ? " g" : ""} gap" title="Right-panel lane — named gap">${bpIcon(ic)}</span>`).join("")}</div>
-  </aside>`;
-
-  // LIGHT application surface, geometry pinned to the reference (glyph-anchored): header h51 · toolcard
-  // groups h55 wrapping at the reference's break points · Legend/right panel right-anchored · tray
-  // bottom-anchored (vh-300). The harness certifies the SHELL cards; the canvas/graph is the live body.
-  const css = `:root{color-scheme:light}*{box-sizing:border-box}
-    body{margin:0;background:#f6f7f9;color:#1c2127;font:14px/1.28581 Source-Sans-Pro,Helvetica,sans-serif}
-    a{color:#215db0;text-decoration:none}
-    .pb-shell{display:flex;height:100vh;width:100vw;overflow:hidden}
-    ${IOI_GRAIL_CSS}
-    .pb-main{flex:1;min-width:0;display:flex;flex-direction:column;height:100vh}
-    .pb-header{flex:0 0 51px;position:relative;height:51px;display:flex;align-items:stretch;background:#fff;box-shadow:0 1px 0 0 #dce0e5;z-index:6}
-    .pb-hchip{width:50px;height:51px;flex:0 0 50px;background:rgba(90,217,207,.1) url('${PIPELINE_APP_ICON_URI}') center no-repeat}
-    .pb-htitles{display:flex;flex-direction:column;padding:4px 0 0 15px;min-width:0}
-    .pb-crumbrow{display:flex;align-items:center;gap:8px;height:20px}
-    .pb-crumb{font-size:14px;color:#1c2127;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:350px;line-height:16px}
-    .pb-cx{color:#8b9099}.pb-cxt{color:#5f6b7c;font-size:12px}
-    .pb-star{position:absolute;left:431.4px;top:6.5px;display:inline-flex;color:#5f6b7c;width:16px}
-    .pb-menurow{display:flex;align-items:center;height:26px;gap:0;margin:-1px 0 0 -7px}
-    .pb-menu{display:inline-flex;align-items:center;gap:8px;font-size:14px;line-height:16.1px;color:#1c2127;padding:0 5px 0 7px;cursor:default}
-    .pb-menu svg{color:#5f6b7c}
-    .pb-menudiv{width:1px;height:16px;background:#d3d8de;margin-left:5px}
-    .pb-menudiv.d2{margin-left:8px}
-    .pb-batch{display:inline-flex;align-items:center;gap:3px;margin-left:11px;color:#5f6b7c;font-size:12px}
-    .pb-batch svg{color:#404854}
-    .pb-batchn{font-size:12px;color:#1c2127}
-    .pb-batchtag{margin-left:5.6px;background:#5f6b7c;color:#fff;font-size:12px;line-height:16px;border-radius:3px;padding:2px 4px}
-    .pb-hmid{position:absolute;left:468px;top:0;width:494px;height:51px;display:flex;align-items:center;gap:7px;overflow:hidden}
-    .pb-btn{display:inline-flex;align-items:center;height:28px;padding:0 10px;border-radius:4px;border:1px solid #d3d8de;background:#fff;color:#1c2127;font:inherit;font-size:13px;line-height:16px;font-weight:400;cursor:pointer}
-    .pb-btn.primary{background:#0e9f6e;color:#fff;border-color:#0e9f6e}
-    .pb-btn.link{border-color:transparent;background:transparent;color:#215db0;padding:0 5px}
-    .pb-btn[disabled]{opacity:.5;cursor:not-allowed}
-    .pb-hright{margin-left:auto;display:flex;align-items:flex-start;gap:0;padding-right:20px}
-    .pb-hbtn{display:inline-flex;align-items:center;gap:8px;height:30px;margin-top:10px;padding:0 12px;border-radius:4px;font-size:14px;line-height:16px;color:#1c2127;cursor:default}
-    .pb-hdrdiv{width:1px;height:30px;background:#d3d8de;margin:10px 0 0 6.6px}
-    .pb-hdrdiv+.pb-hbtn{margin-left:5.4px}
-    .pb-hbtn svg{color:#5f6b7c}
-    .pb-hico{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;margin:10px 0 0 2px;color:#5f6b7c;cursor:default}
-    .pb-work{flex:1 1 auto;display:flex;min-height:0}
-    .pb-canvaszone{flex:1 1 auto;min-width:0;position:relative;background:#edeff2;overflow:hidden}
-    .pb-toolband{position:absolute;left:10px;top:10px;width:414px;height:165px;pointer-events:none}
-    @media(min-width:1600px){.pb-toolband{width:872px;height:56px}.pb-tg2{margin-left:30px}.pb-tg3{margin-left:15px}.pb-tghints span.pb-hwrap{width:auto;white-space:nowrap}}
-    .pb-toolcard{position:absolute;left:10px;top:10px;display:flex;flex-wrap:wrap;width:fit-content;max-width:calc(100% - 424px);background:#fff;border-radius:3px;box-shadow:0 1px 3px rgba(20,24,30,.12);z-index:4}
-    .pb-tg{position:relative;height:55px;padding:0}
-    .pb-tgrow{display:flex;align-items:center;height:30px;margin-top:0;gap:15px}
-    .pb-seg{display:inline-flex}
-    .pb-seg .pb-ticon+.pb-ticon{margin-left:-1px}
-    .pb-seg .pb-ticon{border-radius:0}.pb-seg .pb-ticon:first-child{border-radius:4px 0 0 4px}.pb-seg .pb-ticon:last-child{border-radius:0 4px 4px 0}.pb-seg .pb-ticon:only-child{border-radius:4px}
-    .pb-ticon{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border:0;background:#f7f8f8;color:#5f6b7c;border-radius:4px;padding:0;cursor:default;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
-    .pb-ticon.act{background:#dfe0e2;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.2)}
-    .pb-ticon.dim{background:rgba(143,153,168,.2);box-shadow:none;color:#8f99a8}
-    a.pb-ticon{cursor:pointer}
-    .pb-ticon[disabled]{opacity:1}
-    .pb-tghints{position:relative;height:19px;font-size:12px;line-height:15px;color:#5f6b7c}
-    .pb-tghints span{position:absolute;top:4px;white-space:nowrap}
-    .pb-tghints span.pb-hwrap{white-space:normal;width:46px;text-align:center;line-height:15.4297px}
-    .pb-tg2{display:flex;align-items:flex-start;gap:15px;padding:0}
-    .pb-twide{display:inline-flex;align-items:center;gap:8px;height:30px;padding:0 8px;border:0;border-radius:4px;background:#f7f8f8;color:#1c2127;font:inherit;font-size:14px;line-height:16px;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
-    .pb-twide svg{color:#5f6b7c}
-    .pb-twide[disabled]{cursor:not-allowed}
-    .pb-i-blue svg{color:#4c90f0}.pb-i-cyan svg{color:#3fa6da}.pb-i-rose svg{color:#db2c6f}.pb-i-green svg{color:#32a467}.pb-i-violet svg{color:#7961db}
-    .pb-floatbtns{position:absolute;right:330px;top:10px;display:flex;gap:10px;z-index:4}
-    .pb-zoomstack .pb-ticon+.pb-ticon{margin-top:-1px}
-    .pb-zoomstack .pb-ticon:first-child{border-radius:4px 4px 0 0}.pb-zoomstack .pb-ticon:nth-child(2){border-radius:0}.pb-zoomstack .pb-ticon:last-child{border-radius:0 0 4px 4px}
-    .pb-zoomstack{position:absolute;left:10px;bottom:310px;display:flex;flex-direction:column;z-index:4}
-    .pb-legend{position:absolute;right:7px;top:9px;width:314px;background:#f6f7f9;border:1px solid #cbccd0;border-radius:3px;padding:0 10px 8px;z-index:4}
-    .pb-legendhd{display:flex;align-items:center;justify-content:space-between;height:30px;font-size:14px;line-height:16px;color:#1c2127;padding:0;margin:0 0 0 -2px}
-    .pb-legcaret{display:inline-flex;color:#5f6b7c}
-    .pb-leggrid{display:grid;grid-template-columns:1fr 1fr;gap:0 8px;margin-top:2px}
-    .pb-legrow{display:flex;align-items:center;gap:5px;height:29px;font-size:12px;line-height:15.4297px;color:#1c2127}
-    .pb-legchip{width:14px;height:14px;border-radius:3px;flex:0 0 14px}
-    .pb-legname{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:70px}
-    .pb-legeye{display:inline-flex;color:#5f6b7c;margin:0 7px 0 auto}
-    .pb-addcolor{display:flex;align-items:center;justify-content:center;gap:7.5px;width:140px;height:24px;margin:4.5px 2px 0 auto;padding:0;border:1px solid rgba(33,93,176,.6);border-radius:4px;background:transparent;color:#215db0;font:inherit;font-size:12px;line-height:13.8px;cursor:not-allowed}
-    .pb-canvas{position:absolute;inset:51px 0 300px 0;overflow:auto;padding:60px 20px 20px}
-    .pb-pickrow{margin:110px 0 14px}
-    .pb-pick{position:relative;display:inline-block}
-    .pb-pick>summary{list-style:none;cursor:pointer;font-size:13px;color:#5f6b7c;background:#fff;border:1px solid #d3d8de;border-radius:4px;padding:4px 10px}
-    .pb-pick>summary::-webkit-details-marker{display:none}
-    .pb-picklist{position:absolute;top:32px;left:0;min-width:240px;background:#fff;border:1px solid #e0e3e8;border-radius:8px;box-shadow:0 8px 28px rgba(20,24,31,.14);padding:6px;z-index:20}
-    .pb-pipe{display:flex;align-items:center;justify-content:space-between;padding:6px 9px;border-radius:6px;color:#3a3f46}
-    .pb-pipe:hover{background:#f1f3f6}.pb-pipe.on{background:#eef2fb;color:#1a1d21;font-weight:600}
-    .pb-tag{font-size:10px;padding:1px 6px;border-radius:999px;background:#eafaf1;color:#0e8a53;border:1px solid #8fdcb6}
-    .pb-flow{display:flex;align-items:stretch;gap:0}
-    .pb-arrow{flex:0 0 auto;color:#a9b0bb;padding:0 8px;font-size:17px;align-self:center}
-    .pb-node{flex:0 0 auto;width:156px;border:1px solid #dfe2e7;border-radius:6px;padding:11px 12px;background:#fff;cursor:pointer;box-shadow:0 1px 3px rgba(20,24,30,.05)}
-    .pb-node:hover{border-color:#0e9f6e}
-    .pb-node.pb-live{border-top:3px solid #2f9e6b}.pb-node.pb-declared{border-top:3px solid #d68a2a}.pb-node.pb-missing{border-top:3px solid #c2c6cd}
-    .pb-nhead{display:flex;align-items:center;justify-content:space-between}.pb-nicon{font-size:18px}
-    .pb-nlabel{font-weight:600;font-size:13px;margin:5px 0 6px;color:#15181d}
-    .pb-dot{width:8px;height:8px;border-radius:50%;background:#b8bdc6}.pb-dot.pb-live{background:#2f9e6b}.pb-dot.pb-declared{background:#d68a2a}
-    .pb-ncount{font-size:12px;color:#3a3f49}.pb-ndetail{font-size:10.5px;color:#8a909c;margin:3px 0 0;min-height:14px}
-    .pb-tray{position:absolute;left:0;right:0;bottom:0;height:300px;background:#fff;display:flex;flex-direction:column;z-index:5}
-    .pb-traytabs{flex:0 0 35px;display:flex;align-items:stretch}
-    .pb-tab{display:inline-flex;align-items:center;gap:5px;padding:0 8px;font-size:14px;line-height:16px;font-weight:600;color:#1c2127;border-right:1px solid #dce0e5}
-    .pb-tab.s2 svg{color:#7961db}
-    .pb-tabpill{width:20px;height:20px;border-radius:4px;background:rgba(143,153,168,.15)}
-    .pb-tab svg{color:#5f6b7c}
-    .pb-tab.on{background:rgba(138,187,255,.4);color:#215db0}.pb-tab.on svg{color:#215db0}
-    .pb-tab.warn{color:#935610}.pb-tab.warn svg{color:#c87619}
-    .pb-traycollapse{margin-left:auto;display:inline-flex;align-items:center;padding:0 14px;color:#5f6b7c}
-    .pb-traybody{flex:1;overflow:auto;padding:12px 16px}
-    .pb-table{border-collapse:collapse;width:100%;font-size:12px}.pb-table th{text-align:left;color:#7b8494;font-weight:600;padding:4px 12px 4px 0;border-bottom:1px solid #e2e4e8}
-    .pb-table td{padding:4px 12px 4px 0;border-bottom:1px solid #f0f1f4;color:#2a2f38}
-    .pb-empty-cell{text-align:center;color:#8a909c;padding:16px 8px}
-    .pb-empty{color:#7b8494;padding:14px;border:1px dashed #d8dbe1;border-radius:10px;background:#fbfbfc}
-    .pb-gapnote{margin:12px 0 0;padding:10px 12px;border:1px solid #e5e7eb;border-radius:9px;background:#f7f8fa;color:#5b6270;font-size:11.5px;line-height:1.6}
-    .pb-right{flex:0 0 386px;width:386px;display:flex;background:#fff;border-left:1px solid #dce0e5}
-    .pb-rmain{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;padding:0 0 9px}
-    .pb-righthd{display:flex;align-items:center;height:auto;padding:6.5px 9px 0 7px}
-    .pb-righttitle{font-size:14px;line-height:18.0013px;font-weight:600;color:#1c2127;flex:1}
-    .pb-rhdico{display:inline-flex;color:#5f6b7c;padding:0 7px;cursor:default}
-    .pb-addbtn{display:inline-flex;align-items:center;gap:8px;height:30px;margin-left:11px;padding:0 8px;border:0;border-radius:4px;background:#f7f8f8;color:#1c2127;font:inherit;font-size:14px;line-height:16px;cursor:not-allowed;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
-    .pb-rsearch{display:flex;align-items:center;gap:7px;height:30px;margin:15.5px 10px 0 7px;border:0;border-radius:4px;background:#fff;padding:0 8px;color:#5f6b7c;box-shadow:inset 0 0 0 1px rgba(17,20,24,.2),inset 0 1px 1px rgba(17,20,24,.3)}
-    .pb-rsearch input{flex:1;border:0;background:transparent;font:inherit;font-size:14px;line-height:16px;color:#1c2127;outline:none;padding:0}
-    .pb-rsearch input::placeholder{color:#5f6b7c}
-    .pb-outcard{margin:12px 8px 0;border:1px solid #e5e7eb;border-radius:3px;padding:9px 10px;background:#fff}
-    .pb-outcode{display:flex;align-items:center;gap:7px;font-size:14px;line-height:16px;color:#215db0;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    .pb-outcode svg{color:#2d72d2;flex:0 0 16px}
-    .pb-outsub{font-size:12px;color:#5f6b7c;margin:3px 0 0 23px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    .pb-outmapped{font-size:12px;color:#0e8a53;margin:6px 0 0 23px}
-    .pb-outstat{margin:10px 8px 0;font-size:12px;color:#5f6b7c}
-    .pb-settings{margin-top:auto;padding:12px 10px 0 8px;border-top:1px solid #eef0f2}
-    .pb-outboxt{font-size:14px;line-height:18.0013px;font-weight:600;color:#1c2127;margin:0 0 10px}
-    .pb-setrow{display:flex;gap:10px;font-size:12px;line-height:15.4297px;color:#1c2127;padding:0 0 8px}
-    .pb-setk{color:#5f6b7c;width:96px;flex:0 0 96px}
-    .pb-setv{font-style:italic;color:#5f6b7c;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-    .pb-editrow{display:flex;align-items:center;gap:0;margin-top:2px}
-    .pb-editbtn{flex:1;display:inline-flex;align-items:center;justify-content:center;height:30px;border:0;border-radius:4px 0 0 4px;background:#f7f8f8;color:#1c2127;font-size:14px;line-height:16px;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
-    .pb-moreico{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border:0;border-radius:0 4px 4px 0;color:#5f6b7c;background:#f7f8f8;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
-    .pb-rstrip{flex:0 0 50px;width:50px;background:#fff;border-left:1px solid #e2e4e8;display:flex;flex-direction:column;align-items:center;padding:5px 0;gap:5px}
-    .pb-stripico{display:inline-flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:4px;color:#5f6b7c}
-    .pb-stripico.g{margin-top:14px;position:relative}
-    .pb-stripico.g::before{content:"";position:absolute;top:-7.5px;left:0;width:40px;height:1px;background:#d8dbde}
-    .pb-stripico.on{background:#dfe0e1}`;
-
-  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Pipeline Builder</title><style>${css}</style></head>
-    <body><div class="pb-shell">${globalRail}<div class="pb-main">${header}<div class="pb-work">${canvasWrap}${rightPanel}</div></div></div></body></html>`;
-}
-
+// ============================ PIPELINE BUILDER: EXTRACTED to surfaces/pipeline/index.mjs =========
+// (functional-runtime wave) — the first app module; the surface registry mounts it. The INCIDENTS
+// banner below is the next inline surface awaiting extraction.
 // ============================ INCIDENTS (#45 — the Missions incident inbox as a faithful
 // reference port of the issues-app capture, over REAL daemon truth: run failures + GoalRun
 // blockers). Status-lane grammar: open = blockers on non-terminal mission runs + failed runs
@@ -5662,68 +5336,8 @@ function renderOntologyManager(ov, lists, selectedId) {
 // (theme + IA landmarks + region geometry, #34 review) can certify visual parity. Wired to the REAL
 // ODK CanonicalObjectModel; READ-ONLY (authoring + object materialization stay in /__ioi/odk).
 
-// ---- SHARED pixel-aligned GLOBAL RAIL (the reference Foundry-shell left chrome, reproduced to the
-// measured spec: 230px · rgb(37,42,49) · items y61 @32px pitch · APPLICATIONS section y369 · active app
-// row h36 with the extracted app-icon chip · bottom cluster AIP/Support/Account y794/826/858). Used by
-// every shell-pixel-certified port (schema #41, approvals #42, …) so the rail is aligned ONCE.
-function ioiGlobalRailHtml(active) {
-  // Per-reference rail variant: each certified surface reproduces ITS reference capture's rail state
-  // (badges / View-all / star / gradient AIP / account-chip style differ across captures). Defaults
-  // keep the schema/approvals-certified rail untouched.
-  const gi = (icon, label, opts = {}) => {
-    const kbd = opts.kbd ? `<kbd class="og-gkbd">${opts.kbd.split("+").map((k) => `<span>${k.trim()}</span>`).join("<span>+</span>")}</kbd>` : "";
-    const ico = icon === "@aip-grad" ? AIP_GRADIENT_SVG_RAIL : bpIcon(icon);
-    const inner = `<span class="og-gico">${ico}${opts.badge ? '<span class="og-gbadge"></span>' : ""}</span><span class="og-glabel">${CX_ESC(label)}</span>${kbd}`;
-    return opts.href ? `<a class="og-gitem${opts.ctx ? " ctx" : ""}" href="${opts.href}">${inner}</a>` : `<span class="og-gitem muted">${inner}</span>`;
-  };
-  return `<aside class="og-grail${active.railVariant ? " " + active.railVariant : ""}">
-    <div class="og-gtop"><span class="og-gmark">◗</span><span class="og-gmenu">${bpIcon("menu-closed")}</span></div>
-    ${gi("home", "Home", { href: "/ai" })}
-    ${gi("search", "Search…", { kbd: "ctrl + J" })}
-    ${gi("notifications", "Notifications", { badge: active.badges })}
-    ${gi("whatsnew-gift", "What's New", { badge: active.badges })}
-    <div class="og-gdiv"></div>
-    ${gi("history", "Recent", {})}
-    ${gi("folder-open", "Files", {})}
-    ${gi("cubes", "Ontology", { href: "/__ioi/odk", ctx: active.hiliteNav === "Ontology" })}
-    ${gi("layout-grid", "Applications", { href: "/__ioi/home" })}
-    <div class="og-gsecrow"><span class="og-gsec">APPLICATIONS</span>${active.viewAll === false ? "" : `<a class="og-gviewall" href="/__ioi/home">View all</a>`}</div>
-    <a class="og-gitem on" href="${active.href}"><span class="og-gappico" style="background-image:url('${active.iconUri}')"></span><span class="og-glabel og-strong">${CX_ESC(active.label)}</span>${active.star === false ? "" : `<span class="og-gstar">${bpIcon("star-empty")}</span>`}</a>
-    <div class="og-gspacer"></div>
-    ${gi(active.aipGradient ? "@aip-grad" : "aip-logo", "AIP Assist", { kbd: "ctrl + shift + U" })}
-    ${gi("help", "Support", {})}
-    <span class="og-gitem muted og-gaccount"><span class="og-gavatar${active.acctMuted ? " alt" : ""}">LJ</span><span class="og-glabel">Account</span></span>
-  </aside>`;
-}
-const IOI_GRAIL_CSS = `
-    .og-grail{flex:0 0 230px;width:230px;height:100vh;background:#252a31;color:#f6f7f9;display:flex;flex-direction:column;padding:0 12px 10px;overflow:hidden;font:14px/1.28581 Source-Sans-Pro,Helvetica,sans-serif}
-    .og-gtop{height:61px;display:flex;align-items:center;justify-content:space-between;padding:0 19px 0 6px;flex:0 0 61px}
-    .og-gmark{font-size:20px;color:#f6f7f9}
-    .og-gmenu{display:inline-flex;color:#abb3bf}
-    .og-gappico{width:24px;height:24px;flex:0 0 24px;margin:-4px -4px -4px -4px;border-radius:3px;background-color:rgba(102,158,255,.1);background-position:center;background-size:16px;background-repeat:no-repeat}
-    .og-strong{font-weight:600}
-    .og-gstar{display:inline-flex;color:#abb3bf;width:16px;flex:0 0 16px}
-    .og-gitem{display:flex;align-items:center;gap:12px;height:32px;padding:0 8px 0 5px;border-radius:6px;color:#f6f7f9;font-size:14px;font-weight:400}
-    .og-gitem:hover{background:#2f353d;color:#fff}.og-gitem.on{background:#2f353d;color:#fff;font-weight:600;height:36px}
-    .og-gitem.muted{color:#f6f7f9;cursor:default}.og-gitem.muted:hover{background:transparent}
-    .og-gico{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;color:#abb3bf;flex:0 0 16px;position:relative}
-    .og-gbadge{position:absolute;left:9px;top:-3px;width:8px;height:8px;background:#fbb360;border:1px solid #2f343c;border-radius:50%}
-    .og-gavatar.alt{background:rgba(45,114,210,.2);color:#8abbff;border-radius:50%;margin-left:-2px;margin-right:-2px}
-    .og-gitem.ctx{background:#2f353d;color:#fff;font-weight:600}.og-gitem.ctx .og-gico{color:#f6f7f9}
-    .rv-pipe .og-gitem.on{background:#1c2127;margin:0 -12px;padding:0 20px 0 17px;border-radius:0}
-    .rv-pipe .og-gkbd{gap:0;margin-right:-2px}
-    .rv-pipe .og-gkbd span:nth-child(even){display:inline-flex;justify-content:center;width:16px;margin:0}
-    .rv-pipe .og-gsecrow{padding-top:31.3px;padding-bottom:6.3px}
-    .rv-pipe .og-gsec{letter-spacing:0}
-    .og-gitem.on .og-gico{color:#f6f7f9}
-    .og-glabel{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1 1 auto}
-    .og-gkbd{display:inline-flex;align-items:center;gap:3px;font-size:14px;color:#abb3bf;font-family:inherit;margin-right:4px}
-    .og-gdiv{height:21px}
-    .og-gsecrow{display:flex;align-items:center;justify-content:space-between;padding:30px 8px 5px 5px}
-    .og-gsec{font-size:12px;letter-spacing:.02em;color:#abb3bf;font-weight:600}
-    .og-gviewall{font-size:14px;color:#abb3bf;font-weight:400}
-    .og-gavatar{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;margin-left:0;margin-right:-4px;border-radius:3px;background:#1e6ba1;color:#8abbff;font-size:12px;font-weight:600;flex:0 0 20px}
-    .og-gspacer{flex:1 1 auto;min-height:14px}`;
+// ---- SHARED GLOBAL RAIL: MOVED VERBATIM to surfaces/chrome.mjs (imported above) — the rail is
+// aligned once and certified in every port shell; it now lives with the surface modules.
 
 function renderOntologyManagerPort(ov, lists, selectedId) {
   const enc = encodeURIComponent, esc = CX_ESC;
@@ -7763,41 +7377,6 @@ ${error ? `<div class="err">${error}</div>` : ""}
 }
 
 // 2) Front server: IOI /api adapter first, proxy everything else to the productUi.
-// ---- Surface bindings — registry-mounted implementations whose code still lives in this file
-// (each moves into its own module as the wave extracts it; the registry stays the mount point).
-// Pipeline is the pilot: loaders/render identical to the flat branch it replaces.
-bindSurface("pipeline", {
-  loaders: async () => {
-    const J = (p) => fetch(`${DAEMON}${p}`).then((r) => r.json()).catch(() => ({}));
-    const [o, ds, cm, pv, tr, op, lp, mr, cs, ms] = await Promise.all([
-      J("/v1/hypervisor/odk/domain-ontologies"),
-      J("/v1/hypervisor/data-sources"),
-      J("/v1/hypervisor/odk/connector-mappings"),
-      J("/v1/hypervisor/odk/policy-bound-data-views"),
-      J("/v1/hypervisor/odk/transformation-runs"),
-      J("/v1/hypervisor/odk/ontology-projections"),
-      J("/v1/hypervisor/odk/capability-lease-plans"),
-      J("/v1/hypervisor/odk/materializing-runs"),
-      J("/v1/hypervisor/odk/connector-sessions"),
-      J("/v1/hypervisor/odk/materialized-object-sets"),
-    ]);
-    return {
-      ontologies: o.ontologies || [],
-      data_sources: ds.data_sources || [],
-      connector_mappings: cm.connector_mappings || [],
-      policy_views: pv.policy_bound_data_views || [],
-      transformation_runs: tr.transformation_runs || [],
-      ontology_projections: op.ontology_projections || [],
-      capability_lease_plans: lp.capability_lease_plans || [],
-      materializing_runs: mr.materializing_runs || [],
-      connector_sessions: cs.connector_sessions || [],
-      materialized_sets: ms.materialized_object_sets || [],
-    };
-  },
-  render: (data, url) => renderPipelineBuilder(data, url.searchParams.get("ontology") || ""),
-  actions: [], // Build/Preview command discipline arrives later in the wave
-});
-
 const server = http.createServer((req, res) => {
   const chunks = [];
   req.on("data", (c) => chunks.push(c));
@@ -8703,7 +8282,7 @@ async function handleEstateRequest(req, res, body) {
       try {
         const r = await fetch(`${DAEMON}/v1/hypervisor/scm-connect/github-app/manifest`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ owner, callback_base: `http://${req.headers.host || "127.0.0.1:4173"}` }) });
         const d = await r.json();
-        const esc = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+        const esc = CX_ESC; // the kit escaper (surfaces/kit.mjs) — no local duplicates
         page = githubAppShell("Create your GitHub App", `
           <p>Hypervisor doesn't own a GitHub App — you'll create one in <b>your own</b> account. GitHub will show you exactly what it can access (Contents + Pull requests), then hand the key straight to your daemon. Nothing is shared with us.</p>
           <form id="gh" action="${esc(d.create_url)}" method="post">
@@ -8804,7 +8383,7 @@ async function handleEstateRequest(req, res, body) {
     // hand off to the standard OAuth-native Connect launcher.
     if (pathname === "/__ioi/slack/setup" && req.method !== "POST") {
       const redirect = `${publicBase(req)}/__ioi/integrations/oauth/callback`;
-      const esc = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+      const esc = CX_ESC; // the kit escaper (surfaces/kit.mjs) — no local duplicates
       const inp = 'style="width:100%;box-sizing:border-box;margin:4px 0 12px;padding:10px;border-radius:9px;border:1px solid #2a2c33;background:#0e0f13;color:#e6e7ea;font:inherit"';
       const page = githubAppShell("Connect Slack (BYOA OAuth)", `
         <p>Create a Slack app, then paste its <b>Client ID</b> + <b>Client Secret</b>. The secret is sealed in your daemon — it never touches the agent or this chat.</p>
@@ -10112,16 +9691,16 @@ async function handleEstateRequest(req, res, body) {
     // ---- Surface registry dispatch — ported application surfaces mount through the explicit
     // table (surface-registry.mjs), not the flat branch chain. This sits exactly where the
     // pipeline branch lived so registry surfaces keep the chain position (after auth/posture
-    // gates) the flat branches had. Renderers are BOUND at startup (bindSurface below) until
-    // each app's code is extracted into its own module; an unbound surface isn't matched here,
-    // so registration is additive and behavior-preserving.
+    // gates) the flat branches had. Surface MODULES (surfaces/<slug>/index.mjs) bind in the
+    // registry itself under the load(ctx)/render(model, ctx) contract; an unbound surface isn't
+    // matched here, so registration is additive and behavior-preserving.
     {
       const hit = boundSurface(pathname, req.method);
       if (hit) {
-        const url = new URL(req.url, "http://x");
-        const data = hit.impl.loaders ? await hit.impl.loaders(url) : null;
+        const ctx = { url: new URL(req.url, "http://x"), daemon: DAEMON };
+        const model = hit.impl.load ? await hit.impl.load(ctx) : null;
         res.writeHead(200, HTMLH);
-        res.end(hit.impl.render(data, url));
+        res.end(hit.impl.render(model, ctx));
         return;
       }
     }

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -4,12 +4,12 @@
 // (presentation truth — app-catalog.mjs reads it from here), canonical route, and the paths of
 // its verifier + certification artifact.
 //
-// Implementations bind at runtime: serve-product-ui.mjs calls bindSurface(slug, { loaders,
-// render, actions }) for surfaces whose code still lives in the serve file, and the serve's
-// registry dispatch mounts whatever is bound. As apps extract into their own modules (next PRs),
-// the module itself becomes the binding — the table stays the single mount point either way.
-// An entry with no binding is metadata-only: it lists in the catalog but keeps its flat-branch
-// handler until it is deliberately migrated. Registration is additive and behavior-preserving.
+// Implementations bind under the surface-module contract { meta, load(ctx), render(model, ctx),
+// actions } — extracted modules (surfaces/<slug>/index.mjs) are imported and bound HERE, so the
+// registry is the single mount point; a surface whose code still lives in the serve file may
+// bind at serve startup the same way. An entry with no binding is metadata-only: it lists in
+// the catalog but keeps its flat-branch handler until it is deliberately migrated. Registration
+// is additive and behavior-preserving.
 import { ONTOLOGY_APP_ICON_URI, APPROVALS_APP_ICON_URI, PIPELINE_APP_ICON_URI, ISSUES_APP_ICON_URI, EXPLORER_APP_ICON_URI, MODELS_APP_ICON_URI } from "./bp-icons.mjs";
 import { MARKETPLACE_APP_ICON_URI } from "./marketplace-assets.mjs";
 import { DSG_APP_TILE_URI } from "./designer-assets.mjs";
@@ -18,6 +18,7 @@ import { MON_APP_TILE_URI } from "./monitors-assets.mjs";
 import { SRC_APP_TILE_URI } from "./sources-assets.mjs";
 import { CHG_APP_TILE_URI } from "./changes-assets.mjs";
 import { EVL_APP_TILE_URI } from "./evalsuites-assets.mjs";
+import * as pipelineModule from "../surfaces/pipeline/index.mjs";
 
 export const SURFACES = [
   { slug: "pipeline", owner: "Data", title: "Pipeline Builder", icon: PIPELINE_APP_ICON_URI, route: "/__ioi/pipeline", verifier: "scripts/verify-hypervisor-app-parity-pipeline.mjs", certification: "pixel-certifications/pipeline.json" },
@@ -57,3 +58,6 @@ export function boundSurface(pathname, method) {
   }
   return null;
 }
+
+// ---- Extracted surface modules — imported and bound here (the registry IS the mount point).
+bindSurface("pipeline", pipelineModule);

--- a/apps/hypervisor/scripts/verify-hypervisor-surface-modules.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-surface-modules.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Surface-module verifier (functional-runtime wave — the Pipeline extraction + interaction kit).
+//
+// Proves the module shape PR #57 builds on:
+//   1. CONTRACT — surfaces/pipeline/index.mjs exports { meta, load, render, actions }; meta agrees
+//      with its surface-registry entry AND its parity-matrix seed (one identity, three records).
+//   2. MOUNT — the registry binds the module itself (identity, not a copy), and the module renders
+//      OFFLINE against a dead daemon: honest empty lists, the certified shell landmarks intact.
+//   3. EXTRACTION HYGIENE — the serve monolith no longer carries the moved code (renderer, global
+//      rail, escaper definition); the kit's escHtml is the single escaper definition.
+//   4. KIT UNITS — the interaction helpers behave (escaping, stable selection URLs, shells carrying
+//      the ids/testids the interaction verifiers will drive, disabled commands naming reasons).
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-surface-modules.mjs
+// Exit 0 = all assertions pass; exit 1 = one or more failed.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { SURFACES, boundSurface, surfaceBySlug } from "./surface-registry.mjs";
+import * as pipeline from "../surfaces/pipeline/index.mjs";
+import { escHtml, parseSelection, selectionQuery, inspectorShell, trayShell, disabledCommand, proofLink, semanticMask } from "../surfaces/kit.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP = join(HERE, "..");
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+
+async function run() {
+  // 1. Contract + identity agreement.
+  ok("pipeline module exports the surface contract", typeof pipeline.load === "function" && typeof pipeline.render === "function" && Array.isArray(pipeline.actions) && pipeline.meta && typeof pipeline.meta === "object");
+  const reg = surfaceBySlug("pipeline");
+  ok("module meta agrees with the registry entry", !!reg && pipeline.meta.slug === reg.slug && pipeline.meta.route === reg.route && pipeline.meta.verifier === reg.verifier && pipeline.meta.certification === reg.certification);
+  const matrix = JSON.parse(readFileSync(join(APP, "harvest-app-parity-matrix.json"), "utf8"));
+  const seed = (matrix.seeds || []).find((s) => s.slug === "pipeline");
+  ok("module meta agrees with the parity-matrix seed", !!seed && seed.candidate_surface.split("?")[0] === pipeline.meta.route && seed.shell_pixel_certification_artifact === pipeline.meta.certification && seed.shell_pixel_certified === true);
+  ok("no wired actions yet (command discipline is a later PR)", pipeline.actions.length === 0);
+
+  // 2. Registry mounts the module itself; offline render keeps the certified shell landmarks.
+  const hit = boundSurface("/__ioi/pipeline", "GET");
+  ok("registry binds the module (identity, not a copy)", !!hit && hit.impl.render === pipeline.render && hit.impl.load === pipeline.load, hit ? "bound" : "no binding for /__ioi/pipeline");
+  const ctx = { url: new URL("http://x/__ioi/pipeline"), daemon: "http://127.0.0.1:1" };
+  const model = await pipeline.load(ctx);
+  ok("dead daemon loads to honest empty lists", Object.values(model).every((v) => Array.isArray(v) && v.length === 0), `${Object.keys(model).length} list keys`);
+  const html = pipeline.render(model, ctx);
+  ok("offline render keeps the certified shell landmarks", ["<title>Pipeline Builder</title>", "Pipeline outputs", "pb-shell", "APPLICATIONS"].every((m) => html.includes(m)));
+  const selCtx = { url: new URL("http://x/__ioi/pipeline?ontology=does-not-exist"), daemon: "http://127.0.0.1:1" };
+  ok("selection param accepted without drift on empty truth", pipeline.render(model, selCtx) === html, "unknown ontology falls back identically");
+
+  // 3. Extraction hygiene — the monolith no longer carries the moved code.
+  const serveSrc = readFileSync(join(HERE, "serve-product-ui.mjs"), "utf8");
+  ok("serve no longer defines renderPipelineBuilder", !serveSrc.includes("function renderPipelineBuilder"));
+  ok("serve no longer defines the global rail", !serveSrc.includes("function ioiGlobalRailHtml") && !serveSrc.includes("const IOI_GRAIL_CSS"));
+  ok("serve aliases the kit escaper (no duplicate definition)", serveSrc.includes("const CX_ESC = escHtml") && !serveSrc.includes('replace(/&/g, "&amp;").replace(/</g'));
+  ok("registry lists pipeline exactly once", SURFACES.filter((s) => s.slug === "pipeline").length === 1);
+
+  // 4. Interaction kit units.
+  ok("escHtml escapes the four metacharacters", escHtml('&<>"') === "&amp;&lt;&gt;&quot;" && escHtml(null) === "" && escHtml(0) === "0");
+  const u = new URL("http://x/r?node=mapping&ontology=ont-1&empty=&noise=z");
+  const sel = parseSelection(u, ["node", "ontology", "empty", "absent"]);
+  ok("parseSelection reads only present, non-empty keys", sel.node === "mapping" && sel.ontology === "ont-1" && !("empty" in sel) && !("absent" in sel) && !("noise" in sel));
+  ok("selectionQuery is stable (sorted keys, empties dropped)", selectionQuery("/r", { ontology: "ont-1", node: "mapping", gone: "" }) === "/r?node=mapping&ontology=ont-1" && selectionQuery("/r", {}) === "/r");
+  ok("selection roundtrip preserves state", JSON.stringify(parseSelection(new URL("http://x" + selectionQuery("/r", sel)), ["node", "ontology"])) === JSON.stringify(sel));
+  ok("selectionQuery encodes values", selectionQuery("/r", { q: "a b&c" }) === "/r?q=a%20b%26c");
+  const insp = inspectorShell({ id: "pb-insp", title: 'T<"', subtitle: "s", body: "<b>body</b>", cls: "x" });
+  ok("inspectorShell carries id/testid and escapes chrome, not body", insp.includes('id="pb-insp"') && insp.includes('data-testid="ioi-inspector"') && insp.includes("T&lt;&quot;") && insp.includes("<b>body</b>"));
+  const tray = trayShell({ id: "pb-tray", title: "Preview", body: "rows" });
+  ok("trayShell carries id/testid", tray.includes('id="pb-tray"') && tray.includes('data-testid="ioi-tray"') && tray.includes("Preview"));
+  const cmd = disabledCommand({ label: "Deploy", reason: 'needs release gate & lease "x"' });
+  ok("disabledCommand is visibly disabled and names its reason", cmd.includes("disabled") && cmd.includes('aria-disabled="true"') && cmd.includes("data-ioi-disabled-reason=") && cmd.includes("&amp;") && cmd.includes("Deploy"));
+  const pl = proofLink({ href: '/__ioi/run-timeline/r?a=1&b=2', label: "timeline", external: true });
+  ok("proofLink escapes href and marks external", pl.includes('href="/__ioi/run-timeline/r?a=1&amp;b=2"') && pl.includes('rel="noopener"') && pl.includes('data-testid="ioi-proof-link"'));
+  ok("semanticMask tags the region by id", semanticMask("rows", "<tr></tr>") === '<span data-ioi-sem-mask="rows"><tr></tr></span>');
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  if (fails.length) process.exit(1);
+  console.log("surface-modules: OK");
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  process.exit(1);
+});

--- a/apps/hypervisor/surfaces/chrome.mjs
+++ b/apps/hypervisor/surfaces/chrome.mjs
@@ -1,0 +1,73 @@
+// Shared surface chrome (functional-runtime wave) — the pixel-certified GLOBAL RAIL every ported
+// shell renders, moved VERBATIM out of serve-product-ui.mjs (which now imports it, as do the
+// extracted surface modules). The rail is aligned ONCE and certified in every port's shell —
+// treat this file as pixel-frozen: changes here move every certified surface at once.
+import { bpIcon, AIP_GRADIENT_SVG_RAIL } from "../scripts/bp-icons.mjs";
+import { escHtml } from "./kit.mjs";
+
+const CX_ESC = escHtml; // local alias so the moved block stays byte-identical to its serve original
+
+// ---- SHARED pixel-aligned GLOBAL RAIL (the reference Foundry-shell left chrome, reproduced to the
+// measured spec: 230px · rgb(37,42,49) · items y61 @32px pitch · APPLICATIONS section y369 · active app
+// row h36 with the extracted app-icon chip · bottom cluster AIP/Support/Account y794/826/858). Used by
+// every shell-pixel-certified port (schema #41, approvals #42, …) so the rail is aligned ONCE.
+function ioiGlobalRailHtml(active) {
+  // Per-reference rail variant: each certified surface reproduces ITS reference capture's rail state
+  // (badges / View-all / star / gradient AIP / account-chip style differ across captures). Defaults
+  // keep the schema/approvals-certified rail untouched.
+  const gi = (icon, label, opts = {}) => {
+    const kbd = opts.kbd ? `<kbd class="og-gkbd">${opts.kbd.split("+").map((k) => `<span>${k.trim()}</span>`).join("<span>+</span>")}</kbd>` : "";
+    const ico = icon === "@aip-grad" ? AIP_GRADIENT_SVG_RAIL : bpIcon(icon);
+    const inner = `<span class="og-gico">${ico}${opts.badge ? '<span class="og-gbadge"></span>' : ""}</span><span class="og-glabel">${CX_ESC(label)}</span>${kbd}`;
+    return opts.href ? `<a class="og-gitem${opts.ctx ? " ctx" : ""}" href="${opts.href}">${inner}</a>` : `<span class="og-gitem muted">${inner}</span>`;
+  };
+  return `<aside class="og-grail${active.railVariant ? " " + active.railVariant : ""}">
+    <div class="og-gtop"><span class="og-gmark">◗</span><span class="og-gmenu">${bpIcon("menu-closed")}</span></div>
+    ${gi("home", "Home", { href: "/ai" })}
+    ${gi("search", "Search…", { kbd: "ctrl + J" })}
+    ${gi("notifications", "Notifications", { badge: active.badges })}
+    ${gi("whatsnew-gift", "What's New", { badge: active.badges })}
+    <div class="og-gdiv"></div>
+    ${gi("history", "Recent", {})}
+    ${gi("folder-open", "Files", {})}
+    ${gi("cubes", "Ontology", { href: "/__ioi/odk", ctx: active.hiliteNav === "Ontology" })}
+    ${gi("layout-grid", "Applications", { href: "/__ioi/home" })}
+    <div class="og-gsecrow"><span class="og-gsec">APPLICATIONS</span>${active.viewAll === false ? "" : `<a class="og-gviewall" href="/__ioi/home">View all</a>`}</div>
+    <a class="og-gitem on" href="${active.href}"><span class="og-gappico" style="background-image:url('${active.iconUri}')"></span><span class="og-glabel og-strong">${CX_ESC(active.label)}</span>${active.star === false ? "" : `<span class="og-gstar">${bpIcon("star-empty")}</span>`}</a>
+    <div class="og-gspacer"></div>
+    ${gi(active.aipGradient ? "@aip-grad" : "aip-logo", "AIP Assist", { kbd: "ctrl + shift + U" })}
+    ${gi("help", "Support", {})}
+    <span class="og-gitem muted og-gaccount"><span class="og-gavatar${active.acctMuted ? " alt" : ""}">LJ</span><span class="og-glabel">Account</span></span>
+  </aside>`;
+}
+const IOI_GRAIL_CSS = `
+    .og-grail{flex:0 0 230px;width:230px;height:100vh;background:#252a31;color:#f6f7f9;display:flex;flex-direction:column;padding:0 12px 10px;overflow:hidden;font:14px/1.28581 Source-Sans-Pro,Helvetica,sans-serif}
+    .og-gtop{height:61px;display:flex;align-items:center;justify-content:space-between;padding:0 19px 0 6px;flex:0 0 61px}
+    .og-gmark{font-size:20px;color:#f6f7f9}
+    .og-gmenu{display:inline-flex;color:#abb3bf}
+    .og-gappico{width:24px;height:24px;flex:0 0 24px;margin:-4px -4px -4px -4px;border-radius:3px;background-color:rgba(102,158,255,.1);background-position:center;background-size:16px;background-repeat:no-repeat}
+    .og-strong{font-weight:600}
+    .og-gstar{display:inline-flex;color:#abb3bf;width:16px;flex:0 0 16px}
+    .og-gitem{display:flex;align-items:center;gap:12px;height:32px;padding:0 8px 0 5px;border-radius:6px;color:#f6f7f9;font-size:14px;font-weight:400}
+    .og-gitem:hover{background:#2f353d;color:#fff}.og-gitem.on{background:#2f353d;color:#fff;font-weight:600;height:36px}
+    .og-gitem.muted{color:#f6f7f9;cursor:default}.og-gitem.muted:hover{background:transparent}
+    .og-gico{display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;color:#abb3bf;flex:0 0 16px;position:relative}
+    .og-gbadge{position:absolute;left:9px;top:-3px;width:8px;height:8px;background:#fbb360;border:1px solid #2f343c;border-radius:50%}
+    .og-gavatar.alt{background:rgba(45,114,210,.2);color:#8abbff;border-radius:50%;margin-left:-2px;margin-right:-2px}
+    .og-gitem.ctx{background:#2f353d;color:#fff;font-weight:600}.og-gitem.ctx .og-gico{color:#f6f7f9}
+    .rv-pipe .og-gitem.on{background:#1c2127;margin:0 -12px;padding:0 20px 0 17px;border-radius:0}
+    .rv-pipe .og-gkbd{gap:0;margin-right:-2px}
+    .rv-pipe .og-gkbd span:nth-child(even){display:inline-flex;justify-content:center;width:16px;margin:0}
+    .rv-pipe .og-gsecrow{padding-top:31.3px;padding-bottom:6.3px}
+    .rv-pipe .og-gsec{letter-spacing:0}
+    .og-gitem.on .og-gico{color:#f6f7f9}
+    .og-glabel{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1 1 auto}
+    .og-gkbd{display:inline-flex;align-items:center;gap:3px;font-size:14px;color:#abb3bf;font-family:inherit;margin-right:4px}
+    .og-gdiv{height:21px}
+    .og-gsecrow{display:flex;align-items:center;justify-content:space-between;padding:30px 8px 5px 5px}
+    .og-gsec{font-size:12px;letter-spacing:.02em;color:#abb3bf;font-weight:600}
+    .og-gviewall{font-size:14px;color:#abb3bf;font-weight:400}
+    .og-gavatar{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;margin-left:0;margin-right:-4px;border-radius:3px;background:#1e6ba1;color:#8abbff;font-size:12px;font-weight:600;flex:0 0 20px}
+    .og-gspacer{flex:1 1 auto;min-height:14px}`;
+
+export { ioiGlobalRailHtml, IOI_GRAIL_CSS };

--- a/apps/hypervisor/surfaces/kit.mjs
+++ b/apps/hypervisor/surfaces/kit.mjs
@@ -1,0 +1,72 @@
+// The surface interaction kit (functional-runtime wave) — shared primitives every app module
+// builds interaction from. Introduced with the Pipeline extraction; DELIBERATELY UNWIRED there
+// (the extraction PR changes zero behavior) — node selection/inspectors wire these next.
+//
+// Design rules the kit encodes:
+//   · The URL is the selection's single source of truth — refresh-preserving, deep-linkable
+//     (parseSelection reads it, selectionQuery writes it with stable key order).
+//   · A command is either a real daemon authority or a VISIBLE disabled control that names its
+//     reason (disabledCommand) — never hidden, never a silent no-op.
+//   · Detail panes and trays are shells the app fills with daemon truth (inspectorShell,
+//     trayShell); proof always deep-links into the owning record (proofLink).
+//   · Data-driven body regions announce themselves for the pixel harness's semantic-mask lane
+//     (semanticMask) instead of being guessed at by selector.
+
+// THE canonical HTML escaper — one definition estate-wide (moved from the serve's CX_ESC;
+// serve and every surface module alias this).
+export const escHtml = (s) => String(s == null ? "" : s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+// Read the selection state carried by a URL: only the requested keys, only non-empty values.
+export function parseSelection(url, keys) {
+  const out = {};
+  for (const k of keys) {
+    const v = url.searchParams.get(k);
+    if (v !== null && v !== "") out[k] = v;
+  }
+  return out;
+}
+
+// Serialize selection state onto a route with a STABLE query (sorted keys, empties dropped) so
+// the same selection always produces the same URL — comparable, cacheable, diff-friendly.
+export function selectionQuery(route, sel) {
+  const q = Object.entries(sel || {})
+    .filter(([, v]) => v !== undefined && v !== null && v !== "")
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+    .join("&");
+  return q ? `${route}?${q}` : route;
+}
+
+// Right-panel detail shell: the app supplies the (already-escaped) body; the shell supplies the
+// stable ids/testids the interaction verifiers drive.
+export function inspectorShell({ id, title, subtitle, body, cls }) {
+  return `<div id="${escHtml(id)}" class="ioi-inspector${cls ? " " + escHtml(cls) : ""}" data-testid="ioi-inspector">` +
+    `<div class="ioi-inspector-hd"><span class="ioi-inspector-title">${escHtml(title)}</span>` +
+    (subtitle ? `<span class="ioi-inspector-sub">${escHtml(subtitle)}</span>` : "") +
+    `</div><div class="ioi-inspector-body">${body || ""}</div></div>`;
+}
+
+// Bottom preview/proof tray shell — same contract as inspectorShell.
+export function trayShell({ id, title, body, cls }) {
+  return `<div id="${escHtml(id)}" class="ioi-tray${cls ? " " + escHtml(cls) : ""}" data-testid="ioi-tray">` +
+    `<div class="ioi-tray-hd">${escHtml(title)}</div><div class="ioi-tray-body">${body || ""}</div></div>`;
+}
+
+// A visible command that is not backed by an existing daemon authority: disabled IN PLACE with
+// the reason named (title + data attribute the action verifiers assert on). Never hidden.
+export function disabledCommand({ label, reason, cls }) {
+  return `<button type="button" disabled aria-disabled="true" class="ioi-cmd-disabled${cls ? " " + escHtml(cls) : ""}"` +
+    ` title="${escHtml(reason)}" data-ioi-disabled-reason="${escHtml(reason)}">${escHtml(label)}</button>`;
+}
+
+// Deep link into the owning daemon record (receipt, timeline, ledger entry, …).
+export function proofLink({ href, label, external }) {
+  return `<a class="ioi-proof-link" data-testid="ioi-proof-link" href="${escHtml(href)}"` +
+    (external ? ` target="_blank" rel="noopener"` : "") + `>${escHtml(label)} ↗</a>`;
+}
+
+// Mark a data-driven body region for the pixel harness's semantic-mask lane: the region is live
+// daemon truth (excluded from shell-pixel diffing by id, verified semantically instead).
+export function semanticMask(id, inner) {
+  return `<span data-ioi-sem-mask="${escHtml(id)}">${inner}</span>`;
+}

--- a/apps/hypervisor/surfaces/pipeline/index.mjs
+++ b/apps/hypervisor/surfaces/pipeline/index.mjs
@@ -1,0 +1,390 @@
+// Pipeline Builder — the first extracted app module (functional-runtime wave). The render/data
+// code below is moved VERBATIM from serve-product-ui.mjs (zero behavior change by construction);
+// this module adds only the surface contract the registry mounts:
+//   meta            — code-side identity (joined with surface-registry.mjs + the parity matrix)
+//   load(ctx)       — daemon-truth loaders (ctx.daemon = daemon base URL)
+//   render(model, ctx) — pure HTML over the loaded model (ctx.url carries selection params)
+//   actions         — empty until the command-discipline PR wires real authority
+// Shell-pixel note: /__ioi/pipeline is a certified shell (pixel-certifications/pipeline.json);
+// pixels are frozen by the harness gate, so edits here must re-certify.
+import { bpIcon, PIPELINE_APP_ICON_URI, AIP_GRADIENT_SVG_TOOLBAR } from "../../scripts/bp-icons.mjs";
+import { ioiGlobalRailHtml, IOI_GRAIL_CSS } from "../chrome.mjs";
+import { escHtml } from "../kit.mjs";
+
+const CX_ESC = escHtml; // local alias so the moved block stays byte-identical to its serve original
+
+export const meta = {
+  slug: "pipeline",
+  route: "/__ioi/pipeline",
+  verifier: "scripts/verify-hypervisor-app-parity-pipeline.mjs",
+  certification: "pixel-certifications/pipeline.json",
+};
+
+// Daemon-truth loaders — the exact fetch set the serve's flat branch (then its #55 inline
+// binding) performed; a dead daemon yields honest empty lists, never fabricated rows.
+export async function load(ctx) {
+  const J = (p) => fetch(`${ctx.daemon}${p}`).then((r) => r.json()).catch(() => ({}));
+  const [o, ds, cm, pv, tr, op, lp, mr, cs, ms] = await Promise.all([
+    J("/v1/hypervisor/odk/domain-ontologies"),
+    J("/v1/hypervisor/data-sources"),
+    J("/v1/hypervisor/odk/connector-mappings"),
+    J("/v1/hypervisor/odk/policy-bound-data-views"),
+    J("/v1/hypervisor/odk/transformation-runs"),
+    J("/v1/hypervisor/odk/ontology-projections"),
+    J("/v1/hypervisor/odk/capability-lease-plans"),
+    J("/v1/hypervisor/odk/materializing-runs"),
+    J("/v1/hypervisor/odk/connector-sessions"),
+    J("/v1/hypervisor/odk/materialized-object-sets"),
+  ]);
+  return {
+    ontologies: o.ontologies || [],
+    data_sources: ds.data_sources || [],
+    connector_mappings: cm.connector_mappings || [],
+    policy_views: pv.policy_bound_data_views || [],
+    transformation_runs: tr.transformation_runs || [],
+    ontology_projections: op.ontology_projections || [],
+    capability_lease_plans: lp.capability_lease_plans || [],
+    materializing_runs: mr.materializing_runs || [],
+    connector_sessions: cs.connector_sessions || [],
+    materialized_sets: ms.materialized_object_sets || [],
+  };
+}
+
+export function render(model, ctx) {
+  return renderPipelineBuilder(model, ctx.url.searchParams.get("ontology") || "");
+}
+
+// No commands are wired yet: Build/Preview/Schedule/Deploy stay exactly as the certified shell
+// renders them (the command-discipline PR gives them the authority-or-disabled contract).
+export const actions = [];
+
+// ============================ PIPELINE BUILDER (reference-UX parity over the ODK ladder) =========
+// The Reference UX Port program (post-#31 reset), substrate for the Data Pipeline Builder. The reference
+// capture (/__apps/pipeline, /workspace/builder/) is the FAMILIAR STARTING POINT; this IOI-owned
+// surface renders the SAME builder grammar — a datasource → transform → output pipeline of nodes on
+// a canvas, with a Build / Preview / Schedule / Deploy toolbar — but every node is DAEMON TRUTH: the
+// landed ODK ladder for the selected ontology IS the pipeline. Supported lanes reflect real daemon
+// state; unsupported builder lanes (freeform canvas authoring, drag-connect, transform code editor,
+// schedule, deploy) are visible but honest named gaps. Reference-familiar UX; IOI truth underneath.
+function pipeStatusPill(cls, label) {
+  const c = cls === "live" ? "ok" : cls === "declared" ? "warn" : "muted";
+  return `<span class="pill ${c}" style="margin:0">${CX_ESC(label)}</span>`;
+}
+// ============================ PIPELINE BUILDER — reference UX PORT (#32, first reference_ported shell).
+// A PORTED reference builder shell, NOT the dark automationsShell: a source-neutral rebuild of the
+// /workspace/builder/ layout — a full-height left RAIL (pipelines + stage palette), a HEADER bar, a
+// graph TOOLBAR (Build/Preview/Schedule/Deploy — unsupported controls disabled IN PLACE, not hidden),
+// a central CANVAS rendering the ODK authority ladder as connected pipeline node cards, a right
+// OUTPUT PANEL (projection schema + output stats), and a bottom TRAY (preview rows + warnings). Every
+// cell is REAL daemon truth. This is `reference_ported`, NOT `daemon_wired`: the local /workspace/
+// builder/* reference currently ERRORS, so parity cannot yet be certified by the Playwright harness —
+// daemon_wired awaits a valid (non-errored) builder reference to compare against.
+function renderPipelineBuilder(lists, selectedId) {
+  const ontologies = Array.isArray(lists.ontologies) ? lists.ontologies : [];
+  const sets = Array.isArray(lists.materialized_sets) ? lists.materialized_sets : [];
+  const builtRefs = new Set(sets.map((s) => s.ontology_ref));
+  // Prefer an explicit selection; else a "built" pipeline (has a materialized set); else most recent.
+  const selected = ontologies.find((x) => x.id === selectedId)
+    || ontologies.find((x) => builtRefs.has(x.ref))
+    || ontologies[0] || null;
+  const oref = selected ? selected.ref : "__none__";
+  const oid = selected ? selected.id : "";
+  const F = (arr) => (Array.isArray(arr) ? arr : []).filter((x) => x.ontology_ref === oref);
+  const maps = F(lists.connector_mappings), views = F(lists.policy_views), truns = F(lists.transformation_runs);
+  const projs = F(lists.ontology_projections), plans = F(lists.capability_lease_plans), mruns = F(lists.materializing_runs);
+  const sessions = F(lists.connector_sessions), osets = F(lists.materialized_sets);
+  const dsIds = new Set(maps.map((m) => m.data_source_id).filter(Boolean));
+  const dsources = (lists.data_sources || []).filter((d) => dsIds.has(d.source_id));
+  const instances = osets.reduce((a, s) => a + (s.count || 0), 0);
+  const anyReady = (arr, pred) => arr.filter(pred).length;
+
+  // The pipeline nodes, in ODK-ladder order. Each node: real daemon state → live / declared / missing.
+  const mk = (icon, label, kind, n, live, declared, count, detail, pane) => ({ icon, label, kind, n, cls: n === 0 ? "missing" : live ? "live" : declared ? "declared" : "declared", count, detail, pane });
+  const nodes = [
+    mk("🌐", "Datasource", "input", dsources.length, dsources.length > 0, true, dsources.length, dsources.map((d) => d.name || d.source_id).slice(0, 2).join(", "), "data"),
+    mk("🔗", "Object mapping", "transform", maps.length, anyReady(maps, (m) => (m.health || {}).status === "ready") > 0, true, maps.length, "source fields → typed properties", "resources"),
+    mk("🛡", "Policy gate", "transform", views.length, anyReady(views, (v) => (v.health || {}).status === "ready") > 0, true, views.length, "capability envelope", "resources"),
+    mk("📋", "Transform plan", "transform", truns.length, anyReady(truns, (r) => r.status === "dry_run_ready") > 0, true, truns.length, "dry-run validated", "resources"),
+    mk("🔭", "Read projection", "transform", projs.length, anyReady(projs, (p) => p.status === "ready") > 0, true, projs.length, "explorer/search shape", "resources"),
+    mk("🎟", "Lease + session", "authority", plans.length, anyReady(mruns, (r) => ["lease_obtained", "executed"].includes(r.status)) > 0 && anyReady(sessions, (c) => c.status === "session_obtained") > 0, plans.length > 0, plans.length, `${anyReady(mruns, (r) => ["lease_obtained", "executed"].includes(r.status))} lease · ${anyReady(sessions, (c) => c.status === "session_obtained")} session`, "resources"),
+    mk("📦", "Materialized objects", "output", osets.length, instances > 0, osets.length > 0, instances, `${instances} object instance${instances === 1 ? "" : "s"}`, "explorer"),
+  ];
+  const enc = encodeURIComponent, esc = CX_ESC;
+  const oname = selected ? esc(selected.domain || selected.id) : "no pipeline";
+
+  // Preview + output projection (daemon truth) — feeds the bottom tray + right output panel.
+  const proj = projs.find((p) => p.status !== "retired") || projs[0] || null;
+  const mset = osets.find((s) => proj && s.ontology_projection_id === proj.id) || osets[0] || null;
+  const cols = proj ? (proj.visible_properties || []) : [];
+  const previewTable = proj
+    ? `<table class="pb-table"><thead><tr>${cols.map((c) => `<th>${esc(c)}</th>`).join("")}</tr></thead><tbody>${(mset && (mset.objects || []).length)
+        ? mset.objects.slice(0, 12).map((o) => `<tr>${cols.map((c) => `<td>${esc(String((o.properties || {})[c] ?? ""))}</td>`).join("")}</tr>`).join("")
+        : `<tr><td colspan="${cols.length || 1}" class="pb-empty-cell">No rows yet — Build a materializing run to populate this output (object_instances stays 0 until then).</td></tr>`}</tbody></table>`
+    : `<div class="pb-empty">No read projection on this pipeline yet — add one in the Ontology Manager.</div>`;
+
+  // ---- SHARED pixel-aligned GLOBAL RAIL (#43) — Pipeline Builder active. The live pipeline PICKER
+  // (no reference counterpart in the rail) lives in the canvas body (excluded region), keeping the rail
+  // pixel-faithful while the control keeps its function.
+  const globalRail = ioiGlobalRailHtml({ label: "Pipeline Builder", href: "/__ioi/pipeline", iconUri: PIPELINE_APP_ICON_URI, railVariant: "rv-pipe", viewAll: false, star: false, badges: true, aipGradient: true, acctMuted: true });
+  const railPipes = ontologies.length
+    ? ontologies.map((x) => { const on = selected && x.id === selected.id; const built = builtRefs.has(x.ref); return `<a class="pb-pipe ${on ? "on" : ""}" href="/__ioi/pipeline?ontology=${enc(x.id)}">${esc(x.domain || x.id)}${built ? `<span class="pb-tag">built</span>` : ""}</a>`; }).join("")
+    : `<div class="pb-empty">No pipelines yet. <a href="/__ioi/odk/ontologies/new">Create an ontology</a>.</div>`;
+  const nodeCard = (nd) => `<div class="pb-node pb-${nd.cls}"${selected ? ` onclick="location.href='/__ioi/odk?ontology=${enc(oid)}#pane-${nd.pane}'"` : ""}>
+    <div class="pb-nhead"><span class="pb-nicon">${nd.icon}</span><span class="pb-dot pb-${nd.cls}"></span></div>
+    <div class="pb-nlabel">${esc(nd.label)}</div>
+    <div class="pb-ncount"><b>${esc(String(nd.count))}</b> ${nd.kind === "output" ? "objects" : nd.kind === "input" ? "source" + (nd.count === 1 ? "" : "s") : "record" + (nd.count === 1 ? "" : "s")}</div>
+    <div class="pb-ndetail">${esc(nd.detail || "")}</div>
+  </div>`;
+  const legendGroups = [
+    ["Input Data", "#8f99a8", dsources.length],
+    ["Data Cleaning", "#238551", maps.length + views.length],
+    ["Calculations", "#d1980b", truns.length + projs.length + plans.length],
+    ["Output Dataset", "#147eb3", osets.length],
+  ];
+
+  // ---- HEADER (h51, white, hairline shadow) — the reference navbar: app chip · breadcrumb title row
+  // (live names → masked as dynamic data) + File/Settings/Help menu row (named gaps) + Batch tag · a
+  // FLUID MIDDLE zone that in the reference carries captured SESSION STATE (tabs/undo/branch/build
+  // state — masked as dynamic residue) and in the port carries the LIVE Build/Preview controls · right
+  // cluster Actions ▾ / Share / panel toggle (named gaps).
+  const header = `<header class="pb-header">
+    <span class="pb-hchip"></span>
+    <div class="pb-htitles">
+      <div class="pb-crumbrow"><span class="pb-crumb">${oname} <span class="pb-cx">›</span> <b>Pipeline Builder</b>${selected ? ` <span class="pb-cxt">— ${instances > 0 ? `<span class="pb-live">built</span>` : `<span class="pb-declared">not built</span>`} · ${nodes.filter((n) => n.cls === "live").length}/${nodes.length} stages live</span>` : ""}</span><span class="pb-star">${bpIcon("star-empty")}</span></div>
+      <div class="pb-menurow">
+        <span class="pb-menu gap" title="File menu is a reference-only lane (named gap)">File ${bpIcon("caret-down", 16)}</span>
+        <span class="pb-menu gap" title="named gap">Settings ${bpIcon("caret-down", 16)}</span>
+        <span class="pb-menu gap" title="named gap">Help ${bpIcon("caret-down", 16)}</span>
+        <span class="pb-menudiv"></span>
+        <span class="pb-batch">${bpIcon("office", 16)}<span class="pb-batchn">1</span></span>
+        <span class="pb-menudiv d2"></span>
+        <span class="pb-batchtag">Batch</span>
+      </div>
+    </div>
+    <div class="pb-hmid">
+      <a class="pb-btn primary" href="/__ioi/odk?ontology=${enc(oid)}">Build</a>
+      <a class="pb-btn ghost" href="#pb-preview">Preview</a>
+      <button class="pb-btn ghost" disabled title="No pipeline scheduler yet — a named gap (author + run via a materializing run).">Schedule</button>
+      <button class="pb-btn ghost" disabled title="No pipeline deploy yet — a named gap.">Deploy</button>
+      <a class="pb-btn link" href="/__ioi/lineage?ontology=${enc(oid)}">Lineage</a>
+      <a class="pb-btn link" href="/__ioi/odk?ontology=${enc(oid)}">Ontology Manager</a>
+    </div>
+    <div class="pb-hright">
+      <span class="pb-hbtn gap" title="Actions menu is a reference-only lane (named gap)">Actions ${bpIcon("caret-down")}</span>
+      <span class="pb-hdrdiv"></span>
+      <span class="pb-hbtn gap" title="Sharing is a reference-only lane (named gap)">${bpIcon("people")} Share</span>
+      <span class="pb-hico gap" title="Panel layout toggle — named gap">${bpIcon("properties")}</span>
+    </div>
+  </header>`;
+
+  // ---- FLOATING TOOL CARD (canvas top-left) — the reference's grouped canvas tools as GROUP UNITS in a
+  // wrapping flex card: at 1440 the groups wrap to three rows exactly like the reference; at 1920 they
+  // fit one row. All named gaps except Add data (routes to the real authoring ladder).
+  const tbtn = (icon, opts = {}) => `<${opts.href ? `a href="${opts.href}"` : "button disabled"} class="pb-ticon${opts.look ? " " + opts.look : ""}${opts.tint ? " pb-i-" + opts.tint : ""}" title="${esc(opts.title || "named gap")}">${icon === "@aip-grad" ? AIP_GRADIENT_SVG_TOOLBAR : bpIcon(icon)}${opts.href ? "</a>" : "</button>"}`;
+  const seg = (...btns) => `<span class="pb-seg">${btns.join("")}</span>`;
+  const toolcard = `<div class="pb-toolcard">
+    <div class="pb-tg">
+      <div class="pb-tgrow">${seg(tbtn("move", { look: "act" }), tbtn("select"))}${seg(tbtn("selection"))}${seg(tbtn("graph-remove", { look: "dim" }))}${seg(tbtn("layout-sorted-clusters"), tbtn("grid"))}${seg(tbtn("new-text-box"))}</div>
+      <div class="pb-tghints"><span style="left:15.5px">Tools</span><span style="left:72.3px">Select</span><span class="pb-hwrap" style="left:115px">Remove</span><span style="left:175.5px">Layout</span><span style="left:242px">Text</span></div>
+    </div>
+    <div class="pb-tg pb-tg2">
+      <a class="pb-twide" href="/__ioi/odk?ontology=${enc(oid)}" title="Add data — routes to the real ODK authoring ladder">${bpIcon("import")} Add data ${bpIcon("caret-down")}</a>
+      <button class="pb-twide" disabled title="Reusable transforms library — a named gap">${bpIcon("repeat")} Reusables ${bpIcon("caret-down")}</button>
+    </div>
+    <div class="pb-tg pb-tg3">
+      <div class="pb-tgrow">${seg(tbtn("path", { look: "dim", tint: "blue" }), tbtn("join-table", { look: "dim", tint: "cyan" }), tbtn("add-row-bottom", { look: "dim", tint: "rose" }), tbtn("split-columns", { look: "dim", tint: "green" }), tbtn("model", { look: "dim", tint: "violet" }))}${seg(tbtn("@aip-grad", { look: "dim" }), tbtn("clean", { tint: "violet" }), tbtn("lightbulb", { tint: "violet" }))}${seg(tbtn("edit", { look: "dim" }))}</div>
+      <div class="pb-tghints"><span style="left:45.9px">Transform</span><span style="left:195.3px">AIP</span><span style="left:268.7px">Edit</span></div>
+    </div>
+  </div>`;
+
+  // ---- FLOATING canvas buttons (search / fit) + ZOOM stack (bottom-left) — reference chrome, named gaps.
+  const floatbtns = `<div class="pb-floatbtns">${tbtn("search")}${tbtn("many-to-many")}</div>
+  <div class="pb-zoomstack">${tbtn("zoom-in")}${tbtn("zoom-out")}${tbtn("zoom-to-fit")}</div>`;
+
+  // ---- LEGEND card (canvas top-right, left of the outputs panel) — live category counts masked as data.
+  const legend = `<div class="pb-legend">
+    <div class="pb-legendhd">Legend <span class="pb-legcaret">${bpIcon("caret-up")}</span></div>
+    <div class="pb-leggrid">
+      ${legendGroups.map(([g, c, n]) => `<div class="pb-legrow"><span class="pb-legchip" style="background:${c}"></span><span class="pb-legname">${esc(g)}</span> <b>(${n})</b> <span class="pb-legeye">${bpIcon("eye-open", 14)}</span></div>`).join("")}
+    </div>
+    <button class="pb-addcolor" disabled title="Legend color authoring — a named gap">${bpIcon("plus")} Add color</button>
+  </div>`;
+
+  const canvasWrap = `<div class="pb-canvaszone">
+    <div class="pb-toolband" role="toolbar" aria-label="Canvas tools"></div>
+    ${toolcard}
+    ${floatbtns}
+    ${legend}
+    <div class="pb-canvas" id="pb-canvas">${selected
+      ? `<div class="pb-pickrow"><details class="pb-pick"><summary>Pipeline: ${oname} ▾</summary><div class="pb-picklist">${railPipes}</div></details></div><div class="pb-flow">${nodes.map((nd, i) => `${i ? `<div class="pb-arrow">→</div>` : ""}${nodeCard(nd)}`).join("")}</div>`
+      : `<div class="pb-empty" style="margin:120px auto;max-width:420px">Select or create a pipeline to see its datasource → transform → output graph. <a href="/__ioi/odk/ontologies/new">Create an ontology →</a></div>`}</div>
+    <div class="pb-tray" id="pb-preview">
+      <div class="pb-traytabs">
+        <span class="pb-tab on">${bpIcon("panel-table")} Selection preview</span>
+        <span class="pb-tab s2">${bpIcon("clean")} Suggestions<span class="pb-tabpill" title="suggestions count — reference-only lane"></span></span>
+        <span class="pb-tab warn">${bpIcon("warning-sign")} Pipeline warnings</span>
+        <span class="pb-traycollapse">${bpIcon("double-chevron-down")}</span>
+      </div>
+      <div class="pb-traybody">${previewTable}
+        <div class="pb-gapnote">Freeform canvas authoring — drag-connect nodes, transform code editor, scheduling, deploy — are <b>reference-only lanes disabled above</b>, not yet wired. Author stages in the <a href="/__ioi/odk?ontology=${enc(oid)}">Ontology Manager</a>; execute via a materializing run. Reference: <a href="/__apps/pipeline">Pipeline Builder capture ↗</a>.</div>
+      </div>
+    </div>
+  </div>`;
+
+  // ---- RIGHT "Pipeline outputs" PANEL (w386 = 336 content + 50 icon strip) — live projection values
+  // masked as data; Output settings block bottom-anchored like the reference.
+  const mapped = cols.length;
+  const stripIcons = ["circle-arrow-right", "search", "split-view", "build", "settings", "calendar", "folder-open", "form", "import"];
+  const rightPanel = `<aside class="pb-right">
+    <div class="pb-rmain">
+      <div class="pb-righthd"><span class="pb-righttitle">Pipeline outputs</span><span class="pb-rhdico gap">${bpIcon("cog")}</span><span class="pb-rhdico gap">${bpIcon("panel-table")}</span><button class="pb-addbtn" disabled title="Adding outputs is authored in the ODK substrate — a named gap here">${bpIcon("plus")} Add</button></div>
+      <div class="pb-rsearch">${bpIcon("search")}<input placeholder="Search outputs…" disabled aria-label="Search outputs (reference-only, not wired)"></div>
+      ${proj ? `<div class="pb-outcard"><div class="pb-outcode">${bpIcon("panel-table")} ${esc(proj.name || proj.id)}</div><div class="pb-outsub">${esc(selected ? (selected.domain || selected.id) : "")} · read projection</div><div class="pb-outmapped">✓ ${mapped}/${mapped} column${mapped === 1 ? "" : "s"} mapped</div></div>` : `<div class="pb-empty">No read projection on this pipeline yet.</div>`}
+      <div class="pb-outstat">${instances} object instance${instances === 1 ? "" : "s"} materialized · ${nodes.filter((n) => n.cls === "missing").length ? nodes.filter((n) => n.cls === "missing").map((n) => esc(n.label) + " not built").join(" · ") : "all ladder stages present"}</div>
+      <div class="pb-settings">
+        <div class="pb-outboxt">Output settings</div>
+        <div class="pb-setrow"><span class="pb-setk">Target ontology</span><span class="pb-setv">${selected ? esc(selected.domain || selected.id) : "No ontology selected"}</span></div>
+        <div class="pb-setrow"><span class="pb-setk">Output folder</span><span class="pb-setv">No location selected</span></div>
+        <div class="pb-editrow"><a class="pb-editbtn" href="/__ioi/odk?ontology=${enc(oid)}">Edit output settings</a><span class="pb-moreico gap">${bpIcon("more")}</span></div>
+      </div>
+    </div>
+    <div class="pb-rstrip">${stripIcons.map((ic, i) => `<span class="pb-stripico${i === 0 ? " on" : ""}${i && i % 3 === 0 ? " g" : ""} gap" title="Right-panel lane — named gap">${bpIcon(ic)}</span>`).join("")}</div>
+  </aside>`;
+
+  // LIGHT application surface, geometry pinned to the reference (glyph-anchored): header h51 · toolcard
+  // groups h55 wrapping at the reference's break points · Legend/right panel right-anchored · tray
+  // bottom-anchored (vh-300). The harness certifies the SHELL cards; the canvas/graph is the live body.
+  const css = `:root{color-scheme:light}*{box-sizing:border-box}
+    body{margin:0;background:#f6f7f9;color:#1c2127;font:14px/1.28581 Source-Sans-Pro,Helvetica,sans-serif}
+    a{color:#215db0;text-decoration:none}
+    .pb-shell{display:flex;height:100vh;width:100vw;overflow:hidden}
+    ${IOI_GRAIL_CSS}
+    .pb-main{flex:1;min-width:0;display:flex;flex-direction:column;height:100vh}
+    .pb-header{flex:0 0 51px;position:relative;height:51px;display:flex;align-items:stretch;background:#fff;box-shadow:0 1px 0 0 #dce0e5;z-index:6}
+    .pb-hchip{width:50px;height:51px;flex:0 0 50px;background:rgba(90,217,207,.1) url('${PIPELINE_APP_ICON_URI}') center no-repeat}
+    .pb-htitles{display:flex;flex-direction:column;padding:4px 0 0 15px;min-width:0}
+    .pb-crumbrow{display:flex;align-items:center;gap:8px;height:20px}
+    .pb-crumb{font-size:14px;color:#1c2127;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:350px;line-height:16px}
+    .pb-cx{color:#8b9099}.pb-cxt{color:#5f6b7c;font-size:12px}
+    .pb-star{position:absolute;left:431.4px;top:6.5px;display:inline-flex;color:#5f6b7c;width:16px}
+    .pb-menurow{display:flex;align-items:center;height:26px;gap:0;margin:-1px 0 0 -7px}
+    .pb-menu{display:inline-flex;align-items:center;gap:8px;font-size:14px;line-height:16.1px;color:#1c2127;padding:0 5px 0 7px;cursor:default}
+    .pb-menu svg{color:#5f6b7c}
+    .pb-menudiv{width:1px;height:16px;background:#d3d8de;margin-left:5px}
+    .pb-menudiv.d2{margin-left:8px}
+    .pb-batch{display:inline-flex;align-items:center;gap:3px;margin-left:11px;color:#5f6b7c;font-size:12px}
+    .pb-batch svg{color:#404854}
+    .pb-batchn{font-size:12px;color:#1c2127}
+    .pb-batchtag{margin-left:5.6px;background:#5f6b7c;color:#fff;font-size:12px;line-height:16px;border-radius:3px;padding:2px 4px}
+    .pb-hmid{position:absolute;left:468px;top:0;width:494px;height:51px;display:flex;align-items:center;gap:7px;overflow:hidden}
+    .pb-btn{display:inline-flex;align-items:center;height:28px;padding:0 10px;border-radius:4px;border:1px solid #d3d8de;background:#fff;color:#1c2127;font:inherit;font-size:13px;line-height:16px;font-weight:400;cursor:pointer}
+    .pb-btn.primary{background:#0e9f6e;color:#fff;border-color:#0e9f6e}
+    .pb-btn.link{border-color:transparent;background:transparent;color:#215db0;padding:0 5px}
+    .pb-btn[disabled]{opacity:.5;cursor:not-allowed}
+    .pb-hright{margin-left:auto;display:flex;align-items:flex-start;gap:0;padding-right:20px}
+    .pb-hbtn{display:inline-flex;align-items:center;gap:8px;height:30px;margin-top:10px;padding:0 12px;border-radius:4px;font-size:14px;line-height:16px;color:#1c2127;cursor:default}
+    .pb-hdrdiv{width:1px;height:30px;background:#d3d8de;margin:10px 0 0 6.6px}
+    .pb-hdrdiv+.pb-hbtn{margin-left:5.4px}
+    .pb-hbtn svg{color:#5f6b7c}
+    .pb-hico{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;margin:10px 0 0 2px;color:#5f6b7c;cursor:default}
+    .pb-work{flex:1 1 auto;display:flex;min-height:0}
+    .pb-canvaszone{flex:1 1 auto;min-width:0;position:relative;background:#edeff2;overflow:hidden}
+    .pb-toolband{position:absolute;left:10px;top:10px;width:414px;height:165px;pointer-events:none}
+    @media(min-width:1600px){.pb-toolband{width:872px;height:56px}.pb-tg2{margin-left:30px}.pb-tg3{margin-left:15px}.pb-tghints span.pb-hwrap{width:auto;white-space:nowrap}}
+    .pb-toolcard{position:absolute;left:10px;top:10px;display:flex;flex-wrap:wrap;width:fit-content;max-width:calc(100% - 424px);background:#fff;border-radius:3px;box-shadow:0 1px 3px rgba(20,24,30,.12);z-index:4}
+    .pb-tg{position:relative;height:55px;padding:0}
+    .pb-tgrow{display:flex;align-items:center;height:30px;margin-top:0;gap:15px}
+    .pb-seg{display:inline-flex}
+    .pb-seg .pb-ticon+.pb-ticon{margin-left:-1px}
+    .pb-seg .pb-ticon{border-radius:0}.pb-seg .pb-ticon:first-child{border-radius:4px 0 0 4px}.pb-seg .pb-ticon:last-child{border-radius:0 4px 4px 0}.pb-seg .pb-ticon:only-child{border-radius:4px}
+    .pb-ticon{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border:0;background:#f7f8f8;color:#5f6b7c;border-radius:4px;padding:0;cursor:default;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
+    .pb-ticon.act{background:#dfe0e2;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.2)}
+    .pb-ticon.dim{background:rgba(143,153,168,.2);box-shadow:none;color:#8f99a8}
+    a.pb-ticon{cursor:pointer}
+    .pb-ticon[disabled]{opacity:1}
+    .pb-tghints{position:relative;height:19px;font-size:12px;line-height:15px;color:#5f6b7c}
+    .pb-tghints span{position:absolute;top:4px;white-space:nowrap}
+    .pb-tghints span.pb-hwrap{white-space:normal;width:46px;text-align:center;line-height:15.4297px}
+    .pb-tg2{display:flex;align-items:flex-start;gap:15px;padding:0}
+    .pb-twide{display:inline-flex;align-items:center;gap:8px;height:30px;padding:0 8px;border:0;border-radius:4px;background:#f7f8f8;color:#1c2127;font:inherit;font-size:14px;line-height:16px;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
+    .pb-twide svg{color:#5f6b7c}
+    .pb-twide[disabled]{cursor:not-allowed}
+    .pb-i-blue svg{color:#4c90f0}.pb-i-cyan svg{color:#3fa6da}.pb-i-rose svg{color:#db2c6f}.pb-i-green svg{color:#32a467}.pb-i-violet svg{color:#7961db}
+    .pb-floatbtns{position:absolute;right:330px;top:10px;display:flex;gap:10px;z-index:4}
+    .pb-zoomstack .pb-ticon+.pb-ticon{margin-top:-1px}
+    .pb-zoomstack .pb-ticon:first-child{border-radius:4px 4px 0 0}.pb-zoomstack .pb-ticon:nth-child(2){border-radius:0}.pb-zoomstack .pb-ticon:last-child{border-radius:0 0 4px 4px}
+    .pb-zoomstack{position:absolute;left:10px;bottom:310px;display:flex;flex-direction:column;z-index:4}
+    .pb-legend{position:absolute;right:7px;top:9px;width:314px;background:#f6f7f9;border:1px solid #cbccd0;border-radius:3px;padding:0 10px 8px;z-index:4}
+    .pb-legendhd{display:flex;align-items:center;justify-content:space-between;height:30px;font-size:14px;line-height:16px;color:#1c2127;padding:0;margin:0 0 0 -2px}
+    .pb-legcaret{display:inline-flex;color:#5f6b7c}
+    .pb-leggrid{display:grid;grid-template-columns:1fr 1fr;gap:0 8px;margin-top:2px}
+    .pb-legrow{display:flex;align-items:center;gap:5px;height:29px;font-size:12px;line-height:15.4297px;color:#1c2127}
+    .pb-legchip{width:14px;height:14px;border-radius:3px;flex:0 0 14px}
+    .pb-legname{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:70px}
+    .pb-legeye{display:inline-flex;color:#5f6b7c;margin:0 7px 0 auto}
+    .pb-addcolor{display:flex;align-items:center;justify-content:center;gap:7.5px;width:140px;height:24px;margin:4.5px 2px 0 auto;padding:0;border:1px solid rgba(33,93,176,.6);border-radius:4px;background:transparent;color:#215db0;font:inherit;font-size:12px;line-height:13.8px;cursor:not-allowed}
+    .pb-canvas{position:absolute;inset:51px 0 300px 0;overflow:auto;padding:60px 20px 20px}
+    .pb-pickrow{margin:110px 0 14px}
+    .pb-pick{position:relative;display:inline-block}
+    .pb-pick>summary{list-style:none;cursor:pointer;font-size:13px;color:#5f6b7c;background:#fff;border:1px solid #d3d8de;border-radius:4px;padding:4px 10px}
+    .pb-pick>summary::-webkit-details-marker{display:none}
+    .pb-picklist{position:absolute;top:32px;left:0;min-width:240px;background:#fff;border:1px solid #e0e3e8;border-radius:8px;box-shadow:0 8px 28px rgba(20,24,31,.14);padding:6px;z-index:20}
+    .pb-pipe{display:flex;align-items:center;justify-content:space-between;padding:6px 9px;border-radius:6px;color:#3a3f46}
+    .pb-pipe:hover{background:#f1f3f6}.pb-pipe.on{background:#eef2fb;color:#1a1d21;font-weight:600}
+    .pb-tag{font-size:10px;padding:1px 6px;border-radius:999px;background:#eafaf1;color:#0e8a53;border:1px solid #8fdcb6}
+    .pb-flow{display:flex;align-items:stretch;gap:0}
+    .pb-arrow{flex:0 0 auto;color:#a9b0bb;padding:0 8px;font-size:17px;align-self:center}
+    .pb-node{flex:0 0 auto;width:156px;border:1px solid #dfe2e7;border-radius:6px;padding:11px 12px;background:#fff;cursor:pointer;box-shadow:0 1px 3px rgba(20,24,30,.05)}
+    .pb-node:hover{border-color:#0e9f6e}
+    .pb-node.pb-live{border-top:3px solid #2f9e6b}.pb-node.pb-declared{border-top:3px solid #d68a2a}.pb-node.pb-missing{border-top:3px solid #c2c6cd}
+    .pb-nhead{display:flex;align-items:center;justify-content:space-between}.pb-nicon{font-size:18px}
+    .pb-nlabel{font-weight:600;font-size:13px;margin:5px 0 6px;color:#15181d}
+    .pb-dot{width:8px;height:8px;border-radius:50%;background:#b8bdc6}.pb-dot.pb-live{background:#2f9e6b}.pb-dot.pb-declared{background:#d68a2a}
+    .pb-ncount{font-size:12px;color:#3a3f49}.pb-ndetail{font-size:10.5px;color:#8a909c;margin:3px 0 0;min-height:14px}
+    .pb-tray{position:absolute;left:0;right:0;bottom:0;height:300px;background:#fff;display:flex;flex-direction:column;z-index:5}
+    .pb-traytabs{flex:0 0 35px;display:flex;align-items:stretch}
+    .pb-tab{display:inline-flex;align-items:center;gap:5px;padding:0 8px;font-size:14px;line-height:16px;font-weight:600;color:#1c2127;border-right:1px solid #dce0e5}
+    .pb-tab.s2 svg{color:#7961db}
+    .pb-tabpill{width:20px;height:20px;border-radius:4px;background:rgba(143,153,168,.15)}
+    .pb-tab svg{color:#5f6b7c}
+    .pb-tab.on{background:rgba(138,187,255,.4);color:#215db0}.pb-tab.on svg{color:#215db0}
+    .pb-tab.warn{color:#935610}.pb-tab.warn svg{color:#c87619}
+    .pb-traycollapse{margin-left:auto;display:inline-flex;align-items:center;padding:0 14px;color:#5f6b7c}
+    .pb-traybody{flex:1;overflow:auto;padding:12px 16px}
+    .pb-table{border-collapse:collapse;width:100%;font-size:12px}.pb-table th{text-align:left;color:#7b8494;font-weight:600;padding:4px 12px 4px 0;border-bottom:1px solid #e2e4e8}
+    .pb-table td{padding:4px 12px 4px 0;border-bottom:1px solid #f0f1f4;color:#2a2f38}
+    .pb-empty-cell{text-align:center;color:#8a909c;padding:16px 8px}
+    .pb-empty{color:#7b8494;padding:14px;border:1px dashed #d8dbe1;border-radius:10px;background:#fbfbfc}
+    .pb-gapnote{margin:12px 0 0;padding:10px 12px;border:1px solid #e5e7eb;border-radius:9px;background:#f7f8fa;color:#5b6270;font-size:11.5px;line-height:1.6}
+    .pb-right{flex:0 0 386px;width:386px;display:flex;background:#fff;border-left:1px solid #dce0e5}
+    .pb-rmain{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;padding:0 0 9px}
+    .pb-righthd{display:flex;align-items:center;height:auto;padding:6.5px 9px 0 7px}
+    .pb-righttitle{font-size:14px;line-height:18.0013px;font-weight:600;color:#1c2127;flex:1}
+    .pb-rhdico{display:inline-flex;color:#5f6b7c;padding:0 7px;cursor:default}
+    .pb-addbtn{display:inline-flex;align-items:center;gap:8px;height:30px;margin-left:11px;padding:0 8px;border:0;border-radius:4px;background:#f7f8f8;color:#1c2127;font:inherit;font-size:14px;line-height:16px;cursor:not-allowed;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
+    .pb-rsearch{display:flex;align-items:center;gap:7px;height:30px;margin:15.5px 10px 0 7px;border:0;border-radius:4px;background:#fff;padding:0 8px;color:#5f6b7c;box-shadow:inset 0 0 0 1px rgba(17,20,24,.2),inset 0 1px 1px rgba(17,20,24,.3)}
+    .pb-rsearch input{flex:1;border:0;background:transparent;font:inherit;font-size:14px;line-height:16px;color:#1c2127;outline:none;padding:0}
+    .pb-rsearch input::placeholder{color:#5f6b7c}
+    .pb-outcard{margin:12px 8px 0;border:1px solid #e5e7eb;border-radius:3px;padding:9px 10px;background:#fff}
+    .pb-outcode{display:flex;align-items:center;gap:7px;font-size:14px;line-height:16px;color:#215db0;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .pb-outcode svg{color:#2d72d2;flex:0 0 16px}
+    .pb-outsub{font-size:12px;color:#5f6b7c;margin:3px 0 0 23px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .pb-outmapped{font-size:12px;color:#0e8a53;margin:6px 0 0 23px}
+    .pb-outstat{margin:10px 8px 0;font-size:12px;color:#5f6b7c}
+    .pb-settings{margin-top:auto;padding:12px 10px 0 8px;border-top:1px solid #eef0f2}
+    .pb-outboxt{font-size:14px;line-height:18.0013px;font-weight:600;color:#1c2127;margin:0 0 10px}
+    .pb-setrow{display:flex;gap:10px;font-size:12px;line-height:15.4297px;color:#1c2127;padding:0 0 8px}
+    .pb-setk{color:#5f6b7c;width:96px;flex:0 0 96px}
+    .pb-setv{font-style:italic;color:#5f6b7c;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .pb-editrow{display:flex;align-items:center;gap:0;margin-top:2px}
+    .pb-editbtn{flex:1;display:inline-flex;align-items:center;justify-content:center;height:30px;border:0;border-radius:4px 0 0 4px;background:#f7f8f8;color:#1c2127;font-size:14px;line-height:16px;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
+    .pb-moreico{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border:0;border-radius:0 4px 4px 0;color:#5f6b7c;background:#f7f8f8;box-shadow:inset 0 0 0 1px rgba(64,72,84,.33),0 1px 2px rgba(17,20,24,.1)}
+    .pb-rstrip{flex:0 0 50px;width:50px;background:#fff;border-left:1px solid #e2e4e8;display:flex;flex-direction:column;align-items:center;padding:5px 0;gap:5px}
+    .pb-stripico{display:inline-flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:4px;color:#5f6b7c}
+    .pb-stripico.g{margin-top:14px;position:relative}
+    .pb-stripico.g::before{content:"";position:absolute;top:-7.5px;left:0;width:40px;height:1px;background:#d8dbde}
+    .pb-stripico.on{background:#dfe0e1}`;
+
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Pipeline Builder</title><style>${css}</style></head>
+    <body><div class="pb-shell">${globalRail}<div class="pb-main">${header}<div class="pb-work">${canvasWrap}${rightPanel}</div></div></div></body></html>`;
+}


### PR DESCRIPTION
## Mechanical extraction + toolkit — NOT the interaction PR

Second PR of the functional-runtime wave (stacked on #55). No node selection, no inspector behavior, no command changes, no visual drift — those arrive in #57 using the kit shipped here.

## Pipeline is the first real app module

`surfaces/pipeline/index.mjs` under the surface contract:

- `meta` — code-side identity (slug/route/verifier/certification), asserted to agree with both the registry entry and the parity-matrix seed
- `load(ctx)` — the exact daemon fetch set the flat branch performed; dead daemon → honest empty lists
- `render(model, ctx)` — the renderer moved **verbatim** (local `CX_ESC = escHtml` alias keeps the block byte-identical)
- `actions: []` — command discipline is PR #58

The registry imports and binds the module itself — the registry is now the single mount point; the serve's inline binding is deleted and its dispatch speaks `load/render(model, ctx)`. Route unchanged at the same chain position (behind auth/posture gates).

`surfaces/chrome.mjs`: `ioiGlobalRailHtml` + `IOI_GRAIL_CSS` moved verbatim — the pixel-frozen rail every certified port renders; serve imports it, all 13 other call sites untouched.

## Interaction kit (deliberately unwired)

`surfaces/kit.mjs`: `escHtml` (THE canonical escaper — serve aliases it; two stale local copies deduped), `parseSelection`/`selectionQuery` (URL = selection's single source of truth, stable key order, roundtrip-tested), `inspectorShell`, `trayShell`, `disabledCommand` (visible, names its reason — standing-rule lane 4), `proofLink`, `semanticMask`.

## Zero drift, proven

`/__ioi/pipeline` HTML captured live before the extraction and diffed after: **byte-identical** (checked twice, including post-restart). Pipeline's pixel-cert artifact untouched (`git status` clean on `pixel-certifications/`).

## Done bar

| verifier | result |
|---|---|
| surface-modules (NEW) | 22/22 |
| pipeline | 31/31 |
| app-runtime-safety | 20/20 |
| reference-parity-reset | 23/23 |
| pixel harness | 37/37 |
| approvals (sibling) | 23/23 |
| foundry-models (sibling) | 17/17 |
| home-surface | 56/56 |
| matrix --check | clean |
| NUL/control chars · Rust | none |

Next (PR #57): Pipeline node selection + node-specific inspectors over real daemon records — the wave's acceptance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)