### PR TITLE
feat(hypervisor): Object Explorer semantic selection + inspectors — the semantic layer opens (#60)

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-app-parity-object-explorer.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-app-parity-object-explorer.mjs
@@ -95,6 +95,88 @@ async function run() {
   ok("unsupported reference lanes are DISABLED IN PLACE + named (object search · Filter-by · Recents/Favorites · sort · type-group/application · exploration tabs · ontology selector · per-user set lanes), never hidden", (port.text.match(/disabled/g) || []).length >= 5 && /named gap/.test(port.text) && /reference-only/.test(port.text));
   ok("brand-clean: no Palantir/Foundry branding on the port", !/\bPalantir\b/.test(port.text) && !/\bFoundry\b/.test(port.text));
 
+  // 4b. SEMANTIC SELECTION + INSPECTORS (Ontology wave #60, THE acceptance test): click a type/
+  // shortcut/set → the URL carries the ontology context, the row selects, the semantic inspector
+  // renders REAL COM/set truth, and refresh preserves the context. Explorer can select and
+  // inspect semantic truth; it can NOT edit objects or execute actions (standing boundary).
+  {
+    const jdp = (method, pth, body) => fetch(`${DAEMON}${pth}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined }).then((r) => r.json()).catch(() => ({}));
+    // Fixture: two object types (one a guaranteed never-matches decoy), a link between them, an
+    // action declaration on the first — the inspector must cite exactly THIS COM.
+    const fixDomain = `explorer-inter-${process.pid}`;
+    const fx = await jdp("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: fixDomain, canonical_object_model: {
+      object_types: [
+        { id: "alphaw", name: "AlphaWidgetKind", title_property: "t", properties: [{ id: "t", name: "T", value_type: "string", required: true }, { id: "x", name: "X", value_type: "string" }] },
+        { id: "zzdecoy2", name: "ZZDecoyNeverMatchesTwo", title_property: "d", properties: [{ id: "d", name: "D", value_type: "string" }] },
+      ],
+      link_types: [{ id: "l1", name: "alpha-owns-decoy", from: "alphaw", to: "zzdecoy2", cardinality: "one_to_many" }],
+      action_types: [{ id: "actp", name: "PromoteAlpha", kind: "modify_object", applies_to: "alphaw" }] } });
+    const fixId = fx.ontology?.id;
+    const { chromium } = await import("playwright");
+    const b = await chromium.launch();
+    try {
+      const pg = await b.newPage({ viewport: { width: 1440, height: 900 } });
+      await pg.goto(`${SERVE}/__ioi/ontology/explorer`, { waitUntil: "networkidle" });
+      ok("bare route renders NO inspector (the pixel gate's capture state)", await pg.locator('[data-testid="oe-inspector"]').count() === 0 && await pg.locator("tr.oe-trow").count() > 0);
+      // Type selection.
+      await pg.click('tr.oe-trow[data-objecttype="alphaw"] a.oe-tlink');
+      await pg.waitForLoadState("domcontentloaded");
+      const u1 = new URL(pg.url());
+      ok("type click: URL carries ontology + objectType", u1.searchParams.get("objectType") === "alphaw" && u1.searchParams.get("ontology") === fixId, u1.search);
+      ok("type click: the row selects (exactly one)", await pg.locator('tr.oe-trow.oe-sel[data-objecttype="alphaw"]').count() === 1 && await pg.locator("tr.oe-trow.oe-sel").count() === 1);
+      const ti = ((await pg.locator("#oe-sem-inspector").textContent().catch(() => "")) || "");
+      ok("type inspector cites THE fixture COM (ontology · title property · both properties · link · action declaration)", [fixDomain, "AlphaWidgetKind", "alphaw", "t", "x", "alpha-owns-decoy", "PromoteAlpha", "declarations"].every((m) => ti.includes(m)), [fixDomain, "AlphaWidgetKind", "alpha-owns-decoy", "PromoteAlpha"].filter((m) => !ti.includes(m)).join(",") || "all cited");
+      ok("type inspector shows the honest object count (0 — nothing materialized for the fixture)", />0<\/b>|<b>0<\/b>/.test(await pg.locator("#oe-sem-inspector").innerHTML()) || ti.includes("0 across 0"));
+      ok("semantic breadcrumb renders with the manager backlink", await pg.locator('#oe-sem-inspector [data-testid="ioi-sem-breadcrumb"] a[href*="/__ioi/ontology/manager"]').count() >= 1);
+      ok("action execution is a DISABLED named gap; no editor, no enabled action", await pg.locator("#oe-sem-inspector button.ioi-cmd-disabled[data-ioi-disabled-reason]").count() === 2 && await pg.locator("#oe-sem-inspector button:not([disabled])").count() === 0 && await pg.locator("#oe-sem-inspector form").count() === 0);
+      // Refresh preserves the semantic context.
+      await pg.reload({ waitUntil: "domcontentloaded" });
+      ok("refresh preserves the selected type (URL-persisted context)", await pg.locator('tr.oe-trow.oe-sel[data-objecttype="alphaw"]').count() === 1 && ((await pg.locator("#oe-sem-inspector").textContent()) || "").includes("AlphaWidgetKind"));
+      // Filter interplay: a filter that hides the selection keeps it and EXPLAINS.
+      await pg.goto(`${SERVE}/__ioi/ontology/explorer?objectType=alphaw&ontology=${encodeURIComponent(fixId)}&q=ZZDecoyNeverMatchesTwo`, { waitUntil: "domcontentloaded" });
+      const ft = ((await pg.locator("#oe-sem-inspector").textContent().catch(() => "")) || "");
+      ok("filter hiding the selection keeps it and explains (clear-filter link offered)", ft.includes("AlphaWidgetKind") && ft.includes("hidden by the current filter") && await pg.locator('#oe-sem-inspector a[href*="objectType=alphaw"]').count() >= 1);
+      ok("filter form preserves the selection (hidden context inputs)", await pg.locator('form.oe-filterform input[type="hidden"][name="objectType"][value="alphaw"]').count() === 1);
+      // Invalid selections fail CLOSED.
+      await pg.goto(`${SERVE}/__ioi/ontology/explorer?objectType=nope&ontology=${encodeURIComponent(fixId)}`, { waitUntil: "domcontentloaded" });
+      ok("invalid objectType fails closed with an honest note", (((await pg.locator("#oe-sem-inspector").textContent().catch(() => "")) || "")).includes("fail-closed") && await pg.locator("tr.oe-trow.oe-sel").count() === 0);
+      await pg.goto(`${SERVE}/__ioi/ontology/explorer?objectSet=bogus-set`, { waitUntil: "domcontentloaded" });
+      ok("invalid objectSet fails closed with an honest note", (((await pg.locator("#oe-sem-inspector").textContent().catch(() => "")) || "")).includes("fail-closed"));
+      // Object-set selection over a REAL materialized set (conditional — reuse, never fabricate).
+      if (msets.length) {
+        const m0 = msets[0];
+        await pg.goto(`${SERVE}/__ioi/ontology/explorer`, { waitUntil: "domcontentloaded" });
+        await pg.click(`tr.oe-trow[data-objectset="${m0.id}"] a.oe-tlink`);
+        await pg.waitForLoadState("domcontentloaded");
+        const u2 = new URL(pg.url());
+        ok("set click: URL carries ontology + objectSet", u2.searchParams.get("objectSet") === m0.id, u2.search);
+        ok("set click: the row selects", await pg.locator(`tr.oe-trow.oe-sel[data-objectset="${m0.id}"]`).count() === 1);
+        const si = ((await pg.locator("#oe-sem-inspector").textContent().catch(() => "")) || "");
+        ok("set inspector count + provenance MATCH the daemon set", si.includes(String(m0.count)) && si.includes(m0.materializing_run_ref || "") && (!m0.pre_output_receipt_ref || si.includes(m0.pre_output_receipt_ref)), `count ${m0.count}`);
+        const firstObj = (m0.objects || [])[0];
+        ok("preview rows are REAL daemon objects (first row value present; nothing fabricated)", !firstObj || si.includes(String(Object.values(firstObj.properties || {})[0] ?? "")), firstObj ? "first row cross-checked" : "empty set (honest)");
+        const html3 = await pg.content();
+        ok("set source contact is origin-redacted (full endpoint never renders)", !m0.source_contact || !m0.source_contact.endpoint || (!html3.includes(m0.source_contact.endpoint) && html3.includes("path redacted")));
+        for (const [label, sel2] of [["Pipeline", 'a[href*="/__ioi/pipeline"]'], ["Lineage", 'a[href*="/__ioi/lineage"]'], ["Vertex", 'a[href*="/__ioi/vertex"]'], ["Manager", 'a[href*="/__ioi/ontology/manager"]']]) {
+          const href = await pg.locator(`#oe-sem-inspector ${sel2}`).first().getAttribute("href").catch(() => null);
+          const r2 = href ? await fetch(`${SERVE}${href}`).then((r) => r.status).catch(() => 0) : 0;
+          ok(`set inspector deep-link to ${label} resolves (200)`, r2 === 200, `${href} -> ${r2}`);
+        }
+      } else {
+        ok("set-selection lane skipped honestly (no materialized sets in the daemon)", true);
+      }
+      // Shortcut cards select the represented object type (real sets back them).
+      if (msets.length) {
+        await pg.goto(`${SERVE}/__ioi/ontology/explorer`, { waitUntil: "domcontentloaded" });
+        const shHref = await pg.locator("a.oe-card").first().getAttribute("href");
+        ok("shortcut card targets the represented object type through the ontology context", !!shHref && shHref.includes("objectType=") && shHref.includes("ontology="), shHref || "no cards");
+      }
+    } finally {
+      await b.close();
+      if (fixId) await jdp("DELETE", `/v1/hypervisor/odk/domain-ontologies/${encodeURIComponent(fixId)}`);
+    }
+  }
+
   // 5. SHELL-PIXEL CERTIFICATION — committed, non-pinned, both viewports; body excluded by design.
   {
     let cert = null;

--- a/apps/hypervisor/surfaces/object-explorer/index.mjs
+++ b/apps/hypervisor/surfaces/object-explorer/index.mjs
@@ -5,7 +5,7 @@
 import { bpIcon, EXPLORER_APP_ICON_URI } from "../../scripts/bp-icons.mjs";
 import { ioiGlobalRailHtml, IOI_GRAIL_CSS } from "../chrome.mjs";
 import { escHtml } from "../kit.mjs";
-import { loadOntologyModel } from "../ontology-context.mjs";
+import { loadOntologyModel, parseOntologyContext, managerLink, objectTypeLink, objectSetLink, semanticBreadcrumb, semanticInspectorShell, disabledSemanticAction, formatRef } from "../ontology-context.mjs";
 
 const CX_ESC = escHtml; // local alias so the moved block stays byte-identical to its serve original
 
@@ -21,11 +21,11 @@ export async function load(ctx) {
 }
 
 export function render(model, ctx) {
-  return renderObjectExplorerPort(model.overview, model.lists, { q: ctx.url.searchParams.get("q") || "" });
+  return renderObjectExplorerPort(model.overview, model.lists, { q: ctx.url.searchParams.get("q") || "", sel: parseOntologyContext(ctx.url) });
 }
 
-// Browsing-first: object-type/set selection arrives with the Explorer-interaction PR under the
-// command-discipline contract.
+// Selection is read-navigation through the shared ontology context (never a command); no
+// authority exists on this surface — no object editing, no action execution (standing boundary).
 export const actions = [];
 
 // ============================ OBJECT EXPLORER — reference UX PORT (#35, reference_ported).
@@ -67,10 +67,26 @@ function renderObjectExplorerPort(ov, lists, opts) {
   const shortcuts = msets.slice().sort((a, b) => (b.count || 0) - (a.count || 0)).slice(0, 3);
   const CHIP_COLORS = ["#bd6bbd", "#13c9ba", "#4c90f0"];
 
+  // ---- Semantic selection (Ontology wave): the URL carries the context (ontology/objectType/
+  // objectSet through the shared ontology-context kit). The bare route — the pixel gate's
+  // capture — renders NO inspector and keeps the certified chrome byte-stable; explicit context
+  // params swap in the semantic inspector aside. Unknown context fails CLOSED with an honest
+  // note, never a crash. Rows/cards are the excluded live body, so their selection styling and
+  // retargeted hrefs are pixel-legal.
+  const sel = (opts && opts.sel) || {};
+  const hasSelParam = !!(sel.objectType || sel.objectSet);
+  const selOnt = sel.ontology ? ontologies.find((oo) => oo.id === sel.ontology) || null : null;
+  const selType = sel.objectType && selOnt ? arr(selOnt, "object_types").find((t) => t.id === sel.objectType) || null : null;
+  const selSet = sel.objectSet ? msets.find((m) => m.id === sel.objectSet) || null : null;
+  const selSetOnt = selSet ? ontologies.find((oo) => oo.ref === selSet.ontology_ref) || null : null;
+  const withQ = (href) => (q ? `${href}${href.includes("?") ? "&" : "?"}q=${enc(q)}` : href);
+
   const typeRow = ({ oo, t }) => {
     const n = objectsOf(oo, t);
-    return `<tr class="oe-trow" onclick="location.href='/__ioi/ontology/manager?ontology=${enc(oo.id)}'">
-      <td class="oe-tname"><span class="oe-tchip" style="color:${CHIP_COLORS[(t.id || "").length % 3]}">${bpIcon("cube", 14)}</span>${esc(t.name || t.id)}</td>
+    const href = withQ(objectTypeLink(oo.id, t.id));
+    const on = !!(selType && selOnt && oo.id === selOnt.id && t.id === selType.id);
+    return `<tr class="oe-trow${on ? " oe-sel" : ""}" data-objecttype="${esc(t.id)}"${on ? ' aria-current="true"' : ""} onclick="location.href='${href}'">
+      <td class="oe-tname"><span class="oe-tchip" style="color:${CHIP_COLORS[(t.id || "").length % 3]}">${bpIcon("cube", 14)}</span><a class="oe-tlink" href="${href}">${esc(t.name || t.id)}</a></td>
       <td class="oe-tstatus">${bpIcon("manual", 14)}</td>
       <td>${esc(fmtN(n))}</td>
       <td>${usageOf(oo, t)} link${usageOf(oo, t) === 1 ? "" : "s"}</td>
@@ -78,12 +94,17 @@ function renderObjectExplorerPort(ov, lists, opts) {
       <td class="oe-tdesc">${esc(oo.domain || oo.id)}</td>
     </tr>`;
   };
-  const setRow = (m) => `<tr class="oe-trow" onclick="location.href='/__ioi/odk?ontology=${enc((ontologies.find((oo) => oo.ref === m.ontology_ref) || {}).id || "")}'">
-    <td class="oe-tname"><span class="oe-tchip" style="color:#13c9ba">${bpIcon("layout-grid", 14)}</span>${esc(m.name || m.set_id || m.object_type_id)}</td>
+  const setRow = (m) => {
+    const so = ontologies.find((oo) => oo.ref === m.ontology_ref) || {};
+    const href = withQ(objectSetLink(so.id || "", m.id));
+    const on = !!(selSet && m.id === selSet.id);
+    return `<tr class="oe-trow${on ? " oe-sel" : ""}" data-objectset="${esc(m.id)}"${on ? ' aria-current="true"' : ""} onclick="location.href='${href}'">
+    <td class="oe-tname"><span class="oe-tchip" style="color:#13c9ba">${bpIcon("layout-grid", 14)}</span><a class="oe-tlink" href="${href}">${esc(m.name || m.set_id || m.object_type_id)}</a></td>
     <td>${esc(fmtN(m.count || 0))} object${(m.count || 0) === 1 ? "" : "s"}</td>
-    <td class="oe-tdesc">${esc((ontologies.find((oo) => oo.ref === m.ontology_ref) || {}).domain || m.ontology_ref || "")}</td>
+    <td class="oe-tdesc">${esc(so.domain || m.ontology_ref || "")}</td>
     <td class="oe-tdesc"><a href="/__ioi/ontology/manager">Ontology Manager →</a></td>
   </tr>`;
+  };
 
   const globalRail = ioiGlobalRailHtml({ label: "Object Explorer", href: "/__ioi/ontology/explorer", iconUri: EXPLORER_APP_ICON_URI, railVariant: "rv-pipe", viewAll: false, star: false, badges: true, aipGradient: true, acctMuted: true, hiliteNav: "Ontology" });
 
@@ -104,10 +125,13 @@ function renderObjectExplorerPort(ov, lists, opts) {
     </div>
   </div>`;
 
-  const cards = shortcuts.map((m, i) => `<a class="oe-card" href="/__ioi/odk?ontology=${enc((ontologies.find((oo) => oo.ref === m.ontology_ref) || {}).id || "")}">
+  const cards = shortcuts.map((m, i) => {
+    const so = ontologies.find((oo) => oo.ref === m.ontology_ref) || {};
+    return `<a class="oe-card" data-shortcut-type="${esc(m.object_type_id)}" href="${withQ(objectTypeLink(so.id || "", m.object_type_id))}">
     <span class="oe-cchip" style="background:${CHIP_COLORS[i]}1a;color:${CHIP_COLORS[i]}">${bpIcon("layout-grid", 14)}</span>
     <span class="oe-cbody"><span class="oe-ctitle">${esc(m.name || m.set_id || m.object_type_id)}</span><span class="oe-csub">Object Type&nbsp;&nbsp;•&nbsp;&nbsp;${esc(fmtN(m.count || 0))} object${(m.count || 0) === 1 ? "" : "s"}</span></span>
-  </a>`).join("");
+  </a>`;
+  }).join("");
   const shortcutsBand = `<div class="oe-shrow">
     <span class="oe-shlabel">Shortcuts</span>
     <span class="oe-lanes">
@@ -121,7 +145,7 @@ function renderObjectExplorerPort(ov, lists, opts) {
 
   const catalogBand = `<h3 class="oe-cathead"><span class="oe-cathd">Object type catalog</span></h3>
   <div class="oe-filterrow">
-    <form class="oe-filterform" method="GET" action="/__ioi/ontology/explorer">${bpIcon("filter-funnel")}<input name="q" value="${esc(q)}" placeholder="Filter for an object type..." aria-label="Filter for an object type (live)"><span class="oe-count">${catalog.length} of ${allTypes.length}</span></form>
+    <form class="oe-filterform" method="GET" action="/__ioi/ontology/explorer">${bpIcon("filter-funnel")}<input name="q" value="${esc(q)}" placeholder="Filter for an object type..." aria-label="Filter for an object type (live)">${sel.ontology ? `<input type="hidden" name="ontology" value="${esc(sel.ontology)}">` : ""}${sel.objectType ? `<input type="hidden" name="objectType" value="${esc(sel.objectType)}">` : ""}${sel.objectSet ? `<input type="hidden" name="objectSet" value="${esc(sel.objectSet)}">` : ""}<span class="oe-count">${catalog.length} of ${allTypes.length}</span></form>
     <span class="oe-sortlanes">
       <span class="oe-sort gap" aria-disabled="true" title="Relevancy sorting is a reference-only lane — rows are ordered by ontology then name (named gap)">${bpIcon("sort-desc")}<span class="oe-sortt">Relevancy</span>${bpIcon("caret-down")}</span>
       <span class="oe-lane on gap" aria-disabled="true" title="named gap">All</span>
@@ -152,6 +176,77 @@ function renderObjectExplorerPort(ov, lists, opts) {
     </table>
     <div class="oe-foot">Every row is daemon truth: ${allTypes.length} object type${allTypes.length === 1 ? "" : "s"} across ${ontologies.length} live ontolog${ontologies.length === 1 ? "y" : "ies"} · ${msets.length} materialized set${msets.length === 1 ? "" : "s"}. Schema authoring: <a href="/__ioi/ontology/manager">Ontology Manager →</a> · substrate: <a href="/__ioi/odk">ODK</a> · reference: <a href="/__apps/explorer" target="_blank" rel="noopener">Object Explorer capture ↗</a></div>
   </div>`;
+
+  // ---- Semantic inspectors — real COM/set truth only: declarations stay declarations, no
+  // editor, no action execution (the standing boundary), no fabricated rows. Refs render through
+  // formatRef; the set's source contact is reduced to its ORIGIN (path redacted).
+  const irow = (k, v) => `<div class="oe-irow"><span class="oe-ik">${esc(k)}</span><span class="oe-iv">${v}</span></div>`;
+  const ihint = (h, warn) => `<div class="oe-ihint${warn ? " oe-warnhint" : ""}">${h}</div>`;
+  const safeOrigin = (e) => { try { const u = new URL(e); return `${esc(u.protocol)}//${esc(u.host)}/… <span class="oe-redact">(path redacted)</span>`; } catch { return "(endpoint redacted)"; } };
+  function typeInspector() {
+    const oo = selOnt, t = selType;
+    const props = Array.isArray(t.properties) ? t.properties : [];
+    const links = arr(oo, "link_types").filter((l) => l.from === t.id || l.to === t.id);
+    const acts = arr(oo, "action_types").filter((a) => a.applies_to === t.id);
+    const n = objectsOf(oo, t);
+    const typeSets = msets.filter((m) => m.ontology_ref === oo.ref && m.object_type_id === t.id);
+    const relProjs = projs.filter((p) => p.ontology_ref === oo.ref && (!p.object_type_id || p.object_type_id === t.id));
+    const filteredOut = q && !catalog.some((c) => c.oo.id === oo.id && c.t.id === t.id);
+    return {
+      title: t.name || t.id,
+      sub: `${oo.ref} · object type ${t.id}`,
+      body: [
+        semanticBreadcrumb([{ label: oo.domain || oo.id, href: managerLink({ ontology: oo.id }) }, { label: t.name || t.id }]),
+        filteredOut ? ihint(`The selected type is hidden by the current filter “${esc(q)}” — <a href="${objectTypeLink(oo.id, t.id)}">clear the filter</a> to see its row.`, true) : "",
+        irow("ontology", `${esc(oo.domain || oo.id)} ${formatRef(oo.ref)}`),
+        irow("object type", `${esc(t.name || t.id)} ${formatRef(t.id)}`),
+        irow("title property", t.title_property ? formatRef(t.title_property) : "—"),
+        irow("objects", `<b>${n}</b> across ${typeSets.length} materialized set${typeSets.length === 1 ? "" : "s"}${typeSets.length ? ` — <a href="${objectSetLink(oo.id, typeSets[0].id)}">inspect the set</a>` : ""}`),
+        props.length
+          ? `<table class="oe-itable"><thead><tr><th>property</th><th>value type</th><th></th></tr></thead><tbody>${props.map((p) => `<tr><td>${esc(p.name || p.id)}</td><td>${formatRef(p.value_type || "")}</td><td>${p.id === t.title_property ? "title" : p.required ? "required" : ""}</td></tr>`).join("")}</tbody></table>`
+          : ihint("No properties declared on this type — an honest empty declaration."),
+        irow("link declarations", links.length ? links.map((l) => `${formatRef(l.from)} → ${formatRef(l.to)}${l.name ? ` <span class="oe-redact">(${esc(l.name)})</span>` : ""}`).join("<br>") : "none declared"),
+        irow("action declarations", acts.length ? acts.map((a) => `${esc(a.name || a.id)} ${formatRef(a.kind || "")}`).join("<br>") : "none declared"),
+        acts.length ? ihint("Action <b>declarations</b> only — no action authority exists on this surface; execution stays a named gap (standing boundary).") : "",
+        irow("projections", relProjs.length ? relProjs.map((p) => esc(p.name || p.id)).join(", ") : "none"),
+        irow("open in", `<a href="${managerLink({ ontology: oo.id })}">Ontology Manager</a> · <a href="/__ioi/pipeline?ontology=${enc(oo.id)}">Pipeline</a>`),
+        `<div class="oe-iacts">${disabledSemanticAction({ label: "Execute action", reason: "action declarations carry no execution authority — no action plane exists on this surface (standing boundary)" })}${disabledSemanticAction({ label: "Search instances", reason: "object-instance search is a reference-only lane — objects exist as materialized sets (browse the set catalog)" })}</div>`,
+      ].join(""),
+    };
+  }
+  function setInspector() {
+    const m = selSet, so = selSetOnt || {};
+    const p = projs.find((x) => x.id === m.ontology_projection_id) || null;
+    const pcols = p ? (p.visible_properties || []) : Object.keys(((m.objects || [])[0] || {}).properties || {});
+    const prows = (m.objects || []).slice(0, 8);
+    const typeHref = so.id ? objectTypeLink(so.id, m.object_type_id) : "";
+    return {
+      title: m.name || m.object_type_id || m.id,
+      sub: m.ref || m.id,
+      body: [
+        semanticBreadcrumb([{ label: so.domain || m.ontology_ref || "ontology", href: so.id ? managerLink({ ontology: so.id }) : undefined }, { label: m.object_type_id || "type", href: typeHref || undefined }, { label: "object set" }]),
+        irow("object set", formatRef(m.ref || m.id)),
+        irow("object type", typeHref ? `<a href="${typeHref}">${esc(m.object_type_id)}</a>` : formatRef(m.object_type_id)),
+        irow("objects", `<b>${m.count ?? 0}</b> (rows fetched ${m.rows_fetched ?? "—"}${m.truncated_to_limit ? " · truncated to limit" : ""})`),
+        irow("registered", esc(m.registered_at || "—")),
+        irow("provenance", [m.materializing_run_ref, m.connector_session_ref, m.capability_lease_plan_ref].filter(Boolean).map(formatRef).join(" ") || "—"),
+        irow("pre-output receipt", m.pre_output_receipt_ref ? formatRef(m.pre_output_receipt_ref) : "—"),
+        m.source_contact ? irow("source contact", `${safeOrigin(m.source_contact.endpoint || "")} · http ${esc(String(m.source_contact.http_status ?? "—"))}`) : "",
+        irow("preview", `${prows.length} of ${m.count ?? 0} row${(m.count ?? 0) === 1 ? "" : "s"} below — real daemon objects`),
+        prows.length
+          ? `<table class="oe-itable"><thead><tr>${pcols.map((c) => `<th>${esc(c)}</th>`).join("")}</tr></thead><tbody>${prows.map((o2) => `<tr>${pcols.map((c) => `<td>${esc(String((o2.properties || {})[c] ?? ""))}</td>`).join("")}</tr>`).join("")}</tbody></table>`
+          : ihint("This set holds no rows — honest empty; nothing is fabricated."),
+        irow("open in", `<a href="/__ioi/pipeline?node=materialized&ontology=${enc(so.id || "")}">Pipeline</a> · <a href="/__ioi/lineage?ontology=${enc(so.id || "")}">Lineage</a> · <a href="/__ioi/vertex?ontology=${enc(so.id || "")}">Vertex</a> · <a href="${managerLink({ ontology: so.id || "" })}">Ontology Manager</a>`),
+      ].join(""),
+    };
+  }
+  const insp = !hasSelParam ? null : selSet ? setInspector() : selType ? typeInspector() : {
+    title: "Nothing selected",
+    sub: "fail-closed",
+    body: ihint(`Unknown ${sel.objectSet ? `object set ${formatRef(sel.objectSet)}` : `object type ${formatRef(sel.objectType || "")}${sel.ontology ? ` in ontology ${formatRef(sel.ontology)}` : " (no ontology given)"}`} — nothing is selected (fail-closed).`, true)
+      + ihint("Select an object type or an object set from the catalog to inspect its semantic truth. Nothing is recommended or fabricated."),
+  };
+  const inspectorAside = insp ? `<aside class="oe-inspector" data-testid="oe-inspector">${semanticInspectorShell({ id: "oe-sem-inspector", title: insp.title, subtitle: insp.sub, body: insp.body })}</aside>` : "";
 
   const css = `:root{color-scheme:light}*{box-sizing:border-box}
     body{margin:0;background:#fff;color:#1c2127;font:14px/1.28581 Source-Sans-Pro,Helvetica,sans-serif}
@@ -228,8 +323,32 @@ function renderObjectExplorerPort(ov, lists, opts) {
     .oe-slane{display:inline-flex;align-items:center;height:30px;padding:0 10px;border-radius:30px;font-size:14px;line-height:18.0013px;color:#1c2127;cursor:default}
     .oe-slane.on{background:#c0d4f1;color:#184a90;font-weight:600}
     .oe-setbox{margin:10px 0 30px}
-    .oe-foot{margin-top:14px;color:#7b8494;font-size:12px;line-height:1.5}`;
+    .oe-foot{margin-top:14px;color:#7b8494;font-size:12px;line-height:1.5}
+    .oe-tlink{color:inherit}
+    .oe-trow.oe-sel{background:#f3f8ff;box-shadow:inset 2px 0 0 #2d72d2}
+    .oe-trow.oe-sel:hover{background:#eef4fd}
+    .oe-withinsp{display:flex;overflow:hidden}
+    .oe-withinsp .oe-content{flex:1 1 auto;min-width:0;width:auto;margin:0 30px;overflow-y:auto}
+    .oe-inspector{flex:0 0 380px;border-left:1px solid #dce0e5;background:#fff;overflow-y:auto}
+    .oe-inspector .ioi-inspector-hd{display:flex;flex-direction:column;gap:2px;padding:12px 14px 10px;border-bottom:1px solid #eef0f2}
+    .oe-inspector .ioi-inspector-title{font-size:14px;line-height:18.0013px;font-weight:600;color:#1c2127}
+    .oe-inspector .ioi-inspector-sub{font-size:11px;color:#5f6b7c;font-family:ui-monospace,SFMono-Regular,monospace;word-break:break-all}
+    .oe-inspector .ioi-inspector-body{padding:12px 14px;font-size:12px}
+    .ioi-sem-breadcrumb{font-size:12px;color:#5f6b7c;margin:0 0 12px}
+    span.ioi-sem-crumb{color:#1c2127}
+    .oe-irow{display:flex;gap:10px;font-size:12px;line-height:15.4297px;padding:0 0 8px}
+    .oe-ik{color:#5f6b7c;width:110px;flex:0 0 110px}
+    .oe-iv{color:#1c2127;min-width:0;word-break:break-word}
+    .ioi-ref{font-family:ui-monospace,SFMono-Regular,monospace;font-size:10.5px;background:#f1f3f6;border-radius:3px;padding:1px 4px;word-break:break-all}
+    .oe-redact{color:#8f99a8;font-size:11px}
+    .oe-ihint{margin:6px 0 10px;padding:8px 10px;border:1px solid #e5e7eb;border-radius:6px;background:#f7f8fa;color:#5b6270;font-size:11.5px;line-height:1.55}
+    .oe-warnhint{border-color:#e8c48d;background:#fdf7ec;color:#935610}
+    .oe-itable{border-collapse:collapse;width:100%;font-size:11.5px;margin:0 0 10px;table-layout:auto}
+    .oe-itable th{text-align:left;color:#7b8494;font-weight:600;padding:3px 8px 3px 0;border-bottom:1px solid #e2e4e8;text-transform:none}
+    .oe-itable td{padding:3px 8px 3px 0;border-bottom:1px solid #f0f1f4;color:#2a2f38;word-break:break-word}
+    .oe-iacts{display:flex;gap:8px;margin-top:8px}
+    .ioi-cmd-disabled{display:inline-flex;align-items:center;height:24px;padding:0 8px;border:1px solid #d3d8de;border-radius:4px;background:#f7f8f8;color:#8f99a8;font:inherit;font-size:12px;cursor:not-allowed}`;
 
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Object Explorer</title><style>${css}</style></head>
-    <body><div class="oe-shell">${globalRail}<div class="oe-main">${tabbar}<div class="oe-body"><main class="oe-content" role="main">${hero}${shortcutsBand}${catalogBand}${setBand}</main></div></div></div></body></html>`;
+    <body><div class="oe-shell">${globalRail}<div class="oe-main">${tabbar}<div class="oe-body${insp ? " oe-withinsp" : ""}"><main class="oe-content" role="main">${hero}${shortcutsBand}${catalogBand}${setBand}</main>${inspectorAside}</div></div></div></body></html>`;
 }


### PR DESCRIPTION
## The Explorer acceptance test passes

> "Click an object type, shortcut, or object set → the selection is reflected in the URL, the row/card becomes selected, the semantic inspector shows real daemon truth, and refresh preserves the selected semantic context."

Verified end-to-end (**47/47**, +22 interaction checks). Sixth PR of the functional-runtime wave; second of the Ontology Application Runtime track (stacked on #59).

## What's interactive now

- **Type rows** → `ontology`+`objectType` in the URL, row selected, type inspector: property table with value types, link + action **declarations** (execution = disabled named gap, standing boundary), object count from real materialized sets, related projections, Manager/Pipeline deep-links.
- **Set rows** → `ontology`+`objectSet`, set inspector: count/rows-fetched/truncated, provenance refs (run · session · lease plan · pre-output receipt), source contact **origin-redacted**, real preview rows from the daemon set, deep-links to Pipeline/Lineage/Vertex/Manager (all fetched to 200 by the verifier).
- **Shortcut cards** → select their represented object type (real sets back them).
- **Filter interplay**: `?q=` carries the selection via hidden context inputs; a filter that hides the selection keeps it and *explains*, offering a clear-filter link.
- **Fail-closed**: unknown `objectType`/`objectSet` → honest note, zero selected rows, no crash.
- `semanticBreadcrumb` + `semanticInspectorShell` + `disabledSemanticAction` from the #59 kit, wired for real.

## Boundary held

No object editing, no action execution, no fabricated rows: the verifier asserts zero forms and zero enabled buttons in the inspector, declarations rendered as declarations, and preview rows cross-checked against the daemon set's own objects.

## Pixel discipline

Bare route renders **no inspector** — certified chrome byte-stable (the cert's capture state is unchanged); selection styling and retargeted hrefs live in the excluded catalog rows. Cert untouched; **pixel harness 37/37**.

## Done bar

explorer **47/47** · manager **23/23** · surface-modules **43/43** · pipeline **77/77** · pixel **37/37** · runtime-safety **20/20** · reset **23/23** · approvals **23/23** · models **17/17** · matrix clean · no NUL · no Rust

Next (PR #61): Ontology Manager becomes interactive — per-type inspectors, health-issue selection, resources cross-links; authoring only if the fail-closed ODK patch contract is safe, else inspection-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)