### PR TITLE
fix: remove tracked node_modules symlink from the wave merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ diff_snapshot.md
 ioi-data/
 /.agents/
 ./ioi-data/
-node_modules/
+node_modules
 dist/
 .DS_Store
 .tmp/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/heathledger/Documents/ioi/repos/ioi/node_modules


### PR DESCRIPTION
A worktree convenience symlink slipped past the directory-only ignore pattern (`node_modules/` matches directories, not symlinks) via `git add -A` in the wave integration merge, materializing as a self-referential link on fresh checkouts. Removes the tracked link and drops the trailing slash so the pattern covers symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)