### PR TITLE
canon(R-13/R-15): verification-cost class, the pricing rule, and the adoption bet made measurable

### DIFF
--- a/docs/architecture/components/hypervisor/evaluations.md
+++ b/docs/architecture/components/hypervisor/evaluations.md
@@ -113,6 +113,71 @@ Evaluations does not own:
   claim that all important properties can be reduced to one score; or
 - proof of safety, correctness, or scientific validity from a receipt alone.
 
+## Verification Cost Is A Declared Class
+
+Verification cost is the binding constraint on the Internet of Intelligence,
+not authority plumbing — the category owner
+([`../../foundations/internet-of-intelligence.md`](../../foundations/internet-of-intelligence.md)
+§ The Binding Constraint) states why. This section makes it a contract surface
+instead of prose: a judgment contract that cannot say what it costs to check its
+own subject cannot be routed over, priced against, or honestly compared.
+
+**Every `VerifierPath` and acceptance profile declares a verification-cost
+class.** The class is an order-of-magnitude statement of cost-to-verify relative
+to cost-to-produce, drawn from a closed set:
+
+```text
+verification_cost_class:
+  negligible          verification is a rounding error against production
+                      (a deterministic check, a signature, a hash)
+  sublinear           materially cheaper than producing the result
+                      (a test suite over generated code, a spot check with
+                      declared coverage)
+  comparable          within the same order of magnitude as producing it
+                      (independent replication, adversarial review, a judge
+                      model of similar capability)
+  superlinear         more expensive to verify than to produce
+                      (long-horizon outcomes, causal claims, real-world
+                      effects observable only over time)
+  unverifiable_at_price  no admissible verifier establishes the claim within
+                      the work's declared budget and horizon
+```
+
+The class describes the *verifier*, not the confidence of the result. A
+`negligible` class does not mean the check is weak, and `superlinear` does not
+mean the claim is doubtful — it means checking costs more than doing, which is
+an economic fact with routing and pricing consequences, not a quality judgement.
+
+`unverifiable_at_price` is a real, admissible class and not a failure state.
+Much valuable intelligent work lands there. Naming it is the point: a contract
+that had to choose between overstating its verifier and refusing the work would
+be pressured into the first.
+
+**What may reason over the class.** Routing and acceptance policy may select,
+escalate, or refuse on the declared class — cheapest-adequate verifier
+selection, escalation when a cheap verifier is inconclusive, refusal when the
+declared class exceeds what a budget or horizon can carry. The class is an
+input to those decisions, never itself an authority, an admission, or a verdict.
+`RoutingDecisionEnvelope` changes only by carrying the declared class ref; its
+shape is untouched.
+
+**What the class must not do.** A declared class is not evidence that the
+verifier ran, that it passed, or that its rule was appropriate — those remain
+what they were before this section existed. Reclassifying a verifier downward to
+make work look cheaper to check is a judgment-contract mutation and requires a
+successor epoch, exactly as any other change to admissible evidence does. A
+class declared once and never revisited as the subject distribution shifts is
+stale evidence, and stale evidence is the failure mode this owner already exists
+to catch.
+
+The pricing consequence — that work whose assurance ceiling is
+`unverifiable_at_price` must carry that ceiling visibly rather than price as
+verified — is owned by
+[`../../foundations/economic-flywheel-and-pricing-boundaries.md`](../../foundations/economic-flywheel-and-pricing-boundaries.md).
+`VerifierPath`'s own definition remains owned by
+[`../../domains/ioi-ai/collaborative-outcome-pattern.md`](../../domains/ioi-ai/collaborative-outcome-pattern.md);
+this owner supplies the class it declares, not the object.
+
 ## Evaluation Asset And Epoch Boundary
 
 An evaluation asset says how a capability can be tested. An

--- a/docs/architecture/domains/ioi-ai/collaborative-outcome-pattern.md
+++ b/docs/architecture/domains/ioi-ai/collaborative-outcome-pattern.md
@@ -658,7 +658,13 @@ wallet grant and not a replacement for local/domain governance.
 deterministic checks, tests, static analysis, browser/computer-use evidence,
 LLM-as-judge steps, trained verifier workers, human review, benchmark gates, or
 Foundry eval jobs. Model judges are permitted as evidence, but they are not
-truth by themselves.
+truth by themselves. Every `VerifierPath` declares a verification-cost class
+(`negligible | sublinear | comparable | superlinear | unverifiable_at_price`)
+owned by
+[`../../components/hypervisor/evaluations.md`](../../components/hypervisor/evaluations.md)
+§ Verification Cost Is A Declared Class; orchestration may select, escalate, or
+refuse on that class, and a path that cannot state its class is not a selectable
+verification shape.
 
 `OrchestrationDecisionReceipt` records why the conductor chose the plan it
 chose. It should preserve candidate-set commitment, orchestration policy hash,

--- a/docs/architecture/foundations/economic-flywheel-and-pricing-boundaries.md
+++ b/docs/architecture/foundations/economic-flywheel-and-pricing-boundaries.md
@@ -250,6 +250,92 @@ The graph can become a moat only when its staged evidence measurably improves:
 - user confidence that autonomous work is attributable, replayable, revocable,
   and economically settleable.
 
+## Verification Cost As A Pricing Boundary
+
+A labor economy prices work. Pricing *unverifiable* work silently reintroduces
+exactly the trust the substrate exists to remove — the buyer pays a
+verified-work price and receives an attested-work product, and nothing in the
+receipt says so. This is the binding constraint on the whole category
+([`internet-of-intelligence.md`](./internet-of-intelligence.md) § The Binding
+Constraint), and it lands here as a pricing rule rather than an observation.
+
+Every priced unit of work carries the verification-cost class of the
+`VerifierPath` and acceptance profile that stand behind it — the closed set is
+owned by
+[`../components/hypervisor/evaluations.md`](../components/hypervisor/evaluations.md)
+§ Verification Cost Is A Declared Class:
+
+```text
+negligible | sublinear | comparable | superlinear | unverifiable_at_price
+```
+
+**The pricing rule.** Work whose declared assurance ceiling is
+`unverifiable_at_price` must carry that ceiling **visibly at the point of
+pricing**, and must not be priced, listed, quoted, or settled as verified work.
+Three consequences, each ruling out a way the rule could be evaded while
+technically observed:
+
+1. **The ceiling travels with the price, not with the receipt.** A buyer who
+   discovers the assurance ceiling only after settlement was priced without it.
+   Quotes, listings, marketplace entries, and service orders carry the class;
+   discovering it in a post-hoc evidence bundle is not disclosure.
+2. **Cheap verification is never inferred from cheap work.** A low price is not
+   evidence of a `negligible` class, and a high price is not evidence of a
+   `comparable` one. The class comes from the verifier, and only from the
+   verifier.
+3. **An unverifiable-at-price claim is not thereby worthless, and must not be
+   priced as if it were fraudulent either.** Reputation, repeated-game
+   structure, escrow, milestone release, and dispute rails are the honest
+   instruments for that work — the same residual human labor markets use. What
+   is forbidden is the third option: charging the verified price and staying
+   quiet.
+
+Pricing unverifiable work as verified is an anti-pattern of the same class as
+treating a receipt as correctness. It is listed with the others in
+§ Anti-Patterns, and it is the one most likely to be profitable in the short
+run, which is why it is stated as a rule and not a preference.
+
+## The Adoption Bet, Measured
+
+The category claim is that the machine-authority path becomes unavoidable —
+that institutions with real liability eventually demand the sovereign version
+over vertically integrated, provider-trust, ambient-authority convenience. That
+is a **bet**, and canon says so
+([`internet-of-intelligence.md`](./internet-of-intelligence.md) § The Adoption
+Bet). A claim of that shape should be falsifiable from receipts rather than
+asserted from conviction.
+
+**The indicator: machine-authority share of consequential effects.** Per
+deployment and in aggregate, the share of consequential effects that crossed the
+machine-authority path — bounded, revocable, receipted delegation — versus those
+that crossed an explicitly labeled **provider-trust route**, where the effect
+depended on trusting a provider rather than on a resolved authority boundary.
+
+- **The denominator is consequential effects, not requests.** Reads, drafts, and
+  local-only work are excluded; the bet is about effects that cross an entity
+  boundary, which is the only place the two routes differ.
+- **Both routes are legitimate and both are counted.** A provider-trust route is
+  not a violation — `web4-and-ioi-stack.md` defines the provider-trust boundary
+  as a real posture with real uses. The indicator measures which one the world
+  chooses, and an indicator that could only report success would measure
+  nothing.
+- **Unlabeled is counted as provider-trust.** An effect whose route cannot be
+  determined from receipts is counted against the machine-authority share, never
+  toward it. Any other default lets the indicator improve through poor
+  instrumentation, and the first thing a flattering metric does is stop
+  measuring.
+- **It is an indicator, not a target.** It grants no authority, gates no
+  release, and prices nothing. Routing an effect to satisfy the indicator rather
+  than the work is the failure this sentence exists to name.
+- **A falling share is information, not embarrassment.** The bet is honestly
+  losable. If the machine-authority share does not rise where liability is
+  real, that is the evidence the category argument said it would produce, and
+  suppressing it would forfeit the reason for measuring at all.
+
+The assurance-posture projection that surfaces this indicator to adopters is
+named by
+[`ecosystem-assurance-certification-liability.md`](./ecosystem-assurance-certification-liability.md).
+
 ## Stack Economic Roles
 
 | Layer | Economic role | Boundary |
@@ -1017,6 +1103,13 @@ portable reputation, or economic finality.
 
 Do not model:
 
+- work whose declared assurance ceiling is `unverifiable_at_price` as verified
+  work in any quote, listing, order, or settlement — the ceiling travels with
+  the price, and disclosing it only in a post-hoc evidence bundle is not
+  disclosure;
+- the machine-authority share indicator as a target, a gate, or a release
+  condition, or an effect routed to improve the indicator rather than to fit
+  the work;
 - Agentgres as a priced product surface for every state write or projection;
 - wallet.network as a per-approval, per-connector, or per-authority toll booth;
 - Private mode as a cosmetic upsell without local, BYO private node,

--- a/docs/architecture/foundations/ecosystem-assurance-certification-liability.md
+++ b/docs/architecture/foundations/ecosystem-assurance-certification-liability.md
@@ -462,10 +462,31 @@ AssurancePostureProjection:
   erasure_evidence_state:
     not_requested | pending | crypto_shredded | verified_erased |
     partially_erased | excepted | disputed | unknown
+  machine_authority_share:
+    consequential_effects_observed: integer
+    machine_authority_route_count: integer
+    labeled_provider_trust_route_count: integer
+    unlabeled_route_count: integer   # counted as provider-trust, never as machine-authority
+    window: string
   legal_conformity_claim: not_determined
   evidence_watermark: string
   last_checked_at: timestamp
 ```
+
+`machine_authority_share` is the adoption-bet indicator: the share of
+consequential effects that crossed the machine-authority path versus explicitly
+labeled provider-trust routes. Its definition, denominator, and the rule that
+unlabeled routes count as provider-trust are owned by
+[`economic-flywheel-and-pricing-boundaries.md`](./economic-flywheel-and-pricing-boundaries.md)
+§ The Adoption Bet, Measured. It appears here because an adopter deciding
+whether to depend on this stack is exactly who needs to see it, and because a
+category claim that only its author can check is not falsifiable.
+
+It reports and grants nothing. It is not a certification input, not a
+posture upgrade, not a jurisdiction or liability signal, and a low or falling
+share is not an abuse, incident, or restriction condition. Both routes are
+legitimate postures; the indicator says which one was taken, not which one was
+allowed. Nothing in this projection may be recomputed to improve it.
 
 Projections are rebuildable from Agentgres operations, receipts, policy packs,
 wallet refs, marketplace state, service-order state, and public anchors.


### PR DESCRIPTION
## R-items quoted

> **R-13 — Verifier-economics doctrine.** Adopt "verification cost is the binding constraint" as explicit canon. Concretely: (a) `VerifierPath` and acceptance profiles declare a verification-cost class (order-of-magnitude cost-to-verify relative to cost-to-produce, or typed tiers); (b) routing and acceptance policy may reason over that class; (c) a pricing rule — work whose declared assurance ceiling is unverifiable-at-price must carry that ceiling visibly rather than price as verified. Owners: `components/hypervisor/evaluations.md` (judgment contract) + `foundations/economic-flywheel-and-pricing-boundaries.md` (pricing boundary), with `RoutingDecisionEnvelope` untouched except for the declared class ref.

> **R-15 — Make the adoption bet observable.** Add one measured indicator to the flywheel doctrine: the share of consequential effects crossing the machine-authority path versus explicitly labeled provider-trust routes, per deployment and in aggregate. … Owner: `foundations/economic-flywheel-and-pricing-boundaries.md` (indicator), with `ecosystem-assurance-certification-liability.md` naming it in the assurance posture projection.

## How this closes them

**R-13 (a).** Byte-verified first: `evaluations.md` contained no occurrence of "verification cost", "cost-to-verify", or even "VerifierPath" — the judgment-contract owner could not say what checking its own subject costs. It now declares a closed class on every `VerifierPath` and acceptance profile: `negligible | sublinear | comparable | superlinear | unverifiable_at_price`, with three rulings that make it a contract rather than a label. The class describes the **verifier**, not confidence in the result — `negligible` does not mean weak, `superlinear` does not mean doubtful; it is an economic fact with routing consequences, not a quality judgement. `unverifiable_at_price` is **admissible**, not a failure state, because much valuable intelligent work lands there and a contract forced to choose between overstating its verifier and refusing the work would choose the first. And reclassifying a verifier downward to make work look cheaper to check is a judgment-contract mutation requiring a successor epoch, while a class never revisited as the subject distribution shifts is stale evidence — the failure mode this owner already exists to catch.

**R-13 (b).** Routing and acceptance policy may select, escalate, or refuse on the declared class; the class is never itself authority, admission, or verdict. **`RoutingDecisionEnvelope` is untouched except for carrying the declared class ref**, exactly as the item specifies.

**R-13 (c).** The pricing rule lands in the flywheel owner: work whose declared ceiling is `unverifiable_at_price` must carry it **visibly at the point of pricing** and must not be priced, listed, quoted, or settled as verified. Three anti-evasion consequences — the ceiling travels with the price and not the receipt (a buyer who learns it after settlement was priced without it); cheap verification is never inferred from cheap work; and unverifiable-at-price work is not thereby worthless, since escrow, milestones, reputation, and dispute rails are the honest instruments. The forbidden third option is charging the verified price and staying quiet, which is also the one most likely to be profitable in the short run — hence a rule and not a preference.

**R-15.** `machine_authority_share` measures the bet: consequential effects crossing the machine-authority path versus explicitly labeled provider-trust routes, per deployment and in aggregate. Five rulings keep it honest. The denominator is **consequential effects, not requests**. **Both routes are legitimate and both are counted** — an indicator that could only report success would measure nothing. **Unlabeled counts as provider-trust**, never toward machine-authority, because any other default lets the number improve through poor instrumentation, and the first thing a flattering metric does is stop measuring. It is an **indicator, not a target** — no authority, no gate, no price. And **a falling share is information, not embarrassment**: the bet is honestly losable, and suppressing that forfeits the reason for measuring. `ecosystem-assurance-certification-liability.md` names it on `AssurancePostureProjection` — where an adopter deciding whether to depend on this stack actually looks — and states that it grants nothing.

Both new failure modes are added to the flywheel's own Anti-Patterns list.

## Default exercised — owner deviation under canon precedence

The register assigned R-13's `VerifierPath` clause to `evaluations.md`. Byte-verified: **`VerifierPath` is defined by `domains/ioi-ai/collaborative-outcome-pattern.md:657`**, not by `evaluations.md`. Split accordingly rather than duplicating the definition: `evaluations.md` owns the **class** (it is a judgment-contract property, which is what that owner exists for), and the `VerifierPath` owner carries a one-line declaration requirement plus a link. Neither restates the other. Deviation recorded here and in the commit message.

## Verification

Docs-only, four canon files. All relative links in every touched file resolve (checked mechanically). No schema, code, or generated artifact touched — the class is declared as a contract surface; no registry row, generator change, or proof apparatus is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)