### PR TITLE
canon(R-10): the authenticated time source, its trust boundary, and forged-time refusal

### DIFF
--- a/docs/architecture/components/daemon-runtime/platform-operability.md
+++ b/docs/architecture/components/daemon-runtime/platform-operability.md
@@ -411,6 +411,70 @@ An old receipt or checkpoint may remain authentic and historically valid while
 currentness is unknown. Missing currentness must not erase valid history, and
 valid history must not become current effect authority.
 
+### The authenticated time source, its trust boundary, and forged-time refusal
+
+`INV-36` established that a temporal claim is proposition-scoped;
+[`INV-39`](../../foundations/invariants.md) adds what the clock plane owes about
+the *source* of time and what happens when a party supplies its own. This
+section is that invariant's operational application.
+
+**Admissible source.** The trusted time source for a consequential decision is
+one the operation's `TemporalVerificationProfile` admits through
+`evidence_policy.admitted_source_profile_refs`. Admissible producer classes are
+authenticated network-time clients, hardware counters and boot/incarnation
+evidence, witness services, ledger or finality adapters, and declared operator
+anchors — each with an explicit trust root, failure domain, and
+revocation/update lifecycle. A bare OS or host wall clock is admissible only
+where a profile names it, and never for an operation whose profile requires
+failure-domain separation. Adding a source is a profile change with a new
+`profile_hash`, not a deployment convenience.
+
+**Trust boundary.** Failure-domain separation is the boundary, and it cuts in
+two directions. The evaluator may not produce the observation it then treats as
+independent evidence — already stated above — and, symmetrically, **a party to
+the decision is never a source for it**. A client, peer domain, participant,
+route handler, or request payload may *carry* a time; it never *establishes*
+one. A signed payload's own `issued_at` proves what the signer wrote, not when
+they wrote it. This is `INV-37` applied to the clock plane: the admitting
+component resolves temporal evidence, it does not read it out of the request.
+
+**Skew tolerance.** Declared, never assumed. `maximum_uncertainty_ms` and
+`maximum_evidence_age_ms` in the admitted profile are the tolerance; evidence
+yields a bounded interval, and an interval straddling a boundary resolves
+`indeterminate` rather than rounding toward the caller. A deployment with no
+declared tolerance has no tolerance — it has an unstated assumption.
+
+**Lease TTL, heartbeat, and expiry take this path.** Concluding that a
+`CapabilityLease`, `RoomParticipantLeaseEnvelope`, `WorkClaimLeaseEnvelope`, or
+context/resource/budget lease is still live, that a `heartbeat_valid_until` is
+still in the future, or that an `expires_at` has not yet passed, is an
+`absolute_time_interval` claim under an admitted profile — not a local clock
+read. The consuming PEP maps the claim result to `admit | wait | attenuate |
+refuse` as it does for any other operation class.
+
+**Denial semantics, stated in the negative because that is where the failures
+are.** When the required temporal proposition is `indeterminate`, `failed`, or
+`unavailable`:
+
+- the lease, heartbeat, or grant is treated as **not established** — never as
+  presumed-still-valid, and never as "valid until we can check";
+- unavailable time evidence **never extends** a lease, **never revives** an
+  expired one, **never suppresses** a revocation, and **never converts** a stale
+  heartbeat into a live one. Loss of the clock plane is a loss of authority to
+  proceed, not a grant of grace;
+- **forged or unauthenticated time is refused, not discounted.** There is no
+  reduced-confidence lane for a time a party asserted about itself: it is
+  inadmissible evidence, and admitting it at lower weight is admitting it;
+- the refusal is receipted with its reason code like any other denial, so a
+  counterparty can tell a clock-plane refusal from a policy refusal, an
+  authority refusal, or an outage. A silent hold is not a refusal.
+
+The conservative direction is asymmetric and deliberately so: uncertainty
+shortens authority and never lengthens it. A bounded interval that cannot prove
+`now < expires_at` refuses; the same interval failing to prove `now >= not_before`
+also refuses. Both directions fail closed, because the caller who benefits from
+the ambiguity is exactly the party the boundary exists to bound.
+
 ## Plane SLI and SLO Contract
 
 Each production plane profile must publish, at minimum:

--- a/docs/architecture/foundations/invariants.md
+++ b/docs/architecture/foundations/invariants.md
@@ -382,6 +382,36 @@ Owner application:
 [`../components/hypervisor/providers-and-environments.md`](../components/hypervisor/providers-and-environments.md),
 [`../components/hypervisor/byo-provider-plane.md`](../components/hypervisor/byo-provider-plane.md).
 
+**INV-39 — Time is authenticated, never asserted, and expiry is a claim.** The
+trusted time source for a consequential temporal decision is an admitted
+source under the operation's `TemporalVerificationProfile`, resolved through
+the clock plane; **no party's own assertion of the current time is ever
+admissible evidence about it** — not a client, not a peer domain, not a
+participant, not a request field, not a signed payload's own timestamp, and not
+the evaluator's own reading of a source it operates (`INV-36`, `INV-37`). The
+trust boundary is failure-domain separation: the component that produces a time
+observation may not be the component that treats it as independent evidence.
+Skew tolerance is declared, not assumed — an admitted profile fixes the maximum
+uncertainty and evidence age, evidence yields a bounded interval rather than a
+favorable point, and an interval that straddles a boundary is `indeterminate`,
+never rounded toward the caller.
+
+**Lease TTL, heartbeat freshness, and expiry are consequential temporal
+decisions and take the same path.** Concluding that a lease is still live, that
+a heartbeat is still fresh, or that a claim has not yet expired is a claim about
+the world, not a local clock read; when the required temporal proposition is
+`indeterminate` or `unavailable`, the decision REFUSES by a named reason and the
+authority is treated as **not established** rather than presumed to continue.
+Denial semantics are stated in the negative on purpose: unavailable time
+evidence never extends a lease, never revives an expired one, never suppresses a
+revocation, and never converts a stale heartbeat into a live one. Forged or
+unauthenticated time is refused rather than tolerated at reduced confidence, and
+the refusal is receipted like any other denial.
+Owner application:
+[`../components/daemon-runtime/platform-operability.md`](../components/daemon-runtime/platform-operability.md),
+[`security-privacy-policy-invariants.md`](./security-privacy-policy-invariants.md),
+[`common-objects-and-envelopes.md`](./common-objects-and-envelopes.md).
+
 ## Citation Rule
 
 When a doc needs one of these invariants, it writes one line — the ID, an


### PR DESCRIPTION
## R-item quoted

> **R-10 — Authenticated time source.** Lease TTL, heartbeat, expiry, and forged-time denial all turn on authenticated time; no owner defines the trusted source, trust boundary, skew tolerance, or denial semantics. Owners: `foundations/invariants.md` + `components/daemon-runtime/platform-operability.md`.

## How this closes it — and what byte-verification changed

Measured before writing: **most of R-10 was already closed.** `platform-operability.md` carries a full Temporal Verification Contract with `TemporalVerificationProfile`, `TemporalValidityEvaluation`, a `clock` plane in the plane model, registered v1 wire contracts, and the `established | indeterminate | failed | unavailable` claim ladder; `INV-36` already binds every consequential temporal claim to an exact profile and recomputable evaluation; skew tolerance already exists as `maximum_uncertainty_ms` / `maximum_evidence_age_ms` plus the interval-not-point rule. Asserting "no owner defines" would have been the same class of error the register's own R-12 correction warns about, so the item is re-scoped to the honest residual. Three things were genuinely absent:

1. **`foundations/invariants.md` had nothing** — one incidental mention of a "clock-health flag" and no invariant, despite R-10 naming it a co-owner. `INV-39` now states it: *time is authenticated, never asserted, and expiry is a claim.*
2. **Nothing bound leases to the temporal contract.** The contract covered operation classes; lease TTL, heartbeat freshness, and expiry — the four things R-10 actually names — were never routed through it. Concluding a lease is still live is an `absolute_time_interval` claim under an admitted profile, not a local clock read. `CapabilityLease`, `RoomParticipantLeaseEnvelope`, `WorkClaimLeaseEnvelope`, and context/resource/budget leases are named explicitly so the binding cannot be read as advisory.
3. **Forged-time refusal did not exist.** The trust boundary was stated in one direction only (the evaluator may not produce the observation it treats as independent evidence). It now cuts both ways: **a party to the decision is never a source for it.** A client, peer domain, participant, route handler, or request payload may *carry* a time; it never *establishes* one, and a signed payload's `issued_at` proves what the signer wrote, not when. That is `INV-37` applied to the clock plane.

Denial semantics are written in the negative, because that is where the failures live: unavailable time evidence never extends a lease, never revives an expired one, never suppresses a revocation, never converts a stale heartbeat into a live one — loss of the clock plane is loss of authority to proceed, not a grant of grace. Forged time is **refused, not discounted**: there is no reduced-confidence lane, because admitting it at lower weight is admitting it. Refusals are receipted with a reason code so a counterparty can distinguish a clock-plane refusal from a policy refusal, an authority refusal, or an outage. The conservative direction is deliberately asymmetric — uncertainty shortens authority and never lengthens it, and both boundary directions fail closed, because the caller who benefits from the ambiguity is exactly the party the boundary exists to bound.

## Defaults exercised

- **Byte-verify the gap immediately before working it; re-scope to the honest residual if partially closed.** Exercised, and it changed the deliverable substantially: this PR adds one invariant and one operational subsection rather than a temporal-evidence doctrine that already existed.
- **Accepted canon wins on conflict.** `INV-36`, `INV-37`, and the existing Temporal Verification Contract are cited and extended rather than restated or overridden; `INV-39` adds only the source, party-boundary, lease-binding, and refusal clauses they left open, and the new subsection is written as that invariant's owner application per the file's own Citation Rule.

## Verification

Docs-only, two canon files. All relative links resolve (checked mechanically). No schema, code, or generated artifact touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)