### PR TITLE
safety: emergency containment and claim downscope

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-byo-provider-plane.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-byo-provider-plane.mjs
@@ -271,8 +271,19 @@ async function run() {
     && cls["byo-ssh-node"]?.provider_eligibility?.credential_kind === "ssh_key"
     && cls["byo-ssh-node"]?.provider_eligibility?.spend_posture === "customer_borne_byo"
     && (cls["byo-ssh-node"]?.provider_eligibility?.required_capabilities || []).includes("ssh"));
-  ok("class enabled-honesty: microvm gap fixed; vm/devcontainer honestly disabled (no real path)",
-    cls["microvm"]?.enabled === true && cls["microvm"]?.enabled_backing?.real === true
+  // EVIDENCE QUARANTINE (emergency containment): the microVM half of this bar used to assert
+  // `cls["microvm"].enabled === true && enabled_backing.real === true` against a handler arm
+  // that was an unconditional constant. It tested a literal, could never fail, and carried zero
+  // information about isolation availability — while being labelled "enabled-honesty". That
+  // sub-claim is NON-AUTHORITATIVE and must not be cited as evidence that a microVM lane is
+  // operational. The handler now probes the pinned, checksum-verified VM toolchain, so the
+  // honest bar is that the reported value MATCHES the probe — on a host with no toolchain the
+  // correct answer is `enabled: false` with a named reason, and that must PASS.
+  ok("class enabled-honesty: microvm enablement is probe-derived (not asserted); vm/devcontainer honestly disabled",
+    typeof cls["microvm"]?.enabled === "boolean"
+    && cls["microvm"]?.enabled === cls["microvm"]?.enabled_backing?.real
+    && (cls["microvm"]?.enabled === true
+        || typeof cls["microvm"]?.enabled_backing?.unavailable_reason === "string")
     && cls["local-workspace-v0"]?.enabled === true
     && cls["vm"]?.enabled === false && cls["vm"]?.enabled_backing?.real === false
     && cls["devcontainer"]?.enabled === false);

--- a/crates/node/src/bin/hypervisor_daemon_routes/binding_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/binding_routes.rs
@@ -23,6 +23,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::extract::{Path as AxumPath, Query, State};
 use axum::Json;
+use ioi_services::agentic::runtime::kernel::emergency_containment::{
+    admit_isolated_execution, DeclaredIsolation, ExecutionLocus, IsolatedSubstrate,
+};
 use serde_json::{json, Value};
 
 use super::{iso_now, persist_record, read_record_dir, DaemonState};
@@ -390,6 +393,27 @@ pub(crate) async fn handle_terminal_create(
         .or_else(|| sstr(&body, "environment_id"))
         .unwrap_or_default();
     let env_id = ref_id(&env_ref).to_string();
+
+    // CONTAINMENT: this route spawns an interactive HOST shell (a real PTY, caller-chosen
+    // binary, no guardrail deny-list) and attributes it to an environment. When that environment
+    // declared a `vm_kernel` isolation floor, a host PTY cannot honour it, so it is refused by
+    // name. A process-scoped environment is unaffected — there the label already matches reality.
+    if let Some(env) = load_env(&st.data_dir, &env_id) {
+        let live = st.live_vms.lock().unwrap().contains_key(&env_id);
+        if let Err(refusal) = admit_isolated_execution(
+            DeclaredIsolation::from_env_status(&env["status"]),
+            IsolatedSubstrate::observed(live),
+            ExecutionLocus::Host,
+        ) {
+            return Json(json!({
+                "ok": false,
+                "refused": true,
+                "reason": refusal.reason,
+                "detail": refusal.detail,
+            }));
+        }
+    }
+
     let cwd = match sstr(&body, "cwd").or_else(|| workspace_of(&st.data_dir, &env_id)) {
         Some(c) => c,
         None => {

--- a/crates/node/src/bin/hypervisor_daemon_routes/editor_host.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/editor_host.rs
@@ -293,10 +293,29 @@ pub(crate) async fn start_oss_runtime(
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
     let Some(version) = version else {
+        // CONTAINMENT (cleanup availability): the launcher shell forks the server WITHOUT exec,
+        // so killing only the shell orphaned the child, which kept holding the port. On this path
+        // the runtime was never registered in `st.editor_runtimes`, so `stop_oss_runtime` could
+        // not reach it either — a resource created that nothing could destroy. Kill the whole
+        // process GROUP here, exactly as `stop_oss_runtime` already does on the happy path, and
+        // report whether the group is provably gone rather than assuming it.
         let mut child = child;
+        let pid = child.id() as libc::pid_t;
+        // SAFETY: a negative pid signals the process group the launcher created with setsid.
+        unsafe {
+            libc::kill(-pid, libc::SIGKILL);
+        }
         let _ = child.kill();
         let _ = child.wait();
-        return Err(format!("openvscode-server did not report /version on 127.0.0.1:{port} within timeout (see {log_path})"));
+        let group_gone = unsafe { libc::kill(-pid, 0) } != 0;
+        let cleanup = if group_gone {
+            "process group reaped"
+        } else {
+            "process group MAY still hold the port — cleanup unverified"
+        };
+        return Err(format!(
+            "openvscode-server did not report /version on 127.0.0.1:{port} within timeout ({cleanup}; see {log_path})"
+        ));
     };
 
     st.editor_runtimes.lock().unwrap().insert(

--- a/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
@@ -12,6 +12,11 @@ use std::sync::Arc;
 use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
+use ioi_services::agentic::runtime::kernel::emergency_containment::{
+    admit_cache_path, admit_cache_scope, admit_isolated_execution, close_deletion,
+    truthful_isolation_label, unsafe_path_gate, DeclaredIsolation, DeletionOutcome, ExecutionLocus,
+    IsolatedSubstrate, UNVERIFIED_WORKSPACE_RESTORE_GATE,
+};
 use ioi_types::app::agentic::InferenceOptions;
 use serde_json::{json, Value};
 
@@ -1115,40 +1120,82 @@ fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result
     Ok(())
 }
 
-fn recipe_cache_dir(data_dir: &str, recipe_ref: &str) -> std::path::PathBuf {
+/// The owning scope segment of a recipe cache.
+///
+/// CONTAINMENT: the cache used to be keyed on `recipe_ref` ALONE, so every System/tenant on the
+/// node sharing a recipe also shared one cache directory — and the restored content is then
+/// executed by the prebuild/init tasks. That is a cross-tenant cache-poisoning to code-execution
+/// primitive. The owning scope is now part of the key, and a recipe with no owning scope is
+/// refused rather than silently pooled into a shared cache.
+fn recipe_cache_scope(recipe: &Value) -> Option<String> {
+    for key in ["system_ref", "system_id", "owner_ref", "account_ref"] {
+        if let Some(scope) = recipe.get(key).and_then(|v| v.as_str()) {
+            if let Ok(scope) = admit_cache_scope(Some(scope)) {
+                return Some(scope);
+            }
+        }
+    }
+    None
+}
+
+fn recipe_cache_dir(data_dir: &str, recipe_ref: &str, scope: &str) -> std::path::PathBuf {
     std::path::Path::new(data_dir)
         .join("recipe-cache")
+        .join(safe_id(scope))
         .join(safe_id(recipe_ref))
 }
 
-/// Restore the recipe's declared `cache_paths` from the recipe-keyed cache into the workspace
+/// Admit the recipe's declared `cache_paths`, dropping any that is absolute or escapes the root.
+///
+/// CONTAINMENT: `Path::join` does not normalize. A `cache_paths` entry of `"/root/.ssh"` made
+/// `join` discard the base entirely, and `"../../environments/<other>/workspace"` walked out of
+/// both the cache dir and the workspace. Entries are validated before use.
+fn admitted_cache_paths(recipe: &Value) -> Vec<String> {
+    recipe
+        .get("cache_paths")
+        .and_then(|v| v.as_array())
+        .map(|paths| {
+            paths
+                .iter()
+                .filter_map(|p| p.as_str())
+                .filter(|rel| admit_cache_path(rel).is_ok())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Restore the recipe's declared `cache_paths` from the scope-keyed cache into the workspace
 /// (warmup). Returns (cache_hit, restored_paths) — a second env from the same recipe is faster.
 fn restore_recipe_cache(data_dir: &str, recipe: &Value, ws: &str) -> (bool, Vec<String>) {
     let recipe_ref = recipe["recipe_ref"].as_str().unwrap_or("");
-    let cache = recipe_cache_dir(data_dir, recipe_ref);
+    let Some(scope) = recipe_cache_scope(recipe) else {
+        // Unattributed cache: refuse to read it rather than serve another tenant's bytes.
+        return (false, Vec::new());
+    };
+    let cache = recipe_cache_dir(data_dir, recipe_ref, &scope);
     let mut hit = Vec::new();
-    if let Some(paths) = recipe.get("cache_paths").and_then(|v| v.as_array()) {
-        for rel in paths.iter().filter_map(|p| p.as_str()) {
-            let src = cache.join(rel);
-            if src.exists() {
-                let _ = copy_dir_all(&src, &std::path::Path::new(ws).join(rel));
-                hit.push(rel.to_string());
-            }
+    for rel in admitted_cache_paths(recipe) {
+        let src = cache.join(&rel);
+        if src.exists() {
+            let _ = copy_dir_all(&src, &std::path::Path::new(ws).join(&rel));
+            hit.push(rel);
         }
     }
     (!hit.is_empty(), hit)
 }
 
-/// Save the recipe's `cache_paths` from the workspace into the recipe-keyed cache (after prebuild).
+/// Save the recipe's `cache_paths` from the workspace into the scope-keyed cache (after prebuild).
 fn save_recipe_cache(data_dir: &str, recipe: &Value, ws: &str) {
     let recipe_ref = recipe["recipe_ref"].as_str().unwrap_or("");
-    let cache = recipe_cache_dir(data_dir, recipe_ref);
-    if let Some(paths) = recipe.get("cache_paths").and_then(|v| v.as_array()) {
-        for rel in paths.iter().filter_map(|p| p.as_str()) {
-            let src = std::path::Path::new(ws).join(rel);
-            if src.exists() {
-                let _ = copy_dir_all(&src, &cache.join(rel));
-            }
+    let Some(scope) = recipe_cache_scope(recipe) else {
+        return;
+    };
+    let cache = recipe_cache_dir(data_dir, recipe_ref, &scope);
+    for rel in admitted_cache_paths(recipe) {
+        let src = std::path::Path::new(ws).join(&rel);
+        if src.exists() {
+            let _ = copy_dir_all(&src, &cache.join(&rel));
         }
     }
 }
@@ -1261,6 +1308,22 @@ fn export_guest_workspace(st: &DaemonState, env_id: &str, ws: &str) -> Result<()
     let vm = vms
         .get(env_id)
         .ok_or_else(|| AppError(StatusCode::CONFLICT, "no live microVM for env".into()))?;
+    // CONTAINMENT: the guest is the UNTRUSTED party — this environment is labelled
+    // `trust_posture: untrusted_code_capable`. These bytes are guest-authored, carry no digest
+    // the daemon admitted beforehand, and are extracted onto the HOST filesystem with no
+    // member-level traversal/symlink/permission guard. That is an unverified-provenance restore
+    // across the isolation boundary, so it is gated behind an explicit opt-in that defaults OFF.
+    if let Err(refusal) = unsafe_path_gate(
+        UNVERIFIED_WORKSPACE_RESTORE_GATE,
+        std::env::var(UNVERIFIED_WORKSPACE_RESTORE_GATE)
+            .ok()
+            .as_deref(),
+    ) {
+        return Err(AppError(
+            StatusCode::CONFLICT,
+            format!("{}: {}", refusal.reason, refusal.detail),
+        ));
+    }
     let tar = monitor.export_workspace(vm).map_err(|e| {
         AppError(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1276,14 +1339,57 @@ fn export_guest_workspace(st: &DaemonState, env_id: &str, ws: &str) -> Result<()
     Ok(())
 }
 
-/// Shut down + remove an env's live microVM if present (idempotent). Teardown leaves no orphan VM.
-fn teardown_microvm(st: &DaemonState, env_id: &str) {
-    use super::microvm::{CloudHypervisorMonitor, VmMonitor};
+/// Shut down + remove an env's live microVM if present (idempotent).
+///
+/// CARVE-OUT: deletion of an EXISTING resource always remains callable — this function never
+/// refuses. What containment changes is HONESTY. It previously discarded the stop result
+/// (`let _ = ...`) and the doc claimed "leaves no orphan VM", which the code never verified.
+/// It now returns an exact `succeeded | failed | unknown` disposition and opens a durable
+/// cleanup obligation whenever the outcome is not `succeeded`. `unknown` is first-class: the
+/// monitor's `stop` cannot prove the guest process is gone, so a stop that merely returned Ok
+/// is `unknown`, never `succeeded`.
+fn teardown_microvm(st: &DaemonState, env_id: &str) -> Value {
+    let resource_ref = format!("microvm://environment/{env_id}");
     let mut vm = match st.live_vms.lock().unwrap().remove(env_id) {
         Some(v) => v,
-        None => return,
+        // Nothing live to tear down: the resource is observably absent from this daemon.
+        None => return close_deletion(&resource_ref, DeletionOutcome::Succeeded).to_json(),
     };
-    let _ = CloudHypervisorMonitor.stop(&mut vm);
+    // CONTAINMENT (cleanup availability): teardown used to hardcode `CloudHypervisorMonitor`
+    // even for a VM booted under QEMU or Firecracker. `QemuMonitor` overrides `connect` to use
+    // AF_VSOCK while the default uses a UDS, so the graceful shutdown byte was written to the
+    // wrong transport and never reached those guests. Resolve the monitor that actually booted
+    // this VM from the environment record so graceful stop reaches the right guest.
+    let monitor_id = load_env(&st.data_dir, env_id)
+        .and_then(|env| env["status"]["vm"]["monitor"].as_str().map(str::to_string))
+        .unwrap_or_else(|| "cloud-hypervisor".to_string());
+    let monitor = super::microvm::make_monitor(&monitor_id);
+    let pid = vm.pid;
+    let call_succeeded = monitor.stop(&mut vm).is_ok();
+    // Re-observe: proof of absence is the process no longer existing, not the call returning.
+    let proven_absent = !process_alive(pid);
+    close_deletion(
+        &resource_ref,
+        DeletionOutcome::classify(call_succeeded, proven_absent),
+    )
+    .to_json()
+}
+
+/// Post-teardown observation: is the monitor process still present?
+///
+/// `kill(pid, 0)` reports liveness without signalling. An error other than "no such process"
+/// (e.g. EPERM) means we genuinely do not know, so it reports alive and the outcome degrades to
+/// `unknown` rather than a false `succeeded`.
+fn process_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    // SAFETY: signal 0 performs error checking only; it never delivers a signal.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
 }
 
 // ---- WS-7: stop / idle / activity policy ----
@@ -1312,7 +1418,9 @@ fn stop_environment(st: &DaemonState, env: &mut Value, id: &str, condition_kind:
         "info",
         &format!("stopping ({mode}): {msg}"),
     );
-    teardown_microvm(st, id); // graceful poweroff + socket cleanup (no orphan VM)
+    // CARVE-OUT: stop always runs. Its exact outcome is recorded rather than assumed.
+    let disposition = teardown_microvm(st, id);
+    record_cleanup_disposition(st, env, &disposition);
     for c in [
         "sandbox",
         "resource_isolation",
@@ -1324,14 +1432,53 @@ fn stop_environment(st: &DaemonState, env: &mut Value, id: &str, condition_kind:
     }
     set_phase(env, "stopped");
     recompute_readiness(env);
+    // CLAIM TRUTH: "no orphans" used to be asserted unconditionally while the stop result was
+    // discarded. The message now reports the measured teardown outcome.
+    let outcome = disposition["outcome"].as_str().unwrap_or("unknown");
     observe(
         env,
         "stopping",
         "provisioner",
         condition_kind,
         "info",
-        "environment stopped (workspace retained, no orphans)",
+        &format!("environment stopped (workspace retained; microVM teardown: {outcome})"),
     );
+}
+
+/// Record one cleanup disposition on the environment record.
+///
+/// CARVE-OUT SUPPORT: a non-`succeeded` deletion opens a DURABLE cleanup obligation that
+/// survives on the record. Obligations accumulate and are never erased by a later teardown —
+/// only an explicit receipted disposition may close one.
+fn record_cleanup_disposition(st: &DaemonState, env: &mut Value, disposition: &Value) {
+    env["status"]["last_cleanup_disposition"] = disposition.clone();
+    if disposition["cleanup_obligation_ref"].is_null() {
+        return;
+    }
+    if !env["status"]["cleanup_obligations"].is_array() {
+        env["status"]["cleanup_obligations"] = json!([]);
+    }
+    let obligation = json!({
+        "cleanup_obligation_ref": disposition["cleanup_obligation_ref"],
+        "resource_ref": disposition["resource_ref"],
+        "outcome": disposition["outcome"],
+        "status": "pending",
+        "detail": disposition["detail"],
+        "opened_at": iso_now(),
+    });
+    env["status"]["cleanup_obligations"]
+        .as_array_mut()
+        .expect("cleanup_obligations initialized as an array above")
+        .push(obligation.clone());
+    // Durable beyond the environment record: an obligation must survive parent deletion.
+    if let Some(id) = disposition["cleanup_obligation_ref"].as_str() {
+        let _ = persist_record(
+            &st.data_dir,
+            "cleanup-obligations",
+            &safe_id(id),
+            &obligation,
+        );
+    }
 }
 
 // ---- WS-9: provider failure recovery (incident → candidate → attempt → reconcile → receipts) ----
@@ -1550,7 +1697,26 @@ pub(crate) async fn handle_environment_classes(State(st): State<Arc<DaemonState>
             let id = record["id"].as_str().unwrap_or("").to_string();
             let (enabled, backing) = match id.as_str() {
                 "local-workspace-v0" => (true, json!({ "path": "local host workspace", "real": true })),
-                "microvm" => (true, json!({ "path": "VmMonitor lane (cloud-hypervisor primary; QEMU/Firecracker)", "real": true, "honesty_note": "previously mislabeled enabled:false while the lane was operational" })),
+                // CONTAINMENT (claim truth): this arm was the unconditional constant
+                // `(true, {"real": true})`. It probed nothing, so on a host with no monitor
+                // binary and no pinned VM toolchain the daemon still advertised
+                // `microvm: enabled=true, real=true` — violating this handler's own stated
+                // honesty rule that "a class is enabled only when a real provider/account path
+                // backs it". Enablement is now MEASURED by resolving the pinned, checksum-verified
+                // toolchain that `build_vm_spec` actually requires.
+                "microvm" => {
+                    let toolchain = super::microvm::resolve_toolchain(&st.home_dir);
+                    let operational = toolchain.is_ok();
+                    (
+                        operational,
+                        json!({
+                            "path": "VmMonitor lane (cloud-hypervisor primary; QEMU/Firecracker)",
+                            "real": operational,
+                            "probe": "resolve_toolchain (pinned supply-manifest + sha256 re-hash)",
+                            "unavailable_reason": toolchain.err(),
+                        }),
+                    )
+                }
                 "byo-ssh-node" => (
                     verified_ssh_accounts > 0,
                     json!({ "path": "verified baremetal_ssh ProviderAccount(s)", "verified_accounts": verified_ssh_accounts, "real": verified_ssh_accounts > 0 }),
@@ -2222,10 +2388,24 @@ pub(crate) async fn handle_environment_action(
 
             // WS-10 — record the resource isolation + connectivity profiles (microVM cpu/mem are
             // monitor-enforced; ports namespace-isolated in-guest).
+            //
+            // CONTAINMENT (claim truth): these profiles are keyed on `microvm_ok` — the MEASURED
+            // boot outcome — not on `is_microvm`, the declaration. Previously a microVM whose boot
+            // FAILED still published `enforcement: "vm_kernel (monitor-enforced cpu/mem)"` and
+            // `namespace_isolated: true`, which no longer held. A declared-but-unbooted
+            // environment now reports the weaker truth and carries a withdrawn-label marker.
             env["status"]["resource_isolation_profile"] =
-                resource_isolation_profile(is_microvm, 2, 1024);
+                resource_isolation_profile(microvm_ok, 2, 1024);
             env["status"]["connectivity_profile"] =
-                connectivity_profile(recipe.as_ref(), is_microvm);
+                connectivity_profile(recipe.as_ref(), microvm_ok);
+            env["status"]["measured_isolation"] = json!(truthful_isolation_label(
+                if is_microvm {
+                    DeclaredIsolation::VmKernel
+                } else {
+                    DeclaredIsolation::ProcessScoped
+                },
+                IsolatedSubstrate::observed(microvm_ok),
+            ));
 
             // WS-3 — typed Services / Tasks / Ports. If a recipe is bound, resolve it, RUN its
             // tasks (in-guest for microVM, on the host for local), build typed services/ports, and
@@ -2427,8 +2607,15 @@ pub(crate) async fn handle_environment_action(
             );
         }
         "delete" => {
+            // CARVE-OUT: deletion of an EXISTING environment REMAINS CALLABLE under every
+            // containment in this cut. It never refuses. It returns an exact
+            // `succeeded | failed | unknown` outcome and opens a durable cleanup obligation
+            // whenever the outcome is not `succeeded`, so an operator is never stranded with a
+            // resource they cannot delete — and never told a resource is gone when it may not be.
             set_phase(&mut env, "stopping");
-            teardown_microvm(&st, &id);
+            let disposition = teardown_microvm(&st, &id);
+            record_cleanup_disposition(&st, &mut env, &disposition);
+            env["status"]["deletion_outcome"] = disposition["outcome"].clone();
             let dir = std::path::Path::new(&st.data_dir)
                 .join("environments")
                 .join(safe_id(&id));
@@ -2440,19 +2627,23 @@ pub(crate) async fn handle_environment_action(
             env["status"]["deleted"] = json!(true);
             set_phase(&mut env, "deleted"); // terminal — not "stopped" (the env is gone, not idle)
             recompute_readiness(&mut env);
+            let outcome = disposition["outcome"].as_str().unwrap_or("unknown");
             observe(
                 &mut env,
                 "deleting",
                 "storage",
                 "state_wiped",
                 "info",
-                "environment deleted (scoped workspace removed)",
+                &format!(
+                    "environment deleted (scoped workspace removed; microVM teardown: {outcome})"
+                ),
             );
         }
         "inject-failure" => {
             // WS-9: simulate a provider crash — kill the VM out-of-band; the env still believes
             // it is running until recovery reconciles. The HOST workspace + branches are untouched.
-            teardown_microvm(&st, &id);
+            let disposition = teardown_microvm(&st, &id);
+            record_cleanup_disposition(&st, &mut env, &disposition);
             set_component(
                 &mut env,
                 "sandbox",
@@ -2859,6 +3050,29 @@ pub(crate) async fn handle_workspace_exec(
 
     // WS-4: if a live microVM backs this env, the terminal runs IN-GUEST (real kernel boundary).
     let in_guest = st.live_vms.lock().unwrap().contains_key(env_id);
+
+    // CONTAINMENT: an environment that DECLARED a vm_kernel isolation floor must never silently
+    // execute on the host when its guest is gone (daemon restart, VM crash, teardown). Previously
+    // this fell through to `bash -lc` on the host while the durable record still advertised
+    // `minimum_isolation: vm_kernel`. Refuse by name instead of falling back.
+    if let Err(refusal) = admit_isolated_execution(
+        DeclaredIsolation::from_env_status(&env["status"]),
+        IsolatedSubstrate::observed(in_guest),
+        ExecutionLocus::Guest,
+    ) {
+        return Ok(Json(json!({
+            "ok": false,
+            "refused": true,
+            "reason": refusal.reason,
+            "detail": refusal.detail,
+            "executed": false,
+            "executed_in": "none",
+            "exit_code": 126,
+            "stdout": "",
+            "stderr": "isolation required but no isolated substrate is live (fail-closed)"
+        })));
+    }
+
     let (stdout, stderr, exit_code) = if in_guest {
         use super::microvm::{CloudHypervisorMonitor, VmMonitor};
         let vms = st.live_vms.lock().unwrap();
@@ -3114,10 +3328,15 @@ pub(crate) async fn handle_env_config(
 ///
 /// This is the real Build-Rule inner loop. The daemon's model route (`hypervisor:native-fixture`
 /// offline; a mounted model when present) generates content; the child harness writes it as a
-/// REAL edit on the WorkRun's scoped patch branch and commits under a child identity. The host
-/// repo is never touched — all mutation is confined to the environment's scoped workspace, so
-/// `host_mutation` stays false and the turn is recorded `review_state: proposed` for the
-/// operator/authority gate (daemon EXECUTES · wallet AUTHORIZES the eventual merge crossing).
+/// REAL edit on the WorkRun's scoped patch branch and commits under a child identity.
+///
+/// CLAIM TRUTH: this turn executes ON THE HOST — host `git` subprocesses and a host
+/// `std::fs::write`. The IOI source repo is not touched and mutation is confined to the
+/// environment's scoped workspace, but that is `host_repo_mutation: false`, NOT
+/// `host_mutation: false`. The record reports both, measured rather than asserted (INV-38).
+/// An environment that declared a `vm_kernel` isolation floor refuses this route outright.
+/// The turn is recorded `review_state: proposed` for the operator/authority gate
+/// (daemon EXECUTES · wallet AUTHORIZES the eventual merge crossing).
 pub(crate) async fn handle_workrun_execute(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
@@ -3146,6 +3365,21 @@ pub(crate) async fn handle_workrun_execute(
         })?
         .to_string();
     let branch = wr["branch"].as_str().unwrap_or("HEAD").to_string();
+
+    // CONTAINMENT: this turn executes host-side — host `git` processes and a host
+    // `std::fs::write` against the scoped workspace. That cannot honour a declared vm_kernel
+    // isolation floor, so an environment that declared one refuses here rather than executing
+    // host-side and then recording `host_mutation: false`.
+    if let Err(refusal) = admit_isolated_execution(
+        DeclaredIsolation::from_env_status(&env["status"]),
+        IsolatedSubstrate::observed(st.live_vms.lock().unwrap().contains_key(&env_id)),
+        ExecutionLocus::Host,
+    ) {
+        return Err(AppError(
+            StatusCode::CONFLICT,
+            format!("{}: {}", refusal.reason, refusal.detail),
+        ));
+    }
 
     // Ensure we are on the WorkRun's scoped patch branch — never the host repo, never main.
     run_git(&ws, &["checkout", "-q", &branch]).map_err(|e| {
@@ -3272,7 +3506,14 @@ pub(crate) async fn handle_workrun_execute(
         "output_preview": preview,
         "file_changed": rel,
         "commit": commit,
-        "host_mutation": false,
+        // CONTAINMENT (claim truth): this turn wrote to the host filesystem and ran host `git`
+        // processes. The former hardcoded `host_mutation: false` asserted a fact the code never
+        // measured (INV-37). What is actually true is narrower: the IOI source repo was not
+        // touched; the scoped workspace on the host WAS.
+        "host_mutation": true,
+        "host_mutation_scope": "environment_scoped_workspace",
+        "host_repo_mutation": false,
+        "executed_in": "host",
         "at": now
     });
     if !wr["turns"].is_array() {
@@ -3290,7 +3531,11 @@ pub(crate) async fn handle_workrun_execute(
     wr["route_id"] = json!(route.route_id);
     wr["head_commit"] = json!(commit);
     wr["working_tree_clean"] = json!(dirty.is_empty());
-    wr["host_mutation"] = json!(false);
+    // CONTAINMENT (claim truth): measured, not asserted — see the turn record above.
+    wr["host_mutation"] = json!(true);
+    wr["host_mutation_scope"] = json!("environment_scoped_workspace");
+    wr["host_repo_mutation"] = json!(false);
+    wr["executed_in"] = json!("host");
     wr["updated_at"] = json!(now);
     persist_record(&st.data_dir, "workruns", &id, &wr).map_err(|e| {
         AppError(
@@ -3300,4 +3545,197 @@ pub(crate) async fn handle_workrun_execute(
     })?;
 
     Ok(Json(json!({ "workRun": wr, "turn": turn })))
+}
+
+#[cfg(test)]
+mod containment_tests {
+    use super::*;
+
+    fn microvm_env_status() -> Value {
+        json!({
+            "minimum_isolation": "vm_kernel",
+            "substrate": "microvm",
+            "isolation_claim": "cross_tenant_capable",
+            "trust_posture": "untrusted_code_capable",
+        })
+    }
+
+    fn local_env_status() -> Value {
+        json!({
+            "minimum_isolation": "process + scoped worktree/runtime state",
+            "substrate": "local_host",
+            "isolation_claim": "not_cross_tenant",
+        })
+    }
+
+    // ---- isolation: refuse, never fall back ----
+
+    #[test]
+    fn exec_refuses_host_fallback_when_a_declared_microvm_is_not_live() {
+        // This is the exec route's decision, extracted: previously the same inputs fell through
+        // to `bash -lc` on the host while the record still advertised vm_kernel isolation.
+        let refusal = admit_isolated_execution(
+            DeclaredIsolation::from_env_status(&microvm_env_status()),
+            IsolatedSubstrate::observed(false),
+            ExecutionLocus::Guest,
+        )
+        .expect_err("exec must refuse rather than run on the host");
+        assert_eq!(refusal.reason, "isolation_required_substrate_unavailable");
+    }
+
+    #[test]
+    fn exec_still_runs_in_guest_when_the_microvm_is_live() {
+        assert!(admit_isolated_execution(
+            DeclaredIsolation::from_env_status(&microvm_env_status()),
+            IsolatedSubstrate::observed(true),
+            ExecutionLocus::Guest,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn a_host_executed_workrun_refuses_under_a_declared_isolation_requirement() {
+        // handle_workrun_execute runs host `git` + a host `std::fs::write`. Under a declared
+        // vm_kernel floor that is refused even when a VM happens to be live.
+        for live in [true, false] {
+            let refusal = admit_isolated_execution(
+                DeclaredIsolation::from_env_status(&microvm_env_status()),
+                IsolatedSubstrate::observed(live),
+                ExecutionLocus::Host,
+            )
+            .expect_err("host-executed WorkRun must refuse");
+            assert_eq!(refusal.reason, "isolation_required_host_execution_refused");
+        }
+    }
+
+    #[test]
+    fn local_environments_are_unaffected_by_containment() {
+        // Containment reduces claims; it must not break the honest process-scoped lane.
+        assert!(admit_isolated_execution(
+            DeclaredIsolation::from_env_status(&local_env_status()),
+            IsolatedSubstrate::observed(false),
+            ExecutionLocus::Host,
+        )
+        .is_ok());
+    }
+
+    // ---- withdrawn labels ----
+
+    #[test]
+    fn a_failed_microvm_boot_no_longer_publishes_vm_kernel_enforcement() {
+        // resource_isolation_profile is now keyed on the MEASURED boot outcome.
+        let measured_fail = resource_isolation_profile(false, 2, 1024);
+        assert_eq!(measured_fail["enforcement"], json!("process_scoped"));
+        assert_eq!(measured_fail["ports"]["namespace_isolated"], json!(false));
+
+        let measured_ok = resource_isolation_profile(true, 2, 1024);
+        assert_eq!(
+            measured_ok["enforcement"],
+            json!("vm_kernel (monitor-enforced cpu/mem)")
+        );
+    }
+
+    #[test]
+    fn the_withdrawn_label_names_what_is_actually_unverified() {
+        assert_eq!(
+            truthful_isolation_label(
+                DeclaredIsolation::VmKernel,
+                IsolatedSubstrate::observed(false)
+            ),
+            "unverified_isolation_declared_vm_kernel_substrate_unavailable"
+        );
+    }
+
+    // ---- feature-gated unsafe paths ----
+
+    #[test]
+    fn the_guest_to_host_workspace_restore_is_off_by_default() {
+        let refusal = unsafe_path_gate(UNVERIFIED_WORKSPACE_RESTORE_GATE, None)
+            .expect_err("guest->host restore must be gated OFF by default");
+        assert_eq!(refusal.reason, "unsafe_path_gate_disabled");
+        assert!(unsafe_path_gate(UNVERIFIED_WORKSPACE_RESTORE_GATE, Some("1")).is_ok());
+    }
+
+    // ---- cache containment ----
+
+    #[test]
+    fn recipe_cache_paths_that_escape_the_root_are_dropped() {
+        let recipe = json!({
+            "recipe_ref": "recipe://demo",
+            "system_ref": "system://tenant-a",
+            "cache_paths": ["node_modules", "../../etc", "/root/.ssh", "target"],
+        });
+        assert_eq!(
+            admitted_cache_paths(&recipe),
+            vec!["node_modules", "target"]
+        );
+    }
+
+    #[test]
+    fn an_unattributed_recipe_cache_is_not_shared_across_tenants() {
+        // No owning scope -> no cache at all, rather than a node-global shared directory.
+        let unattributed = json!({ "recipe_ref": "recipe://demo", "cache_paths": ["target"] });
+        assert!(recipe_cache_scope(&unattributed).is_none());
+        assert_eq!(
+            restore_recipe_cache("/tmp/ioi-containment-test", &unattributed, "/tmp/ws"),
+            (false, Vec::new())
+        );
+
+        // Two tenants sharing a recipe get two different cache directories.
+        let a = recipe_cache_dir("/d", "recipe://demo", "system://tenant-a");
+        let b = recipe_cache_dir("/d", "recipe://demo", "system://tenant-b");
+        assert_ne!(a, b);
+    }
+
+    // ---- CARVE-OUT: deletion stays callable with all three outcomes ----
+
+    #[test]
+    fn environment_deletion_reports_each_of_the_three_outcomes_with_obligations() {
+        for (outcome, expects_obligation) in [
+            (DeletionOutcome::Succeeded, false),
+            (DeletionOutcome::Failed, true),
+            (DeletionOutcome::Unknown, true),
+        ] {
+            let disposition = close_deletion("microvm://environment/env_1", outcome);
+            assert_eq!(disposition.outcome, outcome);
+            assert_eq!(
+                disposition.cleanup_obligation_ref.is_some(),
+                expects_obligation,
+                "{outcome:?} obligation expectation"
+            );
+        }
+    }
+
+    #[test]
+    fn a_teardown_that_cannot_prove_absence_is_unknown_not_succeeded() {
+        // teardown_microvm re-observes the monitor pid; a stop call that merely returned Ok is
+        // never reported as a proven deletion.
+        assert_eq!(
+            DeletionOutcome::classify(true, false),
+            DeletionOutcome::Unknown
+        );
+    }
+
+    #[test]
+    fn a_non_succeeded_deletion_records_a_durable_obligation_on_the_record() {
+        let disposition = close_deletion("microvm://environment/env_1", DeletionOutcome::Unknown);
+        let st_dir = std::env::temp_dir().join("ioi-containment-oblig-test");
+        let _ = std::fs::create_dir_all(&st_dir);
+        let mut env = json!({ "status": {} });
+        // Exercise the record-shaping half without a DaemonState.
+        env["status"]["last_cleanup_disposition"] = disposition.to_json();
+        env["status"]["cleanup_obligations"] = json!([{
+            "cleanup_obligation_ref": disposition.cleanup_obligation_ref,
+            "outcome": disposition.outcome.as_str(),
+            "status": "pending",
+        }]);
+        assert_eq!(
+            env["status"]["cleanup_obligations"][0]["outcome"],
+            json!("unknown")
+        );
+        assert_eq!(
+            env["status"]["cleanup_obligations"][0]["status"],
+            json!("pending")
+        );
+    }
 }

--- a/crates/node/src/bin/hypervisor_daemon_routes/microvm.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/microvm.rs
@@ -13,6 +13,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
+use ioi_services::agentic::runtime::kernel::emergency_containment::{
+    admit_guest_transfer_len, UNBOUNDED_GUEST_TRANSFER_GATE,
+};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -229,7 +232,16 @@ pub(crate) trait VmMonitor {
         let mut l = [0u8; 8];
         s.read_exact(&mut l)
             .map_err(|e| format!("export len: {e}"))?;
-        let len = u64::from_le_bytes(l) as usize;
+        // CONTAINMENT: the guest is the untrusted party and it declares this length. The host
+        // used to allocate it verbatim, so a malicious or broken guest returning u64::MAX aborted
+        // the daemon — a guest-to-host denial of service straight across the isolation boundary.
+        // The declaration is now bounded, with an explicit opt-in that defaults OFF.
+        let len = admit_guest_transfer_len(
+            u64::from_le_bytes(l),
+            std::env::var(UNBOUNDED_GUEST_TRANSFER_GATE).ok().as_deref(),
+        )
+        .map_err(|refusal| format!("{}: {}", refusal.reason, refusal.detail))?
+            as usize;
         let mut buf = vec![0u8; len];
         s.read_exact(&mut buf)
             .map_err(|e| format!("export read: {e}"))?;

--- a/crates/node/src/bin/hypervisor_daemon_routes/provider_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/provider_routes.rs
@@ -24,6 +24,10 @@ use sha2::{Digest, Sha256};
 use super::lifecycle_routes::{
     authorize_capability_lease, open_scm_token, seal_scm_token, CapabilityLeaseRequest,
 };
+use ioi_services::agentic::runtime::kernel::emergency_containment::{
+    close_deletion, DeletionOutcome,
+};
+
 use super::{iso_now, persist_record, read_record_dir, DaemonState};
 
 fn nanos() -> u128 {
@@ -38,6 +42,46 @@ fn safe(seg: &str) -> String {
         "_",
     )
 }
+/// Derive the EXACT deletion outcome for a provider teardown.
+///
+/// CARVE-OUT: deletion of an existing provider resource always remains callable — this helper
+/// never refuses. It replaces a hardcoded `cleanup_verified: true` that every adapter emitted
+/// even when the provider-native destroy explicitly reported `destroyed: false` or when the
+/// remote-workspace cleanup was `"unreachable"`.
+///
+/// Mapping (`unknown` is first-class and never coerced):
+/// - `succeeded` — the provider confirmed destruction AND the remote cleanup was not unreachable.
+/// - `failed`    — the provider explicitly reported it did not destroy the resource.
+/// - `unknown`   — the provider returned no `destroyed` verdict, or the remote half was
+///   unreachable, so absence cannot be claimed.
+///
+/// Returns `(teardown_state, cleanup_verified, deletion_disposition)`.
+fn provider_teardown_disposition(
+    resource_ref: &str,
+    native_teardown: &Value,
+    remote_cleanup: &Value,
+) -> (&'static str, bool, Value) {
+    let destroyed = native_teardown.get("destroyed").and_then(Value::as_bool);
+    let remote_unreachable = remote_cleanup.as_str() == Some("unreachable");
+    let outcome = match (destroyed, remote_unreachable) {
+        (Some(true), false) => DeletionOutcome::Succeeded,
+        (Some(false), _) => DeletionOutcome::Failed,
+        // No verdict at all, or destroyed-but-remote-half-unreachable: honestly unknown.
+        (None, _) | (Some(true), true) => DeletionOutcome::Unknown,
+    };
+    let disposition = close_deletion(resource_ref, outcome);
+    let state = match outcome {
+        DeletionOutcome::Succeeded => "torn_down",
+        DeletionOutcome::Failed => "teardown_failed",
+        DeletionOutcome::Unknown => "torn_down_unverified",
+    };
+    (
+        state,
+        outcome == DeletionOutcome::Succeeded,
+        disposition.to_json(),
+    )
+}
+
 fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
@@ -1209,6 +1253,29 @@ impl EnvironmentProvider for VastProvider {
             });
             let body = created?;
             let native_id = body.get("new_contract").cloned().unwrap_or(Value::Null);
+
+            // CONTAINMENT (cleanup availability): the billable lease now EXISTS. Every step below
+            // is fallible, and the full record was previously only persisted at the very end — so
+            // a keygen, read, or seal failure returned Err after the GPU was already leased and
+            // billing, leaving no record at all. `delete` then failed `vast_instance_absent`
+            // forever: a resource the operator could not destroy.
+            //
+            // Persist a minimal TEARDOWN HANDLE immediately, before anything else can fail. It
+            // carries the provider-native id, so deletion stays callable no matter what follows.
+            // The full record overwrites this one on the success path.
+            let teardown_handle = json!({
+                "schema_version": "ioi.hypervisor.vast-instance.v1",
+                "record_id": record_id, "instance_id": format!("vast_{native_id}"),
+                "account_id": self.account_id(), "account_ref": self.account["account_ref"],
+                "environment_ref": env_ref, "status": "provisioning_incomplete",
+                "execution_mode": "live",
+                "teardown_policy": plan["teardown_policy"],
+                "provider_native": { "instance_id": native_id, "note": "provider-native id — evidence only, never restore truth" },
+                "created_at": iso_now(),
+                "containment_note": "teardown handle persisted immediately after the billable lease; delete stays callable even if provisioning fails below",
+            });
+            self.save_instance(data_dir, &teardown_handle);
+
             // Ephemeral per-instance ssh keypair: private key SEALED onto the record (never
             // plaintext), public key attached to the Vast account for this lease.
             let keydir = Path::new(data_dir).join("provider-ssh");
@@ -1494,14 +1561,28 @@ impl EnvironmentProvider for VastProvider {
         } else {
             json!({ "destroyed": true, "note": "simulated control plane — no real instance existed" })
         };
-        inst["status"] = json!("torn_down");
+        // CARVE-OUT: record the EXACT deletion outcome. `teardown_state` was unconditionally
+        // "torn_down" and `cleanup_verified` unconditionally true, even when the provider-native
+        // destroy reported `destroyed: false`. Non-succeeded outcomes now open a durable obligation.
+        let (teardown_state, cleanup_verified, deletion_disposition) =
+            provider_teardown_disposition(
+                &format!(
+                    "provider-account://{}/resource/{}",
+                    self.account_id(),
+                    safe(env_ref)
+                ),
+                &native_teardown,
+                &remote_cleanup,
+            );
+        inst["status"] = json!(teardown_state);
         inst["torn_down_at"] = json!(iso_now());
+        inst["deletion_disposition"] = deletion_disposition.clone();
         self.save_instance(data_dir, &inst);
         Ok(
             json!({ "provider_operation_ref": format!("provider-account://{}/op/delete/{}", self.account_id(), safe(env_ref)),
-                   "instance_id": inst["instance_id"], "teardown_state": "torn_down",
+                   "instance_id": inst["instance_id"], "teardown_state": teardown_state,
                    "remote_workspace_cleanup": remote_cleanup, "native_teardown": native_teardown,
-                   "cleanup_verified": true }),
+                   "cleanup_verified": cleanup_verified, "deletion_disposition": deletion_disposition }),
         )
     }
     fn observe(&self, data_dir: &str, env_ref: &str) -> Value {
@@ -1989,14 +2070,28 @@ impl EnvironmentProvider for RunPodProvider {
         } else {
             json!({ "destroyed": true, "note": "simulated control plane — no real pod existed" })
         };
-        inst["status"] = json!("torn_down");
+        // CARVE-OUT: record the EXACT deletion outcome. `teardown_state` was unconditionally
+        // "torn_down" and `cleanup_verified` unconditionally true, even when the provider-native
+        // destroy reported `destroyed: false`. Non-succeeded outcomes now open a durable obligation.
+        let (teardown_state, cleanup_verified, deletion_disposition) =
+            provider_teardown_disposition(
+                &format!(
+                    "provider-account://{}/resource/{}",
+                    self.account_id(),
+                    safe(env_ref)
+                ),
+                &native_teardown,
+                &remote_cleanup,
+            );
+        inst["status"] = json!(teardown_state);
         inst["torn_down_at"] = json!(iso_now());
+        inst["deletion_disposition"] = deletion_disposition.clone();
         self.save_instance(data_dir, &inst);
         Ok(
             json!({ "provider_operation_ref": format!("provider-account://{}/op/delete/{}", self.account_id(), safe(env_ref)),
-                   "instance_id": inst["instance_id"], "teardown_state": "torn_down",
+                   "instance_id": inst["instance_id"], "teardown_state": teardown_state,
                    "remote_workspace_cleanup": remote_cleanup, "native_teardown": native_teardown,
-                   "cleanup_verified": true }),
+                   "cleanup_verified": cleanup_verified, "deletion_disposition": deletion_disposition }),
         )
     }
     fn observe(&self, data_dir: &str, env_ref: &str) -> Value {
@@ -2521,14 +2616,28 @@ impl EnvironmentProvider for LambdaProvider {
         } else {
             json!({ "destroyed": true, "note": "simulated control plane — no real VM existed" })
         };
-        inst["status"] = json!("torn_down");
+        // CARVE-OUT: record the EXACT deletion outcome. `teardown_state` was unconditionally
+        // "torn_down" and `cleanup_verified` unconditionally true, even when the provider-native
+        // destroy reported `destroyed: false`. Non-succeeded outcomes now open a durable obligation.
+        let (teardown_state, cleanup_verified, deletion_disposition) =
+            provider_teardown_disposition(
+                &format!(
+                    "provider-account://{}/resource/{}",
+                    self.account_id(),
+                    safe(env_ref)
+                ),
+                &native_teardown,
+                &remote_cleanup,
+            );
+        inst["status"] = json!(teardown_state);
         inst["torn_down_at"] = json!(iso_now());
+        inst["deletion_disposition"] = deletion_disposition.clone();
         self.save_instance(data_dir, &inst);
         Ok(
             json!({ "provider_operation_ref": format!("provider-account://{}/op/delete/{}", self.account_id(), safe(env_ref)),
-                   "instance_id": inst["instance_id"], "teardown_state": "torn_down",
+                   "instance_id": inst["instance_id"], "teardown_state": teardown_state,
                    "remote_workspace_cleanup": remote_cleanup, "native_teardown": native_teardown,
-                   "cleanup_verified": true }),
+                   "cleanup_verified": cleanup_verified, "deletion_disposition": deletion_disposition }),
         )
     }
     fn observe(&self, data_dir: &str, env_ref: &str) -> Value {
@@ -2929,8 +3038,22 @@ impl EnvironmentProvider for GcpProvider {
         } else {
             json!({ "destroyed": true, "note": "simulated control plane — instance deleted, Persistent Disk auto-deleted with the instance; no real GCP instance existed" })
         };
-        inst["status"] = json!("torn_down");
+        // CARVE-OUT: record the EXACT deletion outcome. `teardown_state` was unconditionally
+        // "torn_down" and `cleanup_verified` unconditionally true, even when the provider-native
+        // destroy reported `destroyed: false`. Non-succeeded outcomes now open a durable obligation.
+        let (teardown_state, cleanup_verified, deletion_disposition) =
+            provider_teardown_disposition(
+                &format!(
+                    "provider-account://{}/resource/{}",
+                    self.account_id(),
+                    safe(env_ref)
+                ),
+                &native_teardown,
+                &remote_cleanup,
+            );
+        inst["status"] = json!(teardown_state);
         inst["torn_down_at"] = json!(iso_now());
+        inst["deletion_disposition"] = deletion_disposition.clone();
         Self::push_event(
             &mut inst,
             "instance_deleted",
@@ -2939,9 +3062,9 @@ impl EnvironmentProvider for GcpProvider {
         self.save_instance(data_dir, &inst);
         Ok(
             json!({ "provider_operation_ref": format!("provider-account://{}/op/delete/{}", self.account_id(), safe(env_ref)),
-                   "instance_name": inst["instance_name"], "teardown_state": "torn_down",
+                   "instance_name": inst["instance_name"], "teardown_state": teardown_state,
                    "remote_workspace_cleanup": remote_cleanup, "native_teardown": native_teardown,
-                   "cleanup_verified": true }),
+                   "cleanup_verified": cleanup_verified, "deletion_disposition": deletion_disposition }),
         )
     }
     fn events(&self, data_dir: &str, env_ref: &str) -> Result<Value, String> {
@@ -3495,8 +3618,22 @@ impl EnvironmentProvider for K8sProvider {
         } else {
             json!({ "destroyed": true, "note": "simulated control plane — workload/PVC/service deleted in the namespace; no real cluster workload existed" })
         };
-        w["status"] = json!("torn_down");
+        // CARVE-OUT: record the EXACT deletion outcome. `teardown_state` was unconditionally
+        // "torn_down" and `cleanup_verified` unconditionally true, even when the provider-native
+        // destroy reported `destroyed: false`. Non-succeeded outcomes now open a durable obligation.
+        let (teardown_state, cleanup_verified, deletion_disposition) =
+            provider_teardown_disposition(
+                &format!(
+                    "provider-account://{}/resource/{}",
+                    self.account_id(),
+                    safe(env_ref)
+                ),
+                &native_teardown,
+                &fs_cleanup,
+            );
+        w["status"] = json!(teardown_state);
         w["torn_down_at"] = json!(iso_now());
+        w["deletion_disposition"] = deletion_disposition.clone();
         Self::push_event(
             &mut w,
             "workload_deleted",
@@ -3505,9 +3642,9 @@ impl EnvironmentProvider for K8sProvider {
         self.save_workload(data_dir, &w);
         Ok(
             json!({ "provider_operation_ref": format!("provider-account://{}/op/delete/{}", self.account_id(), safe(env_ref)),
-                   "workload_name": w["workload_name"], "teardown_state": "torn_down",
+                   "workload_name": w["workload_name"], "teardown_state": teardown_state,
                    "workload_fs_cleanup": fs_cleanup, "native_teardown": native_teardown,
-                   "cleanup_verified": true }),
+                   "cleanup_verified": cleanup_verified, "deletion_disposition": deletion_disposition }),
         )
     }
     fn observe(&self, data_dir: &str, env_ref: &str) -> Value {
@@ -3904,8 +4041,22 @@ impl EnvironmentProvider for AzureProvider {
         } else {
             json!({ "destroyed": true, "note": "simulated control plane — VM deleted, managed OS disk deleted with the VM per delete option; no real Azure VM existed" })
         };
-        inst["status"] = json!("torn_down");
+        // CARVE-OUT: record the EXACT deletion outcome. `teardown_state` was unconditionally
+        // "torn_down" and `cleanup_verified` unconditionally true, even when the provider-native
+        // destroy reported `destroyed: false`. Non-succeeded outcomes now open a durable obligation.
+        let (teardown_state, cleanup_verified, deletion_disposition) =
+            provider_teardown_disposition(
+                &format!(
+                    "provider-account://{}/resource/{}",
+                    self.account_id(),
+                    safe(env_ref)
+                ),
+                &native_teardown,
+                &remote_cleanup,
+            );
+        inst["status"] = json!(teardown_state);
         inst["torn_down_at"] = json!(iso_now());
+        inst["deletion_disposition"] = deletion_disposition.clone();
         Self::push_event(
             &mut inst,
             "vm_deleted",
@@ -3914,9 +4065,9 @@ impl EnvironmentProvider for AzureProvider {
         self.save_instance(data_dir, &inst);
         Ok(
             json!({ "provider_operation_ref": format!("provider-account://{}/op/delete/{}", self.account_id(), safe(env_ref)),
-                   "vm_name": inst["vm_name"], "teardown_state": "torn_down",
+                   "vm_name": inst["vm_name"], "teardown_state": teardown_state,
                    "remote_workspace_cleanup": remote_cleanup, "native_teardown": native_teardown,
-                   "cleanup_verified": true }),
+                   "cleanup_verified": cleanup_verified, "deletion_disposition": deletion_disposition }),
         )
     }
     fn events(&self, data_dir: &str, env_ref: &str) -> Result<Value, String> {
@@ -4322,8 +4473,22 @@ impl EnvironmentProvider for AwsProvider {
         } else {
             json!({ "destroyed": true, "note": "simulated control plane — instance terminated, EBS root volume deleted on termination; no real AWS instance existed" })
         };
-        inst["status"] = json!("torn_down");
+        // CARVE-OUT: record the EXACT deletion outcome. `teardown_state` was unconditionally
+        // "torn_down" and `cleanup_verified` unconditionally true, even when the provider-native
+        // destroy reported `destroyed: false`. Non-succeeded outcomes now open a durable obligation.
+        let (teardown_state, cleanup_verified, deletion_disposition) =
+            provider_teardown_disposition(
+                &format!(
+                    "provider-account://{}/resource/{}",
+                    self.account_id(),
+                    safe(env_ref)
+                ),
+                &native_teardown,
+                &remote_cleanup,
+            );
+        inst["status"] = json!(teardown_state);
         inst["torn_down_at"] = json!(iso_now());
+        inst["deletion_disposition"] = deletion_disposition.clone();
         Self::push_event(
             &mut inst,
             "instance_terminated",
@@ -4332,9 +4497,9 @@ impl EnvironmentProvider for AwsProvider {
         self.save_instance(data_dir, &inst);
         Ok(
             json!({ "provider_operation_ref": format!("provider-account://{}/op/delete/{}", self.account_id(), safe(env_ref)),
-                   "instance_id": inst["instance_id"], "teardown_state": "torn_down",
+                   "instance_id": inst["instance_id"], "teardown_state": teardown_state,
                    "remote_workspace_cleanup": remote_cleanup, "native_teardown": native_teardown,
-                   "cleanup_verified": true }),
+                   "cleanup_verified": cleanup_verified, "deletion_disposition": deletion_disposition }),
         )
     }
     fn events(&self, data_dir: &str, env_ref: &str) -> Result<Value, String> {
@@ -4892,8 +5057,22 @@ impl EnvironmentProvider for AkashProvider {
                 self.save_lease(data_dir, &lease);
             }
         }
-        dep["status"] = json!("torn_down");
+        // CARVE-OUT: record the EXACT deletion outcome. `teardown_state` was unconditionally
+        // "torn_down" and `cleanup_verified` unconditionally true, even when the provider-native
+        // destroy reported `destroyed: false`. Non-succeeded outcomes now open a durable obligation.
+        let (teardown_state, cleanup_verified, deletion_disposition) =
+            provider_teardown_disposition(
+                &format!(
+                    "provider-account://{}/resource/{}",
+                    self.account_id(),
+                    safe(env_ref)
+                ),
+                &native_teardown,
+                &remote_cleanup,
+            );
+        dep["status"] = json!(teardown_state);
         dep["torn_down_at"] = json!(iso_now());
+        dep["deletion_disposition"] = deletion_disposition.clone();
         Self::push_event(
             &mut dep,
             "closed",
@@ -4902,9 +5081,9 @@ impl EnvironmentProvider for AkashProvider {
         self.save_deployment(data_dir, &dep);
         Ok(
             json!({ "provider_operation_ref": format!("provider-account://{}/op/delete/{}", self.account_id(), safe(env_ref)),
-                   "deployment_ref": dep["deployment_ref"], "teardown_state": "torn_down",
+                   "deployment_ref": dep["deployment_ref"], "teardown_state": teardown_state,
                    "remote_workspace_cleanup": remote_cleanup, "native_teardown": native_teardown,
-                   "cleanup_verified": true }),
+                   "cleanup_verified": cleanup_verified, "deletion_disposition": deletion_disposition }),
         )
     }
     fn observe(&self, data_dir: &str, env_ref: &str) -> Value {
@@ -6277,4 +6456,103 @@ pub(crate) async fn handle_provider_operations(State(st): State<Arc<DaemonState>
     Json(
         json!({ "schema_version": "ioi.hypervisor.provider-operations.v1", "operations": ops, "at": iso_now() }),
     )
+}
+
+#[cfg(test)]
+mod containment_tests {
+    use super::*;
+
+    // ---- CARVE-OUT: provider deletion stays callable and reports exactly ----
+
+    #[test]
+    fn a_confirmed_provider_destroy_is_succeeded_and_opens_no_obligation() {
+        let (state, verified, disposition) = provider_teardown_disposition(
+            "provider-account://acct/resource/env_1",
+            &json!({ "destroyed": true }),
+            &json!("gone"),
+        );
+        assert_eq!(state, "torn_down");
+        assert!(verified);
+        assert_eq!(disposition["outcome"], json!("succeeded"));
+        assert!(disposition["cleanup_obligation_ref"].is_null());
+    }
+
+    #[test]
+    fn an_explicit_destroy_failure_is_failed_and_opens_an_obligation() {
+        // This is the case that used to be reported as `cleanup_verified: true`.
+        let (state, verified, disposition) = provider_teardown_disposition(
+            "provider-account://acct/resource/env_1",
+            &json!({ "destroyed": false, "error": "api_error", "warning": "TEARDOWN MAY BE INCOMPLETE" }),
+            &json!("gone"),
+        );
+        assert_eq!(state, "teardown_failed");
+        assert!(!verified);
+        assert_eq!(disposition["outcome"], json!("failed"));
+        assert!(!disposition["cleanup_obligation_ref"].is_null());
+    }
+
+    #[test]
+    fn an_unimplemented_live_teardown_is_failed_never_verified() {
+        let (state, verified, disposition) = provider_teardown_disposition(
+            "provider-account://acct/resource/env_1",
+            &json!({ "destroyed": false, "error": "aws_live_api_flow_not_implemented" }),
+            &json!("gone"),
+        );
+        assert_eq!(state, "teardown_failed");
+        assert!(!verified);
+        assert_eq!(disposition["outcome"], json!("failed"));
+    }
+
+    #[test]
+    fn an_unreachable_remote_half_degrades_to_unknown_not_success() {
+        // Provider says destroyed, but the remote workspace cleanup could not be reached:
+        // absence is not provable, so the outcome is UNKNOWN and an obligation stays open.
+        let (state, verified, disposition) = provider_teardown_disposition(
+            "provider-account://acct/resource/env_1",
+            &json!({ "destroyed": true }),
+            &json!("unreachable"),
+        );
+        assert_eq!(state, "torn_down_unverified");
+        assert!(!verified);
+        assert_eq!(disposition["outcome"], json!("unknown"));
+        assert!(!disposition["cleanup_obligation_ref"].is_null());
+    }
+
+    #[test]
+    fn a_missing_destroyed_verdict_is_unknown_never_coerced() {
+        let (state, verified, disposition) = provider_teardown_disposition(
+            "provider-account://acct/resource/env_1",
+            &json!({ "note": "simulated control plane" }),
+            &json!("gone"),
+        );
+        assert_eq!(state, "torn_down_unverified");
+        assert!(!verified);
+        assert_eq!(disposition["outcome"], json!("unknown"));
+    }
+
+    #[test]
+    fn provider_deletion_is_total_and_never_refuses() {
+        // The carve-out: every combination yields a disposition; none is an error.
+        for destroyed in [
+            json!({ "destroyed": true }),
+            json!({ "destroyed": false }),
+            json!({}),
+        ] {
+            for remote in [json!("gone"), json!("unreachable")] {
+                let (state, _, disposition) =
+                    provider_teardown_disposition("provider://r", &destroyed, &remote);
+                assert!(matches!(
+                    state,
+                    "torn_down" | "teardown_failed" | "torn_down_unverified"
+                ));
+                let outcome = disposition["outcome"].as_str().unwrap();
+                assert!(matches!(outcome, "succeeded" | "failed" | "unknown"));
+                // Non-succeeded ALWAYS opens a durable obligation.
+                assert_eq!(
+                    disposition["cleanup_obligation_ref"].is_null(),
+                    outcome == "succeeded"
+                );
+            }
+        }
+    }
 }

--- a/crates/services/src/agentic/runtime/kernel/ctee.rs
+++ b/crates/services/src/agentic/runtime/kernel/ctee.rs
@@ -1,3 +1,22 @@
+//! cTEE private-workspace ADMISSION PLANNER.
+//!
+//! CLAIM TRUTH — read this before citing anything here as a confidential-compute property.
+//! This module performs NO execution: no process, no VM, no enclave, and no verification of any
+//! attestation. It validates the shape of an invocation, applies the custody-lane policy, and
+//! emits a receipt-shaped record. Specifically:
+//!
+//! - `execute_and_admit` never runs the described action; its result status is a constant.
+//! - `execution_result_ref` is a formatted string, not a handle to a computation.
+//! - `state_root_after` is a hash of the REQUEST (`state_root_before` + invocation + receipt),
+//!   not of any computed state.
+//! - [`CteeNodeTrust::trusted_for_plaintext`] and `attestation_ref` are CALLER-SUPPLIED over
+//!   HTTP. Nothing verifies a quote, a measurement, or a signature; a present non-empty string
+//!   is the whole of "attestation" here.
+//!
+//! The policy refusals ARE real — an untrusted node cannot take a plaintext mount, and
+//! caller-supplied expected heads are rejected. They just guard a planner, not an enclave.
+//! Report [`CTEE_ISOLATION_STANDING`] rather than a confidential-compute claim.
+
 use super::agentgres_admission::{
     AgentgresAdmissionCore, AgentgresAdmissionError, AgentgresAdmissionRecord,
     AgentgresOperationProposal, AGENTGRES_ADMISSION_SCHEMA_VERSION,
@@ -19,6 +38,19 @@ pub const CTEE_PRIVATE_WORKSPACE_RECEIPT_SCHEMA_VERSION: &str =
     "ioi.ctee_private_workspace_receipt.v1";
 pub const CTEE_PLAINTEXT_UNTRUSTED_NEGATIVE_CONFORMANCE: &str =
     "cTEE private workspace plaintext mount on an untrusted node fails";
+
+/// The WITHDRAWN isolation label for this backend.
+///
+/// CONTAINMENT: nothing in this module establishes a trusted-execution or confidential-compute
+/// property. Surfaces reporting on the cTEE backend must publish this string instead of a
+/// hardware/enclave isolation claim.
+pub const CTEE_ISOLATION_STANDING: &str = "unverified_no_execution_backend";
+
+/// Whether the described action was actually performed by this module.
+///
+/// CONTAINMENT: always `false`. This planner admits and records; it does not execute. Callers
+/// previously reported `action_executed: true` for a code path that runs nothing.
+pub const CTEE_ACTION_EXECUTED: bool = false;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CteePrivateWorkspaceError {

--- a/crates/services/src/agentic/runtime/kernel/emergency_containment.rs
+++ b/crates/services/src/agentic/runtime/kernel/emergency_containment.rs
@@ -1,0 +1,776 @@
+//! Emergency containment and claim-truth core.
+//!
+//! This module is a CLAIM-REDUCING containment layer. It adds no capability and grants no
+//! authority. It exists because several runtime surfaces asserted stronger isolation, cleaner
+//! evidence, and safer restore behaviour than the code actually measured. Every decision here
+//! fails CLOSED and names its reason.
+//!
+//! Five containments live here, each with one entry point:
+//!
+//! 1. [`admit_isolated_execution`] — an execution whose environment DECLARED an isolated
+//!    substrate must never silently run on the host. If the isolated substrate is not live, the
+//!    operation refuses by name instead of falling back.
+//! 2. [`unsafe_path_gate`] — cache/export/restore paths whose safety is not established are
+//!    gated behind an explicit opt-in that defaults OFF.
+//! 3. [`admit_resource_creation`] — nothing NEW may be admitted when its safe cleanup cannot be
+//!    guaranteed.
+//! 4. [`close_deletion`] — the owner-specified CARVE-OUT. Deletion of an EXISTING resource stays
+//!    callable at all times, returns an exact `succeeded | failed | unknown` outcome, and opens a
+//!    durable cleanup obligation whenever the outcome is not `succeeded`. `unknown` is a
+//!    first-class outcome and is NEVER coerced into either of the other two.
+//! 5. [`evidence_citation`] — quarantined evidence is retained but cannot be cited as proof.
+//!
+//! Design rule: these are pure functions over plain values. They hold no I/O, so the route layer
+//! cannot satisfy their preconditions by writing constants into a request (INV-37) — the caller
+//! must pass an OBSERVATION, and the observation type names what was actually measured.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+pub const EMERGENCY_CONTAINMENT_SCHEMA_VERSION: &str = "ioi.runtime.emergency_containment.v1";
+
+/// A fail-closed containment refusal. `reason` is a stable snake_case code.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContainmentRefusal {
+    pub reason: String,
+    pub detail: String,
+}
+
+impl ContainmentRefusal {
+    fn new(reason: &str, detail: impl Into<String>) -> Self {
+        Self {
+            reason: reason.to_string(),
+            detail: detail.into(),
+        }
+    }
+
+    pub fn to_json(&self) -> Value {
+        json!({
+            "schema_version": EMERGENCY_CONTAINMENT_SCHEMA_VERSION,
+            "refused": true,
+            "reason": self.reason,
+            "detail": self.detail,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Isolation: refuse, never fall back.
+// ---------------------------------------------------------------------------
+
+/// What the environment record DECLARES about its isolation floor.
+///
+/// This is the declaration, not a measurement. It is deliberately separate from
+/// [`IsolatedSubstrate`] so a caller cannot conflate "we asked for a VM" with "a VM is running".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeclaredIsolation {
+    /// The environment declared a kernel/VM isolation floor (`minimum_isolation: vm_kernel`,
+    /// `substrate: microvm`, or a microVM environment class).
+    VmKernel,
+    /// The environment declared only process/workspace scoping. Host execution is truthful here.
+    ProcessScoped,
+}
+
+impl DeclaredIsolation {
+    /// Read the declaration off an environment status record.
+    ///
+    /// Any of the three microVM signals is sufficient — a record that lost one field must not
+    /// thereby lose its isolation floor.
+    pub fn from_env_status(status: &Value) -> Self {
+        let minimum = status.get("minimum_isolation").and_then(|v| v.as_str());
+        let substrate = status.get("substrate").and_then(|v| v.as_str());
+        let claim = status.get("isolation_claim").and_then(|v| v.as_str());
+        if minimum == Some("vm_kernel")
+            || substrate == Some("microvm")
+            || claim == Some("cross_tenant_capable")
+        {
+            Self::VmKernel
+        } else {
+            Self::ProcessScoped
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::VmKernel => "vm_kernel",
+            Self::ProcessScoped => "process_scoped",
+        }
+    }
+}
+
+/// A MEASURED observation of whether the isolated substrate is actually live.
+///
+/// Constructed only from a real probe of the live-VM registry. There is deliberately no
+/// `From<bool>` and no `Deserialize`: a request body cannot become an observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsolatedSubstrate {
+    Live,
+    Unavailable,
+}
+
+impl IsolatedSubstrate {
+    /// Build the observation from a live-handle probe performed by the runtime.
+    pub fn observed(live_handle_present: bool) -> Self {
+        if live_handle_present {
+            Self::Live
+        } else {
+            Self::Unavailable
+        }
+    }
+}
+
+/// Where the operation would actually run if it were allowed to proceed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionLocus {
+    /// Inside the isolated guest.
+    Guest,
+    /// On the host — a host process, a host filesystem write, or a host PTY.
+    Host,
+}
+
+/// Refuse host execution whenever an isolated substrate was declared.
+///
+/// Returns `Ok(())` only when the execution is truthful: either it runs in the guest with a live
+/// guest, or the environment never claimed isolation in the first place.
+///
+/// The two refusal reasons are distinct on purpose:
+/// - `isolation_required_substrate_unavailable` — isolation was declared and the substrate is
+///   gone. This is the "do not silently fall back to the host" case.
+/// - `isolation_required_host_execution_refused` — isolation was declared, the substrate may even
+///   be live, but this code path executes host-side regardless. This is the "host-executed
+///   WorkRun" case.
+pub fn admit_isolated_execution(
+    declared: DeclaredIsolation,
+    substrate: IsolatedSubstrate,
+    locus: ExecutionLocus,
+) -> Result<(), ContainmentRefusal> {
+    if declared == DeclaredIsolation::ProcessScoped {
+        return Ok(());
+    }
+    match (locus, substrate) {
+        (ExecutionLocus::Guest, IsolatedSubstrate::Live) => Ok(()),
+        (ExecutionLocus::Guest, IsolatedSubstrate::Unavailable) => Err(ContainmentRefusal::new(
+            "isolation_required_substrate_unavailable",
+            "environment declared minimum_isolation=vm_kernel but no live isolated substrate \
+             backs it; refusing rather than falling back to the host",
+        )),
+        (ExecutionLocus::Host, _) => Err(ContainmentRefusal::new(
+            "isolation_required_host_execution_refused",
+            "environment declared minimum_isolation=vm_kernel; this operation executes host-side \
+             and cannot honour that declaration, so it is refused",
+        )),
+    }
+}
+
+/// Withdraw an isolation label that measurement does not support.
+///
+/// Given the declared floor and what was actually observed, return the label that is TRUE. This
+/// is how the runtime stops publishing `vm_kernel` enforcement for an environment whose microVM
+/// failed to boot.
+pub fn truthful_isolation_label(
+    declared: DeclaredIsolation,
+    substrate: IsolatedSubstrate,
+) -> &'static str {
+    match (declared, substrate) {
+        (DeclaredIsolation::VmKernel, IsolatedSubstrate::Live) => "vm_kernel",
+        // Declared a VM, did not get one: say so, do not inherit the stronger label.
+        (DeclaredIsolation::VmKernel, IsolatedSubstrate::Unavailable) => {
+            "unverified_isolation_declared_vm_kernel_substrate_unavailable"
+        }
+        (DeclaredIsolation::ProcessScoped, _) => "process_scoped",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Unsafe cache / export / restore paths: explicit opt-in, default OFF.
+// ---------------------------------------------------------------------------
+
+/// The explicit opt-in for restoring workspace material whose provenance is not established.
+///
+/// Default: OFF. Recorded in `docs/architecture/_meta/current-canon-defaults.md`.
+pub const UNVERIFIED_WORKSPACE_RESTORE_GATE: &str = "IOI_ALLOW_UNVERIFIED_WORKSPACE_RESTORE";
+
+/// The explicit opt-in for accepting a guest-declared transfer length.
+///
+/// Default: OFF. Recorded in `docs/architecture/_meta/current-canon-defaults.md`.
+pub const UNBOUNDED_GUEST_TRANSFER_GATE: &str = "IOI_ALLOW_UNBOUNDED_GUEST_TRANSFER";
+
+/// Hard ceiling on a guest-declared transfer, applied when the gate is OFF.
+pub const GUEST_TRANSFER_MAX_BYTES: u64 = 1 << 30; // 1 GiB
+
+/// Every containment gate, for canon/documentation cross-checks. Each entry is
+/// `(gate name, default enabled)`. Every default MUST be `false`.
+pub const CONTAINMENT_GATES: &[(&str, bool)] = &[
+    (UNVERIFIED_WORKSPACE_RESTORE_GATE, false),
+    (UNBOUNDED_GUEST_TRANSFER_GATE, false),
+];
+
+/// Whether an opt-in gate is enabled. Absent, empty, `0`, and `false` all mean OFF.
+///
+/// The `enabled` argument is the raw environment value, read by the caller.
+pub fn gate_enabled(raw: Option<&str>) -> bool {
+    matches!(
+        raw.map(str::trim)
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Refuse an unsafe path unless its gate is explicitly enabled.
+pub fn unsafe_path_gate(gate: &str, raw: Option<&str>) -> Result<(), ContainmentRefusal> {
+    if gate_enabled(raw) {
+        return Ok(());
+    }
+    Err(ContainmentRefusal::new(
+        "unsafe_path_gate_disabled",
+        format!(
+            "this path is quarantined pending a provenance/integrity bar; set {gate}=1 to opt in \
+             (default OFF)"
+        ),
+    ))
+}
+
+/// Bound a guest-declared transfer length.
+///
+/// A guest inside the isolation boundary declares how many bytes the host should allocate. With
+/// the gate OFF, an over-large declaration is refused instead of being allocated.
+pub fn admit_guest_transfer_len(
+    declared_len: u64,
+    raw_gate: Option<&str>,
+) -> Result<u64, ContainmentRefusal> {
+    if declared_len <= GUEST_TRANSFER_MAX_BYTES || gate_enabled(raw_gate) {
+        return Ok(declared_len);
+    }
+    Err(ContainmentRefusal::new(
+        "guest_declared_transfer_too_large",
+        format!(
+            "guest declared {declared_len} bytes, ceiling is {GUEST_TRANSFER_MAX_BYTES}; set \
+             {UNBOUNDED_GUEST_TRANSFER_GATE}=1 to opt in (default OFF)"
+        ),
+    ))
+}
+
+/// Admit one relative cache path declared by a recipe.
+///
+/// A cache path is copied both INTO and OUT OF a workspace. `Path::join` does not normalize, so
+/// an absolute segment silently replaces the base and `..` walks out of it. Both are refused.
+pub fn admit_cache_path(rel: &str) -> Result<(), ContainmentRefusal> {
+    let trimmed = rel.trim();
+    if trimmed.is_empty() {
+        return Err(ContainmentRefusal::new(
+            "cache_path_not_relative",
+            "empty cache path",
+        ));
+    }
+    let path = std::path::Path::new(trimmed);
+    if path.is_absolute() || trimmed.starts_with('/') || trimmed.starts_with('\\') {
+        return Err(ContainmentRefusal::new(
+            "cache_path_not_relative",
+            format!("cache path {rel:?} is absolute; Path::join would discard the cache root"),
+        ));
+    }
+    if trimmed.contains('\0') {
+        return Err(ContainmentRefusal::new(
+            "cache_path_not_relative",
+            format!("cache path {rel:?} contains NUL"),
+        ));
+    }
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                return Err(ContainmentRefusal::new(
+                    "cache_path_escapes_root",
+                    format!("cache path {rel:?} contains '..' and escapes the cache root"),
+                ))
+            }
+            _ => {
+                return Err(ContainmentRefusal::new(
+                    "cache_path_not_relative",
+                    format!("cache path {rel:?} has a root or prefix component"),
+                ))
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build the tenant-scoped cache key segment.
+///
+/// A cache keyed only by recipe is SHARED across every System on the node: one tenant's build
+/// output is restored into another tenant's workspace and then executed. The owning scope is part
+/// of the key, and an unattributed cache is refused rather than silently shared.
+pub fn admit_cache_scope(owner_scope_ref: Option<&str>) -> Result<String, ContainmentRefusal> {
+    match owner_scope_ref.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(scope) => Ok(scope.to_string()),
+        None => Err(ContainmentRefusal::new(
+            "cache_scope_unattributed",
+            "refusing to use a cache that is not scoped to an owning System/tenant; an \
+             unattributed cache is shared across tenants",
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Admission: block NEW resources when safe cleanup is unavailable.
+// ---------------------------------------------------------------------------
+
+/// A MEASURED observation of whether this resource kind can be cleanly destroyed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CleanupCapability {
+    /// A teardown path exists AND its outcome is observed.
+    Available,
+    /// No teardown path, or teardown outcome is discarded.
+    Unavailable,
+}
+
+impl CleanupCapability {
+    pub fn observed(teardown_path_exists: bool, teardown_outcome_observed: bool) -> Self {
+        if teardown_path_exists && teardown_outcome_observed {
+            Self::Available
+        } else {
+            Self::Unavailable
+        }
+    }
+}
+
+/// Refuse to admit a NEW resource whose safe cleanup cannot be guaranteed.
+///
+/// This deliberately governs CREATION ONLY. Deletion of already-existing resources is never
+/// routed through here — see [`close_deletion`].
+pub fn admit_resource_creation(
+    resource_kind: &str,
+    cleanup: CleanupCapability,
+) -> Result<(), ContainmentRefusal> {
+    match cleanup {
+        CleanupCapability::Available => Ok(()),
+        CleanupCapability::Unavailable => Err(ContainmentRefusal::new(
+            "safe_cleanup_unavailable",
+            format!(
+                "refusing to admit a new {resource_kind}: its teardown outcome is not observable, \
+                 so admitting it would create a resource that cannot be provably destroyed"
+            ),
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. CARVE-OUT: deletion of existing resources always remains callable.
+// ---------------------------------------------------------------------------
+
+/// The exact outcome of deleting an EXISTING resource.
+///
+/// `Unknown` is first-class. It means the delete was attempted and the runtime cannot prove
+/// whether the underlying resource is gone. It is never coerced to `Succeeded` (which would
+/// strand a live resource silently) nor to `Failed` (which would falsely imply the resource is
+/// definitely still there).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeletionOutcome {
+    Succeeded,
+    Failed,
+    Unknown,
+}
+
+impl DeletionOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Classify a teardown attempt WITHOUT collapsing ambiguity.
+    ///
+    /// `proven_absent` must come from a post-delete observation, not from the fact that the
+    /// delete call returned. A delete call that returned `Ok` but was never re-observed is
+    /// `Unknown`, not `Succeeded`.
+    pub fn classify(call_succeeded: bool, proven_absent: bool) -> Self {
+        match (call_succeeded, proven_absent) {
+            (_, true) => Self::Succeeded,
+            (false, false) => Self::Failed,
+            // The call returned but absence was never confirmed: honestly unknown.
+            (true, false) => Self::Unknown,
+        }
+    }
+
+    /// Whether this outcome leaves a durable obligation open.
+    pub fn opens_obligation(self) -> bool {
+        !matches!(self, Self::Succeeded)
+    }
+}
+
+/// The disposition of one deletion: the exact outcome plus any obligation it opened.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeletionDisposition {
+    pub schema_version: String,
+    pub resource_ref: String,
+    pub outcome: DeletionOutcome,
+    /// Present exactly when `outcome != succeeded`.
+    pub cleanup_obligation_ref: Option<String>,
+    pub detail: String,
+}
+
+impl DeletionDisposition {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "schema_version": self.schema_version,
+            "resource_ref": self.resource_ref,
+            "outcome": self.outcome.as_str(),
+            "cleanup_obligation_ref": self.cleanup_obligation_ref,
+            "detail": self.detail,
+        })
+    }
+}
+
+/// Close out a deletion of an EXISTING resource.
+///
+/// This function NEVER refuses. Containment must not strand an operator with resources they
+/// cannot delete, so deletion stays callable under every containment above. What containment
+/// changes is honesty: a non-`succeeded` outcome opens a durable cleanup obligation rather than
+/// being reported as done.
+pub fn close_deletion(resource_ref: &str, outcome: DeletionOutcome) -> DeletionDisposition {
+    let cleanup_obligation_ref = if outcome.opens_obligation() {
+        Some(format!(
+            "cleanup-obligation://containment/{}/{}",
+            outcome.as_str(),
+            resource_ref.replace([':', '/'], "_")
+        ))
+    } else {
+        None
+    };
+    let detail = match outcome {
+        DeletionOutcome::Succeeded => {
+            "resource observed absent after delete; nothing further is owed".to_string()
+        }
+        DeletionOutcome::Failed => {
+            "delete attempt failed; the resource is presumed live and an obligation is open"
+                .to_string()
+        }
+        DeletionOutcome::Unknown => {
+            "delete attempted but absence could not be confirmed; the obligation stays open until \
+             the resource is reconciled"
+                .to_string()
+        }
+    };
+    DeletionDisposition {
+        schema_version: EMERGENCY_CONTAINMENT_SCHEMA_VERSION.to_string(),
+        resource_ref: resource_ref.to_string(),
+        outcome,
+        cleanup_obligation_ref,
+        detail,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Evidence quarantine: retained, but not citable as proof.
+// ---------------------------------------------------------------------------
+
+/// Whether a retained evidence artifact may be cited as proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceStanding {
+    /// Citable as proof of what it measured.
+    Authoritative,
+    /// Retained for the record, NEVER citable. Quarantine never deletes evidence.
+    Quarantined,
+}
+
+impl EvidenceStanding {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Authoritative => "authoritative",
+            Self::Quarantined => "quarantined_non_authoritative",
+        }
+    }
+}
+
+/// Decide whether an evidence artifact can back a claim.
+pub fn evidence_citation(
+    evidence_ref: &str,
+    standing: EvidenceStanding,
+) -> Result<(), ContainmentRefusal> {
+    match standing {
+        EvidenceStanding::Authoritative => Ok(()),
+        EvidenceStanding::Quarantined => Err(ContainmentRefusal::new(
+            "evidence_quarantined_non_authoritative",
+            format!(
+                "{evidence_ref} is retained but quarantined: it asserted more than it measured, \
+                 so it cannot be cited as proof"
+            ),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- 1. isolation ---
+
+    #[test]
+    fn isolation_required_with_unavailable_substrate_refuses_by_name() {
+        let refusal = admit_isolated_execution(
+            DeclaredIsolation::VmKernel,
+            IsolatedSubstrate::Unavailable,
+            ExecutionLocus::Guest,
+        )
+        .expect_err("must refuse");
+        assert_eq!(refusal.reason, "isolation_required_substrate_unavailable");
+    }
+
+    #[test]
+    fn host_execution_under_declared_isolation_refuses_even_when_substrate_is_live() {
+        // A host-executed WorkRun cannot honour a vm_kernel declaration even if a VM happens to
+        // be running beside it — the work is still on the host.
+        let refusal = admit_isolated_execution(
+            DeclaredIsolation::VmKernel,
+            IsolatedSubstrate::Live,
+            ExecutionLocus::Host,
+        )
+        .expect_err("must refuse");
+        assert_eq!(refusal.reason, "isolation_required_host_execution_refused");
+    }
+
+    #[test]
+    fn guest_execution_with_live_substrate_is_admitted() {
+        assert!(admit_isolated_execution(
+            DeclaredIsolation::VmKernel,
+            IsolatedSubstrate::Live,
+            ExecutionLocus::Guest,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn process_scoped_environments_may_still_execute_on_the_host() {
+        // Containment reduces claims; it does not break honest process-scoped environments.
+        assert!(admit_isolated_execution(
+            DeclaredIsolation::ProcessScoped,
+            IsolatedSubstrate::Unavailable,
+            ExecutionLocus::Host,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn declared_isolation_reads_every_microvm_signal() {
+        assert_eq!(
+            DeclaredIsolation::from_env_status(&json!({"minimum_isolation": "vm_kernel"})),
+            DeclaredIsolation::VmKernel
+        );
+        assert_eq!(
+            DeclaredIsolation::from_env_status(&json!({"substrate": "microvm"})),
+            DeclaredIsolation::VmKernel
+        );
+        assert_eq!(
+            DeclaredIsolation::from_env_status(&json!({"isolation_claim": "cross_tenant_capable"})),
+            DeclaredIsolation::VmKernel
+        );
+        assert_eq!(
+            DeclaredIsolation::from_env_status(&json!({"substrate": "local"})),
+            DeclaredIsolation::ProcessScoped
+        );
+    }
+
+    #[test]
+    fn a_failed_microvm_boot_withdraws_the_vm_kernel_label() {
+        assert_eq!(
+            truthful_isolation_label(DeclaredIsolation::VmKernel, IsolatedSubstrate::Unavailable),
+            "unverified_isolation_declared_vm_kernel_substrate_unavailable"
+        );
+        assert_eq!(
+            truthful_isolation_label(DeclaredIsolation::VmKernel, IsolatedSubstrate::Live),
+            "vm_kernel"
+        );
+    }
+
+    // --- 2. gates ---
+
+    #[test]
+    fn every_containment_gate_defaults_off() {
+        for (name, default_enabled) in CONTAINMENT_GATES {
+            assert!(!default_enabled, "{name} must default OFF");
+            assert!(
+                unsafe_path_gate(name, None).is_err(),
+                "{name} must refuse when unset"
+            );
+        }
+    }
+
+    #[test]
+    fn unsafe_path_refuses_when_gate_is_off_and_admits_when_opted_in() {
+        let refusal = unsafe_path_gate(UNVERIFIED_WORKSPACE_RESTORE_GATE, None)
+            .expect_err("must refuse by default");
+        assert_eq!(refusal.reason, "unsafe_path_gate_disabled");
+        assert!(refusal.detail.contains(UNVERIFIED_WORKSPACE_RESTORE_GATE));
+        assert!(unsafe_path_gate(UNVERIFIED_WORKSPACE_RESTORE_GATE, Some("1")).is_ok());
+    }
+
+    #[test]
+    fn gate_parsing_treats_falsey_values_as_off() {
+        for off in ["", " ", "0", "false", "no", "off", "maybe"] {
+            assert!(!gate_enabled(Some(off)), "{off:?} must be OFF");
+        }
+        for on in ["1", "true", "TRUE", "yes", "on"] {
+            assert!(gate_enabled(Some(on)), "{on:?} must be ON");
+        }
+    }
+
+    #[test]
+    fn oversized_guest_declared_transfer_is_refused_by_default() {
+        let refusal = admit_guest_transfer_len(u64::MAX, None).expect_err("must refuse");
+        assert_eq!(refusal.reason, "guest_declared_transfer_too_large");
+        // A sane length still passes with the gate off.
+        assert_eq!(admit_guest_transfer_len(4096, None).unwrap(), 4096);
+        // The opt-in restores the old behaviour explicitly.
+        assert_eq!(
+            admit_guest_transfer_len(u64::MAX, Some("1")).unwrap(),
+            u64::MAX
+        );
+    }
+
+    #[test]
+    fn traversing_and_absolute_cache_paths_are_refused() {
+        for escape in ["../../etc", "a/../../b", ".."] {
+            let refusal = admit_cache_path(escape).expect_err("must refuse");
+            assert_eq!(refusal.reason, "cache_path_escapes_root", "{escape:?}");
+        }
+        for absolute in ["/root/.ssh", "/etc/passwd"] {
+            let refusal = admit_cache_path(absolute).expect_err("must refuse");
+            assert_eq!(refusal.reason, "cache_path_not_relative", "{absolute:?}");
+        }
+        assert!(admit_cache_path("").is_err());
+    }
+
+    #[test]
+    fn ordinary_relative_cache_paths_still_work() {
+        // Containment must not break the legitimate build-cache use case.
+        for ok in ["node_modules", "target", ".venv", "a/b/c", "./target"] {
+            assert!(admit_cache_path(ok).is_ok(), "{ok:?} must be admitted");
+        }
+    }
+
+    #[test]
+    fn an_unattributed_cache_scope_is_refused() {
+        let refusal = admit_cache_scope(None).expect_err("must refuse");
+        assert_eq!(refusal.reason, "cache_scope_unattributed");
+        assert!(admit_cache_scope(Some("   ")).is_err());
+        assert_eq!(admit_cache_scope(Some("system://a")).unwrap(), "system://a");
+    }
+
+    // --- 3. admission ---
+
+    #[test]
+    fn admission_refuses_when_safe_cleanup_is_unavailable() {
+        let refusal = admit_resource_creation("microvm", CleanupCapability::Unavailable)
+            .expect_err("must refuse");
+        assert_eq!(refusal.reason, "safe_cleanup_unavailable");
+        assert!(refusal.detail.contains("microvm"));
+    }
+
+    #[test]
+    fn admission_proceeds_when_teardown_outcome_is_observed() {
+        assert!(
+            admit_resource_creation("microvm", CleanupCapability::observed(true, true)).is_ok()
+        );
+        // A teardown path that exists but discards its outcome is NOT cleanup capability.
+        assert_eq!(
+            CleanupCapability::observed(true, false),
+            CleanupCapability::Unavailable
+        );
+    }
+
+    // --- 4. CARVE-OUT: deletion ---
+
+    #[test]
+    fn deletion_remains_callable_and_returns_each_of_the_three_outcomes() {
+        let succeeded = close_deletion("env://a", DeletionOutcome::Succeeded);
+        let failed = close_deletion("env://b", DeletionOutcome::Failed);
+        let unknown = close_deletion("env://c", DeletionOutcome::Unknown);
+
+        assert_eq!(succeeded.outcome.as_str(), "succeeded");
+        assert_eq!(failed.outcome.as_str(), "failed");
+        assert_eq!(unknown.outcome.as_str(), "unknown");
+    }
+
+    #[test]
+    fn non_succeeded_deletions_open_a_durable_obligation() {
+        assert!(close_deletion("env://a", DeletionOutcome::Succeeded)
+            .cleanup_obligation_ref
+            .is_none());
+        for outcome in [DeletionOutcome::Failed, DeletionOutcome::Unknown] {
+            let disposition = close_deletion("env://b", outcome);
+            assert!(
+                disposition.cleanup_obligation_ref.is_some(),
+                "{outcome:?} must open an obligation"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_is_never_coerced_to_success_or_failure() {
+        // A delete call that returned Ok but was never re-observed is UNKNOWN.
+        assert_eq!(
+            DeletionOutcome::classify(true, false),
+            DeletionOutcome::Unknown
+        );
+        // Only a post-delete absence observation yields success.
+        assert_eq!(
+            DeletionOutcome::classify(true, true),
+            DeletionOutcome::Succeeded
+        );
+        assert_eq!(
+            DeletionOutcome::classify(false, false),
+            DeletionOutcome::Failed
+        );
+        // And even a failed call with proven absence is honestly succeeded.
+        assert_eq!(
+            DeletionOutcome::classify(false, true),
+            DeletionOutcome::Succeeded
+        );
+    }
+
+    #[test]
+    fn deletion_is_not_gated_by_any_containment() {
+        // The carve-out in one assertion: nothing in this module can make deletion refuse.
+        // close_deletion is total over its input domain and returns a disposition every time.
+        for outcome in [
+            DeletionOutcome::Succeeded,
+            DeletionOutcome::Failed,
+            DeletionOutcome::Unknown,
+        ] {
+            let disposition = close_deletion("provider://vast/instance/1", outcome);
+            assert_eq!(disposition.outcome, outcome);
+            assert_eq!(
+                disposition.schema_version,
+                EMERGENCY_CONTAINMENT_SCHEMA_VERSION
+            );
+            assert_eq!(
+                disposition.cleanup_obligation_ref.is_some(),
+                outcome != DeletionOutcome::Succeeded
+            );
+        }
+    }
+
+    // --- 5. evidence quarantine ---
+
+    #[test]
+    fn quarantined_evidence_cannot_be_cited_as_proof() {
+        let refusal = evidence_citation("evidence://vm-boot/phase1", EvidenceStanding::Quarantined)
+            .expect_err("must refuse");
+        assert_eq!(refusal.reason, "evidence_quarantined_non_authoritative");
+        assert!(evidence_citation("evidence://ok", EvidenceStanding::Authoritative).is_ok());
+    }
+
+    #[test]
+    fn quarantine_is_a_standing_change_not_a_deletion() {
+        // Quarantine must be expressible as a status; nothing here removes an artifact.
+        assert_eq!(
+            EvidenceStanding::Quarantined.as_str(),
+            "quarantined_non_authoritative"
+        );
+    }
+}

--- a/crates/services/src/agentic/runtime/kernel/governed_receipt.rs
+++ b/crates/services/src/agentic/runtime/kernel/governed_receipt.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-use super::ctee::{CteeNodeTrust, PrivateWorkspaceCteeModule};
+use super::ctee::{self, CteeNodeTrust, PrivateWorkspaceCteeModule};
 use super::marketplace::{
     WorkerServicePackageInvocationCore, WorkerServicePackageInvocationRequest,
 };
@@ -97,7 +97,14 @@ pub fn execute_private_workspace_ctee_action_protocol_response(
         "schema_version": "ioi.runtime.ctee_private_workspace_admission.v1",
         "object": "ioi.runtime_ctee_private_workspace_admission",
         "status": "admitted",
-        "action_executed": true,
+        // CONTAINMENT (claim truth): the cTEE module ADMITS; it executes nothing. This field was
+        // hardcoded `true` for a path that spawns no process, boots no VM, enters no enclave, and
+        // verifies no attestation. It now reports what is true, alongside the withdrawn isolation
+        // label so a consumer cannot read admission as confidential execution.
+        "action_executed": ctee::CTEE_ACTION_EXECUTED,
+        "isolation_standing": ctee::CTEE_ISOLATION_STANDING,
+        "attestation_verified": false,
+        "node_trust_source": "caller_supplied_unverified",
         "source": "rust_ctee_private_workspace_protocol",
         "backend": "ctee_operator",
         "thread_id": request.thread_id,
@@ -363,7 +370,18 @@ mod tests {
             "ioi.runtime_ctee_private_workspace_admission"
         );
         assert_eq!(response["status"], "admitted");
-        assert_eq!(response["action_executed"], true);
+        // CONTAINMENT (claim truth): this assertion previously pinned `action_executed == true`.
+        // It was pinning an OVERCLAIM: the cTEE path spawns no process, boots no VM, enters no
+        // enclave, and verifies no attestation, so nothing was ever executed. The bar now pins
+        // what the code actually does — admission without execution — plus the withdrawn
+        // isolation standing and the fact that node trust arrived from the caller unverified.
+        assert_eq!(response["action_executed"], false);
+        assert_eq!(
+            response["isolation_standing"],
+            "unverified_no_execution_backend"
+        );
+        assert_eq!(response["attestation_verified"], false);
+        assert_eq!(response["node_trust_source"], "caller_supplied_unverified");
         assert_eq!(response["thread_id"], "thread:ctee");
         assert_eq!(response["agent_id"], "agent:ctee");
         assert_eq!(

--- a/crates/services/src/agentic/runtime/kernel/mod.rs
+++ b/crates/services/src/agentic/runtime/kernel/mod.rs
@@ -16,6 +16,7 @@ pub mod coding_tool_step_module;
 pub mod coding_tool_workspace;
 pub mod ctee;
 pub mod deadline;
+pub mod emergency_containment;
 pub mod evidence;
 pub mod governed_admission;
 pub mod governed_receipt;

--- a/docs/architecture/_meta/current-canon-defaults.md
+++ b/docs/architecture/_meta/current-canon-defaults.md
@@ -497,6 +497,39 @@ synchronized.
   after possible effect becomes rollback/reconciliation/cleanup, and a
   `HypervisorResourceCleanupObligation` survives parent deletion until its
   exact provider resource is reconciled;
+- emergency containment (2026-07-29) applies [INV-38](../foundations/invariants.md)
+  to the environment/provider planes. An environment that declared a `vm_kernel`
+  isolation floor REFUSES rather than falling back to the host: workspace exec
+  refuses `isolation_required_substrate_unavailable` when no guest is live, and
+  the host-executed WorkRun turn and the host PTY refuse
+  `isolation_required_host_execution_refused`. The resource-isolation and
+  connectivity profiles are keyed on the MEASURED boot outcome, so a failed
+  microVM boot publishes `process_scoped` plus a
+  `measured_isolation: unverified_isolation_declared_vm_kernel_substrate_unavailable`
+  marker instead of inheriting `vm_kernel`. Environment-class `enabled` for
+  microvm is probe-derived from the pinned checksum-verified VM toolchain. The
+  cTEE private-workspace module is an ADMISSION PLANNER that executes nothing
+  and verifies no attestation; it reports `action_executed: false`,
+  `isolation_standing: unverified_no_execution_backend`, and
+  `node_trust_source: caller_supplied_unverified`;
+- two containment gates exist, and BOTH default OFF. Enabling either is an
+  explicit operator opt-in that re-admits a path whose safety is not
+  established: `IOI_ALLOW_UNVERIFIED_WORKSPACE_RESTORE` (default OFF) re-admits
+  extraction of guest-authored workspace material onto the host filesystem
+  without admitted-digest provenance, and `IOI_ALLOW_UNBOUNDED_GUEST_TRANSFER`
+  (default OFF) re-admits a guest-declared transfer length above the 1 GiB host
+  allocation ceiling. Absent, empty, `0`, and `false` all mean OFF. Recipe build
+  caches are keyed by owning System/tenant scope AND recipe — an unattributed
+  cache is refused, not shared — and every declared `cache_paths` entry must be
+  relative and non-escaping;
+- deletion of an EXISTING resource always remains callable under containment. It
+  returns an exact `succeeded | failed | unknown` outcome, where `unknown` is
+  first-class and is never coerced into either neighbour: a delete call that
+  returned without a confirming re-observation is `unknown`, not `succeeded`. A
+  non-`succeeded` outcome opens a durable cleanup obligation. Provider adapters
+  derive `cleanup_verified` and `teardown_state`
+  (`torn_down | teardown_failed | torn_down_unverified`) from the observed
+  provider verdict rather than asserting completion;
 - Hypervisor Core is the shared runtime/control substrate whose execution
   owner is the Hypervisor Daemon; it is not a peer runtime beside the daemon,
   not a replacement for wallet.network, and not a replacement for Agentgres;

--- a/docs/architecture/components/hypervisor/byo-provider-plane.md
+++ b/docs/architecture/components/hypervisor/byo-provider-plane.md
@@ -306,8 +306,18 @@ closed with `PROVIDER_KIND_LIFECYCLE_NOT_IMPLEMENTED` — never a fake cloud.
 Environment classes are durable records (`ioi.hypervisor.environment-class.v1`) with
 `provider_eligibility` (provider kinds, required capabilities, credential kind, spend
 posture). `enabled` is computed at read time and is true only when a real provider/account
-path backs the class: local always; microvm while the VmMonitor lane is operational;
-`byo-ssh-node` only while a verified `baremetal_ssh` account exists.
+path backs the class: local always; microvm only while the pinned, checksum-verified VM
+toolchain resolves on the host; `byo-ssh-node` only while a verified `baremetal_ssh`
+account exists.
+
+Claim-truth note (emergency containment, 2026-07-29): the microvm arm previously returned an
+unconditional `enabled: true, real: true` constant that probed nothing, so a host with no
+monitor binary and no pinned toolchain still advertised an operational microVM lane — which
+violated this section's own rule. The arm now resolves the same toolchain `build_vm_spec`
+requires and reports `enabled: false` with a named `unavailable_reason` when it does not. The
+done-bar assertion that pinned the old constant asserted a literal and is quarantined as
+non-authoritative; it is retained, rewritten to check that the reported value matches the
+probe. See [INV-38](../../foundations/invariants.md).
 
 ## Surfaces
 

--- a/docs/architecture/foundations/invariants.md
+++ b/docs/architecture/foundations/invariants.md
@@ -365,6 +365,23 @@ collect — they do not satisfy preconditions.
 Owner application: [`../components/daemon-runtime/doctrine.md`](../components/daemon-runtime/doctrine.md),
 [`../components/daemon-runtime/api.md`](../components/daemon-runtime/api.md).
 
+**INV-38 — An isolation claim is measured, and it never degrades silently.** A
+surface may publish an isolation label only for a boundary the runtime observed
+at the time it reports it; a declared substrate, a requested profile, or a
+class catalog entry is an intent, not a measurement. When a declared isolated
+substrate is unavailable, the operation REFUSES by a named reason — it never
+falls back to a weaker locus while retaining the stronger label, and an
+operation that executes on the host cannot satisfy a declared kernel-isolation
+floor regardless of what else is running. When measurement does not support a
+label, the label is withdrawn to what is true (process-scoped, or explicitly
+unverified) rather than inherited from the declaration. Evidence that asserts a
+property it did not measure is quarantined: retained for the record, never
+citable as proof, never deleted.
+Owner application:
+[`security-privacy-policy-invariants.md`](./security-privacy-policy-invariants.md),
+[`../components/hypervisor/providers-and-environments.md`](../components/hypervisor/providers-and-environments.md),
+[`../components/hypervisor/byo-provider-plane.md`](../components/hypervisor/byo-provider-plane.md).
+
 ## Citation Rule
 
 When a doc needs one of these invariants, it writes one line — the ID, an


### PR DESCRIPTION
Owner-directed emergency containment, ordered ahead of all queued work. **This cut only REDUCES claims.** No capability claim is added.

## Root cause
`minimum_isolation` / `isolation_claim` were **write-only — five assignments, zero readers tree-wide.** Nothing ever consulted a declared isolation floor before executing, so every isolation label downstream was decorative.

## Findings (12; file:line evidence in the commit)
**Critical:** exec fell through to **host `bash -lc`** whenever the in-memory VM map lacked an entry — daemon restart, VM crash, teardown — while the durable record still advertised `vm_kernel` · the workspace-write path runs host `git` and host `fs::write` while `host_mutation: false` was a **hardcoded literal** · the terminal binding is an interactive **host** PTY with a **caller-supplied shell binary**, no isolation check · the recipe build cache was keyed on the recipe ref **alone**, giving node-global **cross-tenant sharing of executed content**, with cache paths joined unvalidated · `cleanup_verified: true` was **hardcoded** across eight provider adapters and emitted even when the native destroy returned `destroyed: false` · five fallible steps sat between a **billable** lease and persistence, so a failure there made delete fail *forever* on an instance that keeps billing.

**High:** enforcement was keyed on the *declaration* rather than the measured boot, so a **failed** microVM boot still published `vm_kernel` · `microvm real:true` was an unconditional constant that probes nothing · a confidential-workspace receipt claimed `action_executed: true` with an attestation while executing nothing, hashing the *request* as its post-state, with trust fields **caller-supplied over HTTP** · a guest-declared transfer length was allocated verbatim (a `u64::MAX` aborts the daemon) · teardown discarded its result and used one monitor transport for all guest kinds.

## Contained
Refuse, never fall back: isolation-required work refuses by name when the isolated substrate is unavailable, and host execution under a declared isolation requirement refuses. Labels withdrawn to measured truth. Two unsafe paths feature-gated, **both default OFF**. Caches tenant-scoped with path validation. New observation types carry **no `Deserialize` and no `From<bool>`**, so a request body cannot become an observation.

## The carve-out holds: deletion never refuses
`DeletionOutcome::classify` maps a call that returned *without re-observation* to **`Unknown`** — never coerced to success or failure. All eight adapters plus microVM teardown derive their teardown state from observed verdicts, and anything non-succeeded opens a **durable cleanup obligation**. Proven by `provider_deletion_is_total_and_never_refuses`, `unknown_is_never_coerced_to_success_or_failure`, `an_unreachable_remote_half_degrades_to_unknown_not_success`, and `environment_deletion_reports_each_of_the_three_outcomes_with_obligations`.

## Deliberately not contained
**No fabricated VM evidence exists** — the isolation verifiers are genuinely sound (guest-vs-host kernel comparison, fail-on-skip, orphan scan); they are unretained and ungated, not false. One non-probative bar was quarantined because it asserted a constant and could never fail.

## One held bar deliberately changed
A confidential-workspace receipt test pinned `action_executed == true` — **the bar was pinning the overclaim.** It now pins admission-without-execution and the withdrawn isolation standing.

## Gates
`cargo test -p ioi-services -p ioi-node` **3504 + 415 pass, 0 fail** (39 new) · fmt clean · architecture-docs and contract bar pass. `pre-next-leg` is 48/60 and **proven inherited** — the identical failure set occurs on base `360853b78`; the cause is the stale route census left by the publication rebuild, owned by its successor record, not by this cut.

## Follow-up, stated plainly
Eight provider verifier scripts assert `teardown_state === "torn_down"` and will now **correctly fail** when the remote cleanup half is unreachable — previously that was reported as verified. Same pattern as the publication bars: they pinned the overclaim. They require a live daemon and were not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)