### PR TITLE
fix(services): repair the three excluded test failures — all were real regressions

### DIFF
--- a/crates/services/src/agentic/runtime/execution/system/sys_exec.rs
+++ b/crates/services/src/agentic/runtime/execution/system/sys_exec.rs
@@ -85,9 +85,17 @@ pub(super) async fn handle_sys_exec(
 
     let mut retained_snapshot: Option<RetainedCommandSnapshot> = None;
 
-    let result = if let Some(sleep_secs) =
+    // The foreground-sleep guard only applies to fully blocking launches. When the
+    // caller requests an async boundary (`wait_ms_before_async`), the command is
+    // retained after the boundary and cannot block the agent loop — that IS the
+    // "retained shell/session command" path this guard's error message recommends.
+    let blocking_foreground_sleep = if wait_ms_before_async.is_none() {
         foreground_sleep_duration_seconds(&invocation.command, &invocation.args, detach)
-    {
+    } else {
+        None
+    };
+
+    let result = if let Some(sleep_secs) = blocking_foreground_sleep {
         let mut result = ToolExecutionResult::failure(format!(
             "ERROR_CLASS=TimeoutOrHang Foreground sleep command would block for {} second(s). Re-run with detach=true or use a retained shell/session command.",
             sleep_secs

--- a/crates/services/src/agentic/runtime/execution/system/tests.rs
+++ b/crates/services/src/agentic/runtime/execution/system/tests.rs
@@ -971,7 +971,11 @@ async fn shell_terminate_stops_retained_command() {
     )
     .await;
 
-    assert!(result.success);
+    assert!(
+        result.success,
+        "retained launch should succeed: error={:?}",
+        result.error
+    );
     let launch_payload = retained_payload(&result);
     let command_id = launch_payload
         .get("command_id")

--- a/crates/services/src/agentic/runtime/kernel/policy/thread_lifecycle.rs
+++ b/crates/services/src/agentic/runtime/kernel/policy/thread_lifecycle.rs
@@ -5311,9 +5311,23 @@ mod tests {
             .run
             .get("skill_hook_materialization_request")
             .is_none());
+        // Manifest id contract: `skill_hook_manifest_{run_id}_{manifestHash[..12]}`
+        // (content-addressed suffix from the materializer). The runtime task record
+        // must link to exactly that manifest id.
+        let manifest_hash = record.run["activeSkillHookManifest"]["manifestHash"]
+            .as_str()
+            .expect("manifest hash");
+        let expected_manifest_id = format!(
+            "skill_hook_manifest_run_create_one_{}",
+            &manifest_hash[..12]
+        );
+        assert_eq!(
+            record.run["activeSkillHookManifest"]["manifestId"],
+            Value::String(expected_manifest_id.clone())
+        );
         assert_eq!(
             record.run["runtimeTask"]["activeSkillHookManifestId"],
-            "skill_hook_manifest_run_create_one"
+            Value::String(expected_manifest_id)
         );
         assert!(record.run["runtimeTask"]["evidenceRefs"]
             .as_array()

--- a/crates/services/src/agentic/runtime/tools/contracts.rs
+++ b/crates/services/src/agentic/runtime/tools/contracts.rs
@@ -594,6 +594,9 @@ fn primitive_capabilities_for(policy_target: &str) -> Vec<String> {
         "fs::read" => Some("prim:fs.read"),
         "fs::write" => Some("prim:fs.write"),
         _ if policy_target.starts_with("file__") => Some("prim:fs.write"),
+        // Accepting a change writes the accepted content to the target path, the
+        // same filesystem primitive as rollback restoring the prior content.
+        "workspace_change::accept" => Some("prim:fs.write"),
         "workspace_change::rollback" => Some("prim:fs.write"),
         "workspace_change::reject" => Some("prim:runtime.control"),
         "sys::exec" | "software::install_execute" => Some("prim:sys.exec"),
@@ -764,6 +767,22 @@ mod tests {
     fn workspace_change_rollback_contract_is_filesystem_mutation_by_handle() {
         let contract = runtime_tool_contract_for_definition(&tool("workspace_change__rollback"));
         assert_eq!(contract.policy_target, "workspace_change::rollback");
+        assert!(contract.is_effectful());
+        assert_eq!(contract.primitive_capabilities, vec!["prim:fs.write"]);
+        assert!(contract
+            .approval_scope_fields
+            .iter()
+            .any(|item| item == "change_id"));
+        assert!(contract
+            .evidence_requirements
+            .iter()
+            .any(|item| item == "diff_summary"));
+    }
+
+    #[test]
+    fn workspace_change_accept_contract_is_filesystem_mutation_by_handle() {
+        let contract = runtime_tool_contract_for_definition(&tool("workspace_change__accept"));
+        assert_eq!(contract.policy_target, "workspace_change::accept");
         assert!(contract.is_effectful());
         assert_eq!(contract.primitive_capabilities, vec!["prim:fs.write"]);
         assert!(contract


### PR DESCRIPTION
Root-caused all three tests excluded by name in the M2 stage module. **None was host-specific** — the earlier environment-contamination disposition was wrong; all three are deterministic and provable from git history:

1. `shell_terminate_stops_retained_command` — the foreground-sleep guard (9c9f61c68) ignored `wait_ms_before_async`, refusing the exact retained async path its own error message recommends. Product fix: guard applies only when no async boundary is requested.
2. `rust_policy_materializes_skill_hook_run_create_truth` — literal id assertion never matched the materializer's `{run_id}_{manifestHash[..12]}` contract introduced the same day (born broken). Replaced with the exact structural derivation plus cross-record linkage — strictly stronger.
3. `builtin_tools_project_complete_runtime_contracts` — `workspace_change__accept` is effectful but carried no primitive capabilities; it literally writes accepted content to disk. Product fix: map to `prim:fs.write` (matching rollback) + new unit test.

Full suite: **3483 passed, 0 failed** + all 9 integration binaries green. The by-name exclusions in the stage module are lifted in the estate alongside this landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)