### PR TITLE
Repair Agentgres managed-session replay and wallet interception E2E

### DIFF
--- a/crates/cli/tests/wallet_network_session_channel_e2e/bridge_interceptions.rs
+++ b/crates/cli/tests/wallet_network_session_channel_e2e/bridge_interceptions.rs
@@ -62,20 +62,13 @@ async fn wallet_network_bridge_records_firewall_interceptions_from_ingestion() -
 
         wait_for_height(rpc_addr, 1, Duration::from_secs(30)).await?;
 
-        let start_params = StartAgentParams {
-            session_id: [0x91u8; 32],
-            goal: "Open calculator".to_string(),
-            runtime_route_frame: None,
-            max_steps: 1,
-            parent_session_id: None,
-            initial_budget: 1_000_000,
-            mode: AgentMode::Agent,
-        };
         let tx = create_call_service_tx(
             &client_keypair,
             "desktop_agent",
-            "start@v1",
-            start_params,
+            "software_install__execute_plan",
+            // Keep this bridge test on policy verdict admission; non-UTF8 input avoids
+            // exercising the separate desktop-agent PII egress path.
+            vec![0xff],
             nonce,
             chain_id,
         )?;
@@ -119,7 +112,7 @@ async fn wallet_network_bridge_records_firewall_interceptions_from_ingestion() -
         assert_eq!(interception.session_id, None);
         assert_eq!(
             interception.target.canonical_label(),
-            "start@v1".to_string()
+            "software_install__execute_plan".to_string()
         );
         assert_eq!(interception.reason, "manual approval required".to_string());
 

--- a/crates/cli/tests/wallet_network_session_channel_e2e/mod.rs
+++ b/crates/cli/tests/wallet_network_session_channel_e2e/mod.rs
@@ -11,7 +11,6 @@ use ioi_cli::testing::{
 use ioi_crypto::security::SecurityLevel;
 use ioi_crypto::sign::dilithium::{MldsaKeyPair, MldsaScheme};
 use ioi_crypto::sign::eddsa::Ed25519KeyPair;
-use ioi_services::agentic::runtime::{AgentMode, StartAgentParams};
 use ioi_services::wallet_network::{
     ApprovalConsumptionState, BumpRevocationEpochParams, ConsumeApprovalGrantParams,
     IssueSessionGrantParams, LeaseConsumptionState, RegisterApprovalAuthorityParams,
@@ -461,7 +460,10 @@ fn wallet_network_user_policy() -> ServicePolicy {
 
 fn desktop_agent_user_policy() -> ServicePolicy {
     let mut methods = BTreeMap::new();
-    methods.insert("start@v1".to_string(), MethodPermission::User);
+    methods.insert(
+        "software_install__execute_plan".to_string(),
+        MethodPermission::User,
+    );
     ServicePolicy {
         methods,
         allowed_system_prefixes: vec![],

--- a/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
@@ -864,7 +864,7 @@ pub(crate) async fn handle_agent_run_create(
     Ok(Json(run))
 }
 
-/// Append admitted runtime events to the thread's persisted Agentgres event log
+/// Append runtime events to the thread's legacy compatibility event log
 /// (`<state_dir>/events/<sha256(stream_id)>.jsonl`). The kernel reads every
 /// `*.jsonl` under `events/` and filters by `event_stream_id`, so one file per
 /// stream keeps appends contiguous without clobbering sibling streams.
@@ -894,11 +894,6 @@ fn append_persisted_events(
     Ok(())
 }
 
-/// Admit a single custom runtime event (e.g. a context-policy / workspace-trust
-/// decision) onto the persisted log via the kernel admission planner — it reads the
-/// stream's `latest_seq` from `<state_dir>/events/*.jsonl` and assigns seq+1, so the
-/// event lands AFTER the thread.started + turn events already on the log — then
-/// append the admitted event. Returns the admitted event (with seq, event_id, refs).
 /// Admit one runtime event onto its stream's Agentgres chain.
 ///
 /// Idempotency is NOT re-implemented here. "This key admits exactly once" is
@@ -4313,6 +4308,8 @@ pub(crate) async fn handle_approval_revoke(
 /// GET /v1/threads/:id/managed-sessions — project the thread's managed sessions
 /// (read-only). The kernel projection record carries no `status`; the JS client asserts
 /// `status == "projected"`, so the envelope injects it (as the napi projection API does).
+/// Candidate state comes from this daemon's classified event-stream replay: admitted
+/// streams read Agentgres and legacy streams read only their inert pre-migration log.
 pub(crate) async fn handle_managed_sessions(
     State(st): State<Arc<DaemonState>>,
     AxumPath(thread_id): AxumPath<String>,
@@ -4323,6 +4320,8 @@ pub(crate) async fn handle_managed_sessions(
             format!("thread not found: {thread_id}"),
         ));
     }
+    let event_stream_id = format!("{thread_id}:events");
+    let events = replay_runtime_events(&st, "stream", &event_stream_id, None)?;
     let request: RuntimeManagedSessionProjectionRequest = serde_json::from_value(json!({
         "schema_version": RUNTIME_MANAGED_SESSION_PROJECTION_REQUEST_SCHEMA_VERSION,
         "operation": "managed_session_inspection",
@@ -4339,7 +4338,7 @@ pub(crate) async fn handle_managed_sessions(
     }))
     .map_err(|error| AppError(StatusCode::BAD_REQUEST, error.to_string()))?;
     let record = RuntimeKernelService::new()
-        .project_runtime_managed_session_projection(&request)
+        .project_runtime_managed_session_projection_from_replayed_events(&request, &events)
         .map_err(|error| AppError(StatusCode::BAD_GATEWAY, debug_string(error)))?;
     Ok(Json(json!({
         "schema_version": "ioi.runtime.managed_session_projection.v1",
@@ -4360,9 +4359,9 @@ pub(crate) async fn handle_managed_sessions(
 /// POST /v1/threads/:id/managed-sessions/control — operator control (observe /
 /// take_over / return_agent) of a managed session. The kernel
 /// plan_runtime_managed_session_control reads the prior managed_session record from
-/// the persisted event log (produced by the runtime event-log bridge when a real
-/// `browser__*` turn drives a sandbox session) and synthesizes the
-/// `managed_session.controlled` transition, which is admitted onto the log. Returns
+/// classified event-stream replay (produced by the runtime event-log bridge when a
+/// real `browser__*` turn drives a sandbox session) and synthesizes the
+/// `managed_session.controlled` transition, which is admitted onto the stream. Returns
 /// the admitted event. Errors (e.g. record_required) surface when no managed session
 /// has been produced for the thread yet.
 pub(crate) async fn handle_managed_session_control(
@@ -4382,12 +4381,14 @@ pub(crate) async fn handle_managed_session_control(
             "managed_session_id is required".to_string(),
         ));
     };
+    let event_stream_id = format!("{thread_id}:events");
+    let events = replay_runtime_events(&st, "stream", &event_stream_id, None)?;
     let request: RuntimeManagedSessionControlRequest = serde_json::from_value(json!({
         "schema_version": RUNTIME_MANAGED_SESSION_CONTROL_REQUEST_SCHEMA_VERSION,
         "operation": "managed_session_control",
         "operation_kind": "managed_session.control",
         "thread_id": thread_id,
-        "event_stream_id": format!("{thread_id}:events"),
+        "event_stream_id": event_stream_id,
         "state_dir": st.data_dir,
         "managed_session_id": managed_session_id,
         "control_state": body.get("control_state").and_then(|v| v.as_str()),
@@ -4396,7 +4397,7 @@ pub(crate) async fn handle_managed_session_control(
     }))
     .map_err(|error| AppError(StatusCode::BAD_REQUEST, error.to_string()))?;
     let record = RuntimeKernelService::new()
-        .plan_runtime_managed_session_control(&request)
+        .plan_runtime_managed_session_control_from_replayed_events(&request, &events)
         .map_err(|error| AppError(StatusCode::BAD_GATEWAY, debug_string(error)))?;
     let event = serde_json::to_value(&record.event)
         .map_err(|error| AppError(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;

--- a/crates/services/src/agentic/runtime/event_log_bridge.rs
+++ b/crates/services/src/agentic/runtime/event_log_bridge.rs
@@ -2,10 +2,10 @@
 //!
 //! Turn execution (`RuntimeAgentService`) writes the execution-layer KV via
 //! [`StateAccess`](ioi_api::state::StateAccess) and emits [`KernelEvent`]s on a
-//! broadcast channel, but the hypervisor daemon's HTTP projections read a
-//! filesystem event log at `<state_dir>/events/<sha256(stream_id)>.jsonl`. The two
-//! are otherwise decoupled processes joined only by `state_dir`: the runtime never
-//! touches the daemon's log, and the daemon has no handle to the runtime KV.
+//! broadcast channel, while the hypervisor daemon owns the sole Agentgres handle
+//! steward and serves HTTP projections from classified event-stream replay. The
+//! runtime cannot acquire that handle; the daemon injects the bounded
+//! [`agentgres::event_stream::EventStreamAdmission`] capability at boot.
 //!
 //! This module is the bridge. Given a runtime-produced thread event keyed by the
 //! runtime `session_id`, it:
@@ -13,18 +13,20 @@
 //!      daemon persisted when the runtime-bridge thread started — it carries
 //!      `runtime_session_id = hex(session_id)`),
 //!   2. injects `thread_id` / `event_stream_id`,
-//!   3. admits the event through the kernel (which assigns `seq` after the events
-//!      already on the log), and
-//!   4. appends it to `<state_dir>/events/<sha256(stream_id)>.jsonl`,
+//!   3. has the kernel shape the event while discarding its legacy sequence, and
+//!   4. admits it through the injected capability, letting Agentgres own sequence.
 //!
-//! exactly mirroring the daemon's own `admit_and_persist_event`, so daemon
-//! projections (e.g. `GET /v1/threads/:id/managed-sessions`) read turn-execution
-//! output as first-class runtime events. This is the one generic carrier path that
-//! lets any turn-execution producer reach the daemon log; managed-session
-//! projection is its first producer.
+//! This mirrors the daemon's own writer path, so classified replay returns
+//! turn-execution output as first-class runtime events to projections such as
+//! `GET /v1/threads/:id/managed-sessions`. This is the one generic carrier path
+//! from turn-execution producers to admitted daemon truth; managed-session
+//! projection is its first producer. A missing capability refuses and never falls
+//! back to the legacy append-only log.
 
 use std::{fs, io::Write, path::Path};
 
+#[cfg(test)]
+use agentgres::event_stream::EventStreamAdmission;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
@@ -242,20 +244,69 @@ fn append_event_line(state_dir: &str, event_stream_id: &str, event: &Value) -> R
     Ok(())
 }
 
-/// Admit a runtime thread event onto its stream's Agentgres chain, through
-/// the injected admission capability.
-///
-/// This crate cannot open the substrate: the handle steward lives in the
-/// daemon. So this writer admits through the injection boundary, and when no
-/// capability has been injected it REFUSES — it never reverts to the legacy
-/// append-only log.
-///
-/// Idempotency is not re-implemented here. The whole-stream key check lives
-/// inside admission, so this writer inherits it through the admit it already
-/// calls; the caller-side log scan this function used to perform is deleted.
-/// The per-stream lock is gone with it: race safety comes from the CAS, whose
-/// loser re-reads and re-derives against the winner's admitted fact.
-pub fn admit_and_persist_runtime_event(state_dir: &str, event: Value) -> Result<Value, String> {
+trait EventStreamAdmissionDispatch {
+    fn read_head(
+        &self,
+        owner_namespace: &str,
+        stream_tail: &str,
+    ) -> Result<Option<agentgres::mux::ExactProjection>, agentgres::event_stream::AdmissionRefusal>;
+
+    fn admit_event(
+        &self,
+        request: agentgres::event_stream::EventAdmission<'_>,
+    ) -> Result<agentgres::event_stream::Admitted, agentgres::event_stream::AdmissionRefusal>;
+}
+
+struct ProductionEventStreamAdmission;
+
+impl EventStreamAdmissionDispatch for ProductionEventStreamAdmission {
+    fn read_head(
+        &self,
+        owner_namespace: &str,
+        stream_tail: &str,
+    ) -> Result<Option<agentgres::mux::ExactProjection>, agentgres::event_stream::AdmissionRefusal>
+    {
+        super::event_stream_admission::read_head(owner_namespace, stream_tail)
+    }
+
+    fn admit_event(
+        &self,
+        request: agentgres::event_stream::EventAdmission<'_>,
+    ) -> Result<agentgres::event_stream::Admitted, agentgres::event_stream::AdmissionRefusal> {
+        // Keep this call through the documented production entry point. The
+        // uninjected proof drives this exact function and would no longer
+        // cover the bridge if production reached around it to the trait object.
+        super::event_stream_admission::admit_event(request)
+    }
+}
+
+#[cfg(test)]
+struct ExplicitEventStreamAdmission<'a>(&'a dyn EventStreamAdmission);
+
+#[cfg(test)]
+impl EventStreamAdmissionDispatch for ExplicitEventStreamAdmission<'_> {
+    fn read_head(
+        &self,
+        owner_namespace: &str,
+        stream_tail: &str,
+    ) -> Result<Option<agentgres::mux::ExactProjection>, agentgres::event_stream::AdmissionRefusal>
+    {
+        self.0.read_head(owner_namespace, stream_tail)
+    }
+
+    fn admit_event(
+        &self,
+        request: agentgres::event_stream::EventAdmission<'_>,
+    ) -> Result<agentgres::event_stream::Admitted, agentgres::event_stream::AdmissionRefusal> {
+        self.0.admit_event(request)
+    }
+}
+
+fn admit_and_persist_runtime_event_via(
+    state_dir: &str,
+    event: Value,
+    admission: impl EventStreamAdmissionDispatch,
+) -> Result<Value, String> {
     let event_stream_id = event
         .get("event_stream_id")
         .and_then(Value::as_str)
@@ -304,15 +355,16 @@ pub fn admit_and_persist_runtime_event(state_dir: &str, event: Value) -> Result<
     }
 
     let tail = super::event_stream_admission::stream_tail(&event_stream_id);
-    let head = super::event_stream_admission::read_head(
-        super::event_stream_admission::THREAD_ORCHESTRATION_NAMESPACE,
-        &tail,
-    )
-    .map_err(|refusal| refusal.to_string())?;
+    let head = admission
+        .read_head(
+            super::event_stream_admission::THREAD_ORCHESTRATION_NAMESPACE,
+            &tail,
+        )
+        .map_err(|refusal| refusal.to_string())?;
     let expected_head = head.as_ref().map(|projection| projection.head.as_str());
 
-    let admitted =
-        super::event_stream_admission::admit_event(agentgres::event_stream::EventAdmission {
+    let admitted = admission
+        .admit_event(agentgres::event_stream::EventAdmission {
             owner_namespace: super::event_stream_admission::THREAD_ORCHESTRATION_NAMESPACE,
             stream_tail: &tail,
             op_kind: "event_stream.append",
@@ -334,14 +386,28 @@ pub fn admit_and_persist_runtime_event(state_dir: &str, event: Value) -> Result<
     Ok(result)
 }
 
-/// Bridge a managed-session snapshot onto the daemon's event log for `session_id`.
-/// Resolves the daemon thread, builds + finalizes the `managed_session.projected`
-/// event, and admits it. A no-op (`Ok(None)`) when the snapshot is empty or no
-/// daemon thread is mapped for the session.
-pub fn persist_managed_session_snapshot(
+/// Admit a runtime thread event onto its Agentgres stream through the daemon's
+/// injected production boundary. Missing injection refuses; it never falls back
+/// to the legacy append-only log. Idempotency and race safety remain owned by the
+/// admission core's whole-stream key check and compare-and-swap.
+pub fn admit_and_persist_runtime_event(state_dir: &str, event: Value) -> Result<Value, String> {
+    admit_and_persist_runtime_event_via(state_dir, event, ProductionEventStreamAdmission)
+}
+
+#[cfg(test)]
+pub(crate) fn admit_and_persist_runtime_event_with_admission(
+    state_dir: &str,
+    event: Value,
+    admission: &dyn EventStreamAdmission,
+) -> Result<Value, String> {
+    admit_and_persist_runtime_event_via(state_dir, event, ExplicitEventStreamAdmission(admission))
+}
+
+fn persist_managed_session_snapshot_via(
     state_dir: &str,
     session_id: &[u8; 32],
     snapshot: &RuntimeManagedSessionSnapshot,
+    persist: impl FnOnce(Value) -> Result<Value, String>,
 ) -> Result<Option<Value>, String> {
     if snapshot.sessions.is_empty() {
         return Ok(None);
@@ -351,18 +417,40 @@ pub fn persist_managed_session_snapshot(
     };
     let mut event = managed_session_projected_event(session_id, snapshot);
     finalize_thread_routing(&mut event, &thread_id);
-    let admitted = admit_and_persist_runtime_event(state_dir, event)?;
-    Ok(Some(admitted))
+    persist(event).map(Some)
 }
 
-/// Persist a pre-serialized, session-keyed runtime thread event (the
-/// [`KernelEvent::RuntimeThreadEvent`](ioi_types::app::KernelEvent) carrier
-/// payload) onto the daemon log: resolve the daemon thread for the session, inject
-/// routing, and admit. A no-op (`Ok(None)`) when no daemon thread is mapped.
-pub fn persist_runtime_thread_event_json(
+/// Bridge a managed-session snapshot onto the daemon's admitted stream for `session_id`.
+/// Resolves the daemon thread, builds + finalizes the `managed_session.projected`
+/// event, and admits it. A no-op (`Ok(None)`) when the snapshot is empty or no
+/// daemon thread is mapped for the session.
+pub fn persist_managed_session_snapshot(
+    state_dir: &str,
+    session_id: &[u8; 32],
+    snapshot: &RuntimeManagedSessionSnapshot,
+) -> Result<Option<Value>, String> {
+    persist_managed_session_snapshot_via(state_dir, session_id, snapshot, |event| {
+        admit_and_persist_runtime_event(state_dir, event)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn persist_managed_session_snapshot_with_admission(
+    state_dir: &str,
+    session_id: &[u8; 32],
+    snapshot: &RuntimeManagedSessionSnapshot,
+    admission: &dyn EventStreamAdmission,
+) -> Result<Option<Value>, String> {
+    persist_managed_session_snapshot_via(state_dir, session_id, snapshot, |event| {
+        admit_and_persist_runtime_event_with_admission(state_dir, event, admission)
+    })
+}
+
+fn persist_runtime_thread_event_json_via(
     state_dir: &str,
     session_id: &[u8; 32],
     event_json: &str,
+    persist: impl FnOnce(Value) -> Result<Value, String>,
 ) -> Result<Option<Value>, String> {
     let Some(thread_id) = resolve_thread_id_for_session(state_dir, session_id) else {
         return Ok(None);
@@ -370,8 +458,33 @@ pub fn persist_runtime_thread_event_json(
     let mut event: Value = serde_json::from_str(event_json)
         .map_err(|error| format!("parse runtime thread event: {error}"))?;
     finalize_thread_routing(&mut event, &thread_id);
-    let admitted = admit_and_persist_runtime_event(state_dir, event)?;
-    Ok(Some(admitted))
+    persist(event).map(Some)
+}
+
+/// Persist a pre-serialized, session-keyed runtime thread event (the
+/// [`KernelEvent::RuntimeThreadEvent`](ioi_types::app::KernelEvent) carrier
+/// payload) onto the daemon stream: resolve the daemon thread for the session, inject
+/// routing, and admit. A no-op (`Ok(None)`) when no daemon thread is mapped.
+pub fn persist_runtime_thread_event_json(
+    state_dir: &str,
+    session_id: &[u8; 32],
+    event_json: &str,
+) -> Result<Option<Value>, String> {
+    persist_runtime_thread_event_json_via(state_dir, session_id, event_json, |event| {
+        admit_and_persist_runtime_event(state_dir, event)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn persist_runtime_thread_event_json_with_admission(
+    state_dir: &str,
+    session_id: &[u8; 32],
+    event_json: &str,
+    admission: &dyn EventStreamAdmission,
+) -> Result<Option<Value>, String> {
+    persist_runtime_thread_event_json_via(state_dir, session_id, event_json, |event| {
+        admit_and_persist_runtime_event_with_admission(state_dir, event, admission)
+    })
 }
 
 /// The class an admitted delivery gap is carried under.
@@ -417,8 +530,8 @@ pub fn admit_delivery_gap(state_dir: &str, skipped: u64) -> Result<(), String> {
 }
 
 /// Subscribe to a runtime [`KernelEvent`](ioi_types::app::KernelEvent) broadcast and
-/// persist each [`KernelEvent::RuntimeThreadEvent`] carrier onto the daemon's event
-/// log at `state_dir`. Other variants are ignored (the typed-receipt mapping is a
+/// admit each [`KernelEvent::RuntimeThreadEvent`] carrier onto the daemon's Agentgres
+/// stream. Other variants are ignored (the typed-receipt mapping is a
 /// separate concern). Runs until the channel closes; persistence failures are
 /// logged and skipped so one bad event never tears down the bridge.
 pub async fn run_event_log_bridge(
@@ -495,7 +608,116 @@ pub async fn run_event_log_bridge(
 }
 
 #[cfg(test)]
+pub(crate) mod test_support {
+    use std::{
+        path::{Path, PathBuf},
+        sync::Mutex,
+    };
+
+    use agentgres::{
+        event_stream::{
+            self, AdmissionRefusal, Admitted, EventAdmission, EventStreamAdmission, OperationClass,
+        },
+        mux::{spawn_mux_writer, ExactProjection, MuxEngine, MuxHandle, MuxWriter},
+    };
+    use serde_json::{json, Value};
+
+    /// A per-test admission capability backed by a real Agentgres mux log.
+    ///
+    /// Tests pass this capability explicitly. They never install it in the
+    /// process-global production boundary, so the fail-closed uninjected test
+    /// remains meaningful and parallel test order cannot poison a `OnceLock`.
+    pub(crate) struct TestEventStreamAdmission {
+        handle: MuxHandle,
+        engine_dir: PathBuf,
+        writer: Mutex<Option<MuxWriter>>,
+    }
+
+    impl TestEventStreamAdmission {
+        pub(crate) fn open(engine_dir: impl AsRef<Path>) -> Self {
+            let engine_dir = engine_dir.as_ref().to_path_buf();
+            let engine = MuxEngine::open(&engine_dir, true).expect("open test Agentgres mux");
+            let (handle, writer) = spawn_mux_writer(engine, 128);
+            Self {
+                handle,
+                engine_dir,
+                writer: Mutex::new(Some(writer)),
+            }
+        }
+
+        fn admit_in_class(
+            &self,
+            request: EventAdmission<'_>,
+            class: OperationClass,
+        ) -> Result<Admitted, AdmissionRefusal> {
+            event_stream::require_operation_class(request.op_kind, class)?;
+            event_stream::admit_event_stream_operation(&self.handle, &self.engine_dir, request)
+        }
+
+        /// Replay the authored event values in admitted sequence order, with
+        /// substrate-owned sequence stamped exactly as the daemon replay path does.
+        pub(crate) fn replayed_events(
+            &self,
+            owner_namespace: &str,
+            stream_tail: &str,
+        ) -> Vec<Value> {
+            event_stream::read_event_stream_history(&self.handle, owner_namespace, stream_tail)
+                .expect("replay test Agentgres history")
+                .into_iter()
+                .map(|projection| {
+                    let mut event = projection.operation.payload;
+                    if let Some(object) = event.as_object_mut() {
+                        object.insert("seq".to_string(), json!(projection.seq));
+                    }
+                    event
+                })
+                .collect()
+        }
+    }
+
+    impl EventStreamAdmission for TestEventStreamAdmission {
+        fn admit_event(&self, request: EventAdmission<'_>) -> Result<Admitted, AdmissionRefusal> {
+            self.admit_in_class(request, OperationClass::Event)
+        }
+
+        fn read_head(
+            &self,
+            owner_namespace: &str,
+            stream_tail: &str,
+        ) -> Result<Option<ExactProjection>, AdmissionRefusal> {
+            event_stream::read_event_stream_head(&self.handle, owner_namespace, stream_tail)
+        }
+
+        fn admit_lease_transition(
+            &self,
+            request: EventAdmission<'_>,
+        ) -> Result<Admitted, AdmissionRefusal> {
+            self.admit_in_class(request, OperationClass::LeaseTransition)
+        }
+
+        fn advance_checkpoint(
+            &self,
+            request: EventAdmission<'_>,
+        ) -> Result<Admitted, AdmissionRefusal> {
+            self.admit_in_class(request, OperationClass::CheckpointAdvance)
+        }
+    }
+
+    impl Drop for TestEventStreamAdmission {
+        fn drop(&mut self) {
+            let _ = self.handle.shutdown();
+            if let Ok(writer) = self.writer.get_mut() {
+                if let Some(writer) = writer.take() {
+                    let _ = writer.join.join();
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use super::test_support::TestEventStreamAdmission;
     use super::*;
     use crate::agentic::runtime::kernel::runtime_managed_session_control::{
         RuntimeManagedSessionControlCore, RuntimeManagedSessionControlRequest,
@@ -542,6 +764,13 @@ mod tests {
             replay_ready: true,
             trace_visibility: "runs_tracing".to_string(),
         }
+    }
+
+    fn replayed_events(admission: &TestEventStreamAdmission, thread_id: &str) -> Vec<Value> {
+        admission.replayed_events(
+            super::super::event_stream_admission::THREAD_ORCHESTRATION_NAMESPACE,
+            &super::super::event_stream_admission::stream_tail(&format!("{thread_id}:events")),
+        )
     }
 
     fn snapshot(
@@ -611,6 +840,7 @@ mod tests {
     fn bridge_persists_managed_session_snapshot_and_kernel_projection_reads_it() {
         let temp = tempfile::tempdir().expect("tempdir");
         let state_dir = temp.path();
+        let admission = TestEventStreamAdmission::open(state_dir.join("agentgres"));
         let session_id = [0x38u8; 32];
         // Daemon-side precondition: the runtime-bridge thread linkage.
         write_bridge_agent_record(state_dir, "alpha", session_id);
@@ -618,18 +848,23 @@ mod tests {
         // Real snapshot output (the typed value the snapshot builder produces).
         let snap = snapshot(session_id, vec![card("sandbox_browser:1")]);
 
-        // Bridge it onto the daemon log.
-        let admitted =
-            persist_managed_session_snapshot(&state_dir.to_string_lossy(), &session_id, &snap)
-                .expect("bridge persists")
-                .expect("an event was admitted");
+        // Bridge it through the same Agentgres admission discipline the daemon injects.
+        let admitted = persist_managed_session_snapshot_with_admission(
+            &state_dir.to_string_lossy(),
+            &session_id,
+            &snap,
+            &admission,
+        )
+        .expect("bridge persists")
+        .expect("an event was admitted");
         assert_eq!(admitted["event_kind"], "managed_session.projected");
         assert_eq!(admitted["thread_id"], "thread_alpha");
         assert!(admitted.get("seq").and_then(Value::as_u64).is_some());
 
-        // The daemon's kernel managed-session projection reads it back from the log.
+        // The daemon's kernel managed-session projection consumes admitted replay.
+        let events = replayed_events(&admission, "thread_alpha");
         let record = RuntimeManagedSessionProjectionCore
-            .project(&projection_request(state_dir, "thread_alpha"))
+            .project_from_replayed_events(&projection_request(state_dir, "thread_alpha"), &events)
             .expect("projection");
         assert_eq!(record.operation_kind, "managed_session.inspect");
         assert_eq!(record.record_count, 1);
@@ -653,9 +888,34 @@ mod tests {
     }
 
     #[test]
+    fn production_bridge_refuses_when_the_admission_capability_is_uninjected() {
+        assert!(
+            !super::super::event_stream_admission::is_installed(),
+            "unit-test process must keep the production boundary uninjected"
+        );
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = [0x39u8; 32];
+        let snap = snapshot(session_id, vec![card("sandbox_browser:refusal")]);
+        let mut event = managed_session_projected_event(&session_id, &snap);
+        finalize_thread_routing(&mut event, "thread_uninjected");
+
+        let error = admit_and_persist_runtime_event(&temp.path().to_string_lossy(), event)
+            .expect_err("production bridge must refuse without daemon injection");
+        assert_eq!(
+            error,
+            agentgres::event_stream::AdmissionRefusal::CapabilityAbsent.to_string()
+        );
+        assert!(
+            !temp.path().join("events").exists(),
+            "capability refusal must never create a legacy event-log fallback"
+        );
+    }
+
+    #[test]
     fn carrier_json_round_trips_through_the_bridge() {
         let temp = tempfile::tempdir().expect("tempdir");
         let state_dir = temp.path();
+        let admission = TestEventStreamAdmission::open(state_dir.join("agentgres"));
         let session_id = [0x41u8; 32];
         write_bridge_agent_record(state_dir, "beta", session_id);
 
@@ -666,18 +926,20 @@ mod tests {
             serde_json::to_string(&managed_session_projected_event(&session_id, &snap))
                 .expect("serialize carrier");
 
-        let admitted = persist_runtime_thread_event_json(
+        let admitted = persist_runtime_thread_event_json_with_admission(
             &state_dir.to_string_lossy(),
             &session_id,
             &event_json,
+            &admission,
         )
         .expect("bridge persists")
         .expect("an event was admitted");
         assert_eq!(admitted["thread_id"], "thread_beta");
         assert_eq!(admitted["event_stream_id"], "thread_beta:events");
 
+        let events = replayed_events(&admission, "thread_beta");
         let record = RuntimeManagedSessionProjectionCore
-            .project(&projection_request(state_dir, "thread_beta"))
+            .project_from_replayed_events(&projection_request(state_dir, "thread_beta"), &events)
             .expect("projection");
         assert_eq!(record.record_count, 1);
         let sessions = record.projection.as_array().expect("sessions array");
@@ -688,18 +950,24 @@ mod tests {
     fn control_planner_transitions_a_bridge_produced_session() {
         let temp = tempfile::tempdir().expect("tempdir");
         let state_dir = temp.path();
+        let admission = TestEventStreamAdmission::open(state_dir.join("agentgres"));
         let session_id = [0x55u8; 32];
         write_bridge_agent_record(state_dir, "gamma", session_id);
 
-        // Bridge a real managed session onto the log (the producer side).
+        // Bridge a real managed session onto the admitted stream (the producer side).
         let snap = snapshot(session_id, vec![card("sandbox_browser:9")]);
-        persist_managed_session_snapshot(&state_dir.to_string_lossy(), &session_id, &snap)
-            .expect("bridge persists")
-            .expect("event admitted");
+        persist_managed_session_snapshot_with_admission(
+            &state_dir.to_string_lossy(),
+            &session_id,
+            &snap,
+            &admission,
+        )
+        .expect("bridge persists")
+        .expect("event admitted");
 
         // The kernel control planner reads the bridge-produced managed_session record
-        // from the log and synthesizes the controlled transition — the same path the
-        // daemon's POST /managed-sessions/control route drives.
+        // from admitted replay and synthesizes the controlled transition — the same
+        // path the daemon's POST /managed-sessions/control route drives.
         let request = RuntimeManagedSessionControlRequest {
             schema_version: Some(
                 RUNTIME_MANAGED_SESSION_CONTROL_REQUEST_SCHEMA_VERSION.to_string(),
@@ -719,8 +987,9 @@ mod tests {
             policy_decision_refs: vec![],
             evidence_refs: vec![],
         };
+        let events = replayed_events(&admission, "thread_gamma");
         let record = RuntimeManagedSessionControlCore
-            .plan(&request)
+            .plan_from_replayed_events(&request, &events)
             .expect("control plans over the bridge-produced session");
         assert_eq!(record.control_state, "take_over");
         assert_eq!(record.event["event_kind"], "managed_session.controlled");

--- a/crates/services/src/agentic/runtime/kernel/mod.rs
+++ b/crates/services/src/agentic/runtime/kernel/mod.rs
@@ -1121,11 +1121,27 @@ impl RuntimeKernelService {
         RuntimeManagedSessionProjectionCore.project(request)
     }
 
+    pub fn project_runtime_managed_session_projection_from_replayed_events(
+        &self,
+        request: &RuntimeManagedSessionProjectionRequest,
+        events: &[serde_json::Value],
+    ) -> Result<RuntimeManagedSessionProjectionRecord, RuntimeManagedSessionCommandError> {
+        RuntimeManagedSessionProjectionCore.project_from_replayed_events(request, events)
+    }
+
     pub fn plan_runtime_managed_session_control(
         &self,
         request: &RuntimeManagedSessionControlRequest,
     ) -> Result<RuntimeManagedSessionControlRecord, RuntimeManagedSessionCommandError> {
         RuntimeManagedSessionControlCore.plan(request)
+    }
+
+    pub fn plan_runtime_managed_session_control_from_replayed_events(
+        &self,
+        request: &RuntimeManagedSessionControlRequest,
+        events: &[serde_json::Value],
+    ) -> Result<RuntimeManagedSessionControlRecord, RuntimeManagedSessionCommandError> {
+        RuntimeManagedSessionControlCore.plan_from_replayed_events(request, events)
     }
 
     pub fn project_runtime_workspace_change_projection(

--- a/crates/services/src/agentic/runtime/kernel/runtime_managed_session_control.rs
+++ b/crates/services/src/agentic/runtime/kernel/runtime_managed_session_control.rs
@@ -128,6 +128,40 @@ impl RuntimeManagedSessionProjectionCore {
         &self,
         request: &RuntimeManagedSessionProjectionRequest,
     ) -> Result<RuntimeManagedSessionProjectionRecord, RuntimeManagedSessionCommandError> {
+        self.project_with_candidates(request, |thread_id| {
+            managed_session_candidates_from_state_dir(
+                request.state_dir.as_deref(),
+                thread_id,
+                "runtime_managed_session_projection_state_dir_required",
+                "runtime_managed_session_projection_replay_read_failed",
+                "runtime_managed_session_projection_replay_record_invalid",
+                "managed session projection",
+            )
+        })
+    }
+
+    /// Project from events already replayed by the daemon's Agentgres steward.
+    ///
+    /// This is a Rust-only source seam, not a request transport: the retired
+    /// caller-supplied `projection` field remains rejected below. The daemon
+    /// obtains these values from its classified event-stream replay path, then
+    /// passes them directly to the same validation and projection core used by
+    /// the legacy state-directory compatibility entry point.
+    pub fn project_from_replayed_events(
+        &self,
+        request: &RuntimeManagedSessionProjectionRequest,
+        events: &[Value],
+    ) -> Result<RuntimeManagedSessionProjectionRecord, RuntimeManagedSessionCommandError> {
+        self.project_with_candidates(request, |thread_id| {
+            Ok(managed_session_candidates_from_events(events, thread_id))
+        })
+    }
+
+    fn project_with_candidates(
+        &self,
+        request: &RuntimeManagedSessionProjectionRequest,
+        candidates: impl FnOnce(&str) -> Result<Vec<Value>, RuntimeManagedSessionCommandError>,
+    ) -> Result<RuntimeManagedSessionProjectionRecord, RuntimeManagedSessionCommandError> {
         if let Some(schema_version) = optional_trimmed(request.schema_version.as_deref()) {
             if schema_version != RUNTIME_MANAGED_SESSION_PROJECTION_REQUEST_SCHEMA_VERSION {
                 return Err(RuntimeManagedSessionCommandError::new(
@@ -147,17 +181,7 @@ impl RuntimeManagedSessionProjectionCore {
         })?;
         reject_projection_candidate_transport(request)?;
         let projection_kind = normalized_projection_kind(request)?;
-        let sessions = projected_sessions(
-            managed_session_candidates_from_state_dir(
-                request.state_dir.as_deref(),
-                &thread_id,
-                "runtime_managed_session_projection_state_dir_required",
-                "runtime_managed_session_projection_replay_read_failed",
-                "runtime_managed_session_projection_replay_record_invalid",
-                "managed session projection",
-            )?,
-            &thread_id,
-        );
+        let sessions = projected_sessions(candidates(&thread_id)?, &thread_id);
         let projection = match projection_kind.as_str() {
             "inspect" | "list" => Value::Array(sessions.clone()),
             "summary" => managed_session_summary(&sessions),
@@ -219,6 +243,38 @@ impl RuntimeManagedSessionControlCore {
         &self,
         request: &RuntimeManagedSessionControlRequest,
     ) -> Result<RuntimeManagedSessionControlRecord, RuntimeManagedSessionCommandError> {
+        self.plan_with_candidates(request, |thread_id| {
+            managed_session_candidates_from_state_dir(
+                request.state_dir.as_deref(),
+                thread_id,
+                "runtime_managed_session_control_state_dir_required",
+                "runtime_managed_session_control_replay_read_failed",
+                "runtime_managed_session_control_replay_record_invalid",
+                "managed session control",
+            )
+        })
+    }
+
+    /// Plan control from events already replayed by the daemon's Agentgres steward.
+    ///
+    /// The events are supplied by trusted Rust code after stream homing has
+    /// been classified. They do not revive the retired request-level
+    /// `managed_session` candidate transport, which remains rejected below.
+    pub fn plan_from_replayed_events(
+        &self,
+        request: &RuntimeManagedSessionControlRequest,
+        events: &[Value],
+    ) -> Result<RuntimeManagedSessionControlRecord, RuntimeManagedSessionCommandError> {
+        self.plan_with_candidates(request, |thread_id| {
+            Ok(managed_session_candidates_from_events(events, thread_id))
+        })
+    }
+
+    fn plan_with_candidates(
+        &self,
+        request: &RuntimeManagedSessionControlRequest,
+        candidates: impl FnOnce(&str) -> Result<Vec<Value>, RuntimeManagedSessionCommandError>,
+    ) -> Result<RuntimeManagedSessionControlRecord, RuntimeManagedSessionCommandError> {
         if let Some(schema_version) = optional_trimmed(request.schema_version.as_deref()) {
             if schema_version != RUNTIME_MANAGED_SESSION_CONTROL_REQUEST_SCHEMA_VERSION {
                 return Err(RuntimeManagedSessionCommandError::new(
@@ -271,9 +327,8 @@ impl RuntimeManagedSessionControlCore {
                 )
             })?;
         let control_state = normalized_control_state(Some(requested_control_state.as_str()))?;
-        let current_session = managed_session_control_record_from_state_dir(
-            request,
-            &thread_id,
+        let current_session = managed_session_control_record_from_candidates(
+            candidates(&thread_id)?,
             &managed_session_id,
         )?;
         let previous_control_state = string_field(&current_session, "control_state")
@@ -459,7 +514,7 @@ fn managed_session_candidates_from_state_dir(
     }
     paths.sort();
 
-    let mut candidates = BTreeMap::new();
+    let mut events = Vec::new();
     for path in paths {
         let contents = fs::read_to_string(&path).map_err(|error| {
             RuntimeManagedSessionCommandError::new(
@@ -485,49 +540,52 @@ fn managed_session_candidates_from_state_dir(
                     ),
                 )
             })?;
-            if event_thread_id(&event).as_deref() != Some(thread_id) {
-                continue;
-            }
-            for candidate in managed_session_candidates_from_event(&event, thread_id) {
-                if let Some(id) = string_field(&candidate, "managed_session_id")
-                    .or_else(|| string_field(&candidate, "id"))
-                {
-                    candidates.insert(id, candidate);
-                }
+            events.push(event);
+        }
+    }
+    Ok(managed_session_candidates_from_events(&events, thread_id))
+}
+
+fn managed_session_candidates_from_events(events: &[Value], thread_id: &str) -> Vec<Value> {
+    let mut candidates = BTreeMap::new();
+    for event in events {
+        if event_thread_id(event).as_deref() != Some(thread_id) {
+            continue;
+        }
+        for candidate in managed_session_candidates_from_event(event, thread_id) {
+            if let Some(id) = string_field(&candidate, "managed_session_id")
+                .or_else(|| string_field(&candidate, "id"))
+            {
+                // Replay is sequence ordered. Replacing an earlier card with
+                // a later card preserves the legacy scanner's latest-by-id
+                // semantics without trusting any caller-supplied candidate.
+                candidates.insert(id, candidate);
             }
         }
     }
-    Ok(candidates.into_values().collect())
+    candidates.into_values().collect()
 }
 
-fn managed_session_control_record_from_state_dir(
-    request: &RuntimeManagedSessionControlRequest,
-    thread_id: &str,
+fn managed_session_control_record_from_candidates(
+    candidates: Vec<Value>,
     managed_session_id: &str,
 ) -> Result<Value, RuntimeManagedSessionCommandError> {
-    managed_session_candidates_from_state_dir(
-        request.state_dir.as_deref(),
-        thread_id,
-        "runtime_managed_session_control_state_dir_required",
-        "runtime_managed_session_control_replay_read_failed",
-        "runtime_managed_session_control_replay_record_invalid",
-        "managed session control",
-    )?
-    .into_iter()
-    .find(|record| {
-        string_field(record, "managed_session_id")
-            .or_else(|| string_field(record, "id"))
-            .as_deref()
-            == Some(managed_session_id)
-    })
-    .ok_or_else(|| {
-        RuntimeManagedSessionCommandError::new(
-            "runtime_managed_session_control_record_required",
-            format!(
+    candidates
+        .into_iter()
+        .find(|record| {
+            string_field(record, "managed_session_id")
+                .or_else(|| string_field(record, "id"))
+                .as_deref()
+                == Some(managed_session_id)
+        })
+        .ok_or_else(|| {
+            RuntimeManagedSessionCommandError::new(
+                "runtime_managed_session_control_record_required",
+                format!(
                 "managed session control requires replayed managed session {managed_session_id}"
             ),
-        )
-    })
+            )
+        })
 }
 
 fn managed_session_candidates_from_event(event: &Value, thread_id: &str) -> Vec<Value> {
@@ -970,6 +1028,61 @@ mod tests {
         assert!(record
             .evidence_refs
             .contains(&"runtime_managed_session_projection_rust_owned".to_string()));
+    }
+
+    #[test]
+    fn replayed_projection_uses_the_later_event_for_the_same_managed_session() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let event = |status: &str, control_state: &str, updated_at: &str| {
+            json!({
+                "event_stream_id": "thread_1:events",
+                "thread_id": "thread_1",
+                "event_kind": "managed_session.projected",
+                "status": status,
+                "payload": {
+                    "sessions": [{
+                        "id": "sandbox_browser:1",
+                        "thread_id": "thread_1",
+                        "kind": "sandbox_browser",
+                        "status": status,
+                        "control_state": control_state,
+                        "waiting_for_user": false,
+                        "replay_ready": true,
+                        "updated_at": updated_at,
+                    }]
+                }
+            })
+        };
+        let events = vec![
+            event("browsing", "observe", "2026-08-05T12:00:00.000Z"),
+            event("operator_control", "take_over", "2026-08-05T12:01:00.000Z"),
+        ];
+
+        let record = RuntimeManagedSessionProjectionCore
+            .project_from_replayed_events(&projection_request(temp.path()), &events)
+            .expect("projection from admitted replay");
+        let sessions = record.projection.as_array().expect("sessions array");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0]["managed_session_id"], "sandbox_browser:1");
+        assert_eq!(sessions[0]["status"], "operator_control");
+        assert_eq!(sessions[0]["control_state"], "take_over");
+    }
+
+    #[test]
+    fn replayed_projection_still_rejects_request_candidate_transport() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut request = projection_request(temp.path());
+        request.projection = json!({
+            "sessions": [{"managed_session_id": "caller_supplied"}]
+        });
+
+        let error = RuntimeManagedSessionProjectionCore
+            .project_from_replayed_events(&request, &[])
+            .expect_err("replayed-event API must not revive candidate transport");
+        assert_eq!(
+            error.code(),
+            "runtime_managed_session_projection_candidate_transport_retired"
+        );
     }
 
     #[test]

--- a/crates/services/src/agentic/runtime/service/tool_execution/processing/phases/execute_tool_phase/success_path/tests.rs
+++ b/crates/services/src/agentic/runtime/service/tool_execution/processing/phases/execute_tool_phase/success_path/tests.rs
@@ -657,12 +657,17 @@ fn workspace_change_lifecycle_receipt_details_reject_invalid_transition_payloads
 /// `handle_execution_success` invokes on a successful `browser__*` tool) records a
 /// managed browser session into real KV, rebuilds the snapshot, and emits a
 /// `KernelEvent::RuntimeThreadEvent` carrier; the real event-log bridge resolves the
-/// daemon thread and persists it onto `<state_dir>/events`; and the kernel
+/// daemon thread and admits it through Agentgres; and the kernel
 /// managed-session projection (which `GET /v1/threads/:id/managed-sessions` delegates
-/// to verbatim) reads it back. Closes the producer->channel->bridge->jsonl->projection
+/// to) consumes admitted replay. Closes the producer->channel->bridge->replay->projection
 /// verification gap that the HTTP-only lifecycle ratchet cannot exercise in-process.
 mod managed_session_producer_e2e {
-    use crate::agentic::runtime::event_log_bridge::persist_runtime_thread_event_json;
+    use crate::agentic::runtime::event_log_bridge::{
+        persist_runtime_thread_event_json_with_admission, test_support::TestEventStreamAdmission,
+    };
+    use crate::agentic::runtime::event_stream_admission::{
+        stream_tail, THREAD_ORCHESTRATION_NAMESPACE,
+    };
     use crate::agentic::runtime::kernel::runtime_managed_session_control::{
         RuntimeManagedSessionProjectionCore, RuntimeManagedSessionProjectionRequest,
         RUNTIME_MANAGED_SESSION_PROJECTION_REQUEST_SCHEMA_VERSION,
@@ -762,6 +767,7 @@ mod managed_session_producer_e2e {
     fn real_browser_producer_bridges_a_managed_session_the_daemon_projection_serves() {
         let temp = tempfile::tempdir().expect("tempdir");
         let state_dir = temp.path().to_string_lossy().to_string();
+        let admission = TestEventStreamAdmission::open(temp.path().join("agentgres"));
         let session_id = [0x38u8; 32];
 
         // Daemon-side precondition: the agent record + runtime_session_id linkage the
@@ -817,11 +823,16 @@ mod managed_session_producer_e2e {
         };
         assert_eq!(sent_session, session_id);
 
-        // The event-log bridge persists it onto the daemon log (the body of
+        // The event-log bridge admits it onto the daemon's Agentgres stream (the body of
         // run_event_log_bridge's match arm).
-        let admitted = persist_runtime_thread_event_json(&state_dir, &session_id, &event_json)
-            .expect("bridge persists")
-            .expect("an event was admitted");
+        let admitted = persist_runtime_thread_event_json_with_admission(
+            &state_dir,
+            &session_id,
+            &event_json,
+            &admission,
+        )
+        .expect("bridge persists")
+        .expect("an event was admitted");
         assert_eq!(admitted["event_kind"], "managed_session.projected");
         assert_eq!(admitted["thread_id"], "thread_e2e");
         assert!(admitted
@@ -829,7 +840,11 @@ mod managed_session_producer_e2e {
             .and_then(serde_json::Value::as_u64)
             .is_some());
 
-        // The daemon's projection core (what GET /managed-sessions delegates to) serves it.
+        // The daemon's projection core consumes the same admitted replay as the route.
+        let replayed = admission.replayed_events(
+            THREAD_ORCHESTRATION_NAMESPACE,
+            &stream_tail("thread_e2e:events"),
+        );
         let request: RuntimeManagedSessionProjectionRequest = serde_json::from_value(json!({
             "schema_version": RUNTIME_MANAGED_SESSION_PROJECTION_REQUEST_SCHEMA_VERSION,
             "operation": "managed_session_inspection",
@@ -841,7 +856,7 @@ mod managed_session_producer_e2e {
         }))
         .expect("projection request");
         let record = RuntimeManagedSessionProjectionCore
-            .project(&request)
+            .project_from_replayed_events(&request, &replayed)
             .expect("projection");
         assert_eq!(
             record.record_count, 1,


### PR DESCRIPTION
## What changed

- Preserve the fail-closed production event-stream admission boundary while adding per-test real-Agentgres admission seams.
- Project and control managed sessions from the daemon’s classified replayed event history.
- Wire both managed-session lifecycle routes through the existing Agentgres/legacy replay classifier.
- Retarget the stale wallet interception E2E from fast-admitted `start@v1` to a policy-screened effectful desktop-agent action.

## Why

The M5 event-store migration moved runtime bridge writes to Agentgres, but managed-session projection/control still scanned legacy JSONL. Four service tests and the real daemon read path therefore could not see newly admitted events. Separately, the wallet E2E still used `start@v1` after lifecycle calls were intentionally moved to the fast-admit path, so it no longer generated an ingestion firewall event.

## Impact

Managed-session GET/control now consume the same admitted history written by runtime producers. Legacy streams remain read-only through classified replay, legacy writes still refuse, and missing admission capability remains fail-closed with no JSONL fallback. No timeout, skip, or assertion weakening was introduced.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ioi-services --lib` — 3,531 passed, 0 failed, 4 ignored
- Bridge module — 5/5 passed
- Managed-session core — 12/12 passed
- Real browser producer E2E — passed
- Wallet interception E2E — passed
- `cargo test -p ioi-node --bin hypervisor-daemon --no-run` — passed
