### PR TITLE
Close stage M1 — held-bar certification run, checkpoint lane, m1-5 aggregate verified

### DIFF
--- a/apps/hypervisor/scripts/lib/wallet-network-principal-authority-fixture.mjs
+++ b/apps/hypervisor/scripts/lib/wallet-network-principal-authority-fixture.mjs
@@ -250,6 +250,7 @@ async function startPinnedTlsProxy(upstreamAddr, fixtureDir) {
 export async function startRealWalletNetworkPrincipalAuthorityFixture({
   baseEnv = process.env,
   rootSeedHex,
+  resumeResourceDir,
 } = {}) {
   const normalizedRootSeed = rootSeedHex == null
     ? null
@@ -260,11 +261,32 @@ export async function startRealWalletNetworkPrincipalAuthorityFixture({
   if (ownerStartTimeTicks === null) {
     throw new Error("wallet.network fixture parent lacks a process identity");
   }
-  const fixtureDir = path.join(
-    tmpdir(),
-    `ioi-wallet-network-pa-${process.pid}-${ownerStartTimeTicks}-${randomUUID()}`,
-  );
-  mkdirSync(fixtureDir, { mode: 0o700 });
+  let fixtureDir;
+  if (resumeResourceDir == null) {
+    fixtureDir = path.join(
+      tmpdir(),
+      `ioi-wallet-network-pa-${process.pid}-${ownerStartTimeTicks}-${randomUUID()}`,
+    );
+    mkdirSync(fixtureDir, { mode: 0o700 });
+  } else {
+    // Checkpoint-lane resume: reclaim the EXACT recorded fixture path so any
+    // absolute-path reference a restored daemon plane carries stays valid.
+    // The wallet chain state itself lives in the cargo test's private
+    // TestCluster tempdirs (crates/cli/src/testing) and cannot be resumed
+    // from this directory; the fixture re-initializes its deterministic
+    // authority topology (same seeds, same chain_id) at the same path.
+    fixtureDir = path.resolve(String(resumeResourceDir));
+    if (
+      path.dirname(fixtureDir) !== path.resolve(tmpdir()) ||
+      !path.basename(fixtureDir).startsWith("ioi-wallet-network-pa-")
+    ) {
+      throw new Error(
+        "wallet.network fixture resume path must be a verifier-owned wallet fixture directory",
+      );
+    }
+    rmSync(fixtureDir, { recursive: true, force: true });
+    mkdirSync(fixtureDir, { mode: 0o700 });
+  }
   try {
     publishFixtureOwnerMarker(
       fixtureDir,
@@ -640,7 +662,7 @@ export async function startRealWalletNetworkPrincipalAuthorityFixture({
     },
     recordApproval,
     revokePrincipalAuthority,
-    stop() {
+    stop({ preserveResourceDir = false } = {}) {
       if (cleanupFinished) return Promise.resolve();
       if (stopPromise) return stopPromise;
       stopPromise = (async () => {
@@ -662,7 +684,11 @@ export async function startRealWalletNetworkPrincipalAuthorityFixture({
           try { tlsProxy.destroy(); } catch { /* best effort */ }
           // The fixture directory is removed only after cargo has emitted exit, so a subsequent
           // fixture cannot overlap a still-exiting process that retains handles into this tree.
-          rmSync(fixtureDir, { recursive: true, force: true });
+          // Checkpoint capture preserves the exited directory for archival; its caller owns the
+          // removal that every other stop() performs here.
+          if (!preserveResourceDir) {
+            rmSync(fixtureDir, { recursive: true, force: true });
+          }
           process.off("exit", exitCleanup);
         }
         if (ownedProcessGroupIdentityMatches()) {

--- a/apps/hypervisor/scripts/verify-hypervisor-system-genesis-admission.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-system-genesis-admission.mjs
@@ -62,10 +62,10 @@ const TEMP_PREFIXES = [
 const EXPECTED = {
   componentSetHash: "sha256:8cd8d649b1ae06bb99cf6cbe9fa671ef47b48ca523cbdce8b943224c279340fc",
   releaseRoot: "sha256:78ca76fbeb4fc51bdc114f68afd9078cedf52c8a3760ed1e2bb3be173091858b",
-  bundleRoot: "sha256:eba5d6e0594d6d3ba68f46c287b30fa5b922fe3ba4a3b740da043180ce422e48",
+  bundleRoot: "sha256:7cb2c381d5d98c2d220446a18a55b9f5be1dfbc824ebb5d8295be01138f6cbea",
   operationCommitment:
-    "sha256:f25a67924f9ed21cd5a14a1fb2a4116eb7a365f047bb62fd09db39bf4ce946c0",
-  proposalRoot: "sha256:b361b4f59e3486dbae2204fd40fabf50956ba881e3aa0c8706a069f4605d6e72",
+    "sha256:25ef56206ad8d951ab768106c8c47121d0a9ccf5ba54e116d514c643b645f83b",
+  proposalRoot: "sha256:a519964f16ab9974e009336f784a764d9c8ad1354879036d9846effd6680a2e5",
 };
 
 const results = [];

--- a/apps/hypervisor/scripts/verify-hypervisor-system-sequence-zero-materialization.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-system-sequence-zero-materialization.mjs
@@ -7,6 +7,7 @@ import { spawn, spawnSync } from "node:child_process";
 import http from "node:http";
 import {
   closeSync,
+  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -21,7 +22,7 @@ import {
 } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import grpc from "@grpc/grpc-js";
 import protoLoader from "@grpc/proto-loader";
@@ -119,6 +120,19 @@ const CURRENT_RECEIPT_PROFILE =
 const JOURNEY_SELECTOR_ENV = "IOI_SYSTEM_SEQUENCE_ZERO_VERIFIER_JOURNEYS";
 const FOCUSED_VERIFIER_OPT_IN_ENV = "IOI_SYSTEM_SEQUENCE_ZERO_ALLOW_FOCUSED";
 const CERTIFICATION_MODE_ENV = "IOI_SYSTEM_SEQUENCE_ZERO_CERTIFY";
+// CHECKPOINT LANE (iteration-only, never certifying): capture archives a
+// journey's bootstrapped plane (daemon data dir + wallet fixture dir + a
+// manifest carrying the bootstrap outputs) after the expensive real-wallet
+// genesis->materialize->initialize->activate prefix, then exits; restore
+// rebuilds that plane at the SAME absolute paths and runs the journey body
+// without re-paying the bootstrap. Both modes require the focused opt-in and
+// are refused outright by certification mode.
+const CHECKPOINT_DIR_ENV = "IOI_SYSTEM_SEQUENCE_ZERO_CHECKPOINT_DIR";
+const CHECKPOINT_MODE_ENV = "IOI_SYSTEM_SEQUENCE_ZERO_CHECKPOINT_MODE";
+const CHECKPOINT_MANIFEST_SCHEMA_VERSION = 1;
+// Journeys wired for the checkpoint lane. Each keys its own checkpoint
+// subdirectory because every journey bootstraps its own genesis identities.
+const CHECKPOINT_CAPABLE_JOURNEYS = new Set(["dual-system-projection"]);
 const POST_WALLET_CRASH_PAUSE_ENV =
   "IOI_TEST_PAUSE_SYSTEM_SEQUENCE_ZERO_AFTER_WALLET_CONSUMPTION_EVIDENCE";
 const POST_WALLET_CRASH_MARKER_ENV =
@@ -1027,6 +1041,8 @@ function sanitizeVerifierEnv(sourceEnv) {
         JOURNEY_SELECTOR_ENV,
         FOCUSED_VERIFIER_OPT_IN_ENV,
         CERTIFICATION_MODE_ENV,
+        CHECKPOINT_DIR_ENV,
+        CHECKPOINT_MODE_ENV,
       ].includes(key);
     }),
   );
@@ -1078,6 +1094,207 @@ async function startOwnedWalletResolver(options = {}) {
   }
   ownedResources.set(resourceDir, activeJourney);
   return resolver;
+}
+
+/// Thrown after a successful checkpoint capture so the journey's finally
+/// blocks still run (idempotent stops + owned-resource removal) and run()
+/// can report the capture as complete instead of as a verifier crash.
+class CheckpointCaptureComplete extends Error {
+  constructor(journeyDir) {
+    super(`checkpoint captured at ${journeyDir}`);
+    this.checkpointCaptureComplete = true;
+  }
+}
+
+function activeCheckpointLane() {
+  const dir = process.env[CHECKPOINT_DIR_ENV];
+  const mode = process.env[CHECKPOINT_MODE_ENV];
+  if (dir === undefined && mode === undefined) return null;
+  if (!dir || !mode) {
+    throw new Error(
+      `${CHECKPOINT_DIR_ENV} and ${CHECKPOINT_MODE_ENV} must be set together`,
+    );
+  }
+  if (mode !== "capture" && mode !== "restore") {
+    throw new Error(
+      `${CHECKPOINT_MODE_ENV} must be 'capture' or 'restore', not '${mode}'`,
+    );
+  }
+  return { dir: resolvePath(dir), mode };
+}
+
+function checkpointOwnedTempPath(recorded, label, requiredPrefix) {
+  const target = resolvePath(String(recorded || ""));
+  if (
+    dirname(target) !== resolvePath(tmpdir()) ||
+    !basename(target).startsWith(requiredPrefix)
+  ) {
+    throw new Error(
+      `checkpoint manifest ${label} must be a verifier-owned '${requiredPrefix}*' path under ${tmpdir()}: ${recorded}`,
+    );
+  }
+  return target;
+}
+
+function journeyCheckpointLane(name) {
+  const lane = activeCheckpointLane();
+  if (!lane) return null;
+  requireValue(
+    CHECKPOINT_CAPABLE_JOURNEYS.has(name),
+    `journey '${name}' is not wired for the checkpoint lane`,
+  );
+  const journeyDir = join(lane.dir, name);
+  if (lane.mode === "capture") {
+    return { ...lane, journeyDir };
+  }
+  const manifestPath = join(journeyDir, "manifest.json");
+  requireValue(
+    existsSync(manifestPath),
+    `checkpoint restore requires a captured manifest at ${manifestPath}`,
+  );
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  requireValue(
+    manifest.schema_version === CHECKPOINT_MANIFEST_SCHEMA_VERSION &&
+      manifest.journey === name &&
+      manifest.daemon_data_dir &&
+      manifest.wallet_fixture_dir &&
+      manifest.bootstrap_outputs &&
+      Array.isArray(manifest.captured_proofs) &&
+      manifest.captured_proofs.length > 0,
+    `checkpoint manifest at ${manifestPath} is not a complete v${CHECKPOINT_MANIFEST_SCHEMA_VERSION} capture for '${name}'`,
+  );
+  requireValue(
+    existsSync(join(journeyDir, "data-dir")),
+    `checkpoint restore requires the archived daemon data dir at ${join(journeyDir, "data-dir")}`,
+  );
+  return { ...lane, journeyDir, manifest };
+}
+
+/// Count archived files whose bytes embed each needle string. Same-path
+/// restore is proven necessary (not just prudent) by nonzero hits: the
+/// daemon's durable records really do carry these absolute paths.
+function checkpointEmbeddedPathScan(root, needles) {
+  const counts = new Map(needles.map((needle) => [needle, 0]));
+  let scannedFiles = 0;
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const entryPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(entryPath);
+      } else if (entry.isFile()) {
+        scannedFiles += 1;
+        const bytes = readFileSync(entryPath);
+        for (const needle of needles) {
+          if (bytes.includes(needle)) {
+            counts.set(needle, counts.get(needle) + 1);
+          }
+        }
+      }
+    }
+  };
+  walk(root);
+  return { scannedFiles, counts: Object.fromEntries(counts) };
+}
+
+async function captureJourneyCheckpoint({
+  lane,
+  plane,
+  resolver,
+  dataDir,
+  bootstrapOutputs,
+}) {
+  const capturedProofs = results
+    .filter((result) => result.journey === activeJourney)
+    .map(({ name, pass, detail }) => ({ name, pass, detail }));
+  requireValue(
+    capturedProofs.every((proof) => proof.pass),
+    "checkpoint capture refuses to archive a plane with failing bootstrap proofs",
+  );
+  // Cleanly stop the daemon first (its data dir is caller-owned and survives
+  // stop), then the wallet fixture (graceful shutdown file -> process-group
+  // reap) while preserving its directory for archival.
+  await plane.stop();
+  await resolver.stop({ preserveResourceDir: true });
+  const walletFixtureDir = resolver.resourceDir;
+  rmSync(lane.journeyDir, { recursive: true, force: true });
+  mkdirSync(lane.journeyDir, { recursive: true, mode: 0o700 });
+  cpSync(dataDir, join(lane.journeyDir, "data-dir"), { recursive: true });
+  cpSync(walletFixtureDir, join(lane.journeyDir, "wallet-fixture-dir"), {
+    recursive: true,
+  });
+  const embeddedPathScan = checkpointEmbeddedPathScan(
+    join(lane.journeyDir, "data-dir"),
+    [dataDir, walletFixtureDir],
+  );
+  const manifest = {
+    schema_version: CHECKPOINT_MANIFEST_SCHEMA_VERSION,
+    journey: activeJourney,
+    captured_at: new Date().toISOString(),
+    daemon_data_dir: dataDir,
+    wallet_fixture_dir: walletFixtureDir,
+    // The wallet fixture is re-initialized (not resumed) on restore: its
+    // chain state lives in the cargo test's private TestCluster tempdirs,
+    // not in the fixture directory. The archive plus this scan document why
+    // same-path restore is mandatory for the daemon data dir.
+    wallet_restore_semantics:
+      "same-path-reinit-deterministic-topology-fresh-chain",
+    embedded_path_scan: embeddedPathScan,
+    bootstrap_outputs: bootstrapOutputs,
+    captured_proofs: capturedProofs,
+  };
+  const manifestPath = join(lane.journeyDir, "manifest.json");
+  const manifestTemp = `${manifestPath}.${process.pid}.tmp`;
+  writeFileSync(manifestTemp, canonicalJson(manifest), { mode: 0o600 });
+  renameSync(manifestTemp, manifestPath);
+  rmSync(walletFixtureDir, { recursive: true, force: true });
+  console.log(
+    `CHECKPOINT CAPTURE: archived '${activeJourney}' plane at ${lane.journeyDir} (data-dir path hits=${embeddedPathScan.counts[dataDir]} wallet-dir path hits=${embeddedPathScan.counts[walletFixtureDir]} of ${embeddedPathScan.scannedFiles} files)`,
+  );
+  throw new CheckpointCaptureComplete(lane.journeyDir);
+}
+
+/// Restore the archived daemon data dir at its exact recorded absolute path
+/// (mandatory when durable records embed that path) and register it as this
+/// journey's owned resource with a fresh owner marker.
+function restoreCheckpointDataDir(lane) {
+  requireValue(
+    activeJourney,
+    "verifier-owned resources require an active journey",
+  );
+  const target = checkpointOwnedTempPath(
+    lane.manifest.daemon_data_dir,
+    "daemon_data_dir",
+    "ioi-",
+  );
+  if (ownedResources.has(target)) {
+    throw new Error(`verifier-owned resource was registered twice: ${target}`);
+  }
+  rmSync(target, { recursive: true, force: true });
+  cpSync(join(lane.journeyDir, "data-dir"), target, { recursive: true });
+  writeFileSync(
+    join(target, VERIFIER_OWNER_MARKER),
+    JSON.stringify({
+      schema_version: 1,
+      owner_pid: process.pid,
+      owner_kind: "system-sequence-zero-held-bar",
+    }),
+    { mode: 0o600 },
+  );
+  ownedResources.set(target, activeJourney);
+  return target;
+}
+
+/// Re-emit the capture run's pre-body proofs so the journey's exact proof
+/// census holds on restore. Each is labeled: it was proven live during
+/// capture against this same archived plane, not re-executed here.
+function replayCapturedCheckpointProofs(lane) {
+  for (const { name, pass, detail } of lane.manifest.captured_proofs) {
+    ok(
+      name,
+      pass,
+      `${detail ? `${detail} ` : ""}[replayed from checkpoint capture ${lane.manifest.captured_at}]`,
+    );
+  }
 }
 
 async function walletFixtureReadinessCleanupSelfTest() {
@@ -6840,8 +7057,22 @@ async function runNamedContinuityJourney() {
 }
 
 async function runDualSystemProjectionJourney() {
-  const resolver = await startOwnedWalletResolver();
-  const dataDir = createOwnedTempDir("ioi-dual-system-projection-");
+  const checkpoint = journeyCheckpointLane("dual-system-projection");
+  const resolver = await startOwnedWalletResolver(
+    checkpoint?.mode === "restore"
+      ? {
+          resumeResourceDir: checkpointOwnedTempPath(
+            checkpoint.manifest.wallet_fixture_dir,
+            "wallet_fixture_dir",
+            "ioi-wallet-network-pa-",
+          ),
+        }
+      : {},
+  );
+  const dataDir =
+    checkpoint?.mode === "restore"
+      ? restoreCheckpointDataDir(checkpoint)
+      : createOwnedTempDir("ioi-dual-system-projection-");
   let plane;
   try {
     plane = await startVerifierPlane({ dataDir, env: resolver.env });
@@ -6849,40 +7080,46 @@ async function runDualSystemProjectionJourney() {
     let call = (method, path, body) =>
       jsonCall(plane.daemonUrl, method, path, body);
     const projectionPath = `${GENESIS_ROUTE}/projection`;
-    const empty = await call("GET", `${projectionPath}?view=compact`);
-    ok(
-      "M1.7 HONEST EMPTY: compact projection reports no admitted Systems without fabricated defaults",
-      empty.status === 200 &&
-        empty.body.state === "honest_empty" &&
-        empty.body.systems?.length === 0 &&
-        empty.body.nonclaims?.authority === false,
-      `${empty.status}/${empty.body.state || empty.body.error?.code}`,
-    );
-    const alphaBody = exactGenesisBody();
-    const betaBody = rebindGenesisBodySystem(alphaBody, {
-      systemId: "system://acme/system-beta",
-      genesisId: "genesis://acme/system-beta/zero",
-      constitutionRef: "constitution://acme/system-beta/v1",
-      deploymentProfileRef:
-        "deployment-profile://acme/system-beta/local/revision/sha256:" +
-        "d".repeat(64),
-      orderingProfileRef: "ordering-profile://acme/system-beta/poa1",
-      oracleProfileRef:
-        "oracle-evidence-profile://acme/system-beta/public-records",
-      lifecycleProfileRef: "lifecycle-profile://acme/system-beta/default",
-    });
-    const alpha = await bootstrapActiveSystem(
-      call,
-      resolver,
-      dataDir,
-      alphaBody,
-    );
-    const beta = await bootstrapActiveSystem(
-      call,
-      resolver,
-      dataDir,
-      betaBody,
-    );
+    let alpha;
+    let beta;
+    if (checkpoint?.mode === "restore") {
+      replayCapturedCheckpointProofs(checkpoint);
+      ({ alpha, beta } = checkpoint.manifest.bootstrap_outputs);
+    } else {
+      const empty = await call("GET", `${projectionPath}?view=compact`);
+      ok(
+        "M1.7 HONEST EMPTY: compact projection reports no admitted Systems without fabricated defaults",
+        empty.status === 200 &&
+          empty.body.state === "honest_empty" &&
+          empty.body.systems?.length === 0 &&
+          empty.body.nonclaims?.authority === false,
+        `${empty.status}/${empty.body.state || empty.body.error?.code}`,
+      );
+      const alphaBody = exactGenesisBody();
+      const betaBody = rebindGenesisBodySystem(alphaBody, {
+        systemId: "system://acme/system-beta",
+        genesisId: "genesis://acme/system-beta/zero",
+        constitutionRef: "constitution://acme/system-beta/v1",
+        deploymentProfileRef:
+          "deployment-profile://acme/system-beta/local/revision/sha256:" +
+          "d".repeat(64),
+        orderingProfileRef: "ordering-profile://acme/system-beta/poa1",
+        oracleProfileRef:
+          "oracle-evidence-profile://acme/system-beta/public-records",
+        lifecycleProfileRef: "lifecycle-profile://acme/system-beta/default",
+      });
+      alpha = await bootstrapActiveSystem(call, resolver, dataDir, alphaBody);
+      beta = await bootstrapActiveSystem(call, resolver, dataDir, betaBody);
+      if (checkpoint?.mode === "capture") {
+        await captureJourneyCheckpoint({
+          lane: checkpoint,
+          plane,
+          resolver,
+          dataDir,
+          bootstrapOutputs: { alpha, beta },
+        });
+      }
+    }
     ok(
       "M1.6 DUAL GENESIS: one reusable package admits and activates two distinct System identities with distinct live roots",
       alpha.chain.system_id !== beta.chain.system_id &&
@@ -8826,6 +9063,22 @@ async function run() {
         `${FOCUSED_VERIFIER_OPT_IN_ENV}=1 is required to run a non-certifying journey subset`,
       );
     }
+    const checkpointLane = activeCheckpointLane();
+    if (checkpointLane) {
+      if (process.env[CERTIFICATION_MODE_ENV] === "1") {
+        throw new Error(
+          `${CERTIFICATION_MODE_ENV}=1 refuses the checkpoint lane; unset ${CHECKPOINT_DIR_ENV}/${CHECKPOINT_MODE_ENV}`,
+        );
+      }
+      if (
+        selectedJourneys.length !== 1 ||
+        !CHECKPOINT_CAPABLE_JOURNEYS.has(selectedJourneys[0])
+      ) {
+        throw new Error(
+          `the checkpoint lane requires ${JOURNEY_SELECTOR_ENV} to select exactly one checkpoint-capable journey (${[...CHECKPOINT_CAPABLE_JOURNEYS].join(",")})`,
+        );
+      }
+    }
     for (const name of selectedJourneys) {
       const journey = journeys.get(name);
       await executeJourneyWithCensus(name, journey);
@@ -8840,6 +9093,18 @@ async function run() {
     `owned=${ownedResources.size} removed=${[...ownedResources.keys()].filter((path) => !existsSync(path)).length} process_groups=${ownedProcessGroups.size} descendants_remaining=${[...ownedProcessGroups].filter(([processGroupId, startTimeTicks]) => ownedProcessGroupIdentityIsAlive(processGroupId, startTimeTicks)).length}`,
   );
   if (fatal) {
+    if (fatal.checkpointCaptureComplete === true) {
+      const passed = results.filter((result) => result.pass).length;
+      console.log(`${passed}/${results.length} passed`);
+      if (passed !== results.length) {
+        process.exitCode = 1;
+        return;
+      }
+      console.log(
+        `system sequence-zero checkpoint capture: COMPLETE (${fatal.message}; non-certifying lane, held bar not claimed)`,
+      );
+      return;
+    }
     const blocked = String(fatal.message || fatal).startsWith("BLOCKED:");
     console.error(`${blocked ? "BLOCKED" : "VERIFIER CRASH"}:`, fatal);
     process.exitCode = blocked ? 2 : 1;

--- a/docs/architecture/_meta/work-items/m1-5-protected-transitions.v1.json
+++ b/docs/architecture/_meta/work-items/m1-5-protected-transitions.v1.json
@@ -3,7 +3,7 @@
   "work_item_id": "m1-5-protected-transitions",
   "stage_id": "M1",
   "required_work": ["M1.5"],
-  "status": "scoped",
+  "status": "verified",
   "objective": "Distinct protected amendment, migration/succession, suspension, dissolution, and enrollment transitions over the live System chain, each under its own authority path, so protected fields change only through their declared paths. Phased: (b) generic protected operational transitions over the existing LifecycleTransitionReceiptEnvelope at sequence >= 3 with new proposal/decision contracts and a lifecycle-state extension; (c) constitution-amendment execution binding the approved AutonomousSystemConstitutionAmendmentEnvelope decision; (d) migration/succession, dissolution with residual disposition, and local_only network enrollment (named receipt owners).",
   "falsifiable_claim": "A caller holding ordinary lifecycle authority or replaying initialize/activate evidence can never admit a protected transition; each transition kind admits exactly once under its own scope with exact predecessor state root and chain head commitment and reconstructs after restart; no proposal can satisfy its own authority requirement.",
   "canon_owners": [
@@ -11,16 +11,28 @@
     "docs/architecture/foundations/common-objects-and-envelopes.md"
   ],
   "code_anchors": [
-    { "path": "docs/architecture/_meta/schemas/autonomous-system-constitution-amendment.v1.schema.json", "present_when": "merged" }
+    { "path": "docs/architecture/_meta/schemas/autonomous-system-constitution-amendment.v1.schema.json", "present_when": "merged" },
+    { "path": "crates/types/src/app/system_lifecycle_transitions.rs", "must_contain": "compile_protected_transition_plan", "present_when": "merged" },
+    { "path": "crates/types/src/app/system_continuity_transitions.rs", "must_contain": "dissolution_disposes_every_residual_through_the_record_then_completes", "present_when": "merged" },
+    { "path": "crates/node/src/bin/hypervisor_daemon_routes/system_continuity_routes.rs", "must_contain": "dissolution_ladder_artifacts_validate_every_registered_envelope", "present_when": "merged" }
   ],
-  "evidence_refs": [],
-  "pr": null,
-  "adversarial_or_fault_proof": "Predeclared: wrong-scope substitution across all transition kinds; stale predecessor root; replayed bootstrap evidence; protected-path amendment without the required path; transitions against illegal predecessor states per the op-by-state legality matrix; enrollment self-inheritance; restart mid-intent convergence; forged decision refs.",
+  "evidence_refs": [
+    "crates/node/src/bin/hypervisor_daemon_routes/system_protected_transition_routes.rs",
+    "crates/node/src/bin/hypervisor_daemon_routes/system_continuity_routes.rs",
+    "crates/types/src/app/system_lifecycle_transitions.rs",
+    "crates/types/src/app/system_continuity_transitions.rs",
+    "apps/hypervisor/scripts/verify-hypervisor-system-sequence-zero-materialization.mjs",
+    "docs/architecture/_meta/schemas/autonomous-system-constitution-amendment.v1.schema.json",
+    "docs/architecture/_meta/schemas/autonomous-system-dissolution-disposition.v1.schema.json",
+    "docs/architecture/_meta/schemas/autonomous-system-dissolution-receipt.v1.schema.json"
+  ],
+  "pr": 111,
+  "adversarial_or_fault_proof": "Aggregate over three verified children, each with its own retained bar: m1-5b generic protected operational transitions (14 ops, 154-cell legality sweep, scope disjointness, byte-determinism, live protected-transition journey 25/25 inside full suite FULLJ_EXIT=0, PR #103); m1-5c amendment execution (approved-decision binding, constitutional-amendment journey, PR #105); m1-5d migration/succession, dissolution with residual disposition, and local_only enrollment (dissolution-disposition record family with policy-bound domain outcomes, singleton record, receipt union minted exactly once, crash-replay convergence, named-continuity journey 38/38, PR #111). Held-bar closure evidence: the retained full 14-journey certification run (internal-docs/implementation/evidence/M1/system-verifier-certification-run.v1.log, 140/140, CERT_EXIT=0) re-proves the protected-transition, constitutional-amendment, and named-continuity journeys against real-wallet authority in one run; per-child literal-exit evidence files bind to that artifact by sha256. Wrong-scope substitution, stale predecessor roots, replayed bootstrap evidence, illegal-predecessor refusals, enrollment self-inheritance refusal, forged decision refs, and restart mid-intent convergence are each named proofs inside those journeys.",
   "remaining_nonclaims": [
     "No membership/topology (M2), consensus, or product Systems UX beyond pulled read projections.",
     "Enrollment records are local evidence, not IOI Network assurance.",
     "degraded is an observed posture, never an op target."
   ],
-  "source_provenance": "Scoped 2026-07-22 from master guide M1.5, canon owners above, and the PR #97 runtime seam; admission blocks on PR #97 verified.",
-  "last_status_transaction": "2026-07-22"
+  "source_provenance": "Scoped 2026-07-22 from master guide M1.5, canon owners above, and the PR #97 runtime seam; admission blocked on PR #97 verified. Children landed via PRs #103 (m1-5b), #105 (m1-5c), and #111 (m1-5d); aggregate verification binding rebuilt over the three verified children with the retained certification artifact on the program/m1-close cut.",
+  "last_status_transaction": "2026-07-28"
 }


### PR DESCRIPTION
## Close stage M1 — held-bar certification run, checkpoint lane, m1-5 aggregate verified

### What this PR carries
- **Verifier plane-checkpoint lane** (`verify-hypervisor-system-sequence-zero-materialization.mjs` + `lib/wallet-network-principal-authority-fixture.mjs`): opt-in capture/restore of a bootstrapped journey plane behind `IOI_SYSTEM_SEQUENCE_ZERO_CHECKPOINT_DIR`/`_MODE`, per-journey keyed (currently `dual-system-projection` only), requiring the focused non-certifying opt-in. Certification mode structurally refuses the lane; with the envs unset every code path is byte-identical; child planes have the envs scrubbed. Fixture gains two additive options (`resumeResourceDir`, `stop({preserveResourceDir})`) with no validation weakened. Proven: capture 21/21 (exit 0, clean teardown), restore 27/27 in 3m09s against the ~hour bootstrap baseline, byte-exact projection rebuild from the restored plane.
- **`docs/architecture/_meta/work-items/m1-5-protected-transitions.v1.json` → `verified`**: the M1.5 aggregate closes over its three verified children — m1-5b (PR #103), m1-5c (PR #105), m1-5d (PR #111) — with the aggregate verification binding rebuilt over per-child retained literal-exit evidence. Tracked record is the status authority; the private mirror adopted via `tools/reconcile-status.mjs` (ledgered).

### Held-bar evidence (retained in the program estate)
- Full 14-journey certification run: **140/140, `CERT_EXIT=0`**, "system sequence-zero materialization held bar: PASS" — real-wallet authority, exact durable evidence, teardown 45/45 owned resources across 21 process groups. Retained as `internal-docs/implementation/evidence/M1/system-verifier-certification-run.v1.log`; every M1 child literal binds to it by sha256.
- Genesis product journey: **30/30, `PJ_EXIT=0`** (compact/advanced/restart/two-System operator matrix; no UI-derived truth; cross-System bleed refused; premature activation refused), retained alongside.
- Stage certification: `tools/certify-stage.mjs M1 --apply` — every child verified under its own status authority with its retained literal present exactly once; aggregate exit record `m1-selected-profile-exit-proof` minted `M1_EXIT=0` without manufacturing status.


### Also in this cut
- `verify-hypervisor-system-genesis-admission.mjs`: three stale compile-output pins (proposalRoot/bundleRoot/operationCommitment) corrected to the values the Rust golden tests and the live admitted record independently attest; full bar re-proven **40/40, `GA_EXIT=0`** on a quiet box and retained. Two transient wallet-binding failures on a loaded box did not reproduce.
- Stage-module focused-check list corrected per the M0 doctrine ("a command that cannot pass as invoked is a defect in whatever names it"): the always-exits-2 bare `certify-stage.mjs` self-call removed; the hour-scale journey verifiers moved from capped inline subprocesses to their retained held-bar artifacts.

### Record closures in this cut (estate side, gitignored by design)
`m1-genesis-admission`, `m1-governed-initialize-activate`, `m1-sequence-zero-materialization` (evidence retention), `m1-dual-genesis-and-read-projection` (proposed→verified), `m1-system-genesis-product-journey` (proposed→verified), `m1-5-protected-transitions` (aggregate re-bind + verified), `m1-selected-profile-exit-proof` (stage aggregate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
