### PR TITLE
canon(R-09): define "independently implemented client" by named axes

### DIFF
--- a/docs/architecture/components/hypervisor/core-clients-surfaces.md
+++ b/docs/architecture/components/hypervisor/core-clients-surfaces.md
@@ -542,6 +542,52 @@ adapters. Individual launcher implementations retire only through an exact
 disposition, migration/export evidence, and negative-reachability proof
 (ADR 0025).
 
+### Independently implemented clients
+
+Canon uses "two independently implemented clients" as evidence that a contract
+is real rather than a description of one program's behavior. Independence is
+declared **per axis** and never as a bare adjective (ADR 0032). Four axes:
+
+| Axis | The client… | What it proves | What it does not |
+| --- | --- | --- | --- |
+| `separate_binary` | is a distinct build artifact and process | packaging | anything about contract understanding |
+| `separate_codegen` | derives its types from the registered contract, not from this repository's generated projections | the registered contract carries enough to build against | that the wire format is specified |
+| `separate_transport` | implements framing, encoding, and the auth handshake against the wire specification | the wire contract is specified, not merely implemented | that anyone outside adopted it |
+| `separate_authoring_party` | is authored and maintained by a different disclosed accountable principal | adoption by a party with its own interests | that the contract was sufficient to build against |
+
+The first three are **contract claims**; the fourth is a **party claim**. They
+do not substitute for each other, and this is where `INV-18` binds. Two clients
+differing on binary, codegen, and transport but authored by one principal
+establish contract sufficiency and establish **nothing** about multi-party
+independence — that principal still controls authority, revocation, truth,
+verification, risk, and settlement, which is exactly `INV-18`'s ruling that
+multiplicity is not independence. Two clients from separate parties that both
+import this repository's generated code and transport library establish adoption
+and establish nothing about contract sufficiency — they inherit the same
+assumptions and fail the same way.
+
+**What a two-client exit proof over Hypervisor Core claims.** It claims
+`separate_binary` + `separate_codegen` + `separate_transport`. It does **not**
+claim `separate_authoring_party` unless a disclosed third party in fact authored
+one of them. The reason is structural, not modest: IOI can author a second
+client, and IOI cannot manufacture a second principal — a first-party proof
+asserting the party axis would be claiming precisely what `INV-18` forbids. The
+party axis is claimable only with the party disclosed, as its own claim with its
+own evidence, never inferred as an upgrade from the other three.
+
+**Never independent on any axis:** a second presentation over the same client
+library; a fork of the first client; the same binary in another mode or behind a
+flag; a mock, stub, replay harness, or test double; a client generated from this
+repository's artifacts and re-skinned; and — the one that looks most like
+success — a client whose divergences were resolved by patching the daemon
+instead of by reading the specification. If satisfying the second client
+required changing the contract's implementation, the contract was insufficient
+and the exercise recorded the repair rather than the property.
+
+Declaring axes creates no authority, no admission path, and no conformance claim
+by itself. An independently implemented client is still a client: it does not
+own runtime truth.
+
 ### Protocol Gateways
 
 Protocol gateways are compatibility ingress points over Hypervisor Core. They

--- a/docs/architecture/foundations/invariants.md
+++ b/docs/architecture/foundations/invariants.md
@@ -147,9 +147,13 @@ Owner application: [`common-objects-and-envelopes.md`](./common-objects-and-enve
 runtime nodes, providers, clouds, or keys controlled by one principal remain
 one party when that principal controls authority, revocation, truth,
 verification, risk, or settlement. Multi-party claims require disclosed and
-separate accountable principals and affiliations.
+separate accountable principals and affiliations. This invariant governs the
+**party** axis; the implementation axes of client independence — binary,
+codegen, transport — are separate claims that never establish party
+independence, and are defined by ADR 0032.
 Owner application: [`mixture-of-workers.md`](./mixture-of-workers.md),
-[`common-objects-and-envelopes.md`](./common-objects-and-envelopes.md).
+[`common-objects-and-envelopes.md`](./common-objects-and-envelopes.md),
+[`../components/hypervisor/core-clients-surfaces.md`](../components/hypervisor/core-clients-surfaces.md).
 
 **INV-19 — Complexity collapses when boundaries do.** One user, one process,
 one local authority context, one minimal semantic contract, and no public

--- a/docs/decisions/0032-independently-implemented-client-definition.md
+++ b/docs/decisions/0032-independently-implemented-client-definition.md
@@ -1,0 +1,136 @@
+# ADR 0032: Define "Independently Implemented Client" By Named Axes
+
+- Status: Accepted
+- Date: 2026-08-05
+- Owners: Hypervisor Core clients and surfaces / daemon runtime / SDK / ADK /
+  CLI-headless / schema and conformance
+- Refines: ADR 0002, ADR 0013
+- Unaffected: client categories and their boundaries (ADR 0002 Decision 1–5);
+  execution authority; GoalRun placement
+- Confidence: settled for the axis vocabulary and the claim-statement rule;
+  which axes any particular release claims stays with that release's evidence.
+
+## Context
+
+Canon repeatedly requires "two independently implemented clients" as evidence
+that a contract is real rather than a description of one program's behavior. No
+owner defined independence. Four candidate readings circulated informally —
+separate transport, separate codegen, separate authoring party, separate binary
+— and they are not interchangeable: three are claims about the *contract*, and
+only one is a claim about *parties*.
+
+Leaving this undefined has a specific failure mode, not a vague one. A second UI
+built on the same client library, in the same repository, by the same team,
+generated from the same artifacts, satisfies every colloquial reading of "two
+clients" and proves nothing at all: it inherits every assumption the first
+client makes, so it cannot detect the assumptions that were never written down.
+That is the exact thing a two-client bar exists to catch, and an undefined bar
+cannot catch it.
+
+`INV-18` already rules that multiplicity is not independence for *parties*. It
+does not speak to implementations, and the two have been conflated.
+
+## Decision
+
+1. **Independence is declared per axis, never as a bare adjective.** Four axes
+   exist. A claim of "independently implemented clients" names which axes it
+   asserts and, by omission, which it does not. "Independently implemented",
+   unqualified, is not a claim; it is a word.
+
+   - **`separate_binary`** — a distinct build artifact and process, not the same
+     binary in a second mode, behind a flag, or under a different name. *Proves
+     packaging.* Proves nothing about contract understanding.
+   - **`separate_codegen`** — the client's types are derived independently from
+     the registered contract (regenerated from the schema, or hand-written from
+     it), not imported from this repository's generated projections. *Proves the
+     registered contract carries enough information to build against.* This axis
+     is the one that finds unwritten assumptions.
+   - **`separate_transport`** — the client implements framing, encoding, and the
+     authentication handshake against the wire specification, rather than
+     delegating to a shared client library that owns them. *Proves the wire
+     contract is specified rather than merely implemented.*
+   - **`separate_authoring_party`** — a different disclosed accountable
+     principal authored and maintains it. *Proves adoption by a party whose
+     interests are their own.* This is the only axis that carries `INV-18`
+     weight.
+
+2. **The first three axes make contract claims; the fourth makes a party
+   claim; neither substitutes for the other.** Two clients differing on binary,
+   codegen, and transport but authored by one principal establish **contract
+   sufficiency** and establish nothing about multi-party independence — the
+   principal still controls authority, revocation, truth, verification, risk,
+   and settlement (`INV-18`). Two clients authored by separate parties that both
+   import this repository's generated code and transport library establish
+   **adoption** and establish nothing about contract sufficiency — they inherit
+   the same assumptions and fail the same way. A claim that needs both says
+   both, with evidence for both.
+
+3. **What a two-client exit proof claims, and what it does not.** A
+   sovereign-local or platform exit proof asserting "two independently
+   implemented clients" claims **`separate_binary` + `separate_codegen` +
+   `separate_transport`**, and does **not** claim `separate_authoring_party`
+   unless a disclosed third party in fact authored one of them. The reason is
+   structural rather than modest: IOI can author a second client, and IOI cannot
+   manufacture a second principal. A proof that claimed the party axis on
+   first-party work would be asserting exactly what `INV-18` forbids.
+   `separate_authoring_party` is claimable only with the party disclosed, and it
+   is then a separate claim with its own evidence, never an upgrade inferred
+   from the other three.
+
+4. **What never counts, on any axis.** A second presentation over the same
+   client library; a fork of the first client; the same binary in another mode;
+   a mock, stub, replay harness, or test double; a client generated from this
+   repository's artifacts and then re-skinned; and a client whose divergences
+   from the first are fixed by patching the daemon rather than the client.
+   The last one is the most dangerous, because it looks like success: if
+   satisfying the second client required changing the contract's implementation
+   rather than reading its specification, the contract was insufficient and the
+   proof recorded the repair, not the property.
+
+5. **The axes are evidence, not permission.** Declaring axes creates no
+   authority, no admission path, and no conformance claim by itself. Client
+   boundaries remain exactly as ADR 0002 sets them: clients do not own runtime
+   truth, and an independently implemented client is still a client.
+
+## Consequences
+
+- Any canon, conformance, or release statement using "independently implemented
+  client" now carries its axis list, or it is not a statement.
+- The claim coverage index in `docs/conformance/README.md` can record a
+  two-client claim as a set of named axes rather than a boolean, which makes a
+  partial claim expressible instead of forcing it to overstate.
+- `INV-18`'s scope is clarified rather than changed: it governs the party axis,
+  and this ADR supplies the implementation axes it was being stretched to cover.
+- No client category, adapter target, or protocol gateway boundary changes.
+
+## Rejected Alternatives
+
+- **Pick one axis and call it independence.** Rejected: each of the four proves
+  something different, and collapsing them means every claim is ambiguous about
+  which property it established.
+- **Require all four for any two-client claim.** Rejected: it would make the bar
+  unmeetable by first-party work in principle, which converts a useful
+  contract-sufficiency test into a permanently deferred party test, and would
+  push implementers toward claiming the party axis dishonestly.
+- **Define independence as "different team."** Rejected: organizational
+  distance is not a contract property, is unverifiable from outside, and is
+  exactly the kind of soft identity `INV-18` refuses.
+- **Treat a second UI over the shared client library as a second client.**
+  Rejected: it shares the assumptions under test.
+
+## Cost Of Being Wrong And Reversal
+
+If the axis set proves incomplete — a fifth axis matters, or one of the four
+turns out not to discriminate — the vocabulary extends by a successor ADR and
+existing claims stay readable, because every claim already names its axes.
+Nothing here binds a schema, wire format, or authority path, so reversal is a
+documentation change. Claims already made remain interpretable under the axis
+list they carry.
+
+## Canonical References
+
+- [`0002-execution-authority-and-client-boundaries.md`](./0002-execution-authority-and-client-boundaries.md)
+- [`0013-hypervisor-core-clients-surfaces-and-adapters.md`](./0013-hypervisor-core-clients-surfaces-and-adapters.md)
+- [`../architecture/components/hypervisor/core-clients-surfaces.md`](../architecture/components/hypervisor/core-clients-surfaces.md)
+- [`../architecture/foundations/invariants.md`](../architecture/foundations/invariants.md) — `INV-18`
+- [`../conformance/README.md`](../conformance/README.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -46,3 +46,4 @@ through gate identifiers.
 - [ADR 0029: Admit Direct GoalRun Paths Explicitly And Use Research For Non-Software Proof](./0029-goalrun-direct-path-admission-and-research-proof-profile.md) (refines ADRs 0017, 0020, and 0022)
 - [ADR 0030: Rooms Are A Composition, Not A Primitive Family](./0030-rooms-are-a-composition-not-a-primitive-family.md) (refines ADRs 0003, 0015, 0020, and 0022)
 - [ADR 0031: GoalRun Execution Composes Thread Orchestration](./0031-goalrun-execution-composes-thread-orchestration.md) (refines ADRs 0017, 0022, 0029, and 0030)
+- [ADR 0032: Define "Independently Implemented Client" By Named Axes](./0032-independently-implemented-client-definition.md) (refines ADRs 0002 and 0013)


### PR DESCRIPTION
## R-item quoted

> **R-09 — Define "independently implemented client."** The M5 exit requires two independently implemented clients; no owner defines independence (separate transport? codegen? authoring party? binary?). Owners: ADR 0002 + `components/hypervisor/core-clients-surfaces.md`. Note the definition also interacts with `INV-18` (multiplicity is not independence) — the ruling should say which axes of independence the exit proof actually claims.

## How this closes it

Byte-verified first: the phrase "independently implemented" appears **nowhere** in ADR 0002, `core-clients-surfaces.md`, or `invariants.md` — this gap is whole, not partial. **ADR 0032** (refines ADR 0002 and ADR 0013) defines it, and the canonical owner carries the axis table as an owner section, with `INV-18` amended to state its scope.

**Four axes, declared per axis, never as a bare adjective.** `separate_binary` proves packaging and nothing else. `separate_codegen` proves the registered contract carries enough information to build against — this is the axis that finds unwritten assumptions. `separate_transport` proves the wire contract is specified rather than merely implemented. `separate_authoring_party` proves adoption by a party with its own interests.

**The `INV-18` interaction, which is the substance of the item.** The first three are *contract* claims; the fourth is a *party* claim; neither substitutes for the other. Two clients differing on binary, codegen, and transport under one principal establish contract sufficiency and establish **nothing** about multi-party independence — that principal still controls authority, revocation, truth, verification, risk, and settlement, which is `INV-18` verbatim. Conversely, two clients from separate parties that both import this repository's generated code and transport library establish adoption and establish nothing about contract sufficiency: they inherit the same assumptions and fail the same way. `INV-18` now says it governs the party axis and names ADR 0032 for the implementation axes, because it was being stretched to cover both.

**Which axes the exit proof claims — ruled, not left open.** It claims `separate_binary` + `separate_codegen` + `separate_transport`, and does **not** claim `separate_authoring_party` unless a disclosed third party in fact authored one. The reason is structural rather than modest: IOI can author a second client and cannot manufacture a second principal, so a first-party proof asserting the party axis would be asserting exactly what `INV-18` forbids. The party axis is claimable only with the party disclosed, as its own claim with its own evidence, never inferred as an upgrade from the other three.

**What never counts** — and the last case is the dangerous one: a second presentation over the same client library; a fork; the same binary in another mode; a mock, stub, or replay harness; a re-skinned generated client; and a client whose divergences were resolved by **patching the daemon** instead of reading the specification. That last one looks like success, but if satisfying the second client required changing the contract's implementation, the contract was insufficient and the exercise recorded the repair rather than the property.

## Defaults exercised

- **Byte-verify before working.** Confirmed the gap is total; no re-scope needed here.
- **Resolve ambiguity with the register's own text and record it.** The register said "the ruling should say which axes the exit proof actually claims" without saying which. Resolved by the structural argument above rather than by preference, and stated as a Decision clause so it binds rather than advises.
- **Land it in ADR 0002's orbit rather than editing an accepted ADR.** This repository amends and refines accepted ADRs through successors (ADR 0022 amends 0019/0020; ADR 0031 refines four). ADR 0032 follows that convention; `docs/decisions/README.md` indexes it in sequence.

**Consequence for R-07's lane:** a two-client claim in the conformance index becomes a set of named axes rather than a boolean, so a partial claim is expressible instead of being forced to overstate.

## Verification

Docs-only: one new ADR, its README index entry, one canon owner section, one invariant scope clarification. All relative links resolve (checked mechanically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)