### PR TITLE
feat(hypervisor): Governed surface action runtime + receipted approval transitions — Approvals pilot (#62)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -35,7 +35,7 @@ import { SRC_APP_TILE_URI, SRC_HERO_URI, SRC_SETUP_STRIP_URI } from "./sources-a
 import { CHG_APP_TILE_URI } from "./changes-assets.mjs";
 import { EVL_APP_TILE_URI, EVL_HERO_URI } from "./evalsuites-assets.mjs";
 import { appCatalog } from "./app-catalog.mjs";
-import { bindSurface, boundSurface, embeddableRoutes } from "./surface-registry.mjs";
+import { bindSurface, boundSurface, boundActionRoute, embeddableRoutes } from "./surface-registry.mjs";
 import { escHtml } from "../surfaces/kit.mjs";
 import { ioiGlobalRailHtml, IOI_GRAIL_CSS } from "../surfaces/chrome.mjs";
 import { mintApprovalGrant } from "../../../scripts/lib/mint-approval-grant.mjs";
@@ -5594,163 +5594,8 @@ function govAge(iso) {
   if (h < 48) return `${h}h ${m % 60}m`;
   return `${Math.floor(h / 24)}d`;
 }
-// ============================ APPROVALS INBOX — reference UX PORT (#36, daemon_wired TRUE parity).
-// A FAITHFUL LIGHT port of the reference "Approvals inbox" (dark global RAIL · light HEADER · a light
-// faceted SIDEBAR: Quick filters [Your inbox / Created by you / All requests] + Additional filters
-// [Status wired to ?status=, plus faithful named-gap facets] · a light request LIST with status pills ·
-// an on-select right DETAIL with approve/reject/revoke), over the REAL daemon ApprovalRequest queue —
-// the same records + the same transitions the substrate ?tab=approvals view uses (no new governance
-// semantics). #33 shipped this as a dark native shell; #34's hardened gate correctly refused it; #36
-// REBUILT it faithfully so it passes the hardened harness (theme + IA landmarks) → PROMOTED to
-// `daemon_wired`, closing the #34 reclassification loop. Actions post a same-origin `return` to land here.
-function renderApprovalsPort(records, statusFilter, opts) {
-  const enc = encodeURIComponent, esc = CX_ESC;
-  const all = Array.isArray(records) ? records : [];
-  const STATUSES = [["pending", "Pending approval"], ["approved", "Approved"], ["rejected", "Rejected"], ["revoked", "Revoked"]];
-  const byStatus = { pending: 0, approved: 0, rejected: 0, revoked: 0 };
-  for (const a of all) if (byStatus[a.status] != null) byStatus[a.status]++;
-  const view = ["pending", "approved", "rejected", "revoked", "all"].includes(statusFilter) ? statusFilter : "pending";
-  const rows = view === "all" ? all : all.filter((a) => a.status === view);
-  const selected = (opts && opts.selected) ? all.find((a) => a.id === opts.selected) : null;
-  const svg = (p) => `<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">${p}</svg>`;
-  const CHECK = '<rect x="3" y="3" width="18" height="18" rx="4"/><path d="M8 12l3 3 5-6"/>';
-  const CUBE = '<path d="M12 2l9 5v10l-9 5-9-5V7z"/>';
-
-  // DARK global platform rail — the SHARED pixel-aligned reference shell (ioiGlobalRailHtml, #42).
-  const globalRail = ioiGlobalRailHtml({ label: "Approvals", href: "/__ioi/governance/approvals", iconUri: APPROVALS_APP_ICON_URI });
-
-  // LIGHT faceted filter sidebar — Quick filters (real status shortcuts) + Additional filters (Status
-  // is wired to ?status=; the rest are faithful faceted controls disabled as named gaps).
-  const QF_ICON = { "Your inbox": "inbox", "Created by you": "follower", "All requests": "form" };
-  const qf = (label, count, href, on, gap) => gap
-    ? `<span class="ap-qf gap" title="${esc(label)} needs a per-user creator/identity plane — named gap (no count)"><span class="ap-qfi">${bpIcon(QF_ICON[label] || "form")}</span>${esc(label)}<span class="ap-qfc">—</span></span>`
-    : `<a class="ap-qf${on ? " on" : ""}" href="${href}"><span class="ap-qfi">${bpIcon(QF_ICON[label] || "form")}</span>${esc(label)}<span class="ap-qfc">${count}</span></a>`;
-  const statusOpt = (v, label) => `<option value="${v}"${v === view ? " selected" : ""}>${esc(label)}</option>`;
-  const facets = `<aside class="ap-facets">
-    <div class="ap-ftitle"><span class="ap-fappico" style="background-image:url('${APPROVALS_APP_ICON_URI}')"></span><h5>Approvals</h5><a class="ap-subst" href="/__ioi/governance?tab=approvals" title="The substrate approvals table">⇱</a></div>
-    <div class="ap-fsec first">Quick filters</div>
-    <div class="ap-qfbox">
-      ${qf("Your inbox", byStatus.pending, "/__ioi/governance/approvals?status=pending", view === "pending")}
-      ${qf("Created by you", 0, "", false, true)}
-      <div class="ap-qfdiv"></div>
-      ${qf("All requests", all.length, "/__ioi/governance/approvals?status=all", view === "all")}
-    </div>
-    <div class="ap-fsec">Additional filters <a class="ap-clear" href="/__ioi/governance/approvals">Clear</a></div>
-    <form class="ap-ff" method="GET" action="/__ioi/governance/approvals">
-      <label class="ap-flabel">Request type</label>
-      <select class="ap-fsel" disabled title="Request-type facet is a named gap"><option>Access requests</option></select>
-      <label class="ap-flabel">Status</label>
-      <select class="ap-fsel" name="status" onchange="this.form.submit()">${statusOpt("all", "All requests")}${STATUSES.map(([v, l]) => statusOpt(v, l)).join("")}</select>
-      <label class="ap-flabel">Created by</label>
-      <select class="ap-fsel" disabled title="named gap"><option>Select user</option></select>
-      <label class="ap-fcheck gap" title="named gap"><input type="checkbox" disabled> Assigned to you</label>
-      <label class="ap-flabel">Project requested to</label>
-      <select class="ap-fsel" disabled title="named gap"><option>Select project</option></select>
-      <label class="ap-flabel">Users or groups in request</label>
-      <select class="ap-fsel" disabled title="named gap"><option>Select user or group</option></select>
-      <label class="ap-flabel">Groups requested to</label>
-      <select class="ap-fsel" disabled title="named gap"><option>Select group</option></select>
-    </form>
-  </aside>`;
-
-  const statusPill = (s) => `<span class="ap-pill ${s === "approved" ? "ok" : s === "pending" ? "warn" : "muted"}">${esc(s === "pending" ? "Pending approval" : ((s || "").charAt(0).toUpperCase() + (s || "").slice(1)))}</span>`;
-  const subjShort = (r) => { const s = String(r || ""); return esc(s.length > 46 ? s.slice(0, 46) + "…" : s); };
-  const rowHref = (a) => `/__ioi/governance/approvals?${view ? `status=${view}&` : ""}req=${enc(a.id)}`;
-  const listHeading = view === "pending" ? "Your inbox" : view === "all" ? "All requests" : (STATUSES.find(([v]) => v === view) || [, "Requests"])[1];
-  const list = `<main class="ap-list" role="main">
-    <div class="ap-listhd"><h2>${esc(listHeading)} <span class="ap-n">(${rows.length})</span></h2>
-      <div class="ap-listtools"><span class="ap-search" title="Full-text request search is a named gap">${svg('<circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/>')} Search for requests…</span><span class="ap-sort" title="Sort is a named gap">Sort: Recently created ▾</span></div>
-    </div>
-    ${rows.length ? `<div class="ap-rows">${rows.map((a) => `<a class="ap-row${selected && selected.id === a.id ? " on" : ""}" href="${rowHref(a)}">
-      <span class="ap-rowic">${svg('<rect x="4" y="3" width="14" height="18" rx="2"/><path d="M8 8h6M8 12h6M8 16h3"/>')}</span>
-      <span class="ap-rowmain"><span class="ap-rowtitle">${esc(a.request_kind || "approval")} · ${subjShort(a.subject_ref)} <code class="ap-code">${esc(a.id || "")}</code></span><span class="ap-rowsub">Created ${esc(govAge(a.created_at))}${a.reason ? ` · ${esc(String(a.reason).slice(0, 60))}` : ""}</span></span>
-      <span class="ap-rowst">${statusPill(a.status)}</span></a>`).join("")}</div>`
-      : `<div class="ap-empty">Nothing in <b>${esc(listHeading)}</b> — pick another filter.</div>`}
-  </main>`;
-
-  // Right detail panel — ONLY when a request is selected (faithful: the reference default has no detail).
-  // The approve/reject/revoke forms are the REAL daemon transitions (preserved wiring), return-aware.
-  const RET = `<input type="hidden" name="return" value="${esc(rowHref(selected || { id: "" }))}">`;
-  const blast = (a) => { const wc = (a.would_call || []).length, ar = (a.required_authority_refs || []).length; return (!wc && !ar) ? "none declared" : `${wc ? `${wc} call${wc > 1 ? "s" : ""}` : ""}${wc && ar ? " · " : ""}${ar ? `${ar} authorit${ar > 1 ? "ies" : "y"}` : ""}`; };
-  const decide = (a) => a.status === "pending"
-    ? govTform("approvals", a.id, "approve", "Approve", "primary", `<input name="reviewer_ref" placeholder="reviewer" class="ap-inp">` + RET) + govTform("approvals", a.id, "reject", "Reject", "ghost", RET)
-    : a.status === "approved" ? govTform("approvals", a.id, "revoke", "Revoke", "ghost", RET) : `<span class="ap-muted">terminal — no further transition</span>`;
-  const detail = selected ? `<aside class="ap-detail">
-    <div class="ap-dhd"><b>${esc(selected.request_kind || "approval")}</b> ${statusPill(selected.status)}</div>
-    <div class="ap-drow"><span>Subject</span>${govSubjectLink(selected.subject_ref)}</div>
-    <div class="ap-drow"><span>Request id</span><code class="ap-code">${esc(selected.id || "")}</code></div>
-    <div class="ap-drow"><span>Reason</span>${esc(selected.reason || "—")}</div>
-    <div class="ap-drow"><span>Blast radius</span>${blast(selected)}</div>
-    <div class="ap-drow"><span>Created</span>${esc(selected.created_at || "")}</div>
-    <div class="ap-dactions">${decide(selected)}</div>
-    <a class="ap-dclose" href="/__ioi/governance/approvals${view ? `?status=${view}` : ""}">Close</a>
-    <div class="ap-dgaps">Named gaps: reviewer assignment · delegation · threaded comments · SLA/escalation · audit exports — reference-only lanes.</div>
-  </aside>` : "";
-
-  const css = `html{color-scheme:light}*{box-sizing:border-box}
-    body{margin:0;background:#f6f7f9;color:#1c2127;font:14px/1.28581 Source-Sans-Pro,Helvetica,sans-serif}
-    a{color:#2f6fd8;text-decoration:none}
-    .ap-shell{display:flex;height:100vh;width:100vw;overflow:hidden}
-    ${IOI_GRAIL_CSS}
-    .ap-main{flex:1;min-width:0;display:flex;flex-direction:column;height:100vh;position:relative}
-    .ap-topbar{position:absolute;top:0;left:0;right:0;height:51px;pointer-events:none}
-    .ap-work{flex:1 1 auto;display:flex;justify-content:center;min-height:0}
-    .ap-content{display:flex;flex:0 1 1210px;max-width:1210px;min-width:0}
-    .ap-facets{flex:0 0 300px;width:300px;background:#fff;border-right:1px solid #dce0e5;overflow-y:auto;padding:0 27px 24px 25px}
-    .ap-ftitle{display:flex;align-items:flex-start;height:84px;padding-top:7px}
-    .ap-fappico{width:24px;height:24px;flex:0 0 24px;margin-right:13px;border-radius:3px;background-color:rgba(102,158,255,.1);background-position:center;background-size:16px;background-repeat:no-repeat}
-    .ap-ftitle h5{margin:0;font-size:16px;line-height:36px;font-weight:600;color:#1c2127;flex:1}
-    .ap-subst{font-size:13px;color:#8b9099}
-    .ap-fsec{font-size:14px;font-weight:600;color:#1c2127;height:40px;margin:13px 0 0 30px;display:flex;justify-content:space-between;align-items:center}
-    .ap-clear{font-size:14px;font-weight:400;color:#215db0;margin-right:-4px}
-    .ap-fsec.first{margin-top:7px}
-    .ap-fsec .ap-clear{align-self:center}
-    .ap-qfbox{background:#fff;border:1px solid #d3d8de;border-radius:6px;padding:4px 6px 6px;margin:0 0 0 30px;width:230px}
-    .ap-qf{display:flex;align-items:center;gap:10px;height:35px;margin-bottom:5px;padding:0 8px 0 9px;border-radius:4px;color:#1c2127;font-size:14px}
-    .ap-qf:hover{background:#f6f7f9}.ap-qf.on{background:#f3f8ff;color:#215db0;font-weight:400;box-shadow:inset 0 0 0 1px #689df3;border-radius:3px}
-    .ap-qf.gap{color:#1c2127;cursor:default}.ap-qfi{display:inline-flex;color:#5f6b7c;width:16px;flex:0 0 16px}.ap-qf.on .ap-qfi{color:#215db0}
-    .ap-qfc{margin-left:auto;font-size:12px;color:#1c2127;background:#eef0f3;border-radius:4px;padding:1px 7px;line-height:18px}
-    .ap-qf:last-child{margin-bottom:0}
-    .ap-qfdiv{height:1px;background:#eef0f3;margin:0 0 5px}
-    .ap-ff{display:flex;flex-direction:column;padding:0 0 0 45px;margin-top:0}
-    .ap-ff .ap-flabel:first-child{margin-top:15px}
-    .ap-flabel{display:block;font-size:12px;line-height:15.4297px;height:15.43px;color:#5f6b7c;margin:31px 0 0}
-    .ap-fsel{margin-top:5px;height:30px;padding:0 9px;border:1px solid #d3d8de;border-radius:4px;font:inherit;font-size:14px;background:#fff;color:#1c2127;width:100%}
-    .ap-fsel[disabled]{background:#eef1f5;color:#3a3f46;cursor:not-allowed}
-    .ap-fcheck{display:flex;align-items:center;gap:8px;font-size:14px;color:#1c2127;margin-top:20px}.ap-fcheck.gap{cursor:not-allowed}
-    .ap-list{flex:1 1 auto;overflow:auto;padding:18px 22px;background:#f4f5f7}
-    .ap-listhd{display:flex;align-items:center;justify-content:space-between;gap:12px;margin:0 0 14px}
-    .ap-list h2{font-size:15px;margin:0;font-weight:600}.ap-n{color:#9aa0a8;font-weight:400}
-    .ap-listtools{display:flex;align-items:center;gap:12px}
-    .ap-search{display:inline-flex;align-items:center;gap:7px;background:#fff;border:1px solid #d6dae0;border-radius:8px;padding:6px 12px;color:#9aa0a8;font-size:12.5px;cursor:not-allowed}
-    .ap-sort{color:#6b7178;font-size:12.5px;cursor:not-allowed}
-    .ap-rows{background:#fff;border:1px solid #e6e8ec;border-radius:10px;overflow:hidden}
-    .ap-row{display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid #f0f1f4;color:#1a1d21}
-    .ap-row:last-child{border-bottom:0}.ap-row:hover{background:#f7f9fc}.ap-row.on{background:#eef2fb}
-    .ap-rowic{display:inline-flex;color:#8b9099}
-    .ap-rowmain{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px}
-    .ap-rowtitle{font-weight:600;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-    .ap-rowsub{font-size:12px;color:#8b9099}.ap-rowst{flex:0 0 auto}
-    .ap-detail{flex:0 0 320px;width:320px;background:#fff;border-left:1px solid #e6e8ec;overflow-y:auto;padding:18px}
-    .ap-dhd{display:flex;align-items:center;gap:9px;font-size:14px;margin:0 0 12px}
-    .ap-drow{display:flex;justify-content:space-between;gap:10px;padding:7px 0;border-bottom:1px solid #f0f1f4;font-size:12.5px}.ap-drow>span:first-child{color:#8b9099}
-    .ap-dactions{margin:14px 0 8px;display:flex;gap:6px;align-items:center;flex-wrap:wrap}
-    .ap-dclose{font-size:12.5px}.ap-dgaps{color:#8b9099;font-size:11.5px;margin-top:12px;line-height:1.6}
-    .ap-pill{display:inline-block;padding:2px 10px;border-radius:999px;font-size:11.5px;border:1px solid;white-space:nowrap;font-weight:500}
-    .ap-pill.ok{color:#1a7f43;border-color:#bfe4cd;background:#eafaf0}
-    .ap-pill.warn{color:#2f6fd8;border-color:#c5d8f5;background:#eef4fe}
-    .ap-pill.muted{color:#6b7178;border-color:#e0e3e8;background:#f3f4f6}
-    .ap-muted{color:#8b9099}.ap-code{font-family:ui-monospace,monospace;font-size:11px;color:#6b7178;background:#f1f3f6;padding:1px 5px;border-radius:4px}
-    .ap-empty{color:#8b9099;padding:24px;border:1px dashed #d8dbe0;border-radius:12px;background:#fff}
-    .ap-inp{width:96px;padding:6px 9px;border-radius:7px;border:1px solid #d6dae0;background:#fff;color:#1a1d21;font:inherit;font-size:12px;margin-right:4px}
-    form.inline{display:inline}
-    .act{padding:6px 13px;border-radius:7px;border:1px solid #d6dae0;background:#fff;color:#3a3f46;font:inherit;font-size:12.5px;font-weight:600;cursor:pointer;margin-right:4px}
-    .act.primary{background:#2f6fd8;color:#fff;border-color:#2f6fd8}.act.ghost:hover{border-color:#b6bcc4}`;
-
-  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Approvals inbox</title><style>${css}</style></head>
-    <body><div class="ap-shell">${globalRail}<div class="ap-main"><div class="ap-topbar" aria-hidden="true"></div><div class="ap-work"><div class="ap-content">${facets}${list}${detail}</div></div></div></div></body></html>`;
-}
-
+// ============================ APPROVALS INBOX: EXTRACTED to surfaces/approvals/index.mjs =======
+// (operational wave PR62 — the governed-action-runtime pilot; the registry mounts GET + actions).
 function govApprovalsQueue(records) {
   const enc = encodeURIComponent;
   const byStatus = { pending: 0, approved: 0, rejected: 0, revoked: 0 };
@@ -7003,8 +6848,53 @@ function embedSurfaceHtml(html) {
     const u = addEmbed(path, qs, hash);
     return u ? `location.href='${u}'` : m;
   });
-  html = html.replace(/(<form\b[^>]*\baction="(\/__ioi\/[^"?#]*)"[^>]*>)/g, (m, tag, path) => (routes.has(path) ? `${tag}<input type="hidden" name="embed" value="1">` : m));
+  const embeddablePath = (path) => routes.has(path) || [...routes].some((r) => path.startsWith(r + "/"));
+  html = html.replace(/(<form\b[^>]*\baction="(\/__ioi\/[^"?#]*)"[^>]*>)/g, (m, tag, path) => (embeddablePath(path) ? `${tag}<input type="hidden" name="embed" value="1">` : m));
   return html.replace("</head>", '<style>.og-grail{display:none!important}</style></head>');
+}
+
+// ---- Governed action runtime (operational wave #62) ------------------------------------------
+// ONE runtime for every module action: bounded form parsing, action lookup by declared transition
+// vocabulary, input allowlisting (undeclared fields are NEVER forwarded), same-origin return
+// validation, confirmation enforcement, embed preservation, typed success/refusal results as
+// PRG redirects (duplicate-submit protection), and route-local error containment. Modules never
+// see the raw request/response.
+function safeReturnPath(raw, fallback) {
+  if (!raw || typeof raw !== "string" || raw.length > 512) return fallback;
+  if (!raw.startsWith("/__ioi/") || raw.startsWith("//")) return fallback;
+  if (/[\\"'<>#\r\n\u0000]/.test(raw)) return fallback;
+  try { decodeURIComponent(raw); } catch { return fallback; }
+  return raw;
+}
+async function runSurfaceAction(hit, res, body) {
+  try {
+    const p = new URLSearchParams(body.toString("utf8").slice(0, 16384)); // bounded parse
+    const embed = p.get("embed") === "1";
+    const back = safeReturnPath(p.get("return"), hit.surface.route);
+    const go = (params) => {
+      const url = `${back}${back.includes("?") ? "&" : "?"}${params.toString()}${embed ? "&embed=1" : ""}#ap-result`;
+      res.writeHead(303, { Location: url, "Cache-Control": "no-cache" });
+      res.end();
+    };
+    const refuse = (code, message) => go(new URLSearchParams({ refused: code, reason: String(message || "").slice(0, 200), record: hit.recordId }));
+    const transition = (p.get("transition") || "").trim();
+    const action = hit.actions.find((a) => a.transition === transition);
+    if (!action) return refuse("action_unknown", `unknown transition '${transition.slice(0, 40)}' — declared: ${hit.actions.map((a) => a.transition).join("|")}`);
+    if (action.confirm && p.get("confirm") !== "1") return refuse("confirmation_required", `${action.id} requires explicit confirmation (${action.from} -> ${action.to}) — re-submit with the confirmation checked`);
+    const fields = {};
+    for (const f of action.fields || []) { const v = p.get(f); if (v !== null && v !== "") fields[f] = String(v).slice(0, 500); }
+    const result = await hit.impl.handleAction({ action, id: hit.recordId, fields, daemon: DAEMON });
+    if (!result || typeof result !== "object" || !["success", "refusal", "failure"].includes(result.kind)) {
+      return refuse("action_result_invalid", "the module returned no typed result — failing closed");
+    }
+    if (result.kind === "success") {
+      if (!result.receipt_ref) return refuse("receipt_missing", "success without the declared receipt — failing closed");
+      return go(new URLSearchParams({ acted: action.id, receipt: result.receipt_ref, record: hit.recordId, result: result.status || "" }));
+    }
+    return refuse(result.code || (result.kind === "failure" ? "action_failed" : "action_refused"), result.message);
+  } catch (err) {
+    surfaceErrorBoundary({ method: "POST", url: "surface-action" }, res, err);
+  }
 }
 
 async function handleEstateRequest(req, res, body) {
@@ -9315,6 +9205,16 @@ async function handleEstateRequest(req, res, body) {
         return;
       }
     }
+    // ---- Surface ACTION dispatch (operational wave #62) — the registry-owned action runtime.
+    // Matches POST action routes DECLARED by bound modules (e.g. /__ioi/governance/approvals/
+    // :id/transition) BEFORE any legacy family handler, so a module owns its own mutations.
+    {
+      const hit = boundActionRoute(pathname, req.method);
+      if (hit) {
+        await runSurfaceAction(hit, res, body);
+        return;
+      }
+    }
     // Ontology Manager — reference UX PORT (#34, daemon_wired). Ported schema-workbench shell over the
     // real ODK CanonicalObjectModel; the /__ioi/odk substrate/authoring surface stays as-is.
     if (pathname === "/__ioi/odk" && req.method === "GET") {
@@ -9551,15 +9451,6 @@ async function handleEstateRequest(req, res, body) {
     // Approvals inbox — reference UX PORT (#36, daemon_wired). FAITHFUL light faceted inbox (dark global
     // rail + Quick/Additional filter sidebar + request list + on-select detail) over the real
     // ApprovalRequest queue; substrate table stays at /__ioi/governance?tab=approvals.
-    if (pathname === "/__ioi/governance/approvals" && req.method === "GET") {
-      const sp = new URL(req.url, "http://x").searchParams;
-      const status = sp.get("status") || "";
-      const selected = sp.get("req") || "";
-      const ap = await fetch(`${DAEMON}/v1/hypervisor/governance/approval-requests`).then((x) => x.json()).catch(() => ({}));
-      res.writeHead(200, HTMLH);
-      res.end(renderApprovalsPort(ap.approval_requests || [], status, { selected }));
-      return;
-    }
     // Governance control-object mutations (record-only; the daemon executes no enforcement).
     if (pathname.startsWith("/__ioi/governance/")) {
       const segs = pathname.slice("/__ioi/governance/".length).split("/");

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -21,6 +21,7 @@ import { EVL_APP_TILE_URI } from "./evalsuites-assets.mjs";
 import * as pipelineModule from "../surfaces/pipeline/index.mjs";
 import * as ontologyManagerModule from "../surfaces/ontology-manager/index.mjs";
 import * as objectExplorerModule from "../surfaces/object-explorer/index.mjs";
+import * as approvalsModule from "../surfaces/approvals/index.mjs";
 
 // Capability model (operational wave): `capabilities` is the AUTHORITY-derived set of acts the
 // surface genuinely supports today (never inferred from pixel certification or daemon_wired);
@@ -81,7 +82,66 @@ export function embeddableRoutes() {
   return new Set(SURFACES.filter((s) => bound.has(s.slug)).map((s) => s.route));
 }
 
+// ---- Action routes (operational wave #62) — a module's DECLARED mutations, matched beneath its
+// own surface route (e.g. actions with route "/:id/transition" own POST <route>/<id>/transition).
+// Several descriptors may share one route (discriminated by the posted transition vocabulary);
+// the runtime picks among the returned candidates. Anything undeclared fails closed upstream.
+function actionRouteMatch(pattern, tail) {
+  const ps = pattern.split("/").filter(Boolean);
+  const ts = tail.split("/").filter(Boolean);
+  if (ps.length !== ts.length) return false;
+  return ps.every((seg, i) => (seg.startsWith(":") ? ts[i].length > 0 : seg === ts[i]));
+}
+export function boundActionRoute(pathname, method) {
+  for (const s of SURFACES) {
+    const impl = bound.get(s.slug);
+    if (!impl || typeof impl.handleAction !== "function" || !Array.isArray(impl.actions) || !impl.actions.length) continue;
+    if (!pathname.startsWith(s.route + "/")) continue;
+    const tail = pathname.slice(s.route.length);
+    const candidates = impl.actions.filter((a) => a.method === method && a.route && actionRouteMatch(a.route, tail));
+    if (candidates.length) {
+      let recordId = tail.split("/").filter(Boolean)[0] || "";
+      try { recordId = decodeURIComponent(recordId); } catch { /* keep raw — the daemon lookup fails closed */ }
+      return { surface: s, impl, actions: candidates, recordId };
+    }
+  }
+  return null;
+}
+
 // ---- Extracted surface modules — imported and bound here (the registry IS the mount point).
 bindSurface("pipeline", pipelineModule);
 bindSurface("schema", ontologyManagerModule);
 bindSurface("explorer", objectExplorerModule);
+bindSurface("approvals", approvalsModule);
+
+// Test-only fault surface (NEVER without the runtime-test flag): gives the action-runtime
+// verifier a module whose action THROWS (route isolation proof) and one that claims success
+// WITHOUT a receipt (fail-closed proof). Carries no daemon authority and mutates nothing.
+if (process.env.IOI_APP_RUNTIME_TEST_ROUTE === "1") {
+  SURFACES.push({ slug: "__test_action", owner: "Test", title: "Action Runtime Test", icon: "data:,x", route: "/__ioi/__test/action-surface", verifier: "n/a", certification: "n/a", capabilities: ["browse"], operational_state: "browse" });
+  bindSurface("__test_action", {
+    meta: { slug: "__test_action", route: "/__ioi/__test/action-surface" },
+    load: async () => ({}),
+    render: () => "<!doctype html><title>action test</title>ok",
+    actions: [
+      { id: "boom", method: "POST", route: "/:id/transition", transition: "boom", fields: [], context: ["id"], authority: { plane: "test", operation: "none" }, receipt: "test.v1", confirm: false, success: "return-to-surface", refusal: "typed-banner" },
+      { id: "no-receipt", method: "POST", route: "/:id/transition", transition: "no-receipt", fields: [], context: ["id"], authority: { plane: "test", operation: "none" }, receipt: "test.v1", confirm: false, success: "return-to-surface", refusal: "typed-banner" },
+    ],
+    handleAction: async ({ action }) => {
+      if (action.transition === "boom") throw new Error("intentional action fault (action-runtime verifier)");
+      return { kind: "success", status: "done" }; // deliberately NO receipt_ref — must fail closed
+    },
+  });
+}
+
+// Operational invariants (#62): `act` is EARNED by a bound module with declared receipted
+// mutations — never by raw POST routes outside a module, and never by pixel certification.
+for (const s of SURFACES) {
+  const impl = bound.get(s.slug);
+  const mutations = impl && Array.isArray(impl.actions) ? impl.actions.filter((a) => a.method && a.method !== "GET") : [];
+  if (s.operational_state === "act") {
+    if (!impl || typeof impl.handleAction !== "function" || mutations.length === 0) throw new Error(`surface-registry: '${s.slug}' claims operational_state 'act' without a bound module declaring receipted actions`);
+    if (!mutations.every((a) => a.id && a.authority && a.authority.operation && a.receipt)) throw new Error(`surface-registry: '${s.slug}' declares an action without authority + receipt metadata`);
+  }
+  if (s.operational_state === "read_only_by_contract" && mutations.length > 0) throw new Error(`surface-registry: '${s.slug}' is read_only_by_contract but registers mutation actions`);
+}

--- a/apps/hypervisor/scripts/verify-hypervisor-action-runtime.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-action-runtime.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// Governed action-runtime verifier (operational wave #62 — Approvals pilot).
+//
+// Proves the registry-owned action runtime end to end:
+//   RUNTIME DISCIPLINE — the registry resolves the EXISTING Approvals transition route to the
+//   module; unknown actions/methods/records refuse; undeclared fields are never forwarded;
+//   invalid returns cannot redirect off-origin or inject markup; embed survives action+redirect;
+//   standalone stays standalone; a thrown module action 500s only that request (isolated serve
+//   with the test flag); a success without the declared receipt fails closed; refused actions
+//   mutate nothing.
+//   APPROVALS E2E — create pending → approve through the rendered form → pending→approved with
+//   revision+1, ONE history entry, ONE durable receipt matching subject/transition/statuses →
+//   reload shows authoritative truth → duplicate approve = typed refusal + zero mutation →
+//   revoke (confirmed) = second independent receipt → reject on a separate fixture → malformed
+//   transition/reviewer/return/record lanes → fixtures deleted, receipt-file delta exact.
+//
+// Usage: node apps/hypervisor/scripts/verify-hypervisor-action-runtime.mjs
+// Exit 0 = pass · 1 = fail · 2 = blocked (daemon/serve down).
+
+import { spawn } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SURFACES, boundActionRoute } from "./surface-registry.mjs";
+
+const SERVE = (process.env.IOI_HYPERVISOR_SERVE_URL || "http://127.0.0.1:4173").replace(/\/$/, "");
+const DAEMON = (process.env.IOI_HYPERVISOR_DAEMON_URL || "http://127.0.0.1:8765").replace(/\/$/, "");
+const DATA_DIR = process.env.IOI_HYPERVISOR_DATA_DIR || `${process.env.HOME}/.ioi/hypervisor/data`;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FAULT_PORT = 4606, FAULT_UI_PORT = 9406;
+
+const results = [];
+const ok = (name, cond, detail) => { results.push({ name, pass: !!cond, detail: detail || "" }); };
+const jd = (method, p, body) => fetch(`${DAEMON}${p}`, { method, headers: { "content-type": "application/json" }, body: body ? JSON.stringify(body) : undefined }).then((r) => r.json()).catch(() => ({}));
+// POST a form WITHOUT following the redirect; return {status, location}.
+async function formPost(url, data) {
+  const r = await fetch(url, { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded" }, body: new URLSearchParams(data).toString(), redirect: "manual" });
+  return { status: r.status, location: r.headers.get("location") || "", text: r.status === 200 ? await r.text() : "" };
+}
+const page = (url) => fetch(url).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+const receiptCount = () => { try { return readdirSync(join(DATA_DIR, "governance-approval-transition-receipts")).length; } catch { return 0; } };
+const approvalsCount = async () => ((await jd("GET", "/v1/hypervisor/governance/approval-requests")).approval_requests || []).length;
+
+async function run() {
+  const up = await fetch(`${DAEMON}/v1/hypervisor/governance/approval-requests`).then((r) => r.ok).catch(() => false);
+  const sup = await fetch(`${SERVE}/__ioi/governance/approvals`).then((r) => r.ok).catch(() => false);
+  if (!up || !sup) { console.error("BLOCKED: daemon or serve not reachable"); process.exit(2); }
+
+  // 1. Registry resolution + descriptor contract (static).
+  const hit = boundActionRoute("/__ioi/governance/approvals/appr_x/transition", "POST");
+  ok("registry resolves the EXISTING Approvals transition route to the module", !!hit && hit.surface.slug === "approvals" && hit.recordId === "appr_x" && hit.actions.length === 3);
+  ok("declared vocabulary is exactly approve|reject|revoke (no create/delete/bulk/delegation)", !!hit && hit.actions.map((a) => a.id).sort().join(",") === "approve,reject,revoke");
+  ok("every descriptor carries authority + receipt + confirmation + return policy", !!hit && hit.actions.every((a) => a.authority && a.authority.operation && a.receipt === "ioi.hypervisor.governance.approval-transition-receipt.v1" && typeof a.confirm === "boolean" && a.success && a.refusal));
+  ok("reject and revoke require confirmation; approve submits directly", !!hit && hit.actions.find((a) => a.id === "approve").confirm === false && hit.actions.find((a) => a.id === "reject").confirm === true && hit.actions.find((a) => a.id === "revoke").confirm === true);
+  ok("unknown method does not resolve an action route", boundActionRoute("/__ioi/governance/approvals/appr_x/transition", "PUT") === null && boundActionRoute("/__ioi/governance/approvals/appr_x/nonsense", "POST") === null);
+  ok("`act` invariant holds: approvals is act WITH a bound receipted mutation module", SURFACES.find((s) => s.slug === "approvals").operational_state === "act");
+
+  // 2. APPROVALS E2E over verifier fixtures (sentinel = an UNDECLARED field that must never escape).
+  const SENTINEL = `never-forward-${process.pid}`;
+  const rc0 = receiptCount();
+  const base = `${SERVE}/__ioi/governance/approvals`;
+  const fx = (await jd("POST", "/v1/hypervisor/governance/approval-requests", { subject_ref: `automation://act-rt-${process.pid}`, request_kind: "e2e", reason: "action-runtime e2e" })).approval_request;
+  const fx2 = (await jd("POST", "/v1/hypervisor/governance/approval-requests", { subject_ref: `automation://act-rt2-${process.pid}`, request_kind: "e2e", reason: "reject lane" })).approval_request;
+  try {
+    const inbox = await page(`${base}?req=${encodeURIComponent(fx.id)}`);
+    ok("the ported inbox renders the pending fixture with its transition forms", inbox.status === 200 && inbox.text.includes(fx.id) && inbox.text.includes('name="transition" value="approve"') && inbox.text.includes('name="confirm"'), "confirmation metadata visible on reject");
+    // Approve through the rendered form contract (with an undeclared sentinel field).
+    const ap = await formPost(`${base}/${encodeURIComponent(fx.id)}/transition`, { transition: "approve", reviewer_ref: "agent://verifier", secret_note: SENTINEL, return: `/__ioi/governance/approvals?req=${fx.id}` });
+    ok("approve → 303 PRG redirect carrying acted/receipt/record/result + the banner anchor", ap.status === 303 && /acted=approve/.test(ap.location) && /receipt=agentgres/.test(ap.location) && ap.location.endsWith("#ap-result"), ap.location.slice(0, 120));
+    const after = (await jd("GET", `/v1/hypervisor/governance/approval-requests/${fx.id}`)).approval_request;
+    ok("pending → approved; revision incremented EXACTLY once (1→2)", after.status === "approved" && after.revision === 2);
+    ok("history appended exactly once; receipt_refs carries exactly one ref", (after.history || []).length === 1 && (after.receipt_refs || []).length === 1 && after.history[0].receipt_ref === after.receipt_refs[0]);
+    const rref = after.receipt_refs[0];
+    const rid = rref.split("/").pop();
+    const receipt = (await page(`${SERVE}/__ioi/governance/approvals`)).status ? await jd("GET", `/v1/hypervisor/governance/approval-requests`).then(() => null).catch(() => null) : null;
+    // Read the durable receipt straight from observable storage.
+    const { readFileSync } = await import("node:fs");
+    let rec = null;
+    try { rec = JSON.parse(readFileSync(join(DATA_DIR, "governance-approval-transition-receipts", `${rid}.json`), "utf8")); } catch { /* */ }
+    ok("the durable receipt matches subject/transition/previous/resulting status + reviewer", !!rec && rec.subject_ref === fx.subject_ref && rec.transition === "approve" && rec.previous_status === "pending" && rec.resulting_status === "approved" && rec.reviewer_ref === "agent://verifier", rec ? rec.receipt_ref : "receipt file missing");
+    // Reload: authoritative truth + success banner renders from the redirect params.
+    const banner = await page(`${SERVE}${new URL(ap.location, SERVE).pathname}${new URL(ap.location, SERVE).search}`);
+    ok("the redirect target renders the success banner with the receipt ref (result UX)", banner.text.includes("ap-banner ap-ok") && banner.text.includes(rref) && banner.text.includes("proof stream"));
+    // Duplicate approve → typed refusal, zero mutation.
+    const dup = await formPost(`${base}/${encodeURIComponent(fx.id)}/transition`, { transition: "approve", return: `/__ioi/governance/approvals?req=${fx.id}` });
+    const afterDup = (await jd("GET", `/v1/hypervisor/governance/approval-requests/${fx.id}`)).approval_request;
+    ok("duplicate approve → typed refusal (governance_transition_invalid) with ZERO mutation", /refused=governance_transition_invalid/.test(dup.location) && afterDup.revision === 2 && (afterDup.receipt_refs || []).length === 1);
+    const dupPage = await page(`${SERVE}${new URL(dup.location, SERVE).pathname}${new URL(dup.location, SERVE).search}`);
+    ok("refusal banner renders the typed code + 'state unchanged' (no success color, no receipt)", dupPage.text.includes("ap-banner ap-no") && dupPage.text.includes("governance_transition_invalid") && dupPage.text.includes("state unchanged") && !dupPage.text.includes("ap-banner ap-ok"));
+    // Revoke without confirmation → refusal + zero mutation; with confirmation → second receipt.
+    const rv0 = await formPost(`${base}/${encodeURIComponent(fx.id)}/transition`, { transition: "revoke", return: `/__ioi/governance/approvals?req=${fx.id}` });
+    const afterRv0 = (await jd("GET", `/v1/hypervisor/governance/approval-requests/${fx.id}`)).approval_request;
+    ok("revoke without confirmation → confirmation_required refusal, ZERO mutation", /refused=confirmation_required/.test(rv0.location) && afterRv0.status === "approved" && afterRv0.revision === 2);
+    const rv1 = await formPost(`${base}/${encodeURIComponent(fx.id)}/transition`, { transition: "revoke", confirm: "1", return: `/__ioi/governance/approvals?req=${fx.id}` });
+    const afterRv1 = (await jd("GET", `/v1/hypervisor/governance/approval-requests/${fx.id}`)).approval_request;
+    ok("confirmed revoke → approved→revoked with a SECOND independent receipt (revision 3)", /acted=revoke/.test(rv1.location) && afterRv1.status === "revoked" && afterRv1.revision === 3 && (afterRv1.receipt_refs || []).length === 2 && afterRv1.receipt_refs[1] !== afterRv1.receipt_refs[0]);
+    // Reject lane on the separate pending fixture (confirmed).
+    const rj = await formPost(`${base}/${encodeURIComponent(fx2.id)}/transition`, { transition: "reject", confirm: "1", return: `/__ioi/governance/approvals?req=${fx2.id}` });
+    const afterRj = (await jd("GET", `/v1/hypervisor/governance/approval-requests/${fx2.id}`)).approval_request;
+    ok("confirmed reject → pending→rejected with its own receipt", /acted=reject/.test(rj.location) && afterRj.status === "rejected" && (afterRj.receipt_refs || []).length === 1);
+    // Malformed lanes: unknown transition · unknown record · hostile returns.
+    const bad1 = await formPost(`${base}/${encodeURIComponent(fx2.id)}/transition`, { transition: "escalate", return: `/__ioi/governance/approvals` });
+    ok("unknown transition fails closed (action_unknown), never forwarded to the daemon", /refused=action_unknown/.test(bad1.location));
+    const bad2 = await formPost(`${base}/appr_does_not_exist/transition`, { transition: "approve" });
+    ok("unknown record fails closed with the daemon's typed not-found", /refused=approval_not_found/.test(bad2.location));
+    for (const evil of ["https://evil.example/x", "//evil.example", "/__ioi/x\"><script>alert(1)</script>", "/etc/passwd", "/__ioi/a\r\nSet-Cookie:x=1"]) {
+      const r = await formPost(`${base}/${encodeURIComponent(fx2.id)}/transition`, { transition: "escalate", return: evil });
+      const loc = r.location || "";
+      if (!(loc.startsWith(`${SERVE}/__ioi/governance/approvals?`) || loc.startsWith("/__ioi/governance/approvals?")) || loc.includes("<script>") || loc.includes("evil.example") || /\r|\n/.test(loc)) {
+        ok(`hostile return rejected (${evil.slice(0, 24)}…)`, false, loc.slice(0, 100));
+      }
+    }
+    ok("hostile returns (absolute/protocol-relative/markup/traversal/CRLF) all fall back to the surface route", true, "5 lanes swept");
+    const reflect = await page(`${base}?refused=x&reason=${encodeURIComponent('"><script>alert(1)</script>')}&record=r`);
+    ok("reflected refusal params render ESCAPED (registry-dispatch XSS regression)", !reflect.text.includes("<script>alert(1)</script>") && reflect.text.includes("&lt;script&gt;"));
+    // Sentinel sweep: the undeclared field must appear NOWHERE (record, receipt, HTML, redirects).
+    const finalRec = (await jd("GET", `/v1/hypervisor/governance/approval-requests/${fx.id}`)).approval_request;
+    const inboxHtml = (await page(`${base}?req=${encodeURIComponent(fx.id)}`)).text;
+    ok("undeclared form fields are NEVER forwarded (sentinel absent from record, receipt, HTML, redirect)", !JSON.stringify(finalRec).includes(SENTINEL) && !(rec && JSON.stringify(rec).includes(SENTINEL)) && !inboxHtml.includes(SENTINEL) && !ap.location.includes(SENTINEL));
+    // Embed survival through action + redirect.
+    const em = await formPost(`${base}/${encodeURIComponent(fx2.id)}/transition`, { transition: "escalate", embed: "1", return: `/__ioi/governance/approvals?req=${fx2.id}` });
+    ok("embedded mode survives the action redirect (embed=1 on the PRG Location)", /embed=1/.test(em.location));
+    ok("standalone mode stays standalone (no embed leaks into non-embedded redirects)", !/embed=1/.test(bad1.location));
+    // Exact receipt-file delta: approve + revoke + reject = exactly 3 new durable receipts.
+    ok("receipt-file delta is EXACT (+3: approve, revoke, reject)", receiptCount() === rc0 + 3, `${rc0} → ${receiptCount()}`);
+  } finally {
+    await jd("DELETE", `/v1/hypervisor/governance/approval-requests/${fx.id}`);
+    await jd("DELETE", `/v1/hypervisor/governance/approval-requests/${fx2.id}`);
+  }
+  ok("fixtures deleted — baseline restored", !JSON.stringify(await jd("GET", "/v1/hypervisor/governance/approval-requests")).includes(`act-rt-${process.pid}`));
+
+  // 3. FAULT ISOLATION on an isolated serve with the runtime-test flag (never on the live serve).
+  {
+    const child = spawn(process.execPath, [join(HERE, "serve-product-ui.mjs")], {
+      env: { ...process.env, PORT: String(FAULT_PORT), PRODUCT_UI_PORT: String(FAULT_UI_PORT), IOI_APP_RUNTIME_TEST_ROUTE: "1" },
+      stdio: "ignore",
+    });
+    try {
+      const tbase = `http://127.0.0.1:${FAULT_PORT}`;
+      let up2 = null;
+      for (let i = 0; i < 30 && !up2; i++) { await new Promise((r) => setTimeout(r, 500)); up2 = await page(`${tbase}/__ioi/__test/action-surface`).then((r) => (r.status === 200 ? r : null)).catch(() => null); }
+      ok("isolated test serve reachable (fault surface mounted only under the flag)", !!up2);
+      const n0 = await approvalsCount();
+      const boom = await fetch(`${tbase}/__ioi/__test/action-surface/x/transition`, { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded" }, body: "transition=boom", redirect: "manual" });
+      ok("a thrown module action 500s ONLY that request (route-local containment)", boom.status === 500);
+      const alive = await page(`${tbase}/__ioi/governance/approvals`);
+      ok("other surfaces remain available after the fault", alive.status === 200);
+      const nor = await fetch(`${tbase}/__ioi/__test/action-surface/x/transition`, { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded" }, body: "transition=no-receipt", redirect: "manual" });
+      ok("a success result WITHOUT the declared receipt fails closed (receipt_missing)", nor.status === 303 && /refused=receipt_missing/.test(nor.headers.get("location") || ""));
+      ok("faults + refused actions produced ZERO daemon mutation", (await approvalsCount()) === n0);
+      const live = await page(`${SERVE}/__ioi/__test/action-surface`);
+      ok("the fault surface does NOT exist on the live serve (flag-gated)", live.status !== 200 || !live.text.includes("action test"));
+    } finally {
+      child.kill("SIGTERM");
+    }
+  }
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  if (fails.length) process.exit(1);
+  console.log("governed action runtime: OK");
+}).catch((e) => { console.error("verifier crashed:", e); process.exit(1); });

--- a/apps/hypervisor/surfaces/approvals/index.mjs
+++ b/apps/hypervisor/surfaces/approvals/index.mjs
@@ -1,0 +1,271 @@
+// Approvals — the governed-action-runtime PILOT (operational wave PR62). The render code below is
+// moved VERBATIM from serve-product-ui.mjs; the module adds the surface contract PLUS the first
+// `actions` + `handleAction` implementation: approve/reject/revoke run through the EXISTING daemon
+// authority (PATCH /v1/hypervisor/governance/approval-requests/:id), which now emits a durable
+// approval-transition receipt — a success without that receipt FAILS CLOSED. Reject and revoke
+// require explicit confirmation (a UX safeguard, not substitute authority). No create/delete/
+// reassignment/delegation/comments/bulk actions are declared.
+import { bpIcon, APPROVALS_APP_ICON_URI } from "../../scripts/bp-icons.mjs";
+import { ioiGlobalRailHtml, IOI_GRAIL_CSS } from "../chrome.mjs";
+import { escHtml } from "../kit.mjs";
+
+const CX_ESC = escHtml; // local alias so the moved block stays byte-identical to its serve original
+// Local transition-form builder (the serve's govTform, module-local so the moved block renders
+// byte-identically; the action runtime adds confirm/return/embed fields through `extra`).
+const govTform = (fam, id, transition, label, cls, extra) => `<form class="inline" method="post" action="/__ioi/governance/${fam}/${encodeURIComponent(id)}/transition"><input type="hidden" name="transition" value="${transition}">${extra || ""}<button class="act ${cls || "ghost"}" type="submit">${label}</button></form>`;
+// Module-local copies of the serve's shared governance helpers (verbatim — the serve keeps its
+// own for the remaining inline governance families until they extract).
+function govSubjectLink(ref) {
+  const r = String(ref || "");
+  if (!r) return "—";
+  const code = `<code style="font-size:10.5px">${CX_ESC(r)}</code>`;
+  if (r.startsWith("domain-app://")) return `<a href="/__ioi/domain-apps/${encodeURIComponent(r.slice("domain-app://".length))}" style="text-decoration:none">${code} →</a>`;
+  if (r.startsWith("marketplace-")) return `<a href="/__ioi/marketplace" style="text-decoration:none">${code} →</a>`;
+  if (r.startsWith("failover-run://")) return `<a href="/__ioi/operations" style="text-decoration:none">${code} →</a>`;
+  if (r.startsWith("fspec_") || r.startsWith("frun_")) return `<a href="/__ioi/foundry" style="text-decoration:none">${code} →</a>`;
+  return code;
+}
+function govAge(iso) {
+  const ms = Date.now() - Date.parse(iso || "");
+  if (!isFinite(ms) || ms < 0) return "—";
+  const m = Math.floor(ms / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 48) return `${h}h ${m % 60}m`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+
+export const meta = {
+  slug: "approvals",
+  route: "/__ioi/governance/approvals",
+  verifier: "scripts/verify-hypervisor-app-parity-approvals.mjs",
+  certification: "pixel-certifications/approvals.json",
+};
+
+export async function load(ctx) {
+  const ap = await fetch(`${ctx.daemon}/v1/hypervisor/governance/approval-requests`).then((x) => x.json()).catch(() => ({}));
+  return { records: ap.approval_requests || [] };
+}
+
+export function render(model, ctx) {
+  const sp = ctx.url.searchParams;
+  return renderApprovalsPort(model.records, sp.get("status") || "", {
+    selected: sp.get("req") || "",
+    banner: {
+      acted: sp.get("acted") || "",
+      receipt: sp.get("receipt") || "",
+      refused: sp.get("refused") || "",
+      reason: sp.get("reason") || "",
+      record: sp.get("record") || "",
+      result: sp.get("result") || "",
+    },
+  });
+}
+
+// The action-descriptor contract: id · method · route pattern · allowed transition · allowlisted
+// input fields · required context · authority plane/operation · expected receipt family ·
+// confirmation posture · success return policy · refusal behavior. The runtime enforces it; the
+// module only speaks to the daemon.
+export const actions = [
+  { id: "approve", method: "POST", route: "/:id/transition", transition: "approve", from: "pending", to: "approved", fields: ["reviewer_ref"], context: ["id"], authority: { plane: "governance.approval-requests", operation: "PATCH /v1/hypervisor/governance/approval-requests/:id" }, receipt: "ioi.hypervisor.governance.approval-transition-receipt.v1", confirm: false, success: "return-to-surface", refusal: "typed-banner" },
+  { id: "reject", method: "POST", route: "/:id/transition", transition: "reject", from: "pending", to: "rejected", fields: ["reviewer_ref"], context: ["id"], authority: { plane: "governance.approval-requests", operation: "PATCH /v1/hypervisor/governance/approval-requests/:id" }, receipt: "ioi.hypervisor.governance.approval-transition-receipt.v1", confirm: true, success: "return-to-surface", refusal: "typed-banner" },
+  { id: "revoke", method: "POST", route: "/:id/transition", transition: "revoke", from: "approved", to: "revoked", fields: ["reviewer_ref"], context: ["id"], authority: { plane: "governance.approval-requests", operation: "PATCH /v1/hypervisor/governance/approval-requests/:id" }, receipt: "ioi.hypervisor.governance.approval-transition-receipt.v1", confirm: true, success: "return-to-surface", refusal: "typed-banner" },
+];
+
+// One typed result, always: success carries the authoritative record + receipt ref; refusal
+// carries the daemon's typed code/message with state untouched; failure claims nothing.
+export async function handleAction({ action, id, fields, daemon }) {
+  const payload = { transition: action.transition };
+  if (fields.reviewer_ref) payload.reviewer_ref = fields.reviewer_ref;
+  const r = await fetch(`${daemon}/v1/hypervisor/governance/approval-requests/${encodeURIComponent(id)}`, {
+    method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(payload),
+  }).then((x) => x.json()).catch(() => null);
+  if (!r) return { kind: "failure", http: 502, code: "daemon_unavailable", message: "the daemon did not answer — nothing was changed" };
+  if (r.ok !== true) return { kind: "refusal", http: 409, code: (r.error && r.error.code) || "governance_refused", message: (r.error && r.error.message) || r.reason || "refused — state unchanged" };
+  const receipt = r.transition_receipt;
+  if (!receipt || !receipt.receipt_ref || receipt.schema_version !== action.receipt) {
+    return { kind: "failure", http: 502, code: "receipt_missing", message: "the transition returned no declared receipt — failing closed (do not trust the mutation)" };
+  }
+  return { kind: "success", status: (r.approval_request || {}).status || action.to, record: r.approval_request, receipt_ref: receipt.receipt_ref };
+}
+
+// ============================ APPROVALS INBOX — reference UX PORT (#36, daemon_wired TRUE parity).
+// A FAITHFUL LIGHT port of the reference "Approvals inbox" (dark global RAIL · light HEADER · a light
+// faceted SIDEBAR: Quick filters [Your inbox / Created by you / All requests] + Additional filters
+// [Status wired to ?status=, plus faithful named-gap facets] · a light request LIST with status pills ·
+// an on-select right DETAIL with approve/reject/revoke), over the REAL daemon ApprovalRequest queue —
+// the same records + the same transitions the substrate ?tab=approvals view uses (no new governance
+// semantics). #33 shipped this as a dark native shell; #34's hardened gate correctly refused it; #36
+// REBUILT it faithfully so it passes the hardened harness (theme + IA landmarks) → PROMOTED to
+// `daemon_wired`, closing the #34 reclassification loop. Actions post a same-origin `return` to land here.
+function renderApprovalsPort(records, statusFilter, opts) {
+  const enc = encodeURIComponent, esc = CX_ESC;
+  const all = Array.isArray(records) ? records : [];
+  const STATUSES = [["pending", "Pending approval"], ["approved", "Approved"], ["rejected", "Rejected"], ["revoked", "Revoked"]];
+  const byStatus = { pending: 0, approved: 0, rejected: 0, revoked: 0 };
+  for (const a of all) if (byStatus[a.status] != null) byStatus[a.status]++;
+  const view = ["pending", "approved", "rejected", "revoked", "all"].includes(statusFilter) ? statusFilter : "pending";
+  const rows = view === "all" ? all : all.filter((a) => a.status === view);
+  const selected = (opts && opts.selected) ? all.find((a) => a.id === opts.selected) : null;
+  const svg = (p) => `<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">${p}</svg>`;
+  const CHECK = '<rect x="3" y="3" width="18" height="18" rx="4"/><path d="M8 12l3 3 5-6"/>';
+  const CUBE = '<path d="M12 2l9 5v10l-9 5-9-5V7z"/>';
+
+  // DARK global platform rail — the SHARED pixel-aligned reference shell (ioiGlobalRailHtml, #42).
+  const globalRail = ioiGlobalRailHtml({ label: "Approvals", href: "/__ioi/governance/approvals", iconUri: APPROVALS_APP_ICON_URI });
+
+  // LIGHT faceted filter sidebar — Quick filters (real status shortcuts) + Additional filters (Status
+  // is wired to ?status=; the rest are faithful faceted controls disabled as named gaps).
+  const QF_ICON = { "Your inbox": "inbox", "Created by you": "follower", "All requests": "form" };
+  const qf = (label, count, href, on, gap) => gap
+    ? `<span class="ap-qf gap" title="${esc(label)} needs a per-user creator/identity plane — named gap (no count)"><span class="ap-qfi">${bpIcon(QF_ICON[label] || "form")}</span>${esc(label)}<span class="ap-qfc">—</span></span>`
+    : `<a class="ap-qf${on ? " on" : ""}" href="${href}"><span class="ap-qfi">${bpIcon(QF_ICON[label] || "form")}</span>${esc(label)}<span class="ap-qfc">${count}</span></a>`;
+  const statusOpt = (v, label) => `<option value="${v}"${v === view ? " selected" : ""}>${esc(label)}</option>`;
+  const facets = `<aside class="ap-facets">
+    <div class="ap-ftitle"><span class="ap-fappico" style="background-image:url('${APPROVALS_APP_ICON_URI}')"></span><h5>Approvals</h5><a class="ap-subst" href="/__ioi/governance?tab=approvals" title="The substrate approvals table">⇱</a></div>
+    <div class="ap-fsec first">Quick filters</div>
+    <div class="ap-qfbox">
+      ${qf("Your inbox", byStatus.pending, "/__ioi/governance/approvals?status=pending", view === "pending")}
+      ${qf("Created by you", 0, "", false, true)}
+      <div class="ap-qfdiv"></div>
+      ${qf("All requests", all.length, "/__ioi/governance/approvals?status=all", view === "all")}
+    </div>
+    <div class="ap-fsec">Additional filters <a class="ap-clear" href="/__ioi/governance/approvals">Clear</a></div>
+    <form class="ap-ff" method="GET" action="/__ioi/governance/approvals">
+      <label class="ap-flabel">Request type</label>
+      <select class="ap-fsel" disabled title="Request-type facet is a named gap"><option>Access requests</option></select>
+      <label class="ap-flabel">Status</label>
+      <select class="ap-fsel" name="status" onchange="this.form.submit()">${statusOpt("all", "All requests")}${STATUSES.map(([v, l]) => statusOpt(v, l)).join("")}</select>
+      <label class="ap-flabel">Created by</label>
+      <select class="ap-fsel" disabled title="named gap"><option>Select user</option></select>
+      <label class="ap-fcheck gap" title="named gap"><input type="checkbox" disabled> Assigned to you</label>
+      <label class="ap-flabel">Project requested to</label>
+      <select class="ap-fsel" disabled title="named gap"><option>Select project</option></select>
+      <label class="ap-flabel">Users or groups in request</label>
+      <select class="ap-fsel" disabled title="named gap"><option>Select user or group</option></select>
+      <label class="ap-flabel">Groups requested to</label>
+      <select class="ap-fsel" disabled title="named gap"><option>Select group</option></select>
+    </form>
+  </aside>`;
+
+  const statusPill = (s) => `<span class="ap-pill ${s === "approved" ? "ok" : s === "pending" ? "warn" : "muted"}">${esc(s === "pending" ? "Pending approval" : ((s || "").charAt(0).toUpperCase() + (s || "").slice(1)))}</span>`;
+  const subjShort = (r) => { const s = String(r || ""); return esc(s.length > 46 ? s.slice(0, 46) + "…" : s); };
+  const rowHref = (a) => `/__ioi/governance/approvals?${view ? `status=${view}&` : ""}req=${enc(a.id)}`;
+  const listHeading = view === "pending" ? "Your inbox" : view === "all" ? "All requests" : (STATUSES.find(([v]) => v === view) || [, "Requests"])[1];
+  const list = `<main class="ap-list" role="main">
+    <div class="ap-listhd"><h2>${esc(listHeading)} <span class="ap-n">(${rows.length})</span></h2>
+      <div class="ap-listtools"><span class="ap-search" title="Full-text request search is a named gap">${svg('<circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/>')} Search for requests…</span><span class="ap-sort" title="Sort is a named gap">Sort: Recently created ▾</span></div>
+    </div>
+    ${rows.length ? `<div class="ap-rows">${rows.map((a) => `<a class="ap-row${selected && selected.id === a.id ? " on" : ""}" href="${rowHref(a)}">
+      <span class="ap-rowic">${svg('<rect x="4" y="3" width="14" height="18" rx="2"/><path d="M8 8h6M8 12h6M8 16h3"/>')}</span>
+      <span class="ap-rowmain"><span class="ap-rowtitle">${esc(a.request_kind || "approval")} · ${subjShort(a.subject_ref)} <code class="ap-code">${esc(a.id || "")}</code></span><span class="ap-rowsub">Created ${esc(govAge(a.created_at))}${a.reason ? ` · ${esc(String(a.reason).slice(0, 60))}` : ""}</span></span>
+      <span class="ap-rowst">${statusPill(a.status)}</span></a>`).join("")}</div>`
+      : `<div class="ap-empty">Nothing in <b>${esc(listHeading)}</b> — pick another filter.</div>`}
+  </main>`;
+
+  // Right detail panel — ONLY when a request is selected (faithful: the reference default has no detail).
+  // The approve/reject/revoke forms are the REAL daemon transitions (preserved wiring), return-aware.
+  const RET = `<input type="hidden" name="return" value="${esc(rowHref(selected || { id: "" }))}">`;
+  const blast = (a) => { const wc = (a.would_call || []).length, ar = (a.required_authority_refs || []).length; return (!wc && !ar) ? "none declared" : `${wc ? `${wc} call${wc > 1 ? "s" : ""}` : ""}${wc && ar ? " · " : ""}${ar ? `${ar} authorit${ar > 1 ? "ies" : "y"}` : ""}`; };
+  // Confirmation is a UX safeguard, not substitute authority: reject/revoke carry VISIBLE
+  // transition metadata and a REQUIRED confirmation checkbox (native enforcement, no JS; the
+  // runtime re-enforces server-side with a typed confirmation_required refusal). Approve submits
+  // directly. Every form posts return= (this inbox state); embedded mode adds embed= upstream.
+  const CONFIRM = (a, t, to) => `<label class="ap-confirm"><input type="checkbox" name="confirm" value="1" required> confirm ${t} — ${esc(a.status)} → ${to}, recorded with a transition receipt</label>`;
+  const decide = (a) => a.status === "pending"
+    ? govTform("approvals", a.id, "approve", "Approve", "primary", `<input name="reviewer_ref" placeholder="reviewer" class="ap-inp">` + RET) + govTform("approvals", a.id, "reject", "Reject", "ghost", CONFIRM(a, "reject", "rejected") + RET)
+    : a.status === "approved" ? govTform("approvals", a.id, "revoke", "Revoke", "ghost", CONFIRM(a, "revoke", "revoked") + RET) : `<span class="ap-muted">terminal — no further transition</span>`;
+  // Action-result banner (#ap-result — the runtime's redirect anchor): success shows the
+  // authoritative status + the durable transition receipt ref + proof links; refusal shows the
+  // daemon's typed code/message and states plainly that nothing changed. Renders ONLY when the
+  // runtime redirected here with result params — the bare/certified render carries no banner.
+  const bn = (opts && opts.banner) || {};
+  const banner = bn.acted && bn.receipt
+    ? `<div id="ap-result" class="ap-banner ap-ok" tabindex="-1"><b>${esc(bn.acted)}</b> recorded${bn.result ? ` — status <b>${esc(bn.result)}</b>` : ""} · receipt <code class="ap-rcpt">${esc(bn.receipt)}</code> · <a href="/__ioi/governance/approvals?req=${encodeURIComponent(bn.record)}">record</a> · <a href="/__ioi/work-ledger">proof stream</a></div>`
+    : bn.refused
+      ? `<div id="ap-result" class="ap-banner ap-no" tabindex="-1">refused: <code>${esc(bn.refused)}</code>${bn.reason ? ` — ${esc(bn.reason)}` : ""} · <b>state unchanged</b>${bn.record ? ` · <a href="/__ioi/governance/approvals?req=${encodeURIComponent(bn.record)}">back to the request</a>` : ""}</div>`
+      : "";
+  const detail = selected ? `<aside class="ap-detail">${banner}
+    <div class="ap-dhd"><b>${esc(selected.request_kind || "approval")}</b> ${statusPill(selected.status)}</div>
+    <div class="ap-drow"><span>Subject</span>${govSubjectLink(selected.subject_ref)}</div>
+    <div class="ap-drow"><span>Request id</span><code class="ap-code">${esc(selected.id || "")}</code></div>
+    <div class="ap-drow"><span>Reason</span>${esc(selected.reason || "—")}</div>
+    <div class="ap-drow"><span>Blast radius</span>${blast(selected)}</div>
+    <div class="ap-drow"><span>Created</span>${esc(selected.created_at || "")}</div>
+    <div class="ap-dactions">${decide(selected)}</div>
+    <a class="ap-dclose" href="/__ioi/governance/approvals${view ? `?status=${view}` : ""}">Close</a>
+    <div class="ap-dgaps">Named gaps: reviewer assignment · delegation · threaded comments · SLA/escalation · audit exports — reference-only lanes.</div>
+  </aside>` : (banner ? `<aside class="ap-detail">${banner}</aside>` : "");
+
+  const css = `html{color-scheme:light}*{box-sizing:border-box}
+    body{margin:0;background:#f6f7f9;color:#1c2127;font:14px/1.28581 Source-Sans-Pro,Helvetica,sans-serif}
+    a{color:#2f6fd8;text-decoration:none}
+    .ap-shell{display:flex;height:100vh;width:100vw;overflow:hidden}
+    ${IOI_GRAIL_CSS}
+    .ap-main{flex:1;min-width:0;display:flex;flex-direction:column;height:100vh;position:relative}
+    .ap-topbar{position:absolute;top:0;left:0;right:0;height:51px;pointer-events:none}
+    .ap-work{flex:1 1 auto;display:flex;justify-content:center;min-height:0}
+    .ap-content{display:flex;flex:0 1 1210px;max-width:1210px;min-width:0}
+    .ap-facets{flex:0 0 300px;width:300px;background:#fff;border-right:1px solid #dce0e5;overflow-y:auto;padding:0 27px 24px 25px}
+    .ap-ftitle{display:flex;align-items:flex-start;height:84px;padding-top:7px}
+    .ap-fappico{width:24px;height:24px;flex:0 0 24px;margin-right:13px;border-radius:3px;background-color:rgba(102,158,255,.1);background-position:center;background-size:16px;background-repeat:no-repeat}
+    .ap-ftitle h5{margin:0;font-size:16px;line-height:36px;font-weight:600;color:#1c2127;flex:1}
+    .ap-subst{font-size:13px;color:#8b9099}
+    .ap-fsec{font-size:14px;font-weight:600;color:#1c2127;height:40px;margin:13px 0 0 30px;display:flex;justify-content:space-between;align-items:center}
+    .ap-clear{font-size:14px;font-weight:400;color:#215db0;margin-right:-4px}
+    .ap-fsec.first{margin-top:7px}
+    .ap-fsec .ap-clear{align-self:center}
+    .ap-qfbox{background:#fff;border:1px solid #d3d8de;border-radius:6px;padding:4px 6px 6px;margin:0 0 0 30px;width:230px}
+    .ap-qf{display:flex;align-items:center;gap:10px;height:35px;margin-bottom:5px;padding:0 8px 0 9px;border-radius:4px;color:#1c2127;font-size:14px}
+    .ap-qf:hover{background:#f6f7f9}.ap-qf.on{background:#f3f8ff;color:#215db0;font-weight:400;box-shadow:inset 0 0 0 1px #689df3;border-radius:3px}
+    .ap-qf.gap{color:#1c2127;cursor:default}.ap-qfi{display:inline-flex;color:#5f6b7c;width:16px;flex:0 0 16px}.ap-qf.on .ap-qfi{color:#215db0}
+    .ap-qfc{margin-left:auto;font-size:12px;color:#1c2127;background:#eef0f3;border-radius:4px;padding:1px 7px;line-height:18px}
+    .ap-qf:last-child{margin-bottom:0}
+    .ap-qfdiv{height:1px;background:#eef0f3;margin:0 0 5px}
+    .ap-ff{display:flex;flex-direction:column;padding:0 0 0 45px;margin-top:0}
+    .ap-ff .ap-flabel:first-child{margin-top:15px}
+    .ap-flabel{display:block;font-size:12px;line-height:15.4297px;height:15.43px;color:#5f6b7c;margin:31px 0 0}
+    .ap-fsel{margin-top:5px;height:30px;padding:0 9px;border:1px solid #d3d8de;border-radius:4px;font:inherit;font-size:14px;background:#fff;color:#1c2127;width:100%}
+    .ap-fsel[disabled]{background:#eef1f5;color:#3a3f46;cursor:not-allowed}
+    .ap-fcheck{display:flex;align-items:center;gap:8px;font-size:14px;color:#1c2127;margin-top:20px}.ap-fcheck.gap{cursor:not-allowed}
+    .ap-list{flex:1 1 auto;overflow:auto;padding:18px 22px;background:#f4f5f7}
+    .ap-listhd{display:flex;align-items:center;justify-content:space-between;gap:12px;margin:0 0 14px}
+    .ap-list h2{font-size:15px;margin:0;font-weight:600}.ap-n{color:#9aa0a8;font-weight:400}
+    .ap-listtools{display:flex;align-items:center;gap:12px}
+    .ap-search{display:inline-flex;align-items:center;gap:7px;background:#fff;border:1px solid #d6dae0;border-radius:8px;padding:6px 12px;color:#9aa0a8;font-size:12.5px;cursor:not-allowed}
+    .ap-sort{color:#6b7178;font-size:12.5px;cursor:not-allowed}
+    .ap-rows{background:#fff;border:1px solid #e6e8ec;border-radius:10px;overflow:hidden}
+    .ap-row{display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid #f0f1f4;color:#1a1d21}
+    .ap-row:last-child{border-bottom:0}.ap-row:hover{background:#f7f9fc}.ap-row.on{background:#eef2fb}
+    .ap-rowic{display:inline-flex;color:#8b9099}
+    .ap-rowmain{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px}
+    .ap-rowtitle{font-weight:600;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    .ap-rowsub{font-size:12px;color:#8b9099}.ap-rowst{flex:0 0 auto}
+    .ap-detail{flex:0 0 320px;width:320px;background:#fff;border-left:1px solid #e6e8ec;overflow-y:auto;padding:18px}
+    .ap-dhd{display:flex;align-items:center;gap:9px;font-size:14px;margin:0 0 12px}
+    .ap-drow{display:flex;justify-content:space-between;gap:10px;padding:7px 0;border-bottom:1px solid #f0f1f4;font-size:12.5px}.ap-drow>span:first-child{color:#8b9099}
+    .ap-dactions{margin:14px 0 8px;display:flex;gap:6px;align-items:center;flex-wrap:wrap}
+    .ap-dclose{font-size:12.5px}.ap-dgaps{color:#8b9099;font-size:11.5px;margin-top:12px;line-height:1.6}
+    .ap-pill{display:inline-block;padding:2px 10px;border-radius:999px;font-size:11.5px;border:1px solid;white-space:nowrap;font-weight:500}
+    .ap-pill.ok{color:#1a7f43;border-color:#bfe4cd;background:#eafaf0}
+    .ap-pill.warn{color:#2f6fd8;border-color:#c5d8f5;background:#eef4fe}
+    .ap-pill.muted{color:#6b7178;border-color:#e0e3e8;background:#f3f4f6}
+    .ap-muted{color:#8b9099}.ap-code{font-family:ui-monospace,monospace;font-size:11px;color:#6b7178;background:#f1f3f6;padding:1px 5px;border-radius:4px}
+    .ap-empty{color:#8b9099;padding:24px;border:1px dashed #d8dbe0;border-radius:12px;background:#fff}
+    .ap-inp{width:96px;padding:6px 9px;border-radius:7px;border:1px solid #d6dae0;background:#fff;color:#1a1d21;font:inherit;font-size:12px;margin-right:4px}
+    form.inline{display:inline}
+    .act{padding:6px 13px;border-radius:7px;border:1px solid #d6dae0;background:#fff;color:#3a3f46;font:inherit;font-size:12.5px;font-weight:600;cursor:pointer;margin-right:4px}
+    .act.primary{background:#2f6fd8;color:#fff;border-color:#2f6fd8}.act.ghost:hover{border-color:#b6bcc4}
+    .ap-banner{margin:0 0 12px;padding:9px 12px;border-radius:6px;font-size:12.5px;line-height:1.5;outline:none}
+    .ap-banner code{font-size:10.5px;word-break:break-all}
+    .ap-banner.ap-ok{border:1px solid #8fdcb6;background:#eafaf1;color:#0e6b41}
+    .ap-banner.ap-no{border:1px solid #e8c48d;background:#fdf7ec;color:#935610}
+    .ap-rcpt{background:rgba(14,138,83,.08);border-radius:3px;padding:1px 4px}
+    .ap-confirm{display:flex;align-items:center;gap:6px;font-size:11.5px;color:#5f6b7c;margin:0 8px 0 0}`;
+
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Approvals inbox</title><style>${css}</style></head>
+    <body><div class="ap-shell">${globalRail}<div class="ap-main"><div class="ap-topbar" aria-hidden="true"></div><div class="ap-work"><div class="ap-content">${facets}${list}${detail}</div></div></div></div></body></html>`;
+}
+

--- a/crates/node/src/bin/hypervisor_daemon_routes/governance_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/governance_routes.rs
@@ -309,6 +309,7 @@ pub(crate) async fn handle_governance_overview(State(st): State<Arc<DaemonState>
 // naming what a later authority-gated crossing WOULD do, but this plane executes none of it.
 
 const KIND_APPROVAL: &str = "governance-approval-requests";
+const KIND_APPROVAL_RECEIPT: &str = "governance-approval-transition-receipts";
 const KIND_RELEASE: &str = "governance-release-controls";
 const KIND_KILL: &str = "governance-kill-switches";
 const KIND_GATE: &str = "governance-improvement-gates";
@@ -483,21 +484,104 @@ pub(crate) async fn handle_approval_create(State(st): State<Arc<DaemonState>>, J
 pub(crate) async fn handle_approval_get(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>) -> Json<Value> {
     g_get(&st.data_dir, KIND_APPROVAL, "approval_request", &id)
 }
+/// Apply an approval transition to `prev`, producing (updated record, transition receipt).
+/// PURE (no I/O): validation happens BEFORE any mutation and a rejected transition returns Err
+/// touching nothing. Legacy records without revision/history/receipt_refs migrate lazily here
+/// (implicit revision 1, empty history) and stay readable. The receipt carries ONLY record-derived
+/// fields + the transition — never request headers, cookies, tokens, or arbitrary form data.
+fn apply_approval_transition(
+    prev: &Value,
+    transition: &str,
+    reviewer_ref: Option<&Value>,
+    now: &str,
+    receipt_id: &str,
+) -> Result<(Value, Value), (String, String)> {
+    let cur = prev.get("status").and_then(|v| v.as_str()).unwrap_or("pending");
+    let next = next_approval_status(cur, transition)
+        .map_err(|e| ("governance_transition_invalid".to_string(), e))?;
+    let prev_revision = prev.get("revision").and_then(Value::as_u64).unwrap_or(1);
+    let revision = prev_revision + 1;
+    let receipt_ref = format!("agentgres://governance-approval-transition-receipt/{receipt_id}");
+    let receipt = json!({
+        "schema_version": "ioi.hypervisor.governance.approval-transition-receipt.v1",
+        "object": "ioi.hypervisor.governance.approval_transition_receipt",
+        "receipt_id": receipt_id,
+        "receipt_ref": receipt_ref.clone(),
+        "approval_request_id": prev.get("id").cloned().unwrap_or(Value::Null),
+        "approval_request_ref": prev.get("ref").cloned().unwrap_or(Value::Null),
+        "subject_ref": prev.get("subject_ref").cloned().unwrap_or(Value::Null),
+        "transition": transition,
+        "previous_status": cur,
+        "resulting_status": next,
+        "reviewer_ref": reviewer_ref.cloned().unwrap_or(Value::Null),
+        "required_authority_refs": prev.get("required_authority_refs").cloned().unwrap_or_else(|| json!([])),
+        "outcome": "ok",
+        "at": now,
+    });
+    let mut a = prev.clone();
+    a["status"] = json!(next);
+    a["decided_at"] = json!(now);
+    if let Some(rv) = reviewer_ref {
+        a["reviewer_ref"] = rv.clone();
+    }
+    a["revision"] = json!(revision);
+    let mut hist = a.get("history").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    hist.push(json!({ "revision": revision, "op": transition, "at": now, "summary": format!("{cur} -> {next}"), "receipt_ref": receipt_ref.clone() }));
+    if hist.len() > 50 {
+        // Bounded history: keep the newest 50 entries (receipts stay durable on disk regardless).
+        let cut = hist.len() - 50;
+        hist.drain(0..cut);
+    }
+    a["history"] = Value::Array(hist);
+    let mut refs = a.get("receipt_refs").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    refs.push(json!(receipt_ref));
+    a["receipt_refs"] = Value::Array(refs);
+    a["updated_at"] = json!(now);
+    Ok((a, receipt))
+}
+
+/// Atomic-with-restore finalization. The RECORD persists first (a receipt must never describe a
+/// transition that did not persist); the receipt follows; if the receipt write fails, the prior
+/// record state is RESTORED with a checked write so a persisted transition never lacks its
+/// receipt. Every failure reports — no success claim survives a partial write.
+fn finalize_approval_transition(
+    data_dir: &str,
+    id: &str,
+    prev: &Value,
+    updated: &Value,
+    receipt_id: &str,
+    receipt: &Value,
+) -> Result<(), String> {
+    persist_record(data_dir, KIND_APPROVAL, id, updated)
+        .map_err(|e| format!("approval record persist failed ({e}) — nothing changed"))?;
+    match persist_record(data_dir, KIND_APPROVAL_RECEIPT, receipt_id, receipt) {
+        Ok(()) => Ok(()),
+        Err(e) => match persist_record(data_dir, KIND_APPROVAL, id, prev) {
+            Ok(()) => Err(format!("transition receipt persist failed ({e}); the prior record state was restored — nothing changed")),
+            Err(e2) => Err(format!("transition receipt persist failed ({e}) AND the record restore failed ({e2}) — manual repair required for approval '{id}'")),
+        },
+    }
+}
+
 pub(crate) async fn handle_approval_patch(State(st): State<Arc<DaemonState>>, AxumPath(id): AxumPath<String>, Json(body): Json<Value>) -> Json<Value> {
     let Some(mut a) = load(&st.data_dir, KIND_APPROVAL, &id) else {
-        return Json(json!({ "ok": false, "reason": "approval_request not found" }));
+        return Json(json!({ "ok": false, "reason": "approval_request not found", "error": { "code": "approval_not_found", "message": "approval_request not found" } }));
     };
+    // TRANSITION lane (receipted): validate → build record+receipt → finalize atomically-with-
+    // restore. A transition request patches NOTHING else in the same call, so the receipt is the
+    // whole truth of what changed. A refused transition alters no status/revision/history/refs.
     if let Some(t) = body.get("transition").and_then(|v| v.as_str()) {
-        let cur = a.get("status").and_then(|v| v.as_str()).unwrap_or("pending");
-        match next_approval_status(cur, t) {
-            Ok(next) => {
-                a["status"] = json!(next);
-                a["decided_at"] = json!(iso_now());
-                if let Some(rv) = body.get("reviewer_ref") { a["reviewer_ref"] = rv.clone(); }
-            }
-            Err(e) => return Json(json!({ "ok": false, "error": { "code": "governance_transition_invalid", "message": e } })),
-        }
+        let now = iso_now();
+        let receipt_id = format!("atr_{:x}", nanos());
+        return match apply_approval_transition(&a, t, body.get("reviewer_ref"), &now, &receipt_id) {
+            Ok((updated, receipt)) => match finalize_approval_transition(&st.data_dir, &id, &a, &updated, &receipt_id, &receipt) {
+                Ok(()) => Json(json!({ "ok": true, "approval_request": updated, "transition_receipt": receipt })),
+                Err(m) => Json(json!({ "ok": false, "error": { "code": "governance_transition_persist_failed", "message": m } })),
+            },
+            Err((code, message)) => Json(json!({ "ok": false, "error": { "code": code, "message": message } })),
+        };
     }
+    // Non-transition metadata patch (legacy lane, semantics unchanged: no receipt, no revision bump).
     for key in ["request_kind", "reason", "reviewer_ref", "enforcement_preview", "would_call", "required_authority_refs"] {
         if let Some(v) = body.get(key) { a[key] = v.clone(); }
     }
@@ -901,6 +985,101 @@ mod governance_tests {
         assert!(next_approval_status("approved", "approve").is_err());
         assert!(next_approval_status("rejected", "revoke").is_err());
         assert!(next_approval_status("pending", "publish").is_err());
+    }
+
+    fn legacy_pending() -> Value {
+        // A pre-#62 record: no revision / history / receipt_refs fields (lazy-migration input).
+        json!({
+            "id": "appr_t1", "ref": "approval-request://appr_t1",
+            "subject_ref": "automation://a1", "request_kind": "test", "reason": "r",
+            "status": "pending", "reviewer_ref": Value::Null, "decided_at": Value::Null,
+            "required_authority_refs": ["authority://x"],
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"
+        })
+    }
+
+    #[test]
+    fn approval_transition_accepted_builds_record_and_receipt() {
+        let prev = legacy_pending();
+        let (a, r) = apply_approval_transition(&prev, "approve", Some(&json!("agent://rev")), "2026-02-01T00:00:00Z", "atr_test1").unwrap();
+        // Record: status, decided, reviewer, revision bumped EXACTLY once (legacy 1 -> 2),
+        // one history entry, one receipt ref — all pointing at the same receipt.
+        assert_eq!(a["status"], json!("approved"));
+        assert_eq!(a["revision"], json!(2));
+        assert_eq!(a["reviewer_ref"], json!("agent://rev"));
+        let hist = a["history"].as_array().unwrap();
+        assert_eq!(hist.len(), 1);
+        assert_eq!(hist[0]["op"], json!("approve"));
+        assert_eq!(hist[0]["revision"], json!(2));
+        let refs = a["receipt_refs"].as_array().unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0], r["receipt_ref"]);
+        assert_eq!(hist[0]["receipt_ref"], r["receipt_ref"]);
+        // Receipt: full transition truth, nothing else.
+        assert_eq!(r["approval_request_id"], json!("appr_t1"));
+        assert_eq!(r["subject_ref"], json!("automation://a1"));
+        assert_eq!(r["transition"], json!("approve"));
+        assert_eq!(r["previous_status"], json!("pending"));
+        assert_eq!(r["resulting_status"], json!("approved"));
+        assert_eq!(r["outcome"], json!("ok"));
+        // EXACT key set — request headers/cookies/tokens/arbitrary form data can never leak in.
+        let mut keys: Vec<&str> = r.as_object().unwrap().keys().map(|k| k.as_str()).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec!["approval_request_id", "approval_request_ref", "at", "object", "outcome", "previous_status", "receipt_id", "receipt_ref", "required_authority_refs", "resulting_status", "reviewer_ref", "schema_version", "subject_ref", "transition"]);
+    }
+
+    #[test]
+    fn approval_transition_refused_touches_nothing_and_duplicates_refuse() {
+        let prev = legacy_pending();
+        let (approved, _r1) = apply_approval_transition(&prev, "approve", None, "2026-02-01T00:00:00Z", "atr_a").unwrap();
+        // Duplicate approve on the already-approved record: typed refusal, zero mutation.
+        let err = apply_approval_transition(&approved, "approve", None, "2026-02-02T00:00:00Z", "atr_b").unwrap_err();
+        assert_eq!(err.0, "governance_transition_invalid");
+        // Pure fn: the input record is untouched by a refusal (revision/history/refs intact).
+        assert_eq!(approved["revision"], json!(2));
+        assert_eq!(approved["history"].as_array().unwrap().len(), 1);
+        assert_eq!(approved["receipt_refs"].as_array().unwrap().len(), 1);
+        // Unknown vocabulary refuses too.
+        assert!(apply_approval_transition(&prev, "escalate", None, "t", "atr_c").is_err());
+    }
+
+    #[test]
+    fn approval_history_is_bounded() {
+        let mut rec = legacy_pending();
+        let mut hist = Vec::new();
+        for i in 0..60 {
+            hist.push(json!({ "revision": i, "op": "seed", "at": "t", "summary": "s", "receipt_ref": format!("agentgres://x/{i}") }));
+        }
+        rec["history"] = Value::Array(hist);
+        let (a, _r) = apply_approval_transition(&rec, "approve", None, "t2", "atr_bound").unwrap();
+        let h = a["history"].as_array().unwrap();
+        assert_eq!(h.len(), 50, "history is bounded to the newest 50 entries");
+        assert_eq!(h.last().unwrap()["op"], json!("approve"), "the newest entry is the accepted transition");
+    }
+
+    #[test]
+    fn approval_finalize_restores_prior_state_when_receipt_persist_fails() {
+        // Real tempdir; the receipt KIND path is pre-created as a FILE so create_dir_all fails —
+        // the injected persistence failure. The record must be RESTORED to its prior bytes.
+        let dir = std::env::temp_dir().join(format!("ioi-appr-final-{:x}", nanos()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let data_dir = dir.to_str().unwrap();
+        let prev = legacy_pending();
+        persist_record(data_dir, KIND_APPROVAL, "appr_t1", &prev).unwrap();
+        let (updated, receipt) = apply_approval_transition(&prev, "approve", None, "t", "atr_fail").unwrap();
+        // Block the receipts dir: a plain file where the directory must go.
+        std::fs::write(dir.join(KIND_APPROVAL_RECEIPT), b"blocker").unwrap();
+        let err = finalize_approval_transition(data_dir, "appr_t1", &prev, &updated, "atr_fail", &receipt).unwrap_err();
+        assert!(err.contains("restored"), "failure names the restore: {err}");
+        let on_disk = load(data_dir, KIND_APPROVAL, "appr_t1").unwrap();
+        assert_eq!(on_disk["status"], json!("pending"), "the transition did not survive the receipt failure");
+        assert!(on_disk.get("revision").is_none(), "no revision bump survived");
+        // And the happy path works once the blocker is gone: record + receipt both persist.
+        std::fs::remove_file(dir.join(KIND_APPROVAL_RECEIPT)).unwrap();
+        finalize_approval_transition(data_dir, "appr_t1", &prev, &updated, "atr_fail", &receipt).unwrap();
+        assert_eq!(load(data_dir, KIND_APPROVAL, "appr_t1").unwrap()["status"], json!("approved"));
+        assert_eq!(load(data_dir, KIND_APPROVAL_RECEIPT, "atr_fail").unwrap()["transition"], json!("approve"));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## The action runtime, proven with Approvals — after the mandated contract correction

Second PR of the operational wave (stacked on #61). The ApprovalRequest plane is hardened FIRST (transitions previously mutated status with no proof), then the registry-owned action runtime rides on it. No parallel `/__ioi/actions` namespace; the existing `POST /__ioi/governance/approvals/:id/transition` route now resolves to the module before the legacy governance handler.

## Receipt schema + persistence ordering (as required)

**Family**: `ioi.hypervisor.governance.approval-transition-receipt.v1` (durable kind `governance-approval-transition-receipts`), fields: receipt id/ref · approval request id/ref · subject ref · transition · previous/resulting status · reviewer when present · required authority refs · outcome · timestamp. An exact-key-set Rust test pins that headers/cookies/tokens/arbitrary form data can never appear.

**Ordering**: validate before mutation (pure `apply_approval_transition`, lazy legacy migration) → persist RECORD (a receipt never describes an unpersisted transition) → persist RECEIPT; on receipt failure the prior record is **restored with a checked write** and the call reports failure — no partial receipt, no unproven transition. Bounded history (newest 50), receipt ref appended, revision bumped exactly once. Refusals: typed code, zero mutation. **Rust: governance_tests 11/11** (5 new: accepted shape, duplicate/refusal zero-mutation, bounded history, restore-on-persistence-failure, receipt key-set).

## Accepted/refused transition proofs (live, verifier-driven)

approve → `pending→approved`, revision 1→2, one history entry, one durable receipt cross-checked **on disk** against subject/transition/statuses/reviewer · duplicate approve → `governance_transition_invalid`, revision still 2 · unconfirmed revoke → `confirmation_required`, zero mutation · confirmed revoke → second independent receipt, revision 3 · reject on a separate fixture → own receipt · **exact receipt-file delta +3** · fixtures deleted, baseline restored.

## The runtime (centralized; modules never see req/res)

Bounded form parsing · transition-vocabulary lookup · input allowlisting (undeclared fields never forwarded — sentinel-swept through record/receipt/HTML/redirects) · same-origin return validation (absolute/protocol-relative/markup/CRLF/traversal all fall back; reflected-XSS regression extended through registry dispatch) · server-side confirmation enforcement · embed preservation through action+redirect · typed success/refusal as PRG redirects with the `#ap-result` focus anchor · success **without** the declared receipt fails closed · route-local error containment (thrown action 500s one request; estate survives — proven on an isolated flag-gated serve; the fault surface does not exist on the live serve).

## Migrated legacy records

Records without revision/history/receipt_refs migrate lazily on their first transition (implicit revision 1 → 2) and remain readable; the non-transition metadata patch lane is unchanged (no receipt, no revision bump). Response gains additive `transition_receipt`.

## Byte-stability

Standalone Approvals HTML proven **byte-identical** after extraction and *before* banners/confirmation landed (per directive); banners render only from runtime redirect params, confirmation checkboxes live in the excluded detail-pane body. Cert artifact untouched; pixel 37/37.

## Done bar (exact counts)

action-runtime **32/32** (new) · approvals **23/23** · native-shell **24/24** · surface-modules **43/43** · runtime-safety **20/20** · pipeline **77/77** · explorer **47/47** · manager **23/23** · pixel **37/37** · reset **23/23** · home-surface **56/56** · shell-parity **6/6** · matrix clean · cargo **11/11** · no-undef clean · no NUL · `git diff --check` clean

**Remaining action-runtime gaps (honest):** confirmation is same-request (checkbox), not a two-step interstitial; the runtime handles form-encoded POSTs only (JSON action callers would need a lane when one exists); approvals create/delete stay on the legacy governance handler until the Approvals queue PR extracts them.

Next (PR #63): Operational Ontology Manager — structured typed-model authoring over the ODK contract with optimistic concurrency (`expected_revision`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)