### PR TITLE
feat(hypervisor-web): estate messaging spine + status manifest + build audit

### DIFF
--- a/apps/hypervisor-web/package.json
+++ b/apps/hypervisor-web/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "predev": "ioi-ds-sync-assets",
     "dev": "vite",
-    "prebuild": "ioi-ds-sync-assets",
+    "prebuild": "ioi-ds-sync-assets && node tools/audit-estate.mjs",
     "build": "vite build",
-    "preview": "vite preview --host 127.0.0.1"
+    "preview": "vite preview --host 127.0.0.1",
+    "audit:estate": "node tools/audit-estate.mjs"
   },
   "dependencies": {
     "@ioi/design-system": "*",

--- a/apps/hypervisor-web/src/config/estateMessaging.js
+++ b/apps/hypervisor-web/src/config/estateMessaging.js
@@ -1,0 +1,91 @@
+// Estate messaging spine — hypervisor.com side.
+//
+// SINGLE OWNER of shared public statements is the ioi-ai repo:
+//   ioi-ai/src/config/canonicalMessaging.js  (meaning governed by the
+//   architecture canon in this repo, docs/architecture/ + whitepaper v1.10.0).
+// The VENDORED block below is a pinned snapshot of that file's exports and
+// must only change by re-vendoring from the owner. The ESTATE EXTENSIONS
+// block is authored here first and is pending upstream into the owner file.
+// tools/audit-estate.mjs enforces banned phrases and required literals at
+// build time (wired into `npm run build` via prebuild).
+
+/* ------------------------- VENDORED (owner: ioi-ai) ------------------------- */
+
+export const CATEGORY_LINE =
+  "IOI is the open operating stack for bounded autonomous systems.";
+
+export const CATEGORY_SUBTITLE =
+  "The open operating stack for autonomous systems that prove what they did.";
+
+export const ACTION_LINE =
+  "You declare what a system may do, run it where you choose, and get back a signed record of everything it did.";
+
+export const HYPERVISOR_SUMMARY =
+  "Hypervisor is the operating environment and control plane for autonomous systems: build agents and workflows, grant them bounded authority, run them on local or cloud compute, and get a verifiable record of everything they do.";
+
+export const STATUS_SUMMARY =
+  "IOI is under active implementation. The architecture is published in the v1.10.0 technical whitepaper; Hypervisor runs as a local private preview; marketplace, cross-system AIIP federation, embodied fleets, and IOI L1 services follow the evidence gates on the public roadmap.";
+
+export const LAYER_SUMMARIES = {
+  l0: "IOI L0 lets one governed system distribute useful work across models, services, people, compute, and devices — many machines, one accountable system, one history.",
+  aiip: "AIIP is the interop protocol between independently owned autonomous systems. Cooperation happens only under terms both sides accept; discovery alone creates no authority and no obligation.",
+  l1: "IOI L1 is an optional shared trust layer for the few commitments that need public settlement. It is never required to run an IOI system.",
+};
+
+/* -------------------- ESTATE EXTENSIONS (pending upstream) ------------------ */
+
+// The canonical runtime doctrine pipeline, rendered on hypervisor.com Home.
+export const DOCTRINE_PIPELINE = [
+  ["Daemon", "executes"],
+  ["wallet.network", "authorizes"],
+  ["Agentgres", "remembers"],
+  ["IOI L1", "settles"],
+];
+
+// Hypervisor-type lineage. Type 3 is the public master frame for the product
+// story: hardware (T1) and operating systems (T2) virtualized before;
+// Hypervisor governs the autonomous-work layer above both.
+export const TYPE_LINEAGE = {
+  t1: {
+    label: "Type 1 · Bare metal",
+    governs: "Hardware",
+    peers: "ESXi · Xen · KVM",
+  },
+  t2: {
+    label: "Type 2 · Hosted",
+    governs: "Operating systems",
+    peers: "VMware · VirtualBox · Parallels",
+  },
+  t3: {
+    label: "Type 3 · Hypervisor",
+    governs: "Autonomous work",
+    line: "Isolation, scheduling, policy, receipts, and replay across every machine, model, and tool.",
+  },
+};
+
+// The two product lanes. Run-on: systems built on the substrate — effects
+// exist only through capability exits, leases, and receipts. Attach: the
+// Authority Gateway mediates agents you already run — audit, hold, approve,
+// and receipt the control points it can actually see (never a total-
+// interception claim; see daemon-runtime/doctrine.md).
+export const TWO_LANES = {
+  runOn:
+    "Build and operate autonomous systems on the substrate. Effects only exist through capability exits, leases, and receipts.",
+  attach:
+    "Attach the Authority Gateway to agents you already run. Audit, hold for exact-action approval, and receipt their consequential actions.",
+};
+
+const ESTATE_MESSAGING = {
+  CATEGORY_LINE,
+  CATEGORY_SUBTITLE,
+  ACTION_LINE,
+  HYPERVISOR_SUMMARY,
+  STATUS_SUMMARY,
+  LAYER_SUMMARIES,
+  DOCTRINE_PIPELINE,
+  TYPE_LINEAGE,
+  TWO_LANES,
+};
+
+if (typeof window !== "undefined") window.ESTATE_MESSAGING = ESTATE_MESSAGING;
+export default ESTATE_MESSAGING;

--- a/apps/hypervisor-web/src/config/estateStatus.js
+++ b/apps/hypervisor-web/src/config/estateStatus.js
@@ -1,0 +1,33 @@
+// Estate status manifest — the single place status truth flips when a
+// surface changes stage. Both estate sites consume this shape (ioi-ai mirrors
+// it); public copy must not claim a stage ahead of this file. Keys are
+// hypervisor.com product slugs plus estate-level surfaces. Never mark a
+// surface ahead of what actually ships.
+
+const ESTATE_STATUS = {
+  version: "2026-07-21",
+  labels: {
+    "private-preview": "Private preview",
+    "design-stage": "Design stage",
+    "single-node-proof": "Single-node proof",
+    "evidence-gated": "Evidence-gated",
+    planned: "Planned",
+  },
+  surfaces: {
+    app: "private-preview",
+    web: "private-preview",
+    cli: "private-preview",
+    sdk: "private-preview",
+    adk: "private-preview",
+    odk: "private-preview",
+    mcp: "private-preview",
+    os: "design-stage",
+    embodied: "design-stage",
+    "authority-gateway": "single-node-proof",
+    "ioi-l1": "evidence-gated",
+    "ioi-ai-goal-space": "planned",
+  },
+};
+
+if (typeof window !== "undefined") window.ESTATE_STATUS = ESTATE_STATUS;
+export default ESTATE_STATUS;

--- a/apps/hypervisor-web/src/main.jsx
+++ b/apps/hypervisor-web/src/main.jsx
@@ -114,6 +114,8 @@ function linkToPath(href) {
 
 async function loadFoundation() {
   await import("@ioi/design-system");
+  await import("./config/estateMessaging.js");
+  await import("./config/estateStatus.js");
   await import("./site/HvDots.jsx");
   await import("./site/HvDepthField.jsx");
   await import("./site/HvOcta.jsx");

--- a/apps/hypervisor-web/src/site/ProductData.jsx
+++ b/apps/hypervisor-web/src/site/ProductData.jsx
@@ -1,12 +1,19 @@
 const React = window.React;
 // hypervisor.com — platform product catalog.
 // One record per Platform product; consumed by ProductPage.jsx to render each subpage.
+// Status labels resolve from the estate status manifest (config/estateStatus.js),
+// the single file that flips when a surface changes stage.
+const _st = (k) => {
+  const S = window.ESTATE_STATUS;
+  return S ? S.labels[S.surfaces[k]] : undefined;
+};
 window.HV_PRODUCTS = [
   {
     slug: "app",
     file: "hv-app.html",
     name: "Hypervisor App",
     category: "Client · Desktop command center",
+    status: _st("app"),
     title: "Operate autonomous work from your machine",
     sub: "Start governed sessions, run automations, and supervise agents across projects, tools, models, and providers — with approvals, receipts, and replay in one local-first workspace.",
     visual: "app",
@@ -39,6 +46,7 @@ window.HV_PRODUCTS = [
     file: "hv-web.html",
     name: "Hypervisor Web",
     category: "Client · Browser & teams",
+    status: _st("web"),
     title: "Bring autonomous work to the whole team",
     sub: "Shared projects, remote sessions, approvals, and run history in the browser — without changing the runtime truth or where work actually executes.",
     visual: "web",
@@ -71,6 +79,7 @@ window.HV_PRODUCTS = [
     file: "hv-cli.html",
     name: "Hypervisor CLI",
     category: "Client · Terminal, scripting & CI",
+    status: _st("cli"),
     title: "Script and supervise from the shell",
     sub: "Drive autonomous work from CI, shells, and servers with the same authority, receipts, and replay as the app — headless, scriptable, and pipeline-native.",
     visual: "cli",
@@ -103,6 +112,7 @@ window.HV_PRODUCTS = [
     file: "hv-sdk.html",
     name: "Hypervisor SDK",
     category: "Builder · Protocol library",
+    status: _st("sdk"),
     title: "Build on the substrate, not around it",
     sub: "Integrate Hypervisor into products, agents, and internal tools without reimplementing runtime, authority, receipt, or state semantics.",
     visual: "glow",
@@ -135,6 +145,7 @@ window.HV_PRODUCTS = [
     file: "hv-adk.html",
     name: "Hypervisor ADK",
     category: "Builder · Autonomous-system kit",
+    status: _st("adk"),
     title: "Build and ship autonomous systems",
     sub: "Compose workers, harnesses, evals, manifests, and deployment profiles — packaged as governed autonomous-system bundles ready to run anywhere.",
     visual: "glow",
@@ -167,6 +178,7 @@ window.HV_PRODUCTS = [
     file: "hv-odk.html",
     name: "Hypervisor ODK",
     category: "Builder · Ontology-aware kit",
+    status: _st("odk"),
     title: "Turn domain knowledge into working surfaces",
     sub: "Compile ontologies and data recipes into generated surfaces, domain apps, eval packs, and marketplace-ready ontology packs.",
     visual: "glow",
@@ -199,6 +211,7 @@ window.HV_PRODUCTS = [
     file: "hv-mcp.html",
     name: "Hypervisor MCP",
     category: "Gateway · Scoped external access",
+    status: _st("mcp"),
     title: "Hand external agents a key, never the keyring",
     sub: "Expose selected capabilities to external agents through revocable, auditable MCP profiles — scoped access, every call receipted, never a master key.",
     visual: "light",
@@ -231,7 +244,7 @@ window.HV_PRODUCTS = [
     file: "hv-os.html",
     name: "HypervisorOS",
     category: "Substrate · Bare-metal / cluster control",
-    status: "Design stage",
+    status: _st("os"),
     title: "Govern the substrate autonomy runs on",
     sub: "Operate measured hosts, GPU pools, storage, networks, model runtimes, containers, and microVMs under one policy plane — your hardware, your perimeter.",
     visual: "light",
@@ -264,7 +277,7 @@ window.HV_PRODUCTS = [
     file: "hv-embodied.html",
     name: "Embodied Runtime",
     category: "Substrate · Physical autonomy profile",
-    status: "Design stage",
+    status: _st("embodied"),
     title: "Autonomy that touches the physical world",
     sub: "Operate robot fleets, devices, sensors, command queues, and telemetry under safety gates — with operator handoff and the same receipts as software work.",
     visual: "light",

--- a/apps/hypervisor-web/tools/audit-estate.mjs
+++ b/apps/hypervisor-web/tools/audit-estate.mjs
@@ -1,0 +1,84 @@
+// Estate parity + banned-phrase audit for hypervisor.com. Runs in prebuild;
+// fails the build on any violation. Mirrors the enforcement model of
+// ioi-ai/tools/audit-seo.mjs (single-owner strings + machine checks).
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const failures = [];
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) walk(p, out);
+    else if (/\.(jsx?|html)$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+const files = [...walk(join(ROOT, "src")), join(ROOT, "index.html")];
+const read = (p) => readFileSync(p, "utf8");
+
+/* 1 — banned phrases: unbacked claims, retired domains, retired taxonomy. */
+const BANNED = [
+  "SOC 2",
+  "GDPR",
+  "Fortune 500",
+  "Proven in production",
+  "hypervisor.io",
+  "1.2M",
+  "Production telemetry",
+  "Request for Agent",
+];
+for (const f of files) {
+  const text = read(f);
+  for (const b of BANNED) {
+    if (f.endsWith("audit-estate.mjs")) continue;
+    if (text.includes(b)) failures.push(`${f}: banned phrase "${b}"`);
+  }
+}
+
+/* 2 — required literals: honest status + cross-property links present. */
+const REQUIRED = [
+  ["src/site/HomeSections.jsx", "Local private preview"],
+  ["src/site/Chrome.jsx", "internetofintelligence.com"],
+  ["src/site/HomeSections.jsx", "wallet.network"],
+  ["src/site/HomeSections.jsx", "Agentgres"],
+];
+for (const [rel, needle] of REQUIRED) {
+  if (!read(join(ROOT, rel)).includes(needle)) {
+    failures.push(`${rel}: missing required literal "${needle}"`);
+  }
+}
+
+/* 3 — status manifest integrity + ProductData resolution. */
+const status = (await import(join(ROOT, "src/config/estateStatus.js"))).default;
+for (const [surface, stage] of Object.entries(status.surfaces)) {
+  if (!status.labels[stage]) {
+    failures.push(`estateStatus.js: surface "${surface}" uses undefined stage "${stage}"`);
+  }
+}
+const productData = read(join(ROOT, "src/site/ProductData.jsx"));
+for (const m of productData.matchAll(/_st\("([^"]+)"\)/g)) {
+  if (!status.surfaces[m[1]]) {
+    failures.push(`ProductData.jsx: _st("${m[1]}") has no entry in estateStatus.js`);
+  }
+}
+
+/* 4 — doctrine pipeline parity between spine and rendered Home copy. */
+const spine = (await import(join(ROOT, "src/config/estateMessaging.js"))).default;
+const home = read(join(ROOT, "src/site/HomeSections.jsx"));
+for (const [k, v] of spine.DOCTRINE_PIPELINE) {
+  if (!home.includes(`["${k}", "${v}"]`)) {
+    failures.push(`HomeSections.jsx: doctrine chip ["${k}", "${v}"] drifted from estateMessaging.DOCTRINE_PIPELINE`);
+  }
+}
+
+if (failures.length) {
+  console.error(`estate audit: ${failures.length} violation(s)`);
+  for (const f of failures) console.error(`  ✕ ${f}`);
+  process.exit(1);
+}
+console.log("estate audit: clean");


### PR DESCRIPTION
Phase 0 / PR B of the web-estate program, stacked on #98.

The two change-once mechanisms land here:

1. **Messaging spine** — `estateMessaging.js` vendors the single-owner canonical strings (owner stays `ioi-ai/src/config/canonicalMessaging.js`) and authors the estate extensions (doctrine pipeline, Type-1/2/3 lineage definitions, run-on vs attach lanes) pending upstream.
2. **Status manifest** — `estateStatus.js` is the one file that flips when a surface changes stage. All nine product pages now resolve their hero-eyebrow status from it; nothing on the site may claim a stage ahead of it.

`tools/audit-estate.mjs` runs in prebuild and fails the build on: banned unbacked claims (SOC 2 / GDPR / Fortune 500 / "Proven in production" / hypervisor.io / fabricated telemetry / "Request for Agent"), missing honesty/cross-link literals, manifest integrity violations, or doctrine-chip drift from the spine.

Verified: audit clean, build green, headless render check confirms manifest statuses on /hv-app and /hv-os, zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)