### PR TITLE
feat(hypervisor): Pipeline Build/Preview command discipline — no silent no-ops (#58)

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-pipeline.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-pipeline.mjs
@@ -226,9 +226,11 @@ async function run() {
     }
   }
 
-  // 5. Unsupported controls disabled IN PLACE (not moved to a separate page).
-  ok("Build + Preview are enabled controls in the header", /pb-btn primary"[^>]*>Build</.test(t) && /href="#pb-preview"/.test(t));
-  ok("Schedule + Deploy are present but DISABLED in place (named gaps, not hidden)", /<button[^>]*disabled[^>]*>Schedule<\/button>/.test(t) && /<button[^>]*disabled[^>]*>Deploy<\/button>/.test(t));
+  // 5. COMMAND DISCIPLINE (static) — every header command is a real action or a visible disabled
+  // control naming its reason; nothing is a blank-href/fragment no-op.
+  ok("Preview is a REAL command: a state URL selecting the materialized node with the ontology preserved (not a fragment no-op)", (() => { const m = t.match(/data-cmd="preview" href="([^"]*)"/); return !!m && m[1].includes("node=materialized") && m[1].includes(`ontology=${ont.id}`) && m[1].endsWith("#pb-preview"); })());
+  ok("Build is DISABLED in place naming the exact governed-ladder requirement (no POST pretends to build)", /<button class="pb-btn primary" disabled[^>]*>Build<\/button>/.test(t) && t.includes('data-ioi-disabled-reason="no single-call build authority exists') && t.includes("wallet-approved lease → sealed ConnectorSession → execute"));
+  ok("Schedule + Deploy are present but DISABLED in place with named reasons (named gaps, not hidden)", /<button[^>]*disabled[^>]*>Schedule<\/button>/.test(t) && /<button[^>]*disabled[^>]*>Deploy<\/button>/.test(t) && (t.match(/data-ioi-disabled-reason="/g) || []).length >= 3);
   ok("reference capture linked as the secondary baseline; brand/reference clean", t.includes("/__apps/pipeline") && !/\bPalantir\b/.test(t) && !/\bFoundry\b/.test(t));
 
   // 6. Conditionally honest — a fresh ontology's pipeline is "not built".
@@ -236,6 +238,50 @@ async function run() {
   track("domain-ontologies", fresh);
   const freshPage = await page(`${SERVE}/__ioi/pipeline?ontology=${encodeURIComponent(fresh)}`);
   ok("a fresh ontology's pipeline is honestly 'not built' (0/7 stages live)", /pb-declared">not built/.test(freshPage.text) && /0\/7 stages live/.test(freshPage.text));
+
+  // 6b. COMMAND DISCIPLINE (interactive, #58) — Preview clicked on a BUILT pipeline lands on the
+  // real materialized preview; clicked on an UNBUILT one lands on the honest missing-rung state;
+  // a disabled Build cannot mutate daemon truth; the module's command table IS the contract.
+  {
+    const { chromium } = await import("playwright");
+    const b = await chromium.launch();
+    try {
+      const pg = await b.newPage({ viewport: { width: 1440, height: 900 } });
+      await pg.goto(`${SERVE}/__ioi/pipeline?ontology=${encodeURIComponent(ont.id)}`, { waitUntil: "networkidle" });
+      ok("Build renders visibly disabled with the ladder requirement named (in the reference shell location)", await pg.locator('button.pb-btn.primary[disabled][data-ioi-disabled-reason*="MaterializingRun"]').count() === 1);
+      const setsBefore = ((await jd("GET", "/v1/hypervisor/odk/materialized-object-sets")).j.materialized_object_sets || []).length;
+      await pg.locator("button.pb-btn.primary[disabled]").dispatchEvent("click");
+      await pg.waitForTimeout(400);
+      const setsAfter = ((await jd("GET", "/v1/hypervisor/odk/materialized-object-sets")).j.materialized_object_sets || []).length;
+      ok("a disabled Build cannot mutate daemon truth (forced click → no new materialized set, no navigation)", setsBefore === setsAfter && new URL(pg.url()).pathname === "/__ioi/pipeline", `${setsBefore} sets before and after`);
+      // Preview on the BUILT pipeline.
+      await pg.click('a[data-cmd="preview"]');
+      await pg.waitForLoadState("domcontentloaded");
+      const pu = new URL(pg.url());
+      ok("Preview click: URL selects the materialized node, preserves the ontology, lands on the tray", pu.searchParams.get("node") === "materialized" && pu.searchParams.get("ontology") === ont.id && pu.hash === "#pb-preview", pu.search + pu.hash);
+      const trayText = ((await pg.locator("#pb-tray-node").textContent().catch(() => "")) || "");
+      const daemonSet = ((await jd("GET", "/v1/hypervisor/odk/materialized-object-sets")).j.materialized_object_sets || []).find((s) => s.id === setId);
+      ok("Preview shows THE daemon materialized set's rows (every key value present, count matches)", !!daemonSet && (daemonSet.objects || []).length > 0 && daemonSet.objects.every((o) => trayText.includes(String((o.properties || {}).loan_id))) && ((await pg.locator("#pb-inspector").textContent()) || "").includes(String(daemonSet.count)), daemonSet ? `${daemonSet.count} objects cross-checked` : "set missing");
+      ok("Preview result cites provenance (materializing run ref in the inspector)", (((await pg.locator("#pb-inspector").textContent()) || "")).includes("materializing-run://"));
+      const htmlBuilt = await pg.content();
+      // Preview on the UNBUILT pipeline.
+      await pg.goto(`${SERVE}/__ioi/pipeline?ontology=${encodeURIComponent(fresh)}`, { waitUntil: "networkidle" });
+      await pg.click('a[data-cmd="preview"]');
+      await pg.waitForLoadState("domcontentloaded");
+      const freshTray = ((await pg.locator(".pb-traybody").textContent().catch(() => "")) || "");
+      ok("Preview on an unbuilt pipeline names the missing rungs honestly (no fabricated rows)", freshTray.includes("Nothing is materialized") && freshTray.includes("missing rung") && freshTray.includes("Object mapping") && !freshTray.includes("L-1"));
+      const htmlFresh = await pg.content();
+      // No silent no-ops: every header command is a real (non-fragment) href XOR disabled+reason.
+      const cmds = await pg.evaluate(() => [...document.querySelectorAll(".pb-hmid .pb-btn")].map((el) => ({ tag: el.tagName, href: el.getAttribute("href") || "", disabled: el.hasAttribute("disabled"), reason: el.getAttribute("data-ioi-disabled-reason") || "", text: (el.textContent || "").trim() })));
+      ok("no command is a silent no-op: real state/route href XOR disabled-with-named-reason", cmds.length >= 6 && cmds.every((c) => (c.tag === "A" && c.href && !c.href.startsWith("#")) || (c.disabled && c.reason.length > 20)), cmds.map((c) => `${c.text}:${c.disabled ? "disabled" : c.href.slice(0, 30)}`).join(" · "));
+      // The module's declared command table is the contract the DOM rendered from.
+      const mod = await import(path.join(appRoot, "surfaces", "pipeline", "index.mjs"));
+      ok("module command table: enabled ⇒ route+proof · disabled ⇒ named reason (Build/Schedule/Deploy disabled, Preview read-navigation)", mod.actions.length === 4 && mod.actions.every((a) => a.key && a.label && (a.enabled ? (a.route && a.proof) : (a.reason && a.reason.length > 20))) && !mod.actions.find((a) => a.key === "build").enabled && mod.actions.find((a) => a.key === "preview").enabled);
+      ok("no-secrets sweep across command result pages (built + unbuilt)", !htmlBuilt.includes(SENTINEL) && !htmlFresh.includes(SENTINEL) && !htmlBuilt.includes(`:${port}/rows`) && !htmlFresh.includes(`:${port}/rows`));
+    } finally {
+      await b.close();
+    }
+  }
 
   // 7. The ODK ladder itself is intact + cross-links to the pipeline view.
   const odk = await page(`${SERVE}/__ioi/odk?ontology=${encodeURIComponent(ont.id)}`);

--- a/apps/hypervisor/scripts/verify-hypervisor-surface-modules.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-surface-modules.mjs
@@ -35,7 +35,8 @@ async function run() {
   const matrix = JSON.parse(readFileSync(join(APP, "harvest-app-parity-matrix.json"), "utf8"));
   const seed = (matrix.seeds || []).find((s) => s.slug === "pipeline");
   ok("module meta agrees with the parity-matrix seed", !!seed && seed.candidate_surface.split("?")[0] === pipeline.meta.route && seed.shell_pixel_certification_artifact === pipeline.meta.certification && seed.shell_pixel_certified === true);
-  ok("no wired actions yet (command discipline is a later PR)", pipeline.actions.length === 0);
+  ok("command table honors the discipline contract: enabled ⇒ route+proof, disabled ⇒ named reason", pipeline.actions.length === 4 && pipeline.actions.every((a) => a.key && a.label && (a.enabled ? (typeof a.route === "string" && typeof a.proof === "string") : (typeof a.reason === "string" && a.reason.length > 20))));
+  ok("Build/Schedule/Deploy stay disabled (no authority crossed); Preview is the one enabled read-navigation", pipeline.actions.filter((a) => a.enabled).map((a) => a.key).join(",") === "preview" && pipeline.actions.find((a) => a.key === "build").authority === null);
 
   // 2. Registry mounts the module itself; offline render keeps the certified shell landmarks.
   const hit = boundSurface("/__ioi/pipeline", "GET");

--- a/apps/hypervisor/surfaces/pipeline/index.mjs
+++ b/apps/hypervisor/surfaces/pipeline/index.mjs
@@ -55,9 +55,19 @@ export function render(model, ctx) {
   return renderPipelineBuilder(model, sel.ontology || "", sel.node || "");
 }
 
-// No commands are wired yet: Build/Preview/Schedule/Deploy stay exactly as the certified shell
-// renders them (the command-discipline PR gives them the authority-or-disabled contract).
-export const actions = [];
+// The Pipeline command table (command-discipline contract): every command is either an ENABLED
+// action carrying its route + expected proof, or DISABLED with a reason naming exactly what is
+// missing — never a blank href, never a silent no-op. Build stays DISABLED: materialization is
+// the governed ODK ladder (MaterializingRun citing a CapabilityLeasePlan → wallet-approved lease
+// → sealed ConnectorSession → execute) — a multi-step, wallet-gated authority, not a single safe
+// call; a POST that pretended otherwise would cross an authority line this surface doesn't own.
+// The header renders FROM this table, so the UI cannot drift from the declared command model.
+export const actions = [
+  { key: "preview", label: "Preview", enabled: true, kind: "read_navigation", route: "/__ioi/pipeline?node=materialized", proof: "the materialized set's real rows + provenance refs render in the tray (read-only — no authority crossed)" },
+  { key: "build", label: "Build", enabled: false, authority: null, reason: "no single-call build authority exists — materialization is the governed ODK ladder: MaterializingRun (citing a CapabilityLeasePlan) → wallet-approved lease → sealed ConnectorSession → execute; run the ladder from the Ontology Manager" },
+  { key: "schedule", label: "Schedule", enabled: false, authority: null, reason: "no pipeline scheduler exists yet — a named gap (author + run via a materializing run)" },
+  { key: "deploy", label: "Deploy", enabled: false, authority: null, reason: "no pipeline deploy exists yet — a named gap" },
+];
 
 // ============================ PIPELINE BUILDER (reference-UX parity over the ODK ladder) =========
 // The Reference UX Port program (post-#31 reset), substrate for the Data Pipeline Builder. The reference
@@ -122,6 +132,7 @@ function renderPipelineBuilder(lists, selectedId, nodeParam) {
   const inspectorMode = !!(selected && nodeParam);
   const invalidNode = !!(nodeParam && !nodeValid);
   const nodeHref = (key) => selectionQuery("/__ioi/pipeline", { ontology: oid, node: key });
+  const missingRungs = nodes.filter((n) => n.cls === "missing").map((n) => n.label);
   const enc = encodeURIComponent, esc = CX_ESC;
   const oname = selected ? esc(selected.domain || selected.id) : "no pipeline";
 
@@ -271,7 +282,9 @@ function renderPipelineBuilder(lists, selectedId, nodeParam) {
           irow("reset", disabledCommand({ label: "Delete object set", reason: "deletion is a daemon authority (DELETE …/materialized-object-sets/:id) — command wiring is the command-discipline PR, a named gap here" })),
         ].join("") : emptyStage("Materialized object set"),
         trayTitle: "Materialized objects — preview rows",
-        tray: previewTable,
+        tray: (st ? "" : ihint(missingRungs.length
+          ? `Nothing is materialized on this pipeline yet — missing rung${missingRungs.length === 1 ? "" : "s"}: ${missingRungs.map((l) => `<b>${esc(l)}</b>`).join(" · ")}. Build runs the governed ladder from the <a href="/__ioi/odk?ontology=${enc(oid)}">Ontology Manager</a>; nothing is fabricated here.`
+          : `Every ladder rung is declared but the materializing run has not executed yet — nothing is materialized, and nothing is fabricated here. Execute the run from the <a href="/__ioi/odk?ontology=${enc(oid)}">Ontology Manager</a>.`)) + previewTable,
       };
       default: return { title: "Pipeline", sub: "", body: emptyStage("node"), trayTitle: "Selection", tray: previewTable };
     }
@@ -301,6 +314,16 @@ function renderPipelineBuilder(lists, selectedId, nodeParam) {
     ["Output Dataset", "#147eb3", osets.length],
   ];
 
+  // ---- Command state (command-discipline): the header renders from the module's declared
+  // command table. Preview is a real read-navigation — it selects the materialized node (URL
+  // state, ontology preserved) and lands on the tray, where real rows or the honest missing-rung
+  // state render. Build/Schedule/Deploy are visibly disabled with their named reasons (the whole
+  // cluster sits inside the harness's both-sides session-state mask, so command-state changes
+  // never move certified shell pixels). The old Build→ODK jump lives on as the explicit
+  // "Ontology Manager" link — a labeled navigation, not a command pretending to build.
+  const cmd = Object.fromEntries(actions.map((a) => [a.key, a]));
+  const previewHref = `${nodeHref("materialized")}#pb-preview`;
+
   // ---- HEADER (h51, white, hairline shadow) — the reference navbar: app chip · breadcrumb title row
   // (live names → masked as dynamic data) + File/Settings/Help menu row (named gaps) + Batch tag · a
   // FLUID MIDDLE zone that in the reference carries captured SESSION STATE (tabs/undo/branch/build
@@ -321,10 +344,10 @@ function renderPipelineBuilder(lists, selectedId, nodeParam) {
       </div>
     </div>
     <div class="pb-hmid">
-      <a class="pb-btn primary" href="/__ioi/odk?ontology=${enc(oid)}">Build</a>
-      <a class="pb-btn ghost" href="#pb-preview">Preview</a>
-      <button class="pb-btn ghost" disabled title="No pipeline scheduler yet — a named gap (author + run via a materializing run).">Schedule</button>
-      <button class="pb-btn ghost" disabled title="No pipeline deploy yet — a named gap.">Deploy</button>
+      <button class="pb-btn primary" disabled title="${esc(cmd.build.reason)}" data-ioi-disabled-reason="${esc(cmd.build.reason)}">Build</button>
+      <a class="pb-btn ghost" data-cmd="preview" href="${previewHref}">Preview</a>
+      <button class="pb-btn ghost" disabled title="${esc(cmd.schedule.reason)}" data-ioi-disabled-reason="${esc(cmd.schedule.reason)}">Schedule</button>
+      <button class="pb-btn ghost" disabled title="${esc(cmd.deploy.reason)}" data-ioi-disabled-reason="${esc(cmd.deploy.reason)}">Deploy</button>
       <a class="pb-btn link" href="/__ioi/lineage?ontology=${enc(oid)}">Lineage</a>
       <a class="pb-btn link" href="/__ioi/odk?ontology=${enc(oid)}">Ontology Manager</a>
     </div>


### PR DESCRIPTION
## Commands become honest

Fourth PR of the functional-runtime wave (stacked on #57). Pipeline's commands now follow the discipline: **enabled with route + expected proof, or visibly disabled with the exact missing requirement named. Never a silent no-op.** The header renders from the module's declared command table (`actions` export), so UI and contract cannot drift.

## Preview — a real command

- Selects the materialized node via URL state (`?node=materialized`, ontology preserved) and lands on the tray.
- **Built pipeline** → the daemon materialized set's real rows, count, and provenance refs (verifier cross-checks every row against the set's own objects).
- **Unbuilt pipeline** → the honest missing-rung state naming each absent ladder stage; nothing fabricated.
- Replaces the old `#pb-preview` fragment scroll (a near-no-op).

## Build — disabled, and exact about why

Inventory conclusion: no single safe governed build call exists. Materialization is the wallet-gated ODK ladder — `MaterializingRun` (citing a `CapabilityLeasePlan`) → wallet-approved lease → sealed `ConnectorSession` → execute. So Build stays **disabled in place**, its reason names that ladder verbatim, and no POST pretends to build. The ladder remains reachable through the explicit Ontology Manager link (a labeled navigation, not a fake command). Schedule/Deploy remain named gaps.

## Pixel discipline

The command cluster sits exactly inside the harness's both-sides session-state mask (ref rect x698 w494 ≡ `pb-hmid` at 230+468), verified against the mask-union code path — command-state changes cannot move certified pixels. Cert artifact untouched; **pixel harness 37/37**.

## Verifier (+10, now 77/77)

Preview clicked on built and unbuilt fixtures · rows ≡ daemon set objects · forced click on disabled Build proves **zero daemon mutation** · no-silent-no-op sweep over every header command · module command table asserted as the contract · no-secrets sweep extended to command result pages · #57 selection/persistence checks intact.

## Done bar

pipeline **77/77** · pixel harness **37/37** · surface-modules **23/23** · runtime-safety **20/20** · reset **23/23** · approvals **23/23** · models **17/17** · matrix clean · certs untouched · no NUL · no Rust

Pipeline pilot complete: selection → inspectors → persistence → command discipline. Next: the **Ontology Application Runtime wave** (PR #59 — Manager/Explorer module extraction + shared ontology context, zero behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)