### PR TITLE
canon(R-14): the demotion rule as canon, one clause per owner

### DIFF
--- a/docs/architecture/foundations/institutional-learning-boundary.md
+++ b/docs/architecture/foundations/institutional-learning-boundary.md
@@ -290,6 +290,63 @@ Anonymization language alone does not authorize cross-tenant reuse. Differential
 privacy or another aggregation control can reduce exposure; it cannot create
 missing rights.
 
+## Parameter And Gradient Egress Is Declassification
+
+Canon implied this everywhere and stated it nowhere, which left the front door
+open to the confusion the pooling model carries — that exchanging weights is a
+lighter act than exchanging work products because no document leaves. The
+opposite is true, and it is stated here once.
+
+**Moving parameters, gradients, weight deltas, adapters, embeddings, or
+distillates of protected material across a sovereign boundary is a
+declassification event.** It requires resolved rights and receipts exactly like
+any other consequential effect, because it is one:
+
+- it binds a `DeclassificationApproval` against the exact effective
+  `InstitutionalLearningBoundaryProfile`, the contributing source-rights and
+  eligibility evidence, the destination, the purpose, and the target class,
+  under the information-flow rules in
+  [`security-privacy-policy-invariants.md`](./security-privacy-policy-invariants.md)
+  § Information-Flow Invariants;
+- it is default-deny when any contributing source's rights, consent, retention,
+  route-rights, or destination class is missing or `unknown`, per the same
+  most-restrictive-intersection rule that governs every other learning use;
+- it emits a receipt naming what crossed, from which sources, under which
+  profile version, to which destination, for which purpose.
+
+**Why the stronger treatment rather than a lighter one.** A work product carries
+lineage: it can be attributed, licensed, recalled, superseded, and adjudicated
+after the fact. A parameter delta cannot. Once trained in, provenance is gone —
+nothing downstream can be attributed to a contributor, revoked on a source
+deletion, or adjudicated in a dispute. Egress is therefore **irreversible in a
+way ordinary effects are not**, and the rights question must be resolved before
+it happens, because there is no after. `Recall`, `source deletion`, and
+`retraining` remain distinct observable actions (§ Institutional Learning
+Boundary Invariants 6); none of them undoes an egress, and verified unlearning
+requires its own declared property, method, evaluation, and assurance result.
+
+**What does not authorize it.** Differential privacy, secure aggregation,
+k-anonymity, gradient clipping, or any other aggregation control reduces
+exposure; it does **not** create missing rights, and a control applied to
+material the institution had no right to export is a well-protected violation.
+Neither does a provider's account-level opt-in, a broad service default, a
+changed term, an aggregate-learning program the source never joined, nor the
+observation that "no data leaves" — the parameters are the data, in the only
+form that matters here.
+
+**What this does not restrict.** Movement of parameters *within* one sovereign
+boundary, under one effective profile, is ordinary governed work and needs no
+declassification. Publication of a model trained solely on material the
+institution owns outright is a rights decision its owner may make. The rule
+binds the **crossing**, not the training.
+
+The workload classification — that cross-boundary parameter exchange is a
+governed Worker Training workload and never a substrate primitive — is owned by
+[`worker-training-lifecycle.md`](./worker-training-lifecycle.md); the category
+reasoning is in
+[`internet-of-intelligence.md`](./internet-of-intelligence.md) § The Demotion
+Rule.
+
 ## Portability And Model Independence
 
 `InstitutionalIntelligenceExportBundleEnvelope` is the governed export manifest

--- a/docs/architecture/foundations/security-privacy-policy-invariants.md
+++ b/docs/architecture/foundations/security-privacy-policy-invariants.md
@@ -471,6 +471,19 @@ security-domain application.
 7. A blocked-before-egress claim reaches verified assurance only when the
    pre-effect decision and enforcement seam prove that the external invoker was
    not called. An error returned after network contact is not equivalent.
+8. Parameters, gradients, weight deltas, adapters, embeddings, and distillates
+   of protected material are protected content on egress, not a lighter class
+   because no document leaves. Moving them across a sovereign boundary is a
+   declassification event requiring a `DeclassificationApproval` and receipts
+   under invariant 6, and it is strictly less reversible than exporting a work
+   product: a parameter delta carries no lineage, so nothing downstream can be
+   attributed, revoked on source deletion, or adjudicated afterward.
+   Differential privacy, secure aggregation, or any other statistical control
+   reduces exposure and never creates missing rights. Owned by
+   [`institutional-learning-boundary.md`](./institutional-learning-boundary.md)
+   § Parameter And Gradient Egress Is Declassification; the workload
+   classification is owned by
+   [`worker-training-lifecycle.md`](./worker-training-lifecycle.md).
 
 ### Target information-flow boundary matrix
 

--- a/docs/architecture/foundations/worker-training-lifecycle.md
+++ b/docs/architecture/foundations/worker-training-lifecycle.md
@@ -537,6 +537,53 @@ train a worker
 → route future work through MoW
 ```
 
+## Cross-Boundary Parameter Exchange Is A Workload, Never A Primitive
+
+Federated learning and its relatives — gradient sharing, parameter averaging,
+split learning, cross-institution distillation — are **not refuted by this
+canon; they are classified.** Each is a *governed Worker Training workload
+running on the substrate*, and none is ever a substrate primitive.
+
+A cross-boundary parameter-exchange campaign is an ordinary member of the
+lifecycle above and takes the ordinary path. It is a training engagement with
+an exact scope, a terms root, contribution accounting, metering, eligibility
+gates under the `InstitutionalLearningBoundaryProfile`, evaluation receipts, and
+a bounded worker as its output. It earns nothing by being distributed: a
+participant contributing gradients is a supplier of training material and is
+accounted for as one, with the same attribution, consideration, and exit terms
+any other contributor gets. Every crossing inside it is a declassification event
+governed by
+[`institutional-learning-boundary.md`](./institutional-learning-boundary.md)
+§ Parameter And Gradient Egress Is Declassification.
+
+**What "never a substrate primitive" rules out, concretely.** The coordination
+substrate is authority, receipts, leases, and settlement — not a learning
+protocol. So:
+
+- No aggregation round, parameter server, or gradient exchange is a coordination
+  mechanism between systems. Systems coordinate through AIIP handoffs, bounded
+  leases, and admitted operations; a training topology is a workload's internal
+  shape, not a network layer.
+- Participation in a training campaign creates **no** membership, authority,
+  admission path, or standing between the participating domains. Contributing
+  gradients is not joining a system.
+- A shared or global model is never operational truth, an authority source, or
+  a substitute for admitted domain state. `INV-18` applies unchanged: several
+  institutions feeding one model remain several parties, and one model fed by
+  several institutions is not therefore trustworthy.
+- No campaign may require participants to share one runtime, one operational
+  database, one administrator, or continued trust in the aggregator — the same
+  bar the north-star network proof sets
+  ([`internet-of-intelligence.md`](./internet-of-intelligence.md)).
+
+**Why the classification matters rather than being a taxonomy exercise.** If
+knowledge exchange were the coordination substrate, every participant would need
+to trust the aggregator with rights it cannot revoke, and the network would be
+open only to parties whose interests already align — a consortium, not an
+economy. Making it a workload keeps the substrate neutral about *how* anyone
+trains, while keeping the rights, attribution, and revocation questions where
+they can still be answered.
+
 ## Full-Stack Boundary
 
 Worker Training connects the IOI stack; it does not replace it:


### PR DESCRIPTION
## R-item quoted

> **R-14 — The demotion rule as canon.** One clause, stated once by the right owner: cross-sovereign-boundary exchange of parameters, gradients, or distillates is a rights-bound governed workload (Worker Training lifecycle + `InstitutionalLearningBoundaryProfile`), never a substrate primitive; gradient or parameter egress is a declassification event requiring resolved rights and receipts. Owners: `foundations/institutional-learning-boundary.md` (the egress/rights clause) + `foundations/worker-training-lifecycle.md` (the workload classification), with an information-flow cross-reference in `foundations/security-privacy-policy-invariants.md`. Canon implies all of this today; nothing states it, which leaves the front door open to exactly the substrate confusion the academic model carries.

## How this closes it

Byte-verified first: "gradient", "parameter egress", "declassification", "distillate", "federated", and "cross-sovereign" appeared in **none** of the three owner files. The register's diagnosis was exact — implied everywhere, stated nowhere. Three clauses, one per owner, no restatement between them.

**`institutional-learning-boundary.md` — the egress/rights clause.** Moving parameters, gradients, weight deltas, adapters, embeddings, or distillates of protected material across a sovereign boundary is a **declassification event**: it binds a `DeclassificationApproval` against the exact effective profile and contributing source-rights evidence, is default-deny on any missing or `unknown` axis, and emits a receipt naming what crossed, from which sources, under which profile version, to which destination. The reason for the *stronger* treatment is stated rather than assumed: a work product carries lineage and can be attributed, licensed, recalled, superseded, and adjudicated after the fact, while a parameter delta cannot — once trained in, provenance is gone. Egress is **irreversible in a way ordinary effects are not**, so rights must resolve before it happens, because there is no after. What does *not* authorize it: differential privacy, secure aggregation, k-anonymity, and gradient clipping reduce exposure and do not create missing rights — a control applied to material the institution had no right to export is a well-protected violation — and neither does a provider opt-in, a changed term, an aggregate program the source never joined, nor the claim that "no data leaves", since the parameters *are* the data in the only form that matters here. Scope stays honest: the rule binds the **crossing**, not the training; movement inside one sovereign boundary is ordinary governed work.

**`worker-training-lifecycle.md` — the workload classification.** Federated learning is not refuted; it is classified. Cross-boundary parameter exchange is a governed Worker Training workload taking the ordinary lifecycle path — exact scope, terms root, contribution accounting, metering, eligibility gates, evaluation receipts, bounded worker output — and never a substrate primitive. Four things that rules out concretely: no aggregation round is a coordination mechanism between systems; participation creates no membership, authority, admission path, or standing; a shared model is never operational truth (`INV-18` applies unchanged — several institutions feeding one model remain several parties); and no campaign may require one runtime, one database, one administrator, or continued trust in the aggregator, which is the same bar the north-star network proof sets.

**`security-privacy-policy-invariants.md` — the cross-reference.** New Information-Flow Invariant 8 names parameters and gradients as protected content on egress rather than a lighter class, binds them to invariant 6's `DeclassificationApproval`, and points at both owners without restating either.

## Defaults exercised

- **Byte-verify the gap immediately before working it.** Done; the gap was total, so no re-scope was needed — but the verification is what confirmed the register's "canon implies all of this today" was the right diagnosis rather than an overstatement.
- **Accepted canon wins on conflict.** Every clause composes with existing canon rather than overriding it: the egress clause routes through the existing `DeclassificationApproval` and the most-restrictive-intersection rule; the classification cites `INV-18` unchanged; the new invariant extends the existing Information-Flow list rather than opening a parallel one.

## Verification

Docs-only, three canon files. All relative links resolve (checked mechanically). No schema, code, or generated artifact touched — `DeclassificationApproval` and the information-flow label contracts already exist and are referenced, not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)