### PR TITLE
feat(hypervisor): shared durable filesystem core — mechanical extraction (#73)

### DIFF
--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -40,6 +40,8 @@ mod feedback_routes;
 mod eval_suite_routes;
 #[path = "hypervisor_daemon_routes/state_machine_routes.rs"]
 mod state_machine_routes;
+#[path = "hypervisor_daemon_routes/durable_fs.rs"]
+mod durable_fs;
 #[path = "hypervisor_daemon_routes/goalrun_routes.rs"]
 mod goalrun_routes;
 #[path = "hypervisor_daemon_routes/ioi_agent_routes.rs"]

--- a/crates/node/src/bin/hypervisor_daemon_routes/durable_fs.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/durable_fs.rs
@@ -269,19 +269,20 @@ pub(crate) fn pin_parent(
     rel: &std::path::Path,
     create: bool,
 ) -> std::io::Result<std::fs::File> {
+    // Validate the COMPLETE relative path — every parent component AND the terminal — BEFORE
+    // creating anything (#73 review rounds 1+2): a noncanonical component (`..`, a root, `.`)
+    // anywhere in `rel` is REFUSED with ZERO mutation. Validating only `rel.parent()` would let
+    // `a/..` validate-and-create `a` and then "succeed" without its terminal ever being checked.
+    for comp in rel.components() {
+        if !matches!(comp, std::path::Component::Normal(_)) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("noncanonical path component {comp:?} — refused"),
+            ));
+        }
+    }
     let mut cur = root.try_clone()?;
     if let Some(parent) = rel.parent() {
-        // Validate the ENTIRE walk BEFORE creating anything (#73 review finding 1): a
-        // noncanonical relative path (`..`, a root, `.`) is REFUSED with zero mutation, never
-        // silently skipped and never after a partial mkdir — the walk only ever descends.
-        for comp in parent.components() {
-            if !matches!(comp, std::path::Component::Normal(_)) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    format!("noncanonical path component {comp:?} — refused"),
-                ));
-            }
-        }
         for comp in parent.components() {
             if let std::path::Component::Normal(seg) = comp {
                 if create && mkdir_at(&cur, seg)? {
@@ -574,15 +575,10 @@ pub(crate) fn persist_record_durable(
 ) -> Result<(), PersistFailure> {
     use std::io::Write;
     use PersistFailure::{NotCommitted, RenamedDurabilityUnconfirmed};
-    // Parity with persist_record (#72 round 3): promoted families have exactly one write path;
-    // not-yet-promoted families still feed the opt-in dual-write soak.
-    if super::substrate_store::is_promoted(family) {
-        return super::substrate_store::persist_promoted(data_dir, family, record_id, record)
-            .map_err(NotCommitted);
-    }
-    // Containment inside the shared boundary (#73 review finding 1): the family must be a
-    // single non-traversing component, and an unsafe record id is REJECTED — normalizing it
-    // would let two DISTINCT ids silently collide on one file.
+    // Containment inside the shared boundary (#73 review rounds 1+2), BEFORE any backend
+    // delegation — the refusal is uniform, never backend-dependent: the family must be a single
+    // non-traversing component, and an unsafe record id is REJECTED — normalizing it would let
+    // two DISTINCT ids silently collide on one file.
     if !is_single_component(std::ffi::OsStr::new(family)) {
         return Err(NotCommitted(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -591,6 +587,12 @@ pub(crate) fn persist_record_durable(
     }
     if !is_normalization_safe(record_id) {
         return Err(NotCommitted(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("record id '{record_id}' is not filesystem-safe (would normalize to a different key) — refused, never normalized"))));
+    }
+    // Parity with persist_record (#72 round 3): promoted families have exactly one write path;
+    // not-yet-promoted families still feed the opt-in dual-write soak.
+    if super::substrate_store::is_promoted(family) {
+        return super::substrate_store::persist_promoted(data_dir, family, record_id, record)
+            .map_err(NotCommitted);
     }
     let dir = std::path::Path::new(data_dir).join(family);
     let family_created = !dir.exists();
@@ -886,11 +888,40 @@ mod durable_fs_tests {
         assert!(read_slot_strict(&pinned, "../escape.json").is_err());
         assert!(unlink_at(&pinned, "..").is_err());
         assert!(open_file_at(&pinned, "a/b.json").is_err());
+        // (c) noncanonical relative paths are REFUSED by the walk, not silently skipped —
+        // INCLUDING a noncanonical TERMINAL (#73 round 2): `a/..` must not validate-and-create
+        // `a` and then "succeed" because only the parent was checked.
+        assert!(pin_parent(&pinned, std::path::Path::new("a/.."), true).is_err());
+        assert!(
+            !fam.join("a").exists(),
+            "pin_parent('a/..') refused with ZERO mutation — no partial mkdir"
+        );
         // (c) noncanonical relative paths are REFUSED by the walk, not silently skipped.
         assert!(pin_parent(&pinned, std::path::Path::new("a/../b/file.txt"), true).is_err());
         assert!(
             std::fs::read_dir(&fam).unwrap().next().is_none(),
             "the refused walk created nothing"
+        );
+        // (c2) validation precedes PROMOTED-family delegation (#73 round 2): an unsafe id on a
+        // promoted family is refused by the SHARED boundary itself, uniformly — never handed to
+        // a backend to decide.
+        assert!(
+            super::super::substrate_store::is_promoted("provider-receipts"),
+            "precondition: the promoted domain"
+        );
+        let err =
+            persist_record_durable(data_dir, "provider-receipts", "a/b", &json!({})).unwrap_err();
+        match err {
+            PersistFailure::NotCommitted(e) => assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::InvalidInput,
+                "uniform pre-delegation refusal: {e}"
+            ),
+            other => panic!("expected NotCommitted(InvalidInput), got {other:?}"),
+        }
+        assert!(
+            !dir.join("provider-receipts").exists(),
+            "nothing was created for the refused promoted write"
         );
         // (d) unsafe record ids are REJECTED, never normalized — distinct ids can no longer
         // collide on one file.

--- a/crates/node/src/bin/hypervisor_daemon_routes/durable_fs.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/durable_fs.rs
@@ -17,7 +17,8 @@
 //!     target is re-opened and certified (device/inode + bytes) AFTER the durability barrier;
 //!   - durability outcomes are structural: visible-but-unconfirmed is never reported as success
 //!     and never rolled back "as absent";
-//!   - enumeration goes through the pinned fd (`fdopendir(dup(fd))`) and distinguishes readdir
+//!   - enumeration goes through the pinned fd (`fdopendir` over an independent `openat(fd, ".")`
+//!     description) and distinguishes readdir
 //!     EOF from error via errno (#73 named gap) — an enumeration error propagates typed, never
 //!     as partial or empty truth.
 
@@ -98,6 +99,32 @@ fn cstr(name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<std::ffi::CString>
         .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in path component"))
 }
 
+/// A single, NON-TRAVERSING path component: no `/` separators, not `.`/`..`, not empty. The
+/// shared core enforces its containment contract ITSELF (#73 review finding 1): `O_NOFOLLOW`
+/// only protects the terminal component, so a multi-segment or dot-dot "name" smuggled into an
+/// `*at` helper or a family would otherwise walk wherever it liked.
+fn is_single_component(name: &std::ffi::OsStr) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+    let b = name.as_bytes();
+    !b.is_empty() && b != b"." && b != b".." && !b.contains(&b'/')
+}
+
+/// The validated CString every name-taking `*at` helper uses — a traversing name is refused
+/// typed BEFORE any syscall, inside the shared boundary.
+fn component_cstr(name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<std::ffi::CString> {
+    let n = name.as_ref();
+    if !is_single_component(n) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "'{}' is not a single non-traversing path component — refused",
+                n.to_string_lossy()
+            ),
+        ));
+    }
+    cstr(n)
+}
+
 /// Pin a directory as a walk root: must be a directory, terminal symlink refused.
 pub(crate) fn open_dir_pinned(path: &std::path::Path) -> std::io::Result<std::fs::File> {
     use std::os::unix::fs::OpenOptionsExt;
@@ -108,15 +135,31 @@ pub(crate) fn open_dir_pinned(path: &std::path::Path) -> std::io::Result<std::fs
 }
 
 /// Pin a record-family directory — the walk root for slot reads, enumeration, and commits.
-pub(crate) fn open_family_dir_pinned(data_dir: &str, family: &str) -> std::io::Result<std::fs::File> {
+pub(crate) fn open_family_dir_pinned(
+    data_dir: &str,
+    family: &str,
+) -> std::io::Result<std::fs::File> {
+    if !is_single_component(std::ffi::OsStr::new(family)) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("family '{family}' is not a single non-traversing path component — refused"),
+        ));
+    }
     open_dir_pinned(&std::path::Path::new(data_dir).join(family))
 }
 
-pub(crate) fn open_dir_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<std::fs::File> {
+pub(crate) fn open_dir_at(
+    parent: &std::fs::File,
+    name: impl AsRef<std::ffi::OsStr>,
+) -> std::io::Result<std::fs::File> {
     use std::os::unix::io::{AsRawFd, FromRawFd};
-    let c = cstr(name)?;
+    let c = component_cstr(name)?;
     let fd = unsafe {
-        libc::openat(parent.as_raw_fd(), c.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        libc::openat(
+            parent.as_raw_fd(),
+            c.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
     };
     if fd < 0 {
         return Err(std::io::Error::last_os_error());
@@ -125,9 +168,12 @@ pub(crate) fn open_dir_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsS
 }
 
 /// mkdirat; returns whether the directory was CREATED by this call (EEXIST = false).
-pub(crate) fn mkdir_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<bool> {
+pub(crate) fn mkdir_at(
+    parent: &std::fs::File,
+    name: impl AsRef<std::ffi::OsStr>,
+) -> std::io::Result<bool> {
     use std::os::unix::io::AsRawFd;
-    let c = cstr(name)?;
+    let c = component_cstr(name)?;
     let rc = unsafe { libc::mkdirat(parent.as_raw_fd(), c.as_ptr(), 0o755) };
     if rc != 0 {
         let e = std::io::Error::last_os_error();
@@ -141,9 +187,12 @@ pub(crate) fn mkdir_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>
 
 /// O_NONBLOCK is deliberate (#72 round 7 finding 4): opening a FIFO must never block the
 /// daemon; the regular-file check at the caller then refuses it typed.
-pub(crate) fn open_file_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<std::fs::File> {
+pub(crate) fn open_file_at(
+    parent: &std::fs::File,
+    name: impl AsRef<std::ffi::OsStr>,
+) -> std::io::Result<std::fs::File> {
     use std::os::unix::io::{AsRawFd, FromRawFd};
-    let c = cstr(name)?;
+    let c = component_cstr(name)?;
     let fd = unsafe {
         libc::openat(
             parent.as_raw_fd(),
@@ -158,9 +207,12 @@ pub(crate) fn open_file_at(parent: &std::fs::File, name: impl AsRef<std::ffi::Os
 }
 
 /// O_CREAT|O_EXCL|O_NOFOLLOW create relative to the pinned dir.
-pub(crate) fn create_file_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<std::fs::File> {
+pub(crate) fn create_file_at(
+    parent: &std::fs::File,
+    name: impl AsRef<std::ffi::OsStr>,
+) -> std::io::Result<std::fs::File> {
     use std::os::unix::io::{AsRawFd, FromRawFd};
-    let c = cstr(name)?;
+    let c = component_cstr(name)?;
     let fd = unsafe {
         libc::openat(
             parent.as_raw_fd(),
@@ -175,20 +227,34 @@ pub(crate) fn create_file_at(parent: &std::fs::File, name: impl AsRef<std::ffi::
     Ok(unsafe { std::fs::File::from_raw_fd(fd) })
 }
 
-pub(crate) fn rename_at(parent: &std::fs::File, from: impl AsRef<std::ffi::OsStr>, to: impl AsRef<std::ffi::OsStr>) -> std::io::Result<()> {
+pub(crate) fn rename_at(
+    parent: &std::fs::File,
+    from: impl AsRef<std::ffi::OsStr>,
+    to: impl AsRef<std::ffi::OsStr>,
+) -> std::io::Result<()> {
     use std::os::unix::io::AsRawFd;
-    let cf = cstr(from)?;
-    let ct = cstr(to)?;
-    let rc = unsafe { libc::renameat(parent.as_raw_fd(), cf.as_ptr(), parent.as_raw_fd(), ct.as_ptr()) };
+    let cf = component_cstr(from)?;
+    let ct = component_cstr(to)?;
+    let rc = unsafe {
+        libc::renameat(
+            parent.as_raw_fd(),
+            cf.as_ptr(),
+            parent.as_raw_fd(),
+            ct.as_ptr(),
+        )
+    };
     if rc != 0 {
         return Err(std::io::Error::last_os_error());
     }
     Ok(())
 }
 
-pub(crate) fn unlink_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<()> {
+pub(crate) fn unlink_at(
+    parent: &std::fs::File,
+    name: impl AsRef<std::ffi::OsStr>,
+) -> std::io::Result<()> {
     use std::os::unix::io::AsRawFd;
-    let c = cstr(name)?;
+    let c = component_cstr(name)?;
     if unsafe { libc::unlinkat(parent.as_raw_fd(), c.as_ptr(), 0) } != 0 {
         return Err(std::io::Error::last_os_error());
     }
@@ -198,9 +264,24 @@ pub(crate) fn unlink_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr
 /// Walk (and in `create` mode, mkdirat) each PARENT component of `rel` under `root`,
 /// returning the pinned parent directory fd. A directory CREATED here is made durable by a
 /// checked fsync of the directory that received the new entry (#72 round 7 finding 1).
-pub(crate) fn pin_parent(root: &std::fs::File, rel: &std::path::Path, create: bool) -> std::io::Result<std::fs::File> {
+pub(crate) fn pin_parent(
+    root: &std::fs::File,
+    rel: &std::path::Path,
+    create: bool,
+) -> std::io::Result<std::fs::File> {
     let mut cur = root.try_clone()?;
     if let Some(parent) = rel.parent() {
+        // Validate the ENTIRE walk BEFORE creating anything (#73 review finding 1): a
+        // noncanonical relative path (`..`, a root, `.`) is REFUSED with zero mutation, never
+        // silently skipped and never after a partial mkdir — the walk only ever descends.
+        for comp in parent.components() {
+            if !matches!(comp, std::path::Component::Normal(_)) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("noncanonical path component {comp:?} — refused"),
+                ));
+            }
+        }
         for comp in parent.components() {
             if let std::path::Component::Normal(seg) = comp {
                 if create && mkdir_at(&cur, seg)? {
@@ -217,7 +298,11 @@ pub(crate) fn pin_parent(root: &std::fs::File, rel: &std::path::Path, create: bo
 /// walk → NOFOLLOW|NONBLOCK file open) with fstat-enforced bounds: only REGULAR files, only
 /// up to `max_bytes` — a FIFO can never block the daemon and a huge file can never exhaust
 /// its memory. No path is re-resolved between validation and read.
-pub(crate) fn read_contained(root: &std::fs::File, rel: &std::path::Path, max_bytes: u64) -> Result<Vec<u8>, ReadRefusal> {
+pub(crate) fn read_contained(
+    root: &std::fs::File,
+    rel: &std::path::Path,
+    max_bytes: u64,
+) -> Result<Vec<u8>, ReadRefusal> {
     use std::io::Read;
     let classify = |e: std::io::Error| -> ReadRefusal {
         if matches!(e.raw_os_error(), Some(libc::ELOOP) | Some(libc::ENOTDIR)) {
@@ -227,9 +312,12 @@ pub(crate) fn read_contained(root: &std::fs::File, rel: &std::path::Path, max_by
         }
     };
     let parent = pin_parent(root, rel, false).map_err(&classify)?;
-    let name = rel
-        .file_name()
-        .ok_or_else(|| ReadRefusal::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, "no file name")))?;
+    let name = rel.file_name().ok_or_else(|| {
+        ReadRefusal::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "no file name",
+        ))
+    })?;
     let f = open_file_at(&parent, name).map_err(&classify)?;
     let md = f.metadata().map_err(ReadRefusal::Io)?;
     if !md.file_type().is_file() {
@@ -254,12 +342,19 @@ pub(crate) fn read_contained(root: &std::fs::File, rel: &std::path::Path, max_by
 /// occupant opened O_NOFOLLOW and read; Ok(None) = definitively ABSENT (ENOENT only). EVERY
 /// other outcome — unreadable occupant, symlink (ELOOP), FIFO/device — is Err: the caller must
 /// REFUSE, never treat the slot as empty.
-pub(crate) fn read_slot_strict(dir: &std::fs::File, name: &str) -> std::io::Result<Option<(std::fs::File, Vec<u8>)>> {
+pub(crate) fn read_slot_strict(
+    dir: &std::fs::File,
+    name: &str,
+) -> std::io::Result<Option<(std::fs::File, Vec<u8>)>> {
     use std::io::Read;
     use std::os::unix::io::{AsRawFd, FromRawFd};
-    let c = cstr(name)?;
+    let c = component_cstr(name)?;
     let fd = unsafe {
-        libc::openat(dir.as_raw_fd(), c.as_ptr(), libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
+        libc::openat(
+            dir.as_raw_fd(),
+            c.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+        )
     };
     if fd < 0 {
         let e = std::io::Error::last_os_error();
@@ -270,33 +365,54 @@ pub(crate) fn read_slot_strict(dir: &std::fs::File, name: &str) -> std::io::Resu
     }
     let mut f = unsafe { std::fs::File::from_raw_fd(fd) };
     if !f.metadata()?.is_file() {
-        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, format!("slot '{name}' is occupied by a non-regular file")));
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("slot '{name}' is occupied by a non-regular file"),
+        ));
     }
     let mut bytes = Vec::new();
     f.read_to_end(&mut bytes)?;
     Ok(Some((f, bytes)))
 }
 
-/// Enumerate the entries of an ALREADY-PINNED directory through the fd ITSELF (fdopendir over a
-/// dup) — NOT by re-walking the pathname (#72 round 21 finding 3): a directory-level exchange
-/// cannot redirect enumeration, because the names come from the same inode the caller pinned
-/// and reads through. fdopendir takes ownership of the dup; closedir closes it.
+/// Enumerate the entries of an ALREADY-PINNED directory through the fd ITSELF — NOT by
+/// re-walking the pathname (#72 round 21 finding 3): a directory-level exchange cannot redirect
+/// enumeration, because the names come from the same inode the caller pinned and reads through.
+///
+/// The stream is opened via `openat(fd, ".")`, giving an INDEPENDENT open-file description at
+/// offset 0 — NOT `dup`, which shares the caller's directory offset, so a second enumeration on
+/// the same pinned fd after EOF would read as EMPTY (#73 review finding 2). The caller's fd may
+/// be enumerated any number of times.
+pub(crate) fn enumerate_pinned(dir: &std::fs::File) -> std::io::Result<Vec<String>> {
+    use std::os::unix::io::AsRawFd;
+    let dot = cstr(".")?;
+    let fd = unsafe {
+        libc::openat(
+            dir.as_raw_fd(),
+            dot.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let dp = unsafe { libc::fdopendir(fd) };
+    if dp.is_null() {
+        let e = std::io::Error::last_os_error();
+        unsafe { libc::close(fd) };
+        return Err(e);
+    }
+    drain_dir_stream(dp)
+}
+
+/// The readdir loop over an OWNED directory stream (closedir always runs) — the deterministic
+/// seam for the post-readdir error branch (#73 review finding 2).
 ///
 /// readdir signals BOTH end-of-stream and error by returning NULL; the only way to tell them
 /// apart is errno (#73 named-gap fix): errno is reset before every call and inspected after a
-/// NULL — a genuine enumeration error propagates TYPED, never as partial or empty truth.
-pub(crate) fn enumerate_pinned(dir: &std::fs::File) -> std::io::Result<Vec<String>> {
-    use std::os::unix::io::AsRawFd;
-    let dupfd = unsafe { libc::dup(dir.as_raw_fd()) };
-    if dupfd < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    let dp = unsafe { libc::fdopendir(dupfd) };
-    if dp.is_null() {
-        let e = std::io::Error::last_os_error();
-        unsafe { libc::close(dupfd) };
-        return Err(e);
-    }
+/// NULL. A genuine enumeration error propagates TYPED and DISCARDS every name collected so far —
+/// a partial listing served as truth is exactly the false-empty registry this fixes.
+fn drain_dir_stream(dp: *mut libc::DIR) -> std::io::Result<Vec<String>> {
     let mut names = Vec::new();
     loop {
         unsafe { *libc::__errno_location() = 0 };
@@ -305,8 +421,6 @@ pub(crate) fn enumerate_pinned(dir: &std::fs::File) -> std::io::Result<Vec<Strin
             let errno = unsafe { *libc::__errno_location() };
             unsafe { libc::closedir(dp) };
             if errno != 0 {
-                // A real readdir failure — refuse the WHOLE enumeration; a partial listing
-                // served as truth is exactly the false-empty registry this fixes.
                 return Err(std::io::Error::from_raw_os_error(errno));
             }
             return Ok(names); // genuine EOF
@@ -329,7 +443,12 @@ pub(crate) fn open_tmpfile_at(dir: &std::fs::File) -> std::io::Result<std::fs::F
     use std::os::unix::io::{AsRawFd, FromRawFd};
     let dot = cstr(".")?;
     let fd = unsafe {
-        libc::openat(dir.as_raw_fd(), dot.as_ptr(), libc::O_WRONLY | libc::O_TMPFILE | libc::O_CLOEXEC, 0o644 as libc::c_uint)
+        libc::openat(
+            dir.as_raw_fd(),
+            dot.as_ptr(),
+            libc::O_WRONLY | libc::O_TMPFILE | libc::O_CLOEXEC,
+            0o644 as libc::c_uint,
+        )
     };
     if fd < 0 {
         return Err(std::io::Error::last_os_error());
@@ -341,11 +460,24 @@ pub(crate) fn open_tmpfile_at(dir: &std::fs::File) -> std::io::Result<std::fs::F
 /// binds the committed bytes to the DESCRIPTOR, not to any swappable source name (#72 round 20
 /// finding 1). Uses the /proc/self/fd form (no CAP_DAC_READ_SEARCH needed for non-root); link
 /// fails EEXIST if the target appeared since inspection, exactly like a named no-replace link.
-pub(crate) fn link_tmpfile_at(tmp: &std::fs::File, dir: &std::fs::File, to: &str) -> std::io::Result<()> {
+pub(crate) fn link_tmpfile_at(
+    tmp: &std::fs::File,
+    dir: &std::fs::File,
+    to: &str,
+) -> std::io::Result<()> {
     use std::os::unix::io::AsRawFd;
     let src = cstr(format!("/proc/self/fd/{}", tmp.as_raw_fd()))?;
-    let ct = cstr(to)?;
-    if unsafe { libc::linkat(libc::AT_FDCWD, src.as_ptr(), dir.as_raw_fd(), ct.as_ptr(), libc::AT_SYMLINK_FOLLOW) } != 0 {
+    let ct = component_cstr(to)?;
+    if unsafe {
+        libc::linkat(
+            libc::AT_FDCWD,
+            src.as_ptr(),
+            dir.as_raw_fd(),
+            ct.as_ptr(),
+            libc::AT_SYMLINK_FOLLOW,
+        )
+    } != 0
+    {
         return Err(std::io::Error::last_os_error());
     }
     Ok(())
@@ -364,7 +496,10 @@ pub(crate) fn same_inode(a: &std::fs::File, b: &std::fs::File) -> std::io::Resul
 /// normalizes unsafe characters, so two different keys could silently target the same file —
 /// a caller must reject rather than collide.
 pub(crate) fn is_normalization_safe(id: &str) -> bool {
-    !id.is_empty() && id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    !id.is_empty()
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
 }
 
 /// DELIBERATE TEST FAULT (#72 round 21 finding 1): simulate a CONCURRENT adversary replacing the
@@ -372,12 +507,22 @@ pub(crate) fn is_normalization_safe(id: &str) -> bool {
 /// exercised. Absent env = no effect. `point` is "new" (fresh linkat) or "replay" (byte-compare).
 fn test_swap_target(dir: &std::fs::File, target: &str, point: &str) {
     use std::io::Write;
-    if std::env::var("IOI_TEST_FORCE_RECEIPT_TARGET_SWAP").ok().as_deref() != Some(point) {
+    if std::env::var("IOI_TEST_FORCE_RECEIPT_TARGET_SWAP")
+        .ok()
+        .as_deref()
+        != Some(point)
+    {
         return;
     }
     let _ = unlink_at(dir, target);
     if let Ok(mut f) = open_tmpfile_at(dir) {
-        let _ = f.write_all(format!("{{\"foreign\":\"REPLACED_AFTER_{}\"}}", point.to_uppercase()).as_bytes());
+        let _ = f.write_all(
+            format!(
+                "{{\"foreign\":\"REPLACED_AFTER_{}\"}}",
+                point.to_uppercase()
+            )
+            .as_bytes(),
+        );
         let _ = f.sync_all();
         let _ = link_tmpfile_at(&f, dir, target);
     }
@@ -386,7 +531,13 @@ fn test_swap_target(dir: &std::fs::File, target: &str, point: &str) {
 /// Re-verify the canonical name AFTER the file + directory fsyncs (#72 round 21 finding 1):
 /// re-open the target O_NOFOLLOW, prove it is the SAME inode as the committed descriptor, and
 /// re-read its bytes — a target swapped during the durability barrier is caught and refused.
-pub(crate) fn certify_target(dir: &std::fs::File, target: &str, committed: &std::fs::File, bytes: &[u8], point: &str) -> Result<(), CommitFailure> {
+pub(crate) fn certify_target(
+    dir: &std::fs::File,
+    target: &str,
+    committed: &std::fs::File,
+    bytes: &[u8],
+    point: &str,
+) -> Result<(), CommitFailure> {
     test_swap_target(dir, target, point);
     match read_slot_strict(dir, target) {
         Ok(Some((reopened, on_disk))) => {
@@ -398,8 +549,12 @@ pub(crate) fn certify_target(dir: &std::fs::File, target: &str, committed: &std:
             }
             Ok(())
         }
-        Ok(None) => Err(CommitFailure::Swapped(format!("the receipt name '{target}' vanished after commit — refused"))),
-        Err(e) => Err(CommitFailure::SlotUnreadable(format!("post-commit re-verify of '{target}' failed ({e}) — refused"))),
+        Ok(None) => Err(CommitFailure::Swapped(format!(
+            "the receipt name '{target}' vanished after commit — refused"
+        ))),
+        Err(e) => Err(CommitFailure::SlotUnreadable(format!(
+            "post-commit re-verify of '{target}' failed ({e}) — refused"
+        ))),
     }
 }
 
@@ -411,13 +566,31 @@ pub(crate) fn certify_target(dir: &std::fs::File, target: &str, committed: &std:
 /// `RenamedDurabilityUnconfirmed` (new record visible, durability unknown) so callers can model
 /// the truth instead of pretending nothing happened. A NEWLY CREATED family directory is made
 /// durable by fsyncing its parent before any record lands inside it.
-pub(crate) fn persist_record_durable(data_dir: &str, family: &str, record_id: &str, record: &Value) -> Result<(), PersistFailure> {
+pub(crate) fn persist_record_durable(
+    data_dir: &str,
+    family: &str,
+    record_id: &str,
+    record: &Value,
+) -> Result<(), PersistFailure> {
     use std::io::Write;
     use PersistFailure::{NotCommitted, RenamedDurabilityUnconfirmed};
     // Parity with persist_record (#72 round 3): promoted families have exactly one write path;
     // not-yet-promoted families still feed the opt-in dual-write soak.
     if super::substrate_store::is_promoted(family) {
-        return super::substrate_store::persist_promoted(data_dir, family, record_id, record).map_err(NotCommitted);
+        return super::substrate_store::persist_promoted(data_dir, family, record_id, record)
+            .map_err(NotCommitted);
+    }
+    // Containment inside the shared boundary (#73 review finding 1): the family must be a
+    // single non-traversing component, and an unsafe record id is REJECTED — normalizing it
+    // would let two DISTINCT ids silently collide on one file.
+    if !is_single_component(std::ffi::OsStr::new(family)) {
+        return Err(NotCommitted(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("family '{family}' is not a single non-traversing path component — refused"),
+        )));
+    }
+    if !is_normalization_safe(record_id) {
+        return Err(NotCommitted(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("record id '{record_id}' is not filesystem-safe (would normalize to a different key) — refused, never normalized"))));
     }
     let dir = std::path::Path::new(data_dir).join(family);
     let family_created = !dir.exists();
@@ -425,10 +598,10 @@ pub(crate) fn persist_record_durable(data_dir: &str, family: &str, record_id: &s
     if family_created {
         // A brand-new record family: fsync the data dir so the family directory itself
         // survives a crash (#72 round 7 finding 1).
-        (|| -> std::io::Result<()> { std::fs::File::open(data_dir)?.sync_all() })().map_err(NotCommitted)?;
+        (|| -> std::io::Result<()> { std::fs::File::open(data_dir)?.sync_all() })()
+            .map_err(NotCommitted)?;
     }
-    let safe: String = record_id.replace(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_', "_");
-    let tmp = dir.join(format!(".{safe}.tmp-{:x}", nanos()));
+    let tmp = dir.join(format!(".{record_id}.tmp-{:x}", nanos()));
     let write = (|| -> std::io::Result<()> {
         let mut f = std::fs::File::create(&tmp)?;
         f.write_all(&serde_json::to_vec_pretty(record).unwrap_or_default())?;
@@ -438,7 +611,7 @@ pub(crate) fn persist_record_durable(data_dir: &str, family: &str, record_id: &s
         let _ = std::fs::remove_file(&tmp);
         return Err(NotCommitted(e));
     }
-    if let Err(e) = std::fs::rename(&tmp, dir.join(format!("{safe}.json"))) {
+    if let Err(e) = std::fs::rename(&tmp, dir.join(format!("{record_id}.json"))) {
         let _ = std::fs::remove_file(&tmp);
         return Err(NotCommitted(e));
     }
@@ -448,8 +621,14 @@ pub(crate) fn persist_record_durable(data_dir: &str, family: &str, record_id: &s
     // directory-fsync failure cannot be injected by permissions on a read-then-write seam (the
     // dir listing and the fsync open need the same read bit), so the visible-unconfirmed lane
     // is forced here for the fault verifiers — the rename has genuinely happened.
-    if std::env::var("IOI_TEST_FORCE_DIRSYNC_UNCONFIRMED").ok().as_deref() == Some(family) {
-        return Err(RenamedDurabilityUnconfirmed(std::io::Error::other("test-forced directory-sync failure")));
+    if std::env::var("IOI_TEST_FORCE_DIRSYNC_UNCONFIRMED")
+        .ok()
+        .as_deref()
+        == Some(family)
+    {
+        return Err(RenamedDurabilityUnconfirmed(std::io::Error::other(
+            "test-forced directory-sync failure",
+        )));
     }
     if let Err(e) = (|| -> std::io::Result<()> { std::fs::File::open(&dir)?.sync_all() })() {
         return Err(RenamedDurabilityUnconfirmed(e));
@@ -475,35 +654,62 @@ pub(crate) fn persist_record_durable(data_dir: &str, family: &str, record_id: &s
 ///   - the durability outcome is PRESERVED (#72 round 19 finding 2): visible-but-unconfirmed
 ///     is `DurabilityUnconfirmed`, never Ok — terminal state and intent consumption require a
 ///     DURABLE commit.
-pub(crate) fn persist_receipt_no_clobber(data_dir: &str, family: &str, tail: &str, receipt: &Value) -> Result<(), CommitFailure> {
+pub(crate) fn persist_receipt_no_clobber(
+    data_dir: &str,
+    family: &str,
+    tail: &str,
+    receipt: &Value,
+) -> Result<(), CommitFailure> {
     use std::io::Write;
+    if !is_single_component(std::ffi::OsStr::new(family)) {
+        return Err(CommitFailure::NotCommitted(format!("family '{family}' is not a single non-traversing path component — refused, nothing was written")));
+    }
     if !is_normalization_safe(tail) {
-        return Err(CommitFailure::KeyInvalid(format!("receipt tail '{tail}' is not filesystem-safe")));
+        return Err(CommitFailure::KeyInvalid(format!(
+            "receipt tail '{tail}' is not filesystem-safe"
+        )));
     }
     let bytes = serde_json::to_vec_pretty(receipt).unwrap_or_default();
     let fam_path = std::path::Path::new(data_dir).join(family);
     if let Err(e) = std::fs::create_dir_all(&fam_path) {
-        return Err(CommitFailure::NotCommitted(format!("receipt directory unavailable ({e}) — nothing was written")));
+        return Err(CommitFailure::NotCommitted(format!(
+            "receipt directory unavailable ({e}) — nothing was written"
+        )));
     }
     let dir = match open_family_dir_pinned(data_dir, family) {
         Ok(d) => d,
-        Err(e) => return Err(CommitFailure::NotCommitted(format!("receipt directory pin failed ({e}) — nothing was written"))),
+        Err(e) => {
+            return Err(CommitFailure::NotCommitted(format!(
+                "receipt directory pin failed ({e}) — nothing was written"
+            )))
+        }
     };
     let target = format!("{tail}.json");
     let confirm_dir_durable = |dir: &std::fs::File| -> Result<(), CommitFailure> {
         // DELIBERATE TEST FAULT POINT (same contract as the typed durable writer): absent env =
         // no effect; the receipt is already VISIBLE when this fires.
-        if std::env::var("IOI_TEST_FORCE_DIRSYNC_UNCONFIRMED").ok().as_deref() == Some(family) {
+        if std::env::var("IOI_TEST_FORCE_DIRSYNC_UNCONFIRMED")
+            .ok()
+            .as_deref()
+            == Some(family)
+        {
             return Err(CommitFailure::DurabilityUnconfirmed("test-forced directory-sync failure — the receipt is VISIBLE but its durability is unconfirmed".to_string()));
         }
         dir.sync_all().map_err(|e| CommitFailure::DurabilityUnconfirmed(format!("receipt directory sync failed ({e}) — the receipt is VISIBLE but its durability is unconfirmed")))?;
         // Parent (data_dir) fsync — UNCONDITIONAL (#72 round 21 finding 2); a separate fault hook
         // fails only the parent leg so the failure→restart lane is exact.
-        if std::env::var("IOI_TEST_FORCE_PARENT_FSYNC_UNCONFIRMED").ok().as_deref() == Some(family) {
+        if std::env::var("IOI_TEST_FORCE_PARENT_FSYNC_UNCONFIRMED")
+            .ok()
+            .as_deref()
+            == Some(family)
+        {
             return Err(CommitFailure::DurabilityUnconfirmed("test-forced parent-directory-sync failure — the receipt family entry is VISIBLE but not durable".to_string()));
         }
-        (|| -> std::io::Result<()> { std::fs::File::open(data_dir)?.sync_all() })()
-            .map_err(|e| CommitFailure::DurabilityUnconfirmed(format!("data_dir sync failed ({e}) — the receipt family entry is VISIBLE but not durable")))
+        (|| -> std::io::Result<()> { std::fs::File::open(data_dir)?.sync_all() })().map_err(|e| {
+            CommitFailure::DurabilityUnconfirmed(format!(
+                "data_dir sync failed ({e}) — the receipt family entry is VISIBLE but not durable"
+            ))
+        })
     };
     match read_slot_strict(&dir, &target) {
         Err(e) => Err(CommitFailure::SlotUnreadable(format!("the receipt slot '{tail}' is occupied but NOT readable as a regular file ({e}) — refused; evidence is never replaced on uncertainty"))),
@@ -575,16 +781,141 @@ mod durable_fs_tests {
         std::fs::write(dir.join("a.json"), b"{}").unwrap();
         std::fs::write(dir.join("b.json"), b"{}").unwrap();
         // Pollute errno deliberately with a failing syscall (ENOENT).
-        let missing = std::ffi::CString::new(format!("{}/definitely-missing", dir.display())).unwrap();
+        let missing =
+            std::ffi::CString::new(format!("{}/definitely-missing", dir.display())).unwrap();
         let rc = unsafe { libc::open(missing.as_ptr(), libc::O_RDONLY) };
         assert!(rc < 0, "the polluting open must fail");
         let pinned = open_dir_pinned(&dir).unwrap();
         let mut names = enumerate_pinned(&pinned).unwrap();
         names.sort();
-        assert_eq!(names, vec!["a.json".to_string(), "b.json".to_string()], "EOF with polluted errno is still a COMPLETE listing");
-        // Non-directory fd → typed error, never empty truth.
+        assert_eq!(
+            names,
+            vec!["a.json".to_string(), "b.json".to_string()],
+            "EOF with polluted errno is still a COMPLETE listing"
+        );
+        // Non-directory fd → typed error (openat(".") ENOTDIR), never empty truth.
         let file_fd = std::fs::File::open(dir.join("a.json")).unwrap();
-        assert!(enumerate_pinned(&file_fd).is_err(), "a non-directory fd is a TYPED enumeration error");
+        assert!(
+            enumerate_pinned(&file_fd).is_err(),
+            "a non-directory fd is a TYPED enumeration error"
+        );
+        // TWO CONSECUTIVE COMPLETE enumerations on the SAME pinned fd (#73 review finding 2):
+        // the stream is an independent open-file description, not a dup sharing the offset —
+        // a second listing after EOF must be COMPLETE, never empty.
+        let mut second = enumerate_pinned(&pinned).unwrap();
+        second.sort();
+        assert_eq!(
+            second, names,
+            "the pinned fd is reusable — the second enumeration is complete, not offset-exhausted"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn drain_dir_stream_error_branch_discards_partial_names() {
+        // #73 review finding 2: exercise the ACTUAL `readdir() == NULL && errno != 0` branch
+        // deterministically. The stream's underlying fd is redirected to /dev/null via dup2
+        // (thread-safe: the fd number stays occupied, so closedir cannot close a stranger),
+        // making the first getdents fail ENOTDIR — with entries PRESENT in the directory, the
+        // result must be a typed error carrying NO names, never a partial or empty Ok.
+        use std::os::unix::io::AsRawFd;
+        let dir = temp_dir("drain-err");
+        for n in ["x.json", "y.json", "z.json"] {
+            std::fs::write(dir.join(n), b"{}").unwrap();
+        }
+        let pinned = open_dir_pinned(&dir).unwrap();
+        let dot = std::ffi::CString::new(".").unwrap();
+        let fd = unsafe {
+            libc::openat(
+                pinned.as_raw_fd(),
+                dot.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+            )
+        };
+        assert!(fd >= 0);
+        let dp = unsafe { libc::fdopendir(fd) };
+        assert!(!dp.is_null());
+        let devnull = std::fs::File::open("/dev/null").unwrap();
+        assert_eq!(
+            unsafe { libc::dup2(devnull.as_raw_fd(), fd) },
+            fd,
+            "dup2 sabotage failed"
+        );
+        let err = drain_dir_stream(dp).unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ENOTDIR),
+            "the post-readdir errno branch fired typed: {err}"
+        );
+        // The three real entries were NEVER served as a partial listing — the error carries none.
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn shared_boundary_refuses_traversal_and_collisions_with_zero_mutation() {
+        // #73 review finding 1: containment is enforced INSIDE the shared core.
+        use serde_json::json;
+        let dir = temp_dir("boundary");
+        let data_dir = dir.to_str().unwrap();
+        let outside = dir.join("outside-sentinel");
+        std::fs::create_dir_all(&outside).unwrap();
+        // (a) traversing family names are refused with ZERO mutation outside the boundary.
+        assert!(open_family_dir_pinned(data_dir, "../outside-sentinel").is_err());
+        assert!(matches!(
+            persist_record_durable(data_dir, "../outside-sentinel", "rec", &json!({})).unwrap_err(),
+            PersistFailure::NotCommitted(_)
+        ));
+        assert!(matches!(
+            persist_receipt_no_clobber(
+                data_dir,
+                "fam/../../outside-sentinel",
+                "orr_aa",
+                &json!({})
+            )
+            .unwrap_err(),
+            CommitFailure::NotCommitted(_)
+        ));
+        assert!(
+            std::fs::read_dir(&outside).unwrap().next().is_none(),
+            "nothing was ever written outside the family boundary"
+        );
+        // (b) traversing slot names are refused BEFORE any syscall.
+        let fam = dir.join("fam");
+        std::fs::create_dir_all(&fam).unwrap();
+        let pinned = open_dir_pinned(&fam).unwrap();
+        assert!(read_slot_strict(&pinned, "../escape.json").is_err());
+        assert!(unlink_at(&pinned, "..").is_err());
+        assert!(open_file_at(&pinned, "a/b.json").is_err());
+        // (c) noncanonical relative paths are REFUSED by the walk, not silently skipped.
+        assert!(pin_parent(&pinned, std::path::Path::new("a/../b/file.txt"), true).is_err());
+        assert!(
+            std::fs::read_dir(&fam).unwrap().next().is_none(),
+            "the refused walk created nothing"
+        );
+        // (d) unsafe record ids are REJECTED, never normalized — distinct ids can no longer
+        // collide on one file.
+        persist_record_durable(data_dir, "recs", "a_b", &json!({ "id": "a_b" })).unwrap();
+        assert!(matches!(
+            persist_record_durable(data_dir, "recs", "a/b", &json!({ "id": "a/b" })).unwrap_err(),
+            PersistFailure::NotCommitted(_)
+        ));
+        assert!(matches!(
+            persist_record_durable(data_dir, "recs", "a:b", &json!({ "id": "a:b" })).unwrap_err(),
+            PersistFailure::NotCommitted(_)
+        ));
+        let survivor: Value =
+            serde_json::from_slice(&std::fs::read(dir.join("recs").join("a_b.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            survivor["id"],
+            json!("a_b"),
+            "the honest record was never clobbered by a normalized collision"
+        );
+        assert_eq!(
+            std::fs::read_dir(dir.join("recs")).unwrap().count(),
+            1,
+            "exactly one record exists"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -602,7 +933,10 @@ mod durable_fs_tests {
         assert_eq!(std::fs::metadata(&slot).unwrap().nlink(), 1);
         persist_receipt_no_clobber(data_dir, "evidence", "orr_x0", &receipt).unwrap(); // idempotent replay
         let different = json!({ "receipt_id": "receipt://orr_x0", "attested": false });
-        assert!(matches!(persist_receipt_no_clobber(data_dir, "evidence", "orr_x0", &different).unwrap_err(), CommitFailure::Conflict(_)));
+        assert!(matches!(
+            persist_receipt_no_clobber(data_dir, "evidence", "orr_x0", &different).unwrap_err(),
+            CommitFailure::Conflict(_)
+        ));
         // Swap the canonical name to a different inode; certification refuses.
         let pinned = open_family_dir_pinned(data_dir, "evidence").unwrap();
         let (committed, _) = read_slot_strict(&pinned, "orr_x0.json").unwrap().unwrap();
@@ -614,7 +948,10 @@ mod durable_fs_tests {
         f.write_all(b"{\"foreign\":\"SWAPPED\"}").unwrap();
         f.sync_all().unwrap();
         link_tmpfile_at(&f, &pinned, "orr_x0.json").unwrap();
-        assert!(matches!(certify_target(&pinned, "orr_x0.json", &committed, &bytes, "unit").unwrap_err(), CommitFailure::Swapped(_)));
+        assert!(matches!(
+            certify_target(&pinned, "orr_x0.json", &committed, &bytes, "unit").unwrap_err(),
+            CommitFailure::Swapped(_)
+        ));
         let _ = std::fs::remove_dir_all(&dir_t);
     }
 }

--- a/crates/node/src/bin/hypervisor_daemon_routes/durable_fs.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/durable_fs.rs
@@ -1,0 +1,620 @@
+//! SHARED DURABLE-FILESYSTEM CORE (#73) — the proven syscall-level mechanics extracted verbatim
+//! from the GoalRun plane (#72 rounds 5–9: pinned walks, bounded contained reads, the typed
+//! atomic-replacement writer) and the OutcomeRoom plane (#72 rounds 17–21: strict slot reads,
+//! descriptor-bound O_TMPFILE no-clobber commits, unconditional parent fsync, post-barrier
+//! inode/byte certification, fd-pinned enumeration).
+//!
+//! POLICY STAYS IN THE PLANES. This module knows nothing about rooms, receipts, intents, or
+//! wire error codes — it provides mechanics with TYPED outcomes (`PersistFailure`,
+//! `CommitFailure`, `ReadRefusal`) that each plane maps onto its own contract. Every future
+//! object plane (#74+) builds on THIS instead of copying route-local machinery.
+//!
+//! The doctrine encoded here, in one place:
+//!   - the enforcement IS the open: every component and slot is opened `O_NOFOLLOW` relative to
+//!     a previously PINNED directory fd — no path is ever re-resolved between validation and use;
+//!   - only ENOENT means empty: an unreadable, symlinked, or non-regular occupant REFUSES;
+//!   - commits are bound to DESCRIPTORS, not names: `O_TMPFILE` + `linkat` (no-replace), then the
+//!     target is re-opened and certified (device/inode + bytes) AFTER the durability barrier;
+//!   - durability outcomes are structural: visible-but-unconfirmed is never reported as success
+//!     and never rolled back "as absent";
+//!   - enumeration goes through the pinned fd (`fdopendir(dup(fd))`) and distinguishes readdir
+//!     EOF from error via errno (#73 named gap) — an enumeration error propagates typed, never
+//!     as partial or empty truth.
+
+use serde_json::Value;
+
+fn nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+// ================================ TYPED OUTCOMES =================================================
+
+/// Outcome of the ATOMIC-REPLACEMENT writer (`persist_record_durable`).
+#[derive(Debug)]
+pub(crate) enum PersistFailure {
+    /// The failure happened before or at the rename: the OLD record provably survives, so
+    /// "nothing changed" cleanup/rollback language is truthful.
+    NotCommitted(std::io::Error),
+    /// The rename ALREADY replaced the old record in the live view; only the directory fsync
+    /// failed, so durability is unconfirmed — the new record is visible and may well be
+    /// durable. Callers must PRESERVE evidence and report unknown-but-possibly-applied; rolling
+    /// back "as absent" would be a lie.
+    RenamedDurabilityUnconfirmed(std::io::Error),
+}
+
+impl PersistFailure {
+    pub(crate) fn visible(&self) -> bool {
+        matches!(self, PersistFailure::RenamedDurabilityUnconfirmed(_))
+    }
+    pub(crate) fn detail(&self) -> String {
+        match self {
+            PersistFailure::NotCommitted(e) => format!("not committed ({e}); the prior record is intact"),
+            PersistFailure::RenamedDurabilityUnconfirmed(e) => format!("RENAMED but durability unconfirmed ({e}); the new record is VISIBLE and may already be durable"),
+        }
+    }
+}
+
+/// Outcome of the APPEND-ONLY no-clobber commit (`persist_receipt_no_clobber`). Each variant
+/// carries the full human-readable detail; the owning plane maps variants onto its wire codes.
+#[derive(Debug)]
+pub(crate) enum CommitFailure {
+    /// The evidence key would be normalized to a different filename — refused before any write.
+    KeyInvalid(String),
+    /// Nothing is visible: staging or the link commit failed cleanly.
+    NotCommitted(String),
+    /// The slot is occupied by something that cannot be certified (unreadable, symlink,
+    /// non-regular file) — refused; evidence is never replaced on uncertainty.
+    SlotUnreadable(String),
+    /// The slot holds DIFFERENT evidence (or an occupant appeared mid-commit) — append-only.
+    Conflict(String),
+    /// The evidence is VISIBLE but its durability is unconfirmed (file, directory, or parent
+    /// fsync) — the caller must not consume its replay anchor.
+    DurabilityUnconfirmed(String),
+    /// The canonical name no longer resolves to the certified inode/bytes after the durability
+    /// barrier — a concurrent replacement was caught, nothing was certified.
+    Swapped(String),
+}
+
+/// A bounded-intake read refusal (#72 round 7 finding 4) — each shape is typed distinctly.
+#[derive(Debug)]
+pub(crate) enum ReadRefusal {
+    /// Symlink / non-directory component at use time — a containment escape.
+    Escape(std::io::Error),
+    /// The declared output is not a regular file (FIFO, device, socket, directory).
+    NotRegular(String),
+    /// The file exceeds the per-file or remaining per-attempt byte budget.
+    TooLarge(u64),
+    Io(std::io::Error),
+}
+
+// ============================ PINNED DESCRIPTORS + WALKS =========================================
+
+fn cstr(name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+    std::ffi::CString::new(name.as_ref().as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in path component"))
+}
+
+/// Pin a directory as a walk root: must be a directory, terminal symlink refused.
+pub(crate) fn open_dir_pinned(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+}
+
+/// Pin a record-family directory — the walk root for slot reads, enumeration, and commits.
+pub(crate) fn open_family_dir_pinned(data_dir: &str, family: &str) -> std::io::Result<std::fs::File> {
+    open_dir_pinned(&std::path::Path::new(data_dir).join(family))
+}
+
+pub(crate) fn open_dir_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<std::fs::File> {
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+    let c = cstr(name)?;
+    let fd = unsafe {
+        libc::openat(parent.as_raw_fd(), c.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+}
+
+/// mkdirat; returns whether the directory was CREATED by this call (EEXIST = false).
+pub(crate) fn mkdir_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<bool> {
+    use std::os::unix::io::AsRawFd;
+    let c = cstr(name)?;
+    let rc = unsafe { libc::mkdirat(parent.as_raw_fd(), c.as_ptr(), 0o755) };
+    if rc != 0 {
+        let e = std::io::Error::last_os_error();
+        if e.raw_os_error() != Some(libc::EEXIST) {
+            return Err(e);
+        }
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+/// O_NONBLOCK is deliberate (#72 round 7 finding 4): opening a FIFO must never block the
+/// daemon; the regular-file check at the caller then refuses it typed.
+pub(crate) fn open_file_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<std::fs::File> {
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+    let c = cstr(name)?;
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            c.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+}
+
+/// O_CREAT|O_EXCL|O_NOFOLLOW create relative to the pinned dir.
+pub(crate) fn create_file_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<std::fs::File> {
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+    let c = cstr(name)?;
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            c.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0o644 as libc::c_uint,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+}
+
+pub(crate) fn rename_at(parent: &std::fs::File, from: impl AsRef<std::ffi::OsStr>, to: impl AsRef<std::ffi::OsStr>) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let cf = cstr(from)?;
+    let ct = cstr(to)?;
+    let rc = unsafe { libc::renameat(parent.as_raw_fd(), cf.as_ptr(), parent.as_raw_fd(), ct.as_ptr()) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+pub(crate) fn unlink_at(parent: &std::fs::File, name: impl AsRef<std::ffi::OsStr>) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let c = cstr(name)?;
+    if unsafe { libc::unlinkat(parent.as_raw_fd(), c.as_ptr(), 0) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Walk (and in `create` mode, mkdirat) each PARENT component of `rel` under `root`,
+/// returning the pinned parent directory fd. A directory CREATED here is made durable by a
+/// checked fsync of the directory that received the new entry (#72 round 7 finding 1).
+pub(crate) fn pin_parent(root: &std::fs::File, rel: &std::path::Path, create: bool) -> std::io::Result<std::fs::File> {
+    let mut cur = root.try_clone()?;
+    if let Some(parent) = rel.parent() {
+        for comp in parent.components() {
+            if let std::path::Component::Normal(seg) = comp {
+                if create && mkdir_at(&cur, seg)? {
+                    cur.sync_all()?;
+                }
+                cur = open_dir_at(&cur, seg)?;
+            }
+        }
+    }
+    Ok(cur)
+}
+
+/// Read a workspace file ENTIRELY through pinned descriptors (root fd → NOFOLLOW component
+/// walk → NOFOLLOW|NONBLOCK file open) with fstat-enforced bounds: only REGULAR files, only
+/// up to `max_bytes` — a FIFO can never block the daemon and a huge file can never exhaust
+/// its memory. No path is re-resolved between validation and read.
+pub(crate) fn read_contained(root: &std::fs::File, rel: &std::path::Path, max_bytes: u64) -> Result<Vec<u8>, ReadRefusal> {
+    use std::io::Read;
+    let classify = |e: std::io::Error| -> ReadRefusal {
+        if matches!(e.raw_os_error(), Some(libc::ELOOP) | Some(libc::ENOTDIR)) {
+            ReadRefusal::Escape(e)
+        } else {
+            ReadRefusal::Io(e)
+        }
+    };
+    let parent = pin_parent(root, rel, false).map_err(&classify)?;
+    let name = rel
+        .file_name()
+        .ok_or_else(|| ReadRefusal::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, "no file name")))?;
+    let f = open_file_at(&parent, name).map_err(&classify)?;
+    let md = f.metadata().map_err(ReadRefusal::Io)?;
+    if !md.file_type().is_file() {
+        return Err(ReadRefusal::NotRegular(format!("{:?}", md.file_type())));
+    }
+    if md.len() > max_bytes {
+        return Err(ReadRefusal::TooLarge(md.len()));
+    }
+    let mut bytes = Vec::with_capacity(md.len() as usize);
+    let mut bounded = f.take(max_bytes + 1);
+    bounded.read_to_end(&mut bytes).map_err(ReadRefusal::Io)?;
+    if bytes.len() as u64 > max_bytes {
+        // The file grew between fstat and read — still refused, never swallowed.
+        return Err(ReadRefusal::TooLarge(bytes.len() as u64));
+    }
+    Ok(bytes)
+}
+
+// ============================ STRICT SLOTS + ENUMERATION =========================================
+
+/// STRICT slot inspection (#72 round 19 finding 3): Ok(Some((fd, bytes))) = a REGULAR file
+/// occupant opened O_NOFOLLOW and read; Ok(None) = definitively ABSENT (ENOENT only). EVERY
+/// other outcome — unreadable occupant, symlink (ELOOP), FIFO/device — is Err: the caller must
+/// REFUSE, never treat the slot as empty.
+pub(crate) fn read_slot_strict(dir: &std::fs::File, name: &str) -> std::io::Result<Option<(std::fs::File, Vec<u8>)>> {
+    use std::io::Read;
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+    let c = cstr(name)?;
+    let fd = unsafe {
+        libc::openat(dir.as_raw_fd(), c.as_ptr(), libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
+    };
+    if fd < 0 {
+        let e = std::io::Error::last_os_error();
+        if e.kind() == std::io::ErrorKind::NotFound {
+            return Ok(None); // ONLY ENOENT means empty
+        }
+        return Err(e);
+    }
+    let mut f = unsafe { std::fs::File::from_raw_fd(fd) };
+    if !f.metadata()?.is_file() {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, format!("slot '{name}' is occupied by a non-regular file")));
+    }
+    let mut bytes = Vec::new();
+    f.read_to_end(&mut bytes)?;
+    Ok(Some((f, bytes)))
+}
+
+/// Enumerate the entries of an ALREADY-PINNED directory through the fd ITSELF (fdopendir over a
+/// dup) — NOT by re-walking the pathname (#72 round 21 finding 3): a directory-level exchange
+/// cannot redirect enumeration, because the names come from the same inode the caller pinned
+/// and reads through. fdopendir takes ownership of the dup; closedir closes it.
+///
+/// readdir signals BOTH end-of-stream and error by returning NULL; the only way to tell them
+/// apart is errno (#73 named-gap fix): errno is reset before every call and inspected after a
+/// NULL — a genuine enumeration error propagates TYPED, never as partial or empty truth.
+pub(crate) fn enumerate_pinned(dir: &std::fs::File) -> std::io::Result<Vec<String>> {
+    use std::os::unix::io::AsRawFd;
+    let dupfd = unsafe { libc::dup(dir.as_raw_fd()) };
+    if dupfd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let dp = unsafe { libc::fdopendir(dupfd) };
+    if dp.is_null() {
+        let e = std::io::Error::last_os_error();
+        unsafe { libc::close(dupfd) };
+        return Err(e);
+    }
+    let mut names = Vec::new();
+    loop {
+        unsafe { *libc::__errno_location() = 0 };
+        let ent = unsafe { libc::readdir(dp) };
+        if ent.is_null() {
+            let errno = unsafe { *libc::__errno_location() };
+            unsafe { libc::closedir(dp) };
+            if errno != 0 {
+                // A real readdir failure — refuse the WHOLE enumeration; a partial listing
+                // served as truth is exactly the false-empty registry this fixes.
+                return Err(std::io::Error::from_raw_os_error(errno));
+            }
+            return Ok(names); // genuine EOF
+        }
+        let name = unsafe { std::ffi::CStr::from_ptr((*ent).d_name.as_ptr()) };
+        if let Ok(s) = name.to_str() {
+            if s != "." && s != ".." {
+                names.push(s.to_string());
+            }
+        }
+    }
+}
+
+// ===================== DESCRIPTOR-BOUND NO-CLOBBER COMMIT + CERTIFICATION ========================
+
+/// Open an ANONYMOUS (nameless) inode in the pinned dir via O_TMPFILE (#72 round 20 findings
+/// 1+3): the bytes are written into a descriptor that has NO directory entry, so no named
+/// source ever exists to be swapped, and there is nothing to clean up after the commit.
+pub(crate) fn open_tmpfile_at(dir: &std::fs::File) -> std::io::Result<std::fs::File> {
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+    let dot = cstr(".")?;
+    let fd = unsafe {
+        libc::openat(dir.as_raw_fd(), dot.as_ptr(), libc::O_WRONLY | libc::O_TMPFILE | libc::O_CLOEXEC, 0o644 as libc::c_uint)
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+}
+
+/// Give an O_TMPFILE descriptor EXACTLY ONE name via linkat — the ATOMIC NO-REPLACE commit that
+/// binds the committed bytes to the DESCRIPTOR, not to any swappable source name (#72 round 20
+/// finding 1). Uses the /proc/self/fd form (no CAP_DAC_READ_SEARCH needed for non-root); link
+/// fails EEXIST if the target appeared since inspection, exactly like a named no-replace link.
+pub(crate) fn link_tmpfile_at(tmp: &std::fs::File, dir: &std::fs::File, to: &str) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let src = cstr(format!("/proc/self/fd/{}", tmp.as_raw_fd()))?;
+    let ct = cstr(to)?;
+    if unsafe { libc::linkat(libc::AT_FDCWD, src.as_ptr(), dir.as_raw_fd(), ct.as_ptr(), libc::AT_SYMLINK_FOLLOW) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// True iff two descriptors reference the SAME on-disk object (device + inode). The commit
+/// certifier compares the re-opened canonical name against the pinned committed descriptor
+/// (#72 round 21 finding 1) — a name swapped to a different inode fails this.
+pub(crate) fn same_inode(a: &std::fs::File, b: &std::fs::File) -> std::io::Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+    let (ma, mb) = (a.metadata()?, b.metadata()?);
+    Ok(ma.dev() == mb.dev() && ma.ino() == mb.ino())
+}
+
+/// Is an evidence key filesystem-safe AS WRITTEN (#72 round 17 finding 2)? The atomic writer
+/// normalizes unsafe characters, so two different keys could silently target the same file —
+/// a caller must reject rather than collide.
+pub(crate) fn is_normalization_safe(id: &str) -> bool {
+    !id.is_empty() && id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+/// DELIBERATE TEST FAULT (#72 round 21 finding 1): simulate a CONCURRENT adversary replacing the
+/// canonical target name during the post-commit fsync window, so the re-verification below is
+/// exercised. Absent env = no effect. `point` is "new" (fresh linkat) or "replay" (byte-compare).
+fn test_swap_target(dir: &std::fs::File, target: &str, point: &str) {
+    use std::io::Write;
+    if std::env::var("IOI_TEST_FORCE_RECEIPT_TARGET_SWAP").ok().as_deref() != Some(point) {
+        return;
+    }
+    let _ = unlink_at(dir, target);
+    if let Ok(mut f) = open_tmpfile_at(dir) {
+        let _ = f.write_all(format!("{{\"foreign\":\"REPLACED_AFTER_{}\"}}", point.to_uppercase()).as_bytes());
+        let _ = f.sync_all();
+        let _ = link_tmpfile_at(&f, dir, target);
+    }
+}
+
+/// Re-verify the canonical name AFTER the file + directory fsyncs (#72 round 21 finding 1):
+/// re-open the target O_NOFOLLOW, prove it is the SAME inode as the committed descriptor, and
+/// re-read its bytes — a target swapped during the durability barrier is caught and refused.
+pub(crate) fn certify_target(dir: &std::fs::File, target: &str, committed: &std::fs::File, bytes: &[u8], point: &str) -> Result<(), CommitFailure> {
+    test_swap_target(dir, target, point);
+    match read_slot_strict(dir, target) {
+        Ok(Some((reopened, on_disk))) => {
+            if !same_inode(&reopened, committed).unwrap_or(false) {
+                return Err(CommitFailure::Swapped(format!("the receipt name '{target}' no longer resolves to the certified inode after the durability barrier — refused, never certified over a swapped target")));
+            }
+            if on_disk != bytes {
+                return Err(CommitFailure::Swapped(format!("the receipt bytes at '{target}' changed after the durability barrier — refused")));
+            }
+            Ok(())
+        }
+        Ok(None) => Err(CommitFailure::Swapped(format!("the receipt name '{target}' vanished after commit — refused"))),
+        Err(e) => Err(CommitFailure::SlotUnreadable(format!("post-commit re-verify of '{target}' failed ({e}) — refused"))),
+    }
+}
+
+// =============================== TYPED DURABLE WRITERS ===========================================
+
+/// ATOMIC-DURABLE record persistence (#72 rounds 6 + 7 finding 1): temporary sibling → file
+/// fsync → rename → CHECKED directory fsync → cleanup. Failures before/at the rename return
+/// `NotCommitted` (old record intact); a post-rename directory-sync failure returns
+/// `RenamedDurabilityUnconfirmed` (new record visible, durability unknown) so callers can model
+/// the truth instead of pretending nothing happened. A NEWLY CREATED family directory is made
+/// durable by fsyncing its parent before any record lands inside it.
+pub(crate) fn persist_record_durable(data_dir: &str, family: &str, record_id: &str, record: &Value) -> Result<(), PersistFailure> {
+    use std::io::Write;
+    use PersistFailure::{NotCommitted, RenamedDurabilityUnconfirmed};
+    // Parity with persist_record (#72 round 3): promoted families have exactly one write path;
+    // not-yet-promoted families still feed the opt-in dual-write soak.
+    if super::substrate_store::is_promoted(family) {
+        return super::substrate_store::persist_promoted(data_dir, family, record_id, record).map_err(NotCommitted);
+    }
+    let dir = std::path::Path::new(data_dir).join(family);
+    let family_created = !dir.exists();
+    std::fs::create_dir_all(&dir).map_err(NotCommitted)?;
+    if family_created {
+        // A brand-new record family: fsync the data dir so the family directory itself
+        // survives a crash (#72 round 7 finding 1).
+        (|| -> std::io::Result<()> { std::fs::File::open(data_dir)?.sync_all() })().map_err(NotCommitted)?;
+    }
+    let safe: String = record_id.replace(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_', "_");
+    let tmp = dir.join(format!(".{safe}.tmp-{:x}", nanos()));
+    let write = (|| -> std::io::Result<()> {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(&serde_json::to_vec_pretty(record).unwrap_or_default())?;
+        f.sync_all()
+    })();
+    if let Err(e) = write {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(NotCommitted(e));
+    }
+    if let Err(e) = std::fs::rename(&tmp, dir.join(format!("{safe}.json"))) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(NotCommitted(e));
+    }
+    // The record is VISIBLE from here — dual-write parity fires on visibility.
+    super::substrate_store::dual_write(data_dir, family, record_id, record);
+    // DELIBERATE TEST FAULT POINT (#72 round 8 finding 1): absent env = no effect. A real
+    // directory-fsync failure cannot be injected by permissions on a read-then-write seam (the
+    // dir listing and the fsync open need the same read bit), so the visible-unconfirmed lane
+    // is forced here for the fault verifiers — the rename has genuinely happened.
+    if std::env::var("IOI_TEST_FORCE_DIRSYNC_UNCONFIRMED").ok().as_deref() == Some(family) {
+        return Err(RenamedDurabilityUnconfirmed(std::io::Error::other("test-forced directory-sync failure")));
+    }
+    if let Err(e) = (|| -> std::io::Result<()> { std::fs::File::open(&dir)?.sync_all() })() {
+        return Err(RenamedDurabilityUnconfirmed(e));
+    }
+    Ok(())
+}
+
+/// APPEND-ONLY, no-clobber, DURABILITY-HONEST evidence commit (#72 rounds 18–21). The exact
+/// target slot is inspected through a PINNED no-follow directory fd:
+///   - only ENOENT means empty (#72 round 19 finding 3) — an unreadable occupant, a symlink,
+///     or a non-regular file REFUSES; evidence is never replaced on uncertainty;
+///   - an empty slot commits from an ANONYMOUS O_TMPFILE descriptor via linkat (#72 round 20
+///     findings 1+3): the bytes are bound to the DESCRIPTOR, not a swappable source name, and
+///     no named temp ever exists. link is NO-REPLACE: an occupant appearing between inspection
+///     and commit surfaces EEXIST;
+///   - a byte-identical occupant is RE-FSYNCED (file + directory) before being reported
+///     durable (#72 round 19 finding 2) — an earlier unconfirmed rename may not be on disk;
+///   - the durability barrier fsyncs the family directory AND — UNCONDITIONALLY, never gated on
+///     a visibility check — data_dir, so the family directory ENTRY is durable even if an
+///     earlier parent fsync failed and left the family visible (#72 round 21 finding 2);
+///   - after the barrier, the canonical name is RE-CERTIFIED against the committed descriptor
+///     (device/inode + bytes, #72 round 21 finding 1) — a swap during the window is refused;
+///   - the durability outcome is PRESERVED (#72 round 19 finding 2): visible-but-unconfirmed
+///     is `DurabilityUnconfirmed`, never Ok — terminal state and intent consumption require a
+///     DURABLE commit.
+pub(crate) fn persist_receipt_no_clobber(data_dir: &str, family: &str, tail: &str, receipt: &Value) -> Result<(), CommitFailure> {
+    use std::io::Write;
+    if !is_normalization_safe(tail) {
+        return Err(CommitFailure::KeyInvalid(format!("receipt tail '{tail}' is not filesystem-safe")));
+    }
+    let bytes = serde_json::to_vec_pretty(receipt).unwrap_or_default();
+    let fam_path = std::path::Path::new(data_dir).join(family);
+    if let Err(e) = std::fs::create_dir_all(&fam_path) {
+        return Err(CommitFailure::NotCommitted(format!("receipt directory unavailable ({e}) — nothing was written")));
+    }
+    let dir = match open_family_dir_pinned(data_dir, family) {
+        Ok(d) => d,
+        Err(e) => return Err(CommitFailure::NotCommitted(format!("receipt directory pin failed ({e}) — nothing was written"))),
+    };
+    let target = format!("{tail}.json");
+    let confirm_dir_durable = |dir: &std::fs::File| -> Result<(), CommitFailure> {
+        // DELIBERATE TEST FAULT POINT (same contract as the typed durable writer): absent env =
+        // no effect; the receipt is already VISIBLE when this fires.
+        if std::env::var("IOI_TEST_FORCE_DIRSYNC_UNCONFIRMED").ok().as_deref() == Some(family) {
+            return Err(CommitFailure::DurabilityUnconfirmed("test-forced directory-sync failure — the receipt is VISIBLE but its durability is unconfirmed".to_string()));
+        }
+        dir.sync_all().map_err(|e| CommitFailure::DurabilityUnconfirmed(format!("receipt directory sync failed ({e}) — the receipt is VISIBLE but its durability is unconfirmed")))?;
+        // Parent (data_dir) fsync — UNCONDITIONAL (#72 round 21 finding 2); a separate fault hook
+        // fails only the parent leg so the failure→restart lane is exact.
+        if std::env::var("IOI_TEST_FORCE_PARENT_FSYNC_UNCONFIRMED").ok().as_deref() == Some(family) {
+            return Err(CommitFailure::DurabilityUnconfirmed("test-forced parent-directory-sync failure — the receipt family entry is VISIBLE but not durable".to_string()));
+        }
+        (|| -> std::io::Result<()> { std::fs::File::open(data_dir)?.sync_all() })()
+            .map_err(|e| CommitFailure::DurabilityUnconfirmed(format!("data_dir sync failed ({e}) — the receipt family entry is VISIBLE but not durable")))
+    };
+    match read_slot_strict(&dir, &target) {
+        Err(e) => Err(CommitFailure::SlotUnreadable(format!("the receipt slot '{tail}' is occupied but NOT readable as a regular file ({e}) — refused; evidence is never replaced on uncertainty"))),
+        Ok(Some((occupant, existing))) => {
+            if existing != bytes {
+                return Err(CommitFailure::Conflict(format!("the receipt slot '{tail}' already holds DIFFERENT evidence — receipts are append-only and never overwritten")));
+            }
+            // Byte-identical replay: re-fsync BEFORE reporting durable (#72 round 19 finding 2).
+            if let Err(e) = occupant.sync_all() {
+                return Err(CommitFailure::DurabilityUnconfirmed(format!("receipt re-sync failed ({e}) — the receipt is VISIBLE but its durability is unconfirmed")));
+            }
+            confirm_dir_durable(&dir)?;
+            // Re-verify the name still resolves to the compared inode after the barrier (#72
+            // round 21 finding 1) — a target swapped during the occupant fsync is caught here.
+            certify_target(&dir, &target, &occupant, &bytes, "replay")
+        }
+        Ok(None) => {
+            // ANONYMOUS descriptor (O_TMPFILE) — NO name, so nothing to swap and nothing to clean
+            // up (#72 round 20 findings 1+3). Write + fsync the bytes into the inode, then bind
+            // it to EXACTLY ONE name (the target) with a NO-REPLACE linkat.
+            let write = (|| -> std::io::Result<std::fs::File> {
+                let mut f = open_tmpfile_at(&dir)?;
+                f.write_all(&bytes)?;
+                f.sync_all()?;
+                Ok(f)
+            })();
+            let tmp = match write {
+                Ok(f) => f,
+                Err(e) => return Err(CommitFailure::NotCommitted(format!("receipt staging failed ({e}) — nothing is visible (anonymous inode discarded)"))),
+            };
+            if let Err(e) = link_tmpfile_at(&tmp, &dir, &target) {
+                // The anonymous inode is discarded when `tmp` drops — no residue on any path.
+                if e.kind() == std::io::ErrorKind::AlreadyExists {
+                    return Err(CommitFailure::Conflict(format!("the receipt slot '{tail}' was occupied between inspection and commit — refused atomically (no-replace), nothing overwritten")));
+                }
+                return Err(CommitFailure::NotCommitted(format!("receipt commit failed ({e}) — nothing is visible")));
+            }
+            // The receipt is VISIBLE from here — dual-write parity fires on visibility, exactly
+            // like the typed durable writer.
+            super::substrate_store::dual_write(data_dir, family, tail, receipt);
+            confirm_dir_durable(&dir)?;
+            // Re-verify the name still resolves to the linked inode after the barrier (#72 round
+            // 21 finding 1) — a target replaced during the directory fsync is caught here.
+            certify_target(&dir, &target, &tmp, &bytes, "new")
+        }
+    }
+}
+
+// ====================================== TESTS ====================================================
+
+#[cfg(test)]
+mod durable_fs_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("ioi-durable-fs-{tag}-{:x}", nanos()));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn enumeration_distinguishes_eof_from_error_deterministically() {
+        // #73 named-gap fix, WITHOUT process-global environment faults:
+        // (a) EOF on a valid directory is Ok even when errno enters the call ALREADY polluted —
+        //     a stale errno must never be misread as an enumeration error;
+        // (b) a non-directory fd fails TYPED (fdopendir ENOTDIR) — never an empty listing.
+        let dir = temp_dir("enum");
+        std::fs::write(dir.join("a.json"), b"{}").unwrap();
+        std::fs::write(dir.join("b.json"), b"{}").unwrap();
+        // Pollute errno deliberately with a failing syscall (ENOENT).
+        let missing = std::ffi::CString::new(format!("{}/definitely-missing", dir.display())).unwrap();
+        let rc = unsafe { libc::open(missing.as_ptr(), libc::O_RDONLY) };
+        assert!(rc < 0, "the polluting open must fail");
+        let pinned = open_dir_pinned(&dir).unwrap();
+        let mut names = enumerate_pinned(&pinned).unwrap();
+        names.sort();
+        assert_eq!(names, vec!["a.json".to_string(), "b.json".to_string()], "EOF with polluted errno is still a COMPLETE listing");
+        // Non-directory fd → typed error, never empty truth.
+        let file_fd = std::fs::File::open(dir.join("a.json")).unwrap();
+        assert!(enumerate_pinned(&file_fd).is_err(), "a non-directory fd is a TYPED enumeration error");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn no_clobber_commit_is_descriptor_bound_and_certified() {
+        // The extracted commit preserves the #72 contract end-to-end: fresh commit (nlink 1, no
+        // residue), byte-identical replay Ok, different bytes → Conflict, swapped target after
+        // commit → Swapped via certify_target.
+        use std::os::unix::fs::MetadataExt;
+        let dir_t = temp_dir("commit");
+        let data_dir = dir_t.to_str().unwrap();
+        let receipt = json!({ "receipt_id": "receipt://orr_x0", "attested": true });
+        persist_receipt_no_clobber(data_dir, "evidence", "orr_x0", &receipt).unwrap();
+        let slot = dir_t.join("evidence").join("orr_x0.json");
+        assert_eq!(std::fs::metadata(&slot).unwrap().nlink(), 1);
+        persist_receipt_no_clobber(data_dir, "evidence", "orr_x0", &receipt).unwrap(); // idempotent replay
+        let different = json!({ "receipt_id": "receipt://orr_x0", "attested": false });
+        assert!(matches!(persist_receipt_no_clobber(data_dir, "evidence", "orr_x0", &different).unwrap_err(), CommitFailure::Conflict(_)));
+        // Swap the canonical name to a different inode; certification refuses.
+        let pinned = open_family_dir_pinned(data_dir, "evidence").unwrap();
+        let (committed, _) = read_slot_strict(&pinned, "orr_x0.json").unwrap().unwrap();
+        let bytes = serde_json::to_vec_pretty(&receipt).unwrap();
+        certify_target(&pinned, "orr_x0.json", &committed, &bytes, "unit").unwrap();
+        unlink_at(&pinned, "orr_x0.json").unwrap();
+        use std::io::Write;
+        let mut f = open_tmpfile_at(&pinned).unwrap();
+        f.write_all(b"{\"foreign\":\"SWAPPED\"}").unwrap();
+        f.sync_all().unwrap();
+        link_tmpfile_at(&f, &pinned, "orr_x0.json").unwrap();
+        assert!(matches!(certify_target(&pinned, "orr_x0.json", &committed, &bytes, "unit").unwrap_err(), CommitFailure::Swapped(_)));
+        let _ = std::fs::remove_dir_all(&dir_t);
+    }
+}

--- a/crates/node/src/bin/hypervisor_daemon_routes/goalrun_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/goalrun_routes.rs
@@ -476,6 +476,14 @@ fn nanos() -> u128 {
         .unwrap_or(0)
 }
 
+/// The receipts family keys files by the FULL receipt ref, sanitized. This normalization was
+/// the durable writer's own until #73; the shared core now REJECTS unsafe ids instead of
+/// normalizing them, so the ref→file-key mapping is THIS plane's explicit naming policy — the
+/// on-disk filenames are byte-for-byte what they always were.
+fn receipt_file_key(receipt_ref: &str) -> String {
+    receipt_ref.replace(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_', "_")
+}
+
 fn safe(seg: &str) -> String {
     seg.chars()
         .map(|c| {
@@ -1985,7 +1993,7 @@ pub(crate) async fn handle_goal_run_reconcile(
     // Receipt second (#72 round 8 finding 2): EITHER failure class now aborts WITH a resolving
     // attempt record and a retained backlink — nothing is ever deleted, so the non-durable
     // unlink lane no longer exists in this transaction at all.
-    if let Err(f) = persist_record_durable(&st.data_dir, "receipts", &receipt_ref, &receipt) {
+    if let Err(f) = persist_record_durable(&st.data_dir, "receipts", &receipt_file_key(&receipt_ref), &receipt) {
         let (code, note) = if f.visible() {
             ("goal_run_reconcile_receipt_durability_unconfirmed", "the VISIBLE receipt, the declared attempt record, and the staged manifest are all preserved and linked")
         } else {
@@ -2539,7 +2547,7 @@ pub(crate) async fn handle_goal_run_lifecycle_recovery(
     // receipt KEEPS THE DURABLE INTENT and refuses typed — the completer re-persists the
     // sealed receipt (byte-exact) at restart and finishes. The intent is never consumed while
     // any piece of its evidence is unconfirmed.
-    if let Err(f) = persist_record_durable(&st.data_dir, "receipts", &receipt_id, &receipt) {
+    if let Err(f) = persist_record_durable(&st.data_dir, "receipts", &receipt_file_key(&receipt_id), &receipt) {
         if f.visible() {
             return bad(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2752,7 +2760,7 @@ pub(crate) fn complete_recovery_intents(data_dir: &str) {
                 eprintln!("goal-run recovery completer: a DIFFERENT receipt already exists at '{receipt_id}' for '{goal_run_id}' — conflicting evidence is never overwritten; left for manual repair");
                 continue;
             }
-        } else if let Err(f) = persist_record_durable(data_dir, "receipts", &receipt_id, &receipt) {
+        } else if let Err(f) = persist_record_durable(data_dir, "receipts", &receipt_file_key(&receipt_id), &receipt) {
             // DURABLE required (#72 round 9 finding 2): a visible-unconfirmed receipt must not
             // let the release consume the intent — retained, retried next boot either way.
             eprintln!("goal-run recovery completer: receipt persist for '{goal_run_id}' is {} — intent retained, retried next boot", f.detail());

--- a/crates/node/src/bin/hypervisor_daemon_routes/goalrun_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/goalrun_routes.rs
@@ -52,81 +52,9 @@ pub(crate) static GOAL_RUN_MUTATION_LOCK: Mutex<()> = Mutex::new(());
 
 /// Distinct durable-persist failure OUTCOMES (#72 round 7 finding 1): the two failure classes
 /// have OPPOSITE truthful handling and must never be conflated.
-#[derive(Debug)]
-pub(crate) enum PersistFailure {
-    /// The failure happened before or at the rename: the OLD record provably survives, so
-    /// "nothing changed" cleanup/rollback language is truthful.
-    NotCommitted(std::io::Error),
-    /// The rename ALREADY replaced the old record in the live view; only the directory fsync
-    /// failed, so durability is unconfirmed — the new record is visible and may well be
-    /// durable. Callers must PRESERVE evidence and report unknown-but-possibly-applied; rolling
-    /// back "as absent" would be a lie.
-    RenamedDurabilityUnconfirmed(std::io::Error),
-}
-
-impl PersistFailure {
-    pub(crate) fn visible(&self) -> bool {
-        matches!(self, PersistFailure::RenamedDurabilityUnconfirmed(_))
-    }
-    pub(crate) fn detail(&self) -> String {
-        match self {
-            PersistFailure::NotCommitted(e) => format!("not committed ({e}); the prior record is intact"),
-            PersistFailure::RenamedDurabilityUnconfirmed(e) => format!("RENAMED but durability unconfirmed ({e}); the new record is VISIBLE and may already be durable"),
-        }
-    }
-}
-
-/// ATOMIC-DURABLE record persistence (#72 rounds 6 + 7 finding 1): temporary sibling → file
-/// fsync → rename → CHECKED directory fsync → cleanup. Failures before/at the rename return
-/// `NotCommitted` (old record intact); a post-rename directory-sync failure returns
-/// `RenamedDurabilityUnconfirmed` (new record visible, durability unknown) so callers can model
-/// the truth instead of pretending nothing happened. A NEWLY CREATED family directory is made
-/// durable by fsyncing its parent before any record lands inside it.
-pub(crate) fn persist_record_durable(data_dir: &str, family: &str, record_id: &str, record: &Value) -> Result<(), PersistFailure> {
-    use std::io::Write;
-    use PersistFailure::{NotCommitted, RenamedDurabilityUnconfirmed};
-    // Parity with persist_record (#72 round 3): promoted families have exactly one write path;
-    // not-yet-promoted families still feed the opt-in dual-write soak.
-    if super::substrate_store::is_promoted(family) {
-        return super::substrate_store::persist_promoted(data_dir, family, record_id, record).map_err(NotCommitted);
-    }
-    let dir = std::path::Path::new(data_dir).join(family);
-    let family_created = !dir.exists();
-    std::fs::create_dir_all(&dir).map_err(NotCommitted)?;
-    if family_created {
-        // A brand-new record family: fsync the data dir so the family directory itself
-        // survives a crash (#72 round 7 finding 1).
-        (|| -> std::io::Result<()> { std::fs::File::open(data_dir)?.sync_all() })().map_err(NotCommitted)?;
-    }
-    let safe: String = record_id.replace(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_', "_");
-    let tmp = dir.join(format!(".{safe}.tmp-{:x}", nanos()));
-    let write = (|| -> std::io::Result<()> {
-        let mut f = std::fs::File::create(&tmp)?;
-        f.write_all(&serde_json::to_vec_pretty(record).unwrap_or_default())?;
-        f.sync_all()
-    })();
-    if let Err(e) = write {
-        let _ = std::fs::remove_file(&tmp);
-        return Err(NotCommitted(e));
-    }
-    if let Err(e) = std::fs::rename(&tmp, dir.join(format!("{safe}.json"))) {
-        let _ = std::fs::remove_file(&tmp);
-        return Err(NotCommitted(e));
-    }
-    // The record is VISIBLE from here — dual-write parity fires on visibility.
-    super::substrate_store::dual_write(data_dir, family, record_id, record);
-    // DELIBERATE TEST FAULT POINT (#72 round 8 finding 1): absent env = no effect. A real
-    // directory-fsync failure cannot be injected by permissions on a read-then-write seam (the
-    // dir listing and the fsync open need the same read bit), so the visible-unconfirmed lane
-    // is forced here for the fault verifiers — the rename has genuinely happened.
-    if std::env::var("IOI_TEST_FORCE_DIRSYNC_UNCONFIRMED").ok().as_deref() == Some(family) {
-        return Err(RenamedDurabilityUnconfirmed(std::io::Error::other("test-forced directory-sync failure")));
-    }
-    if let Err(e) = (|| -> std::io::Result<()> { std::fs::File::open(&dir)?.sync_all() })() {
-        return Err(RenamedDurabilityUnconfirmed(e));
-    }
-    Ok(())
-}
+// The typed atomic-replacement writer and its outcome now live in the SHARED durable-fs
+// core (#73) — extracted verbatim from this plane (#72 rounds 6-8).
+use super::durable_fs::{persist_record_durable, PersistFailure};
 
 /// ATOMIC-DURABLE replacement for the mutable goal-run record — the durable helper over the
 /// goal-run family (reservations, recovery intents, and releases order-depend on durability).
@@ -134,169 +62,9 @@ fn persist_goal_run_atomic(data_dir: &str, goal_run_id: &str, record: &Value) ->
     persist_record_durable(data_dir, GOAL_RUN_KIND, goal_run_id, record)
 }
 
-/// Descriptor-relative, symlink-refusing filesystem walks (#72 round 6 finding 3): every
-/// component is opened O_NOFOLLOW relative to the previously PINNED directory fd
-/// (openat/mkdirat/renameat), so a concurrent path or ancestor swap cannot redirect a read or a
-/// write after validation — the enforcement IS the open, not a check before it. A symlink
-/// anywhere in the walk fails with ELOOP/ENOTDIR at use time.
-mod nofollow {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::io::{AsRawFd, FromRawFd};
-
-    fn cstr(name: &std::ffi::OsStr) -> std::io::Result<CString> {
-        CString::new(name.as_bytes())
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in path component"))
-    }
-
-    /// Pin the walk ROOT itself: must be a directory, terminal symlink refused.
-    pub(super) fn open_root(path: &std::path::Path) -> std::io::Result<std::fs::File> {
-        use std::os::unix::fs::OpenOptionsExt;
-        std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-            .open(path)
-    }
-
-    pub(super) fn open_dir_at(parent: &std::fs::File, name: &std::ffi::OsStr) -> std::io::Result<std::fs::File> {
-        let c = cstr(name)?;
-        let fd = unsafe {
-            libc::openat(parent.as_raw_fd(), c.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        Ok(unsafe { std::fs::File::from_raw_fd(fd) })
-    }
-
-    /// mkdirat; returns whether the directory was CREATED by this call (EEXIST = false).
-    pub(super) fn mkdir_at(parent: &std::fs::File, name: &std::ffi::OsStr) -> std::io::Result<bool> {
-        let c = cstr(name)?;
-        let rc = unsafe { libc::mkdirat(parent.as_raw_fd(), c.as_ptr(), 0o755) };
-        if rc != 0 {
-            let e = std::io::Error::last_os_error();
-            if e.raw_os_error() != Some(libc::EEXIST) {
-                return Err(e);
-            }
-            return Ok(false);
-        }
-        Ok(true)
-    }
-
-    /// O_NONBLOCK is deliberate (#72 round 7 finding 4): opening a FIFO must never block the
-    /// daemon; the regular-file check below then refuses it typed.
-    pub(super) fn open_file_at(parent: &std::fs::File, name: &std::ffi::OsStr) -> std::io::Result<std::fs::File> {
-        let c = cstr(name)?;
-        let fd = unsafe {
-            libc::openat(
-                parent.as_raw_fd(),
-                c.as_ptr(),
-                libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
-            )
-        };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        Ok(unsafe { std::fs::File::from_raw_fd(fd) })
-    }
-
-    pub(super) fn create_file_at(parent: &std::fs::File, name: &std::ffi::OsStr) -> std::io::Result<std::fs::File> {
-        let c = cstr(name)?;
-        let fd = unsafe {
-            libc::openat(
-                parent.as_raw_fd(),
-                c.as_ptr(),
-                libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-                0o644 as libc::c_uint,
-            )
-        };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        Ok(unsafe { std::fs::File::from_raw_fd(fd) })
-    }
-
-    pub(super) fn rename_at(parent: &std::fs::File, from: &std::ffi::OsStr, to: &std::ffi::OsStr) -> std::io::Result<()> {
-        let cf = cstr(from)?;
-        let ct = cstr(to)?;
-        let rc = unsafe { libc::renameat(parent.as_raw_fd(), cf.as_ptr(), parent.as_raw_fd(), ct.as_ptr()) };
-        if rc != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        Ok(())
-    }
-
-    pub(super) fn unlink_at(parent: &std::fs::File, name: &std::ffi::OsStr) {
-        if let Ok(c) = cstr(name) {
-            unsafe { libc::unlinkat(parent.as_raw_fd(), c.as_ptr(), 0) };
-        }
-    }
-
-    /// Walk (and in `create` mode, mkdirat) each PARENT component of `rel` under `root`,
-    /// returning the pinned parent directory fd. A directory CREATED here is made durable by a
-    /// checked fsync of the directory that received the new entry (#72 round 7 finding 1).
-    pub(super) fn pin_parent(root: &std::fs::File, rel: &std::path::Path, create: bool) -> std::io::Result<std::fs::File> {
-        let mut cur = root.try_clone()?;
-        if let Some(parent) = rel.parent() {
-            for comp in parent.components() {
-                if let std::path::Component::Normal(seg) = comp {
-                    if create && mkdir_at(&cur, seg)? {
-                        cur.sync_all()?;
-                    }
-                    cur = open_dir_at(&cur, seg)?;
-                }
-            }
-        }
-        Ok(cur)
-    }
-
-    /// A bounded-intake read refusal (#72 round 7 finding 4) — each shape is typed distinctly.
-    #[derive(Debug)]
-    pub(super) enum ReadRefusal {
-        /// Symlink / non-directory component at use time — a containment escape.
-        Escape(std::io::Error),
-        /// The declared output is not a regular file (FIFO, device, socket, directory).
-        NotRegular(String),
-        /// The file exceeds the per-file or remaining per-attempt byte budget.
-        TooLarge(u64),
-        Io(std::io::Error),
-    }
-
-    /// Read a workspace file ENTIRELY through pinned descriptors (root fd → NOFOLLOW component
-    /// walk → NOFOLLOW|NONBLOCK file open) with fstat-enforced bounds: only REGULAR files, only
-    /// up to `max_bytes` — a FIFO can never block the daemon and a huge file can never exhaust
-    /// its memory. No path is re-resolved between validation and read.
-    pub(super) fn read_contained(root: &std::fs::File, rel: &std::path::Path, max_bytes: u64) -> Result<Vec<u8>, ReadRefusal> {
-        use std::io::Read;
-        let classify = |e: std::io::Error| -> ReadRefusal {
-            if matches!(e.raw_os_error(), Some(libc::ELOOP) | Some(libc::ENOTDIR)) {
-                ReadRefusal::Escape(e)
-            } else {
-                ReadRefusal::Io(e)
-            }
-        };
-        let parent = pin_parent(root, rel, false).map_err(&classify)?;
-        let name = rel
-            .file_name()
-            .ok_or_else(|| ReadRefusal::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, "no file name")))?;
-        let f = open_file_at(&parent, name).map_err(&classify)?;
-        let md = f.metadata().map_err(ReadRefusal::Io)?;
-        if !md.file_type().is_file() {
-            return Err(ReadRefusal::NotRegular(format!("{:?}", md.file_type())));
-        }
-        if md.len() > max_bytes {
-            return Err(ReadRefusal::TooLarge(md.len()));
-        }
-        let mut bytes = Vec::with_capacity(md.len() as usize);
-        let mut bounded = f.take(max_bytes + 1);
-        bounded.read_to_end(&mut bytes).map_err(ReadRefusal::Io)?;
-        if bytes.len() as u64 > max_bytes {
-            // The file grew between fstat and read — still refused, never swallowed.
-            return Err(ReadRefusal::TooLarge(bytes.len() as u64));
-        }
-        Ok(bytes)
-    }
-}
+// Descriptor-relative, symlink-refusing filesystem walks now live in the SHARED durable-fs
+// core (#73) — extracted verbatim from this plane's `nofollow` module (#72 rounds 6-7).
+use super::durable_fs as nofollow_fs;
 
 /// A typed seam refusal: (code, message). Codes are wire-facing.
 pub(crate) type SeamErr = (String, String);
@@ -622,7 +390,7 @@ enum CommitFailure {
 fn commit_one(staged: &std::path::Path, target_root: &std::fs::File, rel: &std::path::Path) -> Result<(u64, String), CommitFailure> {
     use std::io::Write;
     use CommitFailure::NotApplied;
-    let parent = nofollow::pin_parent(target_root, rel, true)
+    let parent = nofollow_fs::pin_parent(target_root, rel, true)
         .map_err(|e| NotApplied(format!("'{}': pinned parent walk refused ({e}) — a symlinked or swapped ancestor never redirects a write", rel.display())))?;
     let file_name = rel
         .file_name()
@@ -631,16 +399,16 @@ fn commit_one(staged: &std::path::Path, target_root: &std::fs::File, rel: &std::
     let sha = sha256_hex(&bytes);
     let tmp_name = std::ffi::OsString::from(format!(".{}.wal-tmp-{:x}", file_name.to_string_lossy(), nanos()));
     let write_result = (|| -> std::io::Result<()> {
-        let mut f = nofollow::create_file_at(&parent, &tmp_name)?;
+        let mut f = nofollow_fs::create_file_at(&parent, &tmp_name)?;
         f.write_all(&bytes)?;
         f.sync_all()
     })();
     if let Err(e) = write_result {
-        nofollow::unlink_at(&parent, &tmp_name);
+        let _ = nofollow_fs::unlink_at(&parent, &tmp_name);
         return Err(NotApplied(format!("temporary write failed ({e})")));
     }
-    if let Err(e) = nofollow::rename_at(&parent, &tmp_name, file_name) {
-        nofollow::unlink_at(&parent, &tmp_name);
+    if let Err(e) = nofollow_fs::rename_at(&parent, &tmp_name, file_name) {
+        let _ = nofollow_fs::unlink_at(&parent, &tmp_name);
         return Err(NotApplied(format!("atomic rename failed ({e})")));
     }
     if let Err(e) = parent.sync_all() {
@@ -2010,7 +1778,7 @@ pub(crate) async fn handle_goal_run_reconcile(
     } else {
         match std::path::Path::new(&target_workspace)
             .canonicalize()
-            .and_then(|p| nofollow::open_root(&p).map(|fd| (p, fd)))
+            .and_then(|p| nofollow_fs::open_dir_pinned(&p).map(|fd| (p, fd)))
         {
             // The target root fd is PINNED here (#72 round 6 finding 3): every commit descends
             // from this descriptor, so a later swap of the root path cannot redirect writes.
@@ -2050,7 +1818,7 @@ pub(crate) async fn handle_goal_run_reconcile(
         // The candidate root is PINNED once; every source byte is read through NOFOLLOW
         // descriptor walks from it (#72 round 6 finding 3) — validation and read are the SAME
         // syscall, so no swap window exists between them.
-        let candidate_root = nofollow::open_root(std::path::Path::new(candidate_workspace)).ok();
+        let candidate_root = nofollow_fs::open_dir_pinned(std::path::Path::new(candidate_workspace)).ok();
         for file in changed_of(invocation) {
             let rel = match contained_rel_path(&file) {
                 Ok(rel) => rel,
@@ -2073,22 +1841,22 @@ pub(crate) async fn handle_goal_run_reconcile(
             };
             let remaining = MAX_ATTEMPT_TOTAL_BYTES.saturating_sub(total_bytes);
             let budget = MAX_OUTPUT_FILE_BYTES.min(remaining);
-            let bytes = match nofollow::read_contained(candidate_root, &rel, budget) {
+            let bytes = match nofollow_fs::read_contained(candidate_root, &rel, budget) {
                 Ok(bytes) => bytes,
-                Err(nofollow::ReadRefusal::Escape(e)) => {
+                Err(nofollow_fs::ReadRefusal::Escape(e)) => {
                     escape_errors.push(format!("candidate: '{}' walks through a symlink/non-directory component ({e}) — descriptor-relative reads never follow it", rel.display()));
                     continue;
                 }
-                Err(nofollow::ReadRefusal::NotRegular(kind)) => {
+                Err(nofollow_fs::ReadRefusal::NotRegular(kind)) => {
                     bound_errors.push(("goal_run_output_file_not_regular", format!("'{}' is not a regular file ({kind}) — FIFOs, devices, and sockets never enter an output commit", rel.display())));
                     continue;
                 }
-                Err(nofollow::ReadRefusal::TooLarge(size)) => {
+                Err(nofollow_fs::ReadRefusal::TooLarge(size)) => {
                     let code = if size > MAX_OUTPUT_FILE_BYTES { "goal_run_output_file_too_large" } else { "goal_run_output_attempt_too_large" };
                     bound_errors.push((code, format!("'{}' ({size} bytes) exceeds the byte budget (file limit {MAX_OUTPUT_FILE_BYTES}, attempt limit {MAX_ATTEMPT_TOTAL_BYTES})", rel.display())));
                     continue;
                 }
-                Err(nofollow::ReadRefusal::Io(e)) => {
+                Err(nofollow_fs::ReadRefusal::Io(e)) => {
                     staging_errors.push(format!("{file}: candidate source read failed ({e})"));
                     continue;
                 }
@@ -3211,7 +2979,7 @@ mod goal_run_seam_tests {
         std::fs::create_dir_all(&outside).unwrap();
         let staged = dir.join("staged.txt");
         std::fs::write(&staged, b"FULL_CONTENT").unwrap();
-        let root_fd = nofollow::open_root(&root).unwrap();
+        let root_fd = nofollow_fs::open_dir_pinned(&root).unwrap();
         // Happy path: full content lands, the applied hash is the content hash, no tmp survives.
         let (bytes, sha) = commit_one(&staged, &root_fd, std::path::Path::new("deep/out.txt")).unwrap();
         assert_eq!(bytes, 12);
@@ -3275,11 +3043,11 @@ mod goal_run_seam_tests {
         std::fs::write(root.join("real/inside.txt"), b"INSIDE").unwrap();
         std::fs::write(outside.join("loot.txt"), b"LOOT").unwrap();
         std::os::unix::fs::symlink(&outside, root.join("link")).unwrap();
-        let root_fd = nofollow::open_root(&root).unwrap();
+        let root_fd = nofollow_fs::open_dir_pinned(&root).unwrap();
         // Reads: a symlink component refuses at USE time; a legitimate path reads fine.
-        assert_eq!(nofollow::read_contained(&root_fd, std::path::Path::new("real/inside.txt"), 1 << 20).unwrap(), b"INSIDE");
-        let err = nofollow::read_contained(&root_fd, std::path::Path::new("link/loot.txt"), 1 << 20).unwrap_err();
-        assert!(matches!(err, nofollow::ReadRefusal::Escape(_)), "{err:?}");
+        assert_eq!(nofollow_fs::read_contained(&root_fd, std::path::Path::new("real/inside.txt"), 1 << 20).unwrap(), b"INSIDE");
+        let err = nofollow_fs::read_contained(&root_fd, std::path::Path::new("link/loot.txt"), 1 << 20).unwrap_err();
+        assert!(matches!(err, nofollow_fs::ReadRefusal::Escape(_)), "{err:?}");
         // SWAP LANE (source/target parent swap): pin the root fd, then swap the root path to a
         // symlink pointing outside — the pinned fd still resolves to the ORIGINAL directory.
         let staged = dir.join("staged.txt");
@@ -3322,18 +3090,18 @@ mod goal_run_seam_tests {
         let dir = temp_dir("bounded");
         let root = dir.join("root");
         std::fs::create_dir_all(&root).unwrap();
-        let root_fd = nofollow::open_root(&root).unwrap();
+        let root_fd = nofollow_fs::open_dir_pinned(&root).unwrap();
         // FIFO
         let fifo = std::ffi::CString::new(root.join("pipe").to_str().unwrap()).unwrap();
         assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), 0o644) }, 0, "mkfifo failed");
-        let err = nofollow::read_contained(&root_fd, std::path::Path::new("pipe"), 1 << 20).unwrap_err();
-        assert!(matches!(err, nofollow::ReadRefusal::NotRegular(_)), "{err:?}");
+        let err = nofollow_fs::read_contained(&root_fd, std::path::Path::new("pipe"), 1 << 20).unwrap_err();
+        assert!(matches!(err, nofollow_fs::ReadRefusal::NotRegular(_)), "{err:?}");
         // Oversize regular file
         std::fs::write(root.join("big.bin"), vec![0u8; 4096]).unwrap();
-        let err = nofollow::read_contained(&root_fd, std::path::Path::new("big.bin"), 1024).unwrap_err();
-        assert!(matches!(err, nofollow::ReadRefusal::TooLarge(4096)), "{err:?}");
+        let err = nofollow_fs::read_contained(&root_fd, std::path::Path::new("big.bin"), 1024).unwrap_err();
+        assert!(matches!(err, nofollow_fs::ReadRefusal::TooLarge(4096)), "{err:?}");
         // A within-budget regular file reads fine.
-        assert_eq!(nofollow::read_contained(&root_fd, std::path::Path::new("big.bin"), 8192).unwrap().len(), 4096);
+        assert_eq!(nofollow_fs::read_contained(&root_fd, std::path::Path::new("big.bin"), 8192).unwrap().len(), 4096);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/node/src/bin/hypervisor_daemon_routes/outcome_room_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/outcome_room_routes.rs
@@ -268,53 +268,10 @@ fn is_canonical_room_tail(tail: &str) -> bool {
     is_canonical_receipt_tail(tail, "or")
 }
 
-/// A record id is filesystem-safe iff it survives the persistence normalization unchanged (#72
-/// round 17 finding 2): otherwise two distinct ids (e.g. `ort/collision` and `ort_collision`)
-/// would silently target the same evidence file.
-fn is_normalization_safe(id: &str) -> bool {
-    !id.is_empty() && id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
-}
-
-/// RFC3339 timestamp validation (#72 round 17 finding 3): replay must reject any timestamp
-/// production could not emit (null, empty, or malformed) rather than coerce it to "".
 fn is_rfc3339(v: &Value) -> bool {
     v.as_str()
         .map(|s| time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).is_ok())
         .unwrap_or(false)
-}
-
-/// Enumerate the entries of an ALREADY-PINNED directory through the fd ITSELF (fdopendir over a
-/// dup) — NOT by re-walking the pathname (#72 round 21 finding 3): a directory-level exchange
-/// (the family dir swapped for a symlink to another namespace) cannot redirect enumeration,
-/// because the names come from the same inode the caller pinned and reads through. fdopendir
-/// takes ownership of the dup; closedir closes it.
-fn enumerate_pinned(dir: &std::fs::File) -> std::io::Result<Vec<String>> {
-    use std::os::unix::io::AsRawFd;
-    let dupfd = unsafe { libc::dup(dir.as_raw_fd()) };
-    if dupfd < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    let dp = unsafe { libc::fdopendir(dupfd) };
-    if dp.is_null() {
-        let e = std::io::Error::last_os_error();
-        unsafe { libc::close(dupfd) };
-        return Err(e);
-    }
-    let mut names = Vec::new();
-    loop {
-        let ent = unsafe { libc::readdir(dp) };
-        if ent.is_null() {
-            break;
-        }
-        let name = unsafe { std::ffi::CStr::from_ptr((*ent).d_name.as_ptr()) };
-        if let Ok(s) = name.to_str() {
-            if s != "." && s != ".." {
-                names.push(s.to_string());
-            }
-        }
-    }
-    unsafe { libc::closedir(dp) };
-    Ok(names)
 }
 
 /// Read a NON-promoted room-family directory as (canonical-stem, value) pairs — the file STEM is
@@ -325,14 +282,14 @@ fn enumerate_pinned(dir: &std::fs::File) -> std::io::Result<Vec<String>> {
 /// false-empty list; per-entry non-canonical stems and refused (symlink/non-regular) occupants
 /// are skipped as legitimately-invisible.
 fn read_dir_with_stems(data_dir: &str, family: &str) -> Result<Vec<(String, Value)>, String> {
-    let dir = match open_family_dir_pinned(data_dir, family) {
+    let dir = match super::durable_fs::open_family_dir_pinned(data_dir, family) {
         Ok(d) => d,
         // A not-yet-created family is genuinely empty; anything else (ELOOP from a swapped
         // directory symlink, EACCES, …) is a real error, NOT an empty registry.
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => return Err(format!("family '{family}' directory could not be pinned ({e}) — refusing to report a false-empty registry")),
     };
-    let names = enumerate_pinned(&dir).map_err(|e| format!("family '{family}' could not be enumerated through its pinned fd ({e}) — refusing to report a false-empty registry"))?;
+    let names = super::durable_fs::enumerate_pinned(&dir).map_err(|e| format!("family '{family}' could not be enumerated through its pinned fd ({e}) — refusing to report a false-empty registry"))?;
     let mut out = Vec::new();
     for name in names {
         let Some(stem) = name.strip_suffix(".json") else { continue };
@@ -342,7 +299,7 @@ fn read_dir_with_stems(data_dir: &str, family: &str) -> Result<Vec<(String, Valu
         }
         // Re-resolve the name O_NOFOLLOW relative to the pinned fd — a symlink/non-regular
         // occupant (or one swapped in after enumeration) is skipped, never read-through.
-        match read_slot_strict(&dir, &name) {
+        match super::durable_fs::read_slot_strict(&dir, &name) {
             Ok(Some((_f, bytes))) => {
                 if let Ok(value) = serde_json::from_slice::<Value>(&bytes) {
                     out.push((stem.to_string(), value));
@@ -354,131 +311,6 @@ fn read_dir_with_stems(data_dir: &str, family: &str) -> Result<Vec<(String, Valu
     Ok(out)
 }
 
-/// Pin a record-family directory (O_DIRECTORY|O_NOFOLLOW) — the walk root for every strict
-/// slot inspection and the no-replace link commit below (#72 round 19 findings 1+3).
-fn open_family_dir_pinned(data_dir: &str, family: &str) -> std::io::Result<std::fs::File> {
-    use std::os::unix::fs::OpenOptionsExt;
-    std::fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        .open(std::path::Path::new(data_dir).join(family))
-}
-
-fn slot_cstr(name: &str) -> std::io::Result<std::ffi::CString> {
-    std::ffi::CString::new(name)
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in slot name"))
-}
-
-/// STRICT slot inspection (#72 round 19 finding 3): Ok(Some((fd, bytes))) = a REGULAR file
-/// occupant opened O_NOFOLLOW and read; Ok(None) = definitively ABSENT (ENOENT only). EVERY
-/// other outcome — unreadable occupant, symlink (ELOOP), FIFO/device — is Err: the caller must
-/// REFUSE, never treat the slot as empty.
-fn read_slot_strict(dir: &std::fs::File, name: &str) -> std::io::Result<Option<(std::fs::File, Vec<u8>)>> {
-    use std::io::Read;
-    use std::os::unix::io::{AsRawFd, FromRawFd};
-    let c = slot_cstr(name)?;
-    let fd = unsafe {
-        libc::openat(dir.as_raw_fd(), c.as_ptr(), libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
-    };
-    if fd < 0 {
-        let e = std::io::Error::last_os_error();
-        if e.kind() == std::io::ErrorKind::NotFound {
-            return Ok(None); // ONLY ENOENT means empty
-        }
-        return Err(e);
-    }
-    let mut f = unsafe { std::fs::File::from_raw_fd(fd) };
-    if !f.metadata()?.is_file() {
-        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, format!("slot '{name}' is occupied by a non-regular file")));
-    }
-    let mut bytes = Vec::new();
-    f.read_to_end(&mut bytes)?;
-    Ok(Some((f, bytes)))
-}
-
-/// Open an ANONYMOUS (nameless) inode in the pinned dir via O_TMPFILE (#72 round 20 findings 1+3):
-/// the receipt bytes are written into a descriptor that has NO directory entry, so no named
-/// source ever exists to be swapped, and there is nothing to clean up after the commit.
-fn open_tmpfile_at(dir: &std::fs::File) -> std::io::Result<std::fs::File> {
-    use std::os::unix::io::{AsRawFd, FromRawFd};
-    let dot = slot_cstr(".")?;
-    let fd = unsafe {
-        libc::openat(dir.as_raw_fd(), dot.as_ptr(), libc::O_WRONLY | libc::O_TMPFILE | libc::O_CLOEXEC, 0o644 as libc::c_uint)
-    };
-    if fd < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
-}
-
-/// Give an O_TMPFILE descriptor EXACTLY ONE name via linkat — the ATOMIC NO-REPLACE commit that
-/// binds the committed bytes to the DESCRIPTOR, not to any swappable source name (#72 round 20
-/// finding 1). Uses the /proc/self/fd form (no CAP_DAC_READ_SEARCH needed for non-root); link
-/// fails EEXIST if the target appeared since inspection, exactly like a named no-replace link.
-fn link_tmpfile_at(tmp: &std::fs::File, dir: &std::fs::File, to: &str) -> std::io::Result<()> {
-    use std::os::unix::io::AsRawFd;
-    let src = slot_cstr(&format!("/proc/self/fd/{}", tmp.as_raw_fd()))?;
-    let ct = slot_cstr(to)?;
-    if unsafe { libc::linkat(libc::AT_FDCWD, src.as_ptr(), dir.as_raw_fd(), ct.as_ptr(), libc::AT_SYMLINK_FOLLOW) } != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-fn unlink_at(dir: &std::fs::File, name: &str) -> std::io::Result<()> {
-    use std::os::unix::io::AsRawFd;
-    let c = slot_cstr(name)?;
-    if unsafe { libc::unlinkat(dir.as_raw_fd(), c.as_ptr(), 0) } != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-/// True iff two descriptors reference the SAME on-disk object (device + inode). The receipt
-/// certifier compares the re-opened canonical name against the pinned committed descriptor
-/// (#72 round 21 finding 1) — a name swapped to a different inode fails this.
-fn same_inode(a: &std::fs::File, b: &std::fs::File) -> std::io::Result<bool> {
-    use std::os::unix::fs::MetadataExt;
-    let (ma, mb) = (a.metadata()?, b.metadata()?);
-    Ok(ma.dev() == mb.dev() && ma.ino() == mb.ino())
-}
-
-/// DELIBERATE TEST FAULT (#72 round 21 finding 1): simulate a CONCURRENT adversary replacing the
-/// canonical receipt name during the post-commit fsync window, so the re-verification below is
-/// exercised. Absent env = no effect. `point` is "new" (fresh linkat) or "replay" (byte-compare).
-fn test_swap_receipt_target(dir: &std::fs::File, target: &str, point: &str) {
-    use std::io::Write;
-    if std::env::var("IOI_TEST_FORCE_RECEIPT_TARGET_SWAP").ok().as_deref() != Some(point) {
-        return;
-    }
-    let _ = unlink_at(dir, target);
-    if let Ok(mut f) = open_tmpfile_at(dir) {
-        let _ = f.write_all(format!("{{\"foreign\":\"REPLACED_AFTER_{}\"}}", point.to_uppercase()).as_bytes());
-        let _ = f.sync_all();
-        let _ = link_tmpfile_at(&f, dir, target);
-    }
-}
-
-/// Re-verify the canonical name AFTER the file + directory fsyncs (#72 round 21 finding 1):
-/// re-open the target O_NOFOLLOW, prove it is the SAME inode as the committed descriptor, and
-/// re-read its bytes — a target swapped during the durability barrier is caught and refused.
-fn certify_receipt_target(dir: &std::fs::File, target: &str, committed: &std::fs::File, bytes: &[u8], point: &str) -> Result<(), VErr> {
-    test_swap_receipt_target(dir, target, point);
-    match read_slot_strict(dir, target) {
-        Ok(Some((reopened, on_disk))) => {
-            if !same_inode(&reopened, committed).unwrap_or(false) {
-                return Err(verr("outcome_room_receipt_swapped", format!("the receipt name '{target}' no longer resolves to the certified inode after the durability barrier — refused, never certified over a swapped target")));
-            }
-            if on_disk != bytes {
-                return Err(verr("outcome_room_receipt_swapped", format!("the receipt bytes at '{target}' changed after the durability barrier — refused")));
-            }
-            Ok(())
-        }
-        Ok(None) => Err(verr("outcome_room_receipt_swapped", format!("the receipt name '{target}' vanished after commit — refused"))),
-        Err(e) => Err(verr("outcome_room_receipt_slot_unreadable", format!("post-commit re-verify of '{target}' failed ({e}) — refused"))),
-    }
-}
-
 /// Strict ROOM slot read (#72 round 19 finding 1): the stem is validated CANONICAL before any
 /// filesystem access — a URL-derived `../…` stem never reaches a path join — and the read is a
 /// pinned no-follow open. Ok(None) = definitively absent; Err = unreadable / symlink /
@@ -487,12 +319,12 @@ fn read_room_slot_strict(data_dir: &str, stem: &str) -> Result<Option<Value>, St
     if !is_canonical_room_tail(stem) {
         return Err(format!("non-canonical room stem '{stem}' — refused before any filesystem access"));
     }
-    let dir = match open_family_dir_pinned(data_dir, ROOM_DIR) {
+    let dir = match super::durable_fs::open_family_dir_pinned(data_dir, ROOM_DIR) {
         Ok(d) => d,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => return Err(format!("room directory unavailable ({e})")),
     };
-    match read_slot_strict(&dir, &format!("{stem}.json")) {
+    match super::durable_fs::read_slot_strict(&dir, &format!("{stem}.json")) {
         Ok(None) => Ok(None),
         Ok(Some((_f, bytes))) => serde_json::from_slice::<Value>(&bytes)
             .map(Some)
@@ -859,115 +691,38 @@ fn build_room_receipt_at(
 /// file fsync + rename + checked directory fsync, with the same NotCommitted /
 /// RenamedDurabilityUnconfirmed outcome split — room records and receipts carry the same
 /// crash-durability contract as goal-run evidence.
-fn persist_atomic(data_dir: &str, family: &str, record_id: &str, record: &Value) -> Result<(), super::goalrun_routes::PersistFailure> {
+fn persist_atomic(data_dir: &str, family: &str, record_id: &str, record: &Value) -> Result<(), super::durable_fs::PersistFailure> {
     // Evidence keys must be filesystem-safe AS WRITTEN (#72 round 17 finding 2): the durable
     // writer normalizes unsafe characters, so `ort/collision` and `ort_collision` would silently
     // target the same file. Reject rather than collide — the room plane only ever writes
     // canonical `or_hex` / `orr_hex` / `ort_hex` keys, so this is a no-op for honest callers.
-    if !is_normalization_safe(record_id) {
-        return Err(super::goalrun_routes::PersistFailure::NotCommitted(std::io::Error::new(
+    if !super::durable_fs::is_normalization_safe(record_id) {
+        return Err(super::durable_fs::PersistFailure::NotCommitted(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!("record id '{record_id}' is not filesystem-safe (would normalize to a different key)"),
         )));
     }
-    super::goalrun_routes::persist_record_durable(data_dir, family, record_id, record)
+    super::durable_fs::persist_record_durable(data_dir, family, record_id, record)
 }
 
-/// APPEND-ONLY, no-clobber, DURABILITY-HONEST receipt writer (#72 rounds 18-20). The exact
-/// target slot is inspected through a PINNED no-follow directory fd:
-///   - only ENOENT means empty (#72 round 19 finding 3) — an unreadable occupant, a symlink,
-///     or a non-regular file REFUSES; evidence is never replaced on uncertainty;
-///   - an empty slot commits from an ANONYMOUS O_TMPFILE descriptor via linkat (#72 round 20
-///     findings 1+3): the bytes are bound to the DESCRIPTOR, not a swappable source name, and
-///     no named temp ever exists — so there is nothing to clean up and no source-swap window.
-///     link is NO-REPLACE: an occupant appearing between inspection and commit surfaces EEXIST;
-///   - a byte-identical occupant is RE-FSYNCED (file + directory) before being reported
-///     durable (#72 round 19 finding 2) — an earlier unconfirmed rename may not be on disk;
-///   - the family directory, when first created, is made PARENT-durable by fsyncing data_dir
-///     (#72 round 20 finding 4) — the new directory entry survives a crash;
-///   - the durability outcome is PRESERVED (#72 round 19 finding 2): visible-but-unconfirmed
-///     returns `outcome_room_receipt_durability_unconfirmed`, never Ok — terminal state and
-///     intent consumption require a DURABLE receipt.
-/// Every receipt writer — create, transition, attach, and both boot completers — uses THIS.
+/// APPEND-ONLY, no-clobber, DURABILITY-HONEST receipt writer — the SHARED durable-fs commit
+/// (#73; mechanics proven in #72 rounds 18-21: ENOENT-only-empty strict inspection, O_TMPFILE
+/// descriptor-bound no-replace linkat, byte-identical re-fsync, unconditional directory+parent
+/// durability barrier, post-barrier inode/byte certification), mapped onto THIS plane's wire
+/// codes. Every receipt writer — create, transition, attach, and both boot completers — uses
+/// THIS; the typed outcomes preserve #72's exact contract: visible-but-unconfirmed is
+/// `outcome_room_receipt_durability_unconfirmed`, never Ok — terminal state and intent
+/// consumption require a DURABLE receipt.
 fn persist_receipt_no_clobber(data_dir: &str, tail: &str, receipt: &Value) -> Result<(), VErr> {
-    use std::io::Write;
-    if !is_normalization_safe(tail) {
-        return Err(verr("outcome_room_receipt_key_invalid", format!("receipt tail '{tail}' is not filesystem-safe")));
-    }
-    let bytes = serde_json::to_vec_pretty(receipt).unwrap_or_default();
-    let fam_path = std::path::Path::new(data_dir).join(ROOM_RECEIPT_DIR);
-    if let Err(e) = std::fs::create_dir_all(&fam_path) {
-        return Err(verr("outcome_room_receipt_persist_failed", format!("receipt directory unavailable ({e}) — nothing was written")));
-    }
-    let dir = match open_family_dir_pinned(data_dir, ROOM_RECEIPT_DIR) {
-        Ok(d) => d,
-        Err(e) => return Err(verr("outcome_room_receipt_persist_failed", format!("receipt directory pin failed ({e}) — nothing was written"))),
-    };
-    let target = format!("{tail}.json");
-    // The durability barrier: fsync the receipt file's directory AND — UNCONDITIONALLY, every
-    // write, never gated on a visibility check — data_dir, so the family directory ENTRY is
-    // durable even if an earlier parent fsync failed and left the family visible (#72 round 21
-    // finding 2). A visibility-gated `family_created` would skip the retry forever.
-    let confirm_dir_durable = |dir: &std::fs::File| -> Result<(), VErr> {
-        // DELIBERATE TEST FAULT POINT (same contract as the typed durable writer): absent env =
-        // no effect; the receipt is already VISIBLE when this fires.
-        if std::env::var("IOI_TEST_FORCE_DIRSYNC_UNCONFIRMED").ok().as_deref() == Some(ROOM_RECEIPT_DIR) {
-            return Err(verr("outcome_room_receipt_durability_unconfirmed", "test-forced directory-sync failure — the receipt is VISIBLE but its durability is unconfirmed".to_string()));
-        }
-        dir.sync_all().map_err(|e| verr("outcome_room_receipt_durability_unconfirmed", format!("receipt directory sync failed ({e}) — the receipt is VISIBLE but its durability is unconfirmed")))?;
-        // Parent (data_dir) fsync — UNCONDITIONAL (#72 round 21 finding 2); a separate fault hook
-        // fails only the parent leg so the failure→restart lane is exact.
-        if std::env::var("IOI_TEST_FORCE_PARENT_FSYNC_UNCONFIRMED").ok().as_deref() == Some(ROOM_RECEIPT_DIR) {
-            return Err(verr("outcome_room_receipt_durability_unconfirmed", "test-forced parent-directory-sync failure — the receipt family entry is VISIBLE but not durable".to_string()));
-        }
-        (|| -> std::io::Result<()> { std::fs::File::open(data_dir)?.sync_all() })()
-            .map_err(|e| verr("outcome_room_receipt_durability_unconfirmed", format!("data_dir sync failed ({e}) — the receipt family entry is VISIBLE but not durable")))
-    };
-    match read_slot_strict(&dir, &target) {
-        Err(e) => Err(verr("outcome_room_receipt_slot_unreadable", format!("the receipt slot '{tail}' is occupied but NOT readable as a regular file ({e}) — refused; evidence is never replaced on uncertainty"))),
-        Ok(Some((occupant, existing))) => {
-            if existing != bytes {
-                return Err(verr("outcome_room_receipt_conflict", format!("the receipt slot '{tail}' already holds DIFFERENT evidence — receipts are append-only and never overwritten")));
-            }
-            // Byte-identical replay: re-fsync BEFORE reporting durable (#72 round 19 finding 2).
-            if let Err(e) = occupant.sync_all() {
-                return Err(verr("outcome_room_receipt_durability_unconfirmed", format!("receipt re-sync failed ({e}) — the receipt is VISIBLE but its durability is unconfirmed")));
-            }
-            confirm_dir_durable(&dir)?;
-            // Re-verify the name still resolves to the compared inode after the barrier (#72
-            // round 21 finding 1) — a target swapped during the occupant fsync is caught here.
-            certify_receipt_target(&dir, &target, &occupant, &bytes, "replay")
-        }
-        Ok(None) => {
-            // ANONYMOUS descriptor (O_TMPFILE) — NO name, so nothing to swap and nothing to clean
-            // up (#72 round 20 findings 1+3). Write + fsync the bytes into the inode, then bind
-            // it to EXACTLY ONE name (the target) with a NO-REPLACE linkat.
-            let write = (|| -> std::io::Result<std::fs::File> {
-                let mut f = open_tmpfile_at(&dir)?;
-                f.write_all(&bytes)?;
-                f.sync_all()?;
-                Ok(f)
-            })();
-            let tmp = match write {
-                Ok(f) => f,
-                Err(e) => return Err(verr("outcome_room_receipt_persist_failed", format!("receipt staging failed ({e}) — nothing is visible (anonymous inode discarded)"))),
-            };
-            if let Err(e) = link_tmpfile_at(&tmp, &dir, &target) {
-                // The anonymous inode is discarded when `tmp` drops — no residue on any path.
-                if e.kind() == std::io::ErrorKind::AlreadyExists {
-                    return Err(verr("outcome_room_receipt_conflict", format!("the receipt slot '{tail}' was occupied between inspection and commit — refused atomically (no-replace), nothing overwritten")));
-                }
-                return Err(verr("outcome_room_receipt_persist_failed", format!("receipt commit failed ({e}) — nothing is visible")));
-            }
-            // The receipt is VISIBLE from here — dual-write parity fires on visibility, exactly
-            // like the typed durable writer.
-            super::substrate_store::dual_write(data_dir, ROOM_RECEIPT_DIR, tail, receipt);
-            confirm_dir_durable(&dir)?;
-            // Re-verify the name still resolves to the linked inode after the barrier (#72 round
-            // 21 finding 1) — a target replaced during the directory fsync is caught here.
-            certify_receipt_target(&dir, &target, &tmp, &bytes, "new")
-        }
-    }
+    use super::durable_fs::CommitFailure;
+    super::durable_fs::persist_receipt_no_clobber(data_dir, ROOM_RECEIPT_DIR, tail, receipt).map_err(|f| match f {
+        CommitFailure::KeyInvalid(m) => verr("outcome_room_receipt_key_invalid", m),
+        CommitFailure::NotCommitted(m) => verr("outcome_room_receipt_persist_failed", m),
+        CommitFailure::SlotUnreadable(m) => verr("outcome_room_receipt_slot_unreadable", m),
+        CommitFailure::Conflict(m) => verr("outcome_room_receipt_conflict", m),
+        CommitFailure::DurabilityUnconfirmed(m) => verr("outcome_room_receipt_durability_unconfirmed", m),
+        CommitFailure::Swapped(m) => verr("outcome_room_receipt_swapped", m),
+    })
 }
 
 /// EXACT-PATH room loader (#72 round 18 finding 2): read the file AT the id's stem and require
@@ -2267,34 +2022,6 @@ mod outcome_room_tests {
     }
 
     #[test]
-    fn certify_receipt_target_catches_a_swapped_inode_and_passes_the_untouched_one() {
-        // #72 round 21 finding 1: the post-barrier re-verification (used on both the fresh-create
-        // and byte-identical replay paths) proves the canonical name still resolves to the
-        // committed inode with the committed bytes. Tested against the helper directly (no
-        // process-global env) — the production wiring is proven by the live restart lanes.
-        use std::io::Write;
-        let dir_t = temp_dir("certify");
-        let data_dir = dir_t.to_str().unwrap();
-        let receipt = json!({ "receipt_id": "receipt://orr_s0", "attested": true });
-        persist_receipt_no_clobber(data_dir, "orr_s0", &receipt).unwrap();
-        let bytes = serde_json::to_vec_pretty(&receipt).unwrap();
-        let dir = open_family_dir_pinned(data_dir, ROOM_RECEIPT_DIR).unwrap();
-        let (committed, _) = read_slot_strict(&dir, "orr_s0.json").unwrap().unwrap();
-        // Untouched: same inode, same bytes → certified.
-        certify_receipt_target(&dir, "orr_s0.json", &committed, &bytes, "unit").unwrap();
-        // Swap the canonical name to a DIFFERENT inode carrying foreign bytes.
-        unlink_at(&dir, "orr_s0.json").unwrap();
-        let mut f = open_tmpfile_at(&dir).unwrap();
-        f.write_all(b"{\"foreign\":\"REPLACED\"}").unwrap();
-        f.sync_all().unwrap();
-        link_tmpfile_at(&f, &dir, "orr_s0.json").unwrap();
-        // Re-verify with the ORIGINAL committed descriptor → inode mismatch → refused.
-        let (code, _) = certify_receipt_target(&dir, "orr_s0.json", &committed, &bytes, "unit").unwrap_err();
-        assert_eq!(code, "outcome_room_receipt_swapped", "a name resolving to a different inode after the barrier is refused");
-        let _ = std::fs::remove_dir_all(&dir_t);
-    }
-
-    #[test]
     fn scanner_returns_typed_error_not_false_empty_when_registry_is_unreadable() {
         // #72 round 21 finding 3: a directory-level exchange (registry replaced by a symlink) or
         // any pin/enumerate failure is a TYPED error, never an empty registry served as truth.
@@ -2510,7 +2237,7 @@ mod outcome_room_tests {
         let data_dir = dir.to_str().unwrap();
         persist_atomic(data_dir, ROOM_RECEIPT_DIR, "ort_deadbeef", &json!({ "ok": true })).unwrap();
         let err = persist_atomic(data_dir, ROOM_RECEIPT_DIR, "ort/collision", &json!({ "evil": true })).unwrap_err();
-        assert!(matches!(err, super::super::goalrun_routes::PersistFailure::NotCommitted(_)));
+        assert!(matches!(err, super::super::durable_fs::PersistFailure::NotCommitted(_)));
         // The canonical file is untouched; no collided file was written.
         assert_eq!(read_record_dir(data_dir, ROOM_RECEIPT_DIR).len(), 1);
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## PR #73 — Shared Durable Filesystem Core (strictly mechanical)

Extracts the syscall-level mechanics proven across #72's 21 review rounds into `hypervisor_daemon_routes/durable_fs.rs`, and replaces the GoalRun + OutcomeRoom local copies with the shared primitives. **Policy stays in the planes** — the module knows nothing about rooms, receipts, intents, or wire codes; it exposes typed outcomes (`PersistFailure`, `CommitFailure`, `ReadRefusal`) that each plane maps onto its own contract.

### What moved (verbatim)
- **Pinned descriptors + walks** — `open_dir_pinned` / `open_family_dir_pinned`, `open_dir_at`, `mkdir_at`, `pin_parent` (GoalRun `nofollow`, #72 r5–7).
- **Strict `openat(O_NOFOLLOW)` slot reads** — `read_slot_strict` (ENOENT-only-empty), `open_file_at`, bounded `read_contained` + `ReadRefusal`.
- **Typed atomic replacement** — `persist_record_durable` + `PersistFailure` (#72 r6–8), unchanged incl. promoted-family route + dual-write parity.
- **O_TMPFILE descriptor-bound no-clobber commit** — strict inspection, no-replace `linkat`, byte-identical re-fsync, **unconditional** family+parent durability barrier, post-barrier inode/byte certification (`persist_receipt_no_clobber` + `certify_target`, #72 r18–21). Generalized only by a `family` parameter; OutcomeRoom maps `CommitFailure` → its exact wire codes.
- **fd-pinned enumeration** — `enumerate_pinned` via `fdopendir(dup(fd))`.

### Named gap fixed
`readdir()` EOF is now distinguished from error via `errno` (reset before each call, inspected after NULL). An enumeration error propagates **typed** — never partial or empty truth. Deterministic test without process-global env faults: errno is deliberately polluted before an EOF enumeration (complete listing still returned), and a non-directory fd fails typed.

### Explicitly not in this PR
No step-3 objects, routes, fields, UI, or new durability threat model. Closes under #72's declared threat model — no same-UID data-directory sabotage expansion.

### Behavior preservation proof
- cargo **196/196** · OutcomeRoom **140/140** · WorkResult **63/63** · operational-depth OK · architecture + pre-next-leg gates green · no NUL bytes.
- **Byte-identical before/after**: a journey (create ×2, pause, resume, attach, close, work-result admission) run on the **base** binary (57311dba6) was re-served by the refactored binary with all 10 evidence files byte-identical and zero temp residue.
- **Cross-version sealed-intent replay**: a pending admission intent sealed by the base binary (receipt visible, room absent) was replayed by the refactored binary — receipt byte-identical (the reconstruction byte-compare is the oracle), room admitted, intent consumed.
- **No duplicate syscall helpers remain**: the GoalRun `nofollow` module and all OutcomeRoom fd helpers are deleted; the only raw `libc` call left in either plane is a test fixture (`mkfifo`). Routes shed 561 lines.

Holding for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)