### PR TITLE
docs(R-03): licensing ADR 0033 — split surface, license manifest, two defects fixed

### DIFF
--- a/LICENSE-APACHE-2.0
+++ b/LICENSE-APACHE-2.0
@@ -1,0 +1,217 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--------------------------------------------------------------------------------
+Application to this repository
+--------------------------------------------------------------------------------
+
+   Copyright 2026 IOI Foundation
+
+   This license governs the paths that LICENSE-MANIFEST.json assigns to the
+   license class "apache_2_0" -- the open protocol surface. It is effective as
+   of that manifest's effective date and does not wait for the LICENSE-BBSL
+   Change Date. Paths assigned to other classes are governed by their own
+   license; see LICENSE-MANIFEST.json and docs/decisions/0033.
+
+   No trademark, service mark, or logo right is granted here beyond the limited
+   use permitted by section 6 of the license above.

--- a/LICENSE-BBSL
+++ b/LICENSE-BBSL
@@ -1,17 +1,48 @@
 Bootstrap Business Source License 1.1
 
 Licensor: IOI Foundation
-Licensed Work: The IOI Blockchain Framework (the “IOI Kernel”) as defined in this repository.
+Licensed Work: The paths of this repository that LICENSE-MANIFEST.json assigns to the
+license class "bbsl_1_1". LICENSE-MANIFEST.json, committed alongside this file at the
+repository root, is the definition of the Licensed Work for all purposes of this License;
+see Section 0 below.
 Change Date: November 6, 2029
 Change License: Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+
+--------------------------------------------------------------------------------
+0. Definition of the Licensed Work
+--------------------------------------------------------------------------------
+The Licensed Work is defined by LICENSE-MANIFEST.json, committed alongside this file
+at the root of this repository. That manifest assigns every tracked path to exactly one
+license class by ordered, first-match glob rules. This License governs a path if and
+only if the manifest assigns that path to the class "bbsl_1_1".
+
+Paths the manifest assigns to any other class are NOT the Licensed Work and are not
+governed by this License. In particular, paths assigned to "apache_2_0" are licensed
+under the Apache License, Version 2.0 as of the manifest's effective date and do not
+wait for the Change Date; paths assigned to "cc_by_4_0" are licensed under
+Creative Commons Attribution 4.0 International; paths assigned to "third_party" are
+governed by a LICENSE committed inside their own subtree; and paths assigned to
+"reserved", including paths the manifest does not match at all, are licensed to no one.
+
+The manifest in effect for a given copy of the Licensed Work is the manifest committed
+in that copy. Where this License and the manifest disagree about whether a path is the
+Licensed Work, the manifest controls.
 
 --------------------------------------------------------------------------------
 1. License Grant
 --------------------------------------------------------------------------------
 Under this Business Source License (the “License”), the Licensor hereby grants you a
-worldwide, non-exclusive, non-transferable, royalty-free, and revocable license to use,
-copy, modify, create derivative works of, publicly perform, publicly display, and
-distribute the Licensed Work, subject to the terms and conditions set forth herein.
+worldwide, non-exclusive, non-transferable, royalty-free, perpetual, and irrevocable
+license to use, copy, modify, create derivative works of, publicly perform, publicly
+display, and distribute the Licensed Work, subject to the terms and conditions set
+forth herein.
+
+This grant is irrevocable except as provided in Section 8 (Termination), which
+terminates the grant only upon your violation of a term or condition of this License.
+The Licensor may not otherwise withdraw, revoke, suspend, or narrow this grant as to
+any copy of the Licensed Work already distributed to you, and no later version of this
+License, and no later version of LICENSE-MANIFEST.json, reduces the rights you already
+received under a version you complied with.
 
 You may use the Licensed Work in any field of endeavor, provided that your use does
 not violate the Use Limitation described in Section 2 below.

--- a/LICENSE-DOCS
+++ b/LICENSE-DOCS
@@ -1,0 +1,25 @@
+Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+Copyright 2026 IOI Foundation
+
+This license governs the paths that LICENSE-MANIFEST.json assigns to the license
+class "cc_by_4_0" -- IOI's specification and decision prose. It is effective as of
+that manifest's effective date and does not wait for the LICENSE-BBSL Change Date.
+
+You are free to share and adapt this material for any purpose, including
+commercially, provided you give appropriate credit, provide a link to the license,
+and indicate if changes were made.
+
+The full legal code is at:
+
+    https://creativecommons.org/licenses/by/4.0/legalcode
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Attribution requirement, stated concretely: credit "IOI Foundation" and link to the
+source document. Attribution does not imply endorsement, certification, or any claim
+that a derived work conforms to IOI's contracts.
+
+No trademark, service mark, or logo right is granted. The names "IOI", "IOI Network",
+"IOI Kernel", and "Hypervisor" are reserved; see LICENSE-BBSL section 5,
+LICENSE-MANIFEST.json, and docs/decisions/0033.

--- a/LICENSE-MANIFEST.json
+++ b/LICENSE-MANIFEST.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "manifest_version": "ioi.license-manifest.v1",
+  "licensor": "IOI Foundation",
+  "effective_date": "2026-08-05",
+  "governing_decision": "docs/decisions/0033-licensing-split-surface-and-license-manifest.md",
+  "purpose": "This manifest is the definition of the Licensed Work referenced by LICENSE-BBSL section 0. It binds every tracked path in this repository to exactly one license class. A path not matched by any rule below is Reserved and is licensed to no one; absence from this manifest is never an implied grant, and never an implied denial of a license granted by a file's own LICENSE.",
+  "resolution": {
+    "order": "first_match_wins",
+    "matching": "Rules are evaluated top to bottom. The first rule whose glob matches a path determines that path's class. Globs are POSIX-style; ** matches across directory separators.",
+    "unmatched": "reserved",
+    "precedence_note": "A LICENSE file committed inside a vendored subtree governs that subtree and is recorded here for completeness rather than granted by this manifest."
+  },
+  "license_classes": {
+    "apache_2_0": {
+      "spdx": "Apache-2.0",
+      "text": "LICENSE-APACHE-2.0",
+      "effective": "now",
+      "rationale": "The protocol surface. Anything a third party must read, implement, or run to verify IOI's honesty or to build an interoperable implementation is permissively licensed today, not on the Change Date. Canon requires the open surface to be independently implementable and operable; a surface under a competition-restricted license is not that."
+    },
+    "cc_by_4_0": {
+      "spdx": "CC-BY-4.0",
+      "text": "LICENSE-DOCS",
+      "url": "https://creativecommons.org/licenses/by/4.0/legalcode",
+      "effective": "now",
+      "rationale": "Specification and decision prose. An adopter must be able to quote, translate, and redistribute the specification with attribution in order to implement against it."
+    },
+    "bbsl_1_1": {
+      "spdx": "LicenseRef-IOI-BBSL-1.1",
+      "text": "LICENSE-BBSL",
+      "effective": "now",
+      "converts_to": "Apache-2.0",
+      "change_date": "2029-11-06",
+      "rationale": "The reference implementation. Use is broadly permitted; only redistribution as a competing blockchain development framework or SDK is restricted, and that restriction expires on the Change Date."
+    },
+    "third_party": {
+      "spdx": "SEE-LICENSE-IN-SUBTREE",
+      "effective": "now",
+      "rationale": "Vendored or adopted material governed by its own committed LICENSE. This manifest records it and grants nothing over it."
+    },
+    "reserved": {
+      "spdx": "LicenseRef-IOI-Reserved",
+      "effective": "now",
+      "rationale": "All rights reserved. Internal working material, evidence, marks, and brand assets. No license is granted, and none is implied by publication."
+    }
+  },
+  "rules": [
+    {
+      "class": "third_party",
+      "globs": [
+        "apps/ioi-ai/**",
+        "third_party/**",
+        "examples/**"
+      ],
+      "note": "apps/ioi-ai carries its own MIT LICENSE and IOI-ADOPTION-PROVENANCE.md. third_party/ and examples/ hold upstream material under upstream terms."
+    },
+    {
+      "class": "reserved",
+      "globs": [
+        "internal-docs/**",
+        "docs/evidence/**",
+        "docs/brand-guidelines/**",
+        "docs/assets/**",
+        "ioi-data/**",
+        "node_modules/**",
+        "target/**"
+      ],
+      "note": "Marks and brand assets are reserved under every option; see LICENSE-BBSL section 5 and ADR 0033 on trademark separation."
+    },
+    {
+      "class": "apache_2_0",
+      "globs": [
+        "LICENSE-MANIFEST.json",
+        "LICENSE-BBSL",
+        "LICENSE-APACHE-2.0",
+        "LICENSE-DOCS",
+        "docs/architecture/_meta/schemas/**",
+        "docs/conformance/**",
+        "crates/types/src/app/generated/architecture_contracts.rs",
+        "packages/hypervisor-workbench/src/runtime/generated/architecture-contracts.ts",
+        "packages/wallet-protocol/**",
+        "packages/agent-sdk/**",
+        "packages/hypervisor-adapter-targets/**"
+      ],
+      "note": "The open protocol surface: registered contracts, JSON Schemas, cross-field invariants, fixtures, both generated projections, the conformance tree, and the client-facing protocol type libraries. The license texts themselves are listed here so they remain reproducible with any distribution, as Apache-2.0 section 4 in any case requires; listing LICENSE-BBSL here licenses the TEXT of that license, not the work it governs."
+    },
+    {
+      "class": "cc_by_4_0",
+      "globs": [
+        "docs/architecture/**",
+        "docs/decisions/**",
+        "docs/specs/**",
+        "docs/crypto/**",
+        "docs/security/**",
+        "docs/commitment/**",
+        "docs/templates/**",
+        "docs/ROADMAP.md",
+        "docs/engineering-lessons.md"
+      ],
+      "note": "Specification and decision prose. docs/architecture/_meta/schemas/** is matched by the Apache rule above and is not prose."
+    },
+    {
+      "class": "bbsl_1_1",
+      "globs": [
+        "crates/**",
+        "apps/**",
+        "packages/**",
+        "scripts/**",
+        "tools/**",
+        "ops/**",
+        "*.json",
+        "*.toml",
+        "*.md",
+        "*.js",
+        "*.mjs",
+        "*.ts",
+        ".github/**",
+        "Cargo.lock",
+        "Cargo.toml",
+        ".dockerignore",
+        ".gitignore",
+        ".*",
+        "*.yml",
+        "*.yaml",
+        "*.sh",
+        "*.lock"
+      ],
+      "note": "The reference implementation and its build configuration. Paths already matched by an earlier rule are not reached by this one; in particular the two generated projections and the client-facing protocol packages are Apache-2.0. Build, CI, and repository configuration ride with the implementation they build."
+    }
+  ],
+  "open_protocol_surface": {
+    "note": "The enumeration required by foundations/economic-flywheel-and-pricing-boundaries.md and referenced by the reference-implementation contract in foundations/web4-and-ioi-stack.md. Every entry below is Apache-2.0 or CC-BY-4.0 as of this manifest's effective date, which is what makes the surface independently implementable.",
+    "members": [
+      "docs/architecture/_meta/schemas/architecture-contract-registry.v1.json",
+      "docs/architecture/_meta/schemas/*.schema.json",
+      "docs/architecture/_meta/schemas/invariants/**",
+      "docs/architecture/_meta/schemas/fixtures/**",
+      "crates/types/src/app/generated/architecture_contracts.rs",
+      "packages/hypervisor-workbench/src/runtime/generated/architecture-contracts.ts",
+      "docs/conformance/**",
+      "docs/architecture/foundations/**",
+      "docs/decisions/**"
+    ]
+  },
+  "non_claims": [
+    "This manifest grants no trademark, service mark, or logo rights. Marks are reserved under LICENSE-BBSL section 5 and are licensed separately or not at all.",
+    "This manifest grants no certification, endorsement, or conformance claim. Certification is issued under docs/architecture/foundations/ecosystem-assurance-certification-liability.md and never requires a mark licence.",
+    "This manifest is not legal advice and has not been reviewed by external counsel as of its effective date. See ADR 0033."
+  ]
+}

--- a/docs/architecture/foundations/web4-and-ioi-stack.md
+++ b/docs/architecture/foundations/web4-and-ioi-stack.md
@@ -201,7 +201,7 @@ papered over.
 
 | Property | Owning contract today | Honest state |
 | --- | --- | --- |
-| Open protocol surface | the enumerated open surface and offline-verifiability requirements in [`economic-flywheel-and-pricing-boundaries.md`](./economic-flywheel-and-pricing-boundaries.md) | doctrine, not yet a versioned protocol-surface manifest; see gaps below |
+| Open protocol surface | the enumerated open surface and offline-verifiability requirements in [`economic-flywheel-and-pricing-boundaries.md`](./economic-flywheel-and-pricing-boundaries.md), enumerated and versioned in [`../../../LICENSE-MANIFEST.json`](../../../LICENSE-MANIFEST.json) `open_protocol_surface` under [ADR 0033](../../decisions/0033-licensing-split-surface-and-license-manifest.md) | contracted; the surface is enumerated and permissively licensed, and ADR 0033 is unreviewed by counsel |
 | Reference implementation | § The Reference-Implementation Contract below — five designation conditions, the parity claim (fixture, refusal, surface completeness, independence disclosure), and the rule that a designated release cannot legislate | contracted, planned; no release is designated and no parity claim exists |
 | Conformance certification | `ConformanceProfile` / `CertificationClaim` / `EcosystemAssuranceProfile` in [`ecosystem-assurance-certification-liability.md`](./ecosystem-assurance-certification-liability.md), plus the defined public profile `ioi_public_conformance_profile_v1` in [`../../conformance/README.md`](../../conformance/README.md) | contracted, planned; the public profile is defined and unpopulated, and no issuer-accreditation or issuer-separation rule exists |
 | Credible neutrality | [`marketplace-neutrality.md`](../domains/marketplace-neutrality.md) for routing/marketplace; [`protocol-governance-neutrality.md`](./protocol-governance-neutrality.md) for IOI as spec owner and network operator | both owned; the governance contract is written and its change process, objection record, and designation record are unimplemented |
@@ -217,14 +217,20 @@ certification lineage and interop reach. That argument currently has two open
 flanks, and pretending otherwise would be exactly the theater this doctrine
 forbids:
 
-1. **The license question is unresolved.** Kernel/runtime components carry
-   `LICENSE-BBSL` while this doctrine requires the load-bearing open surface
-   to be "implementable and independently operable" under permissive or
-   standards-compatible terms. Both ADR 0015 and the flywheel doc require a
-   separate accepted licensing ADR to resolve this, and none exists. Until it
-   does, the single most load-bearing adopt-vs-fork input — may a third party
-   legally implement and operate L0 — is open. Owner: a dedicated licensing
-   ADR with legal review; tracked as a recorded gap, not silently assumed.
+1. **The license question is architecturally resolved and legally unreviewed.**
+   [ADR 0033](../../decisions/0033-licensing-split-surface-and-license-manifest.md)
+   splits the surface: the protocol surface — registered contracts, schemas,
+   invariants, fixtures, both generated projections, the conformance tree, and
+   the client-facing protocol type libraries — is Apache-2.0 **now**;
+   specification and decision prose is CC BY 4.0 **now**; the reference
+   implementation stays under `LICENSE-BBSL` until the 2029-11-06 Change Date;
+   marks and certification are separate. `LICENSE-MANIFEST.json` defines the
+   Licensed Work per path, and the grant is now perpetual and irrevocable except
+   on the licensee's own breach. So the load-bearing input — may a third party
+   legally implement and operate L0 — is answered yes for the open surface.
+   **The remaining flank is that ADR 0033 has not been reviewed by external
+   counsel**, and it says so itself; no public release should rely on it until
+   that review happens.
 2. **The conformance suite is not yet runnable by an outsider.** What an
    adopter runs and what passing entitles them to say is now defined —
    `ioi_public_conformance_profile_v1` in

--- a/docs/decisions/0033-licensing-split-surface-and-license-manifest.md
+++ b/docs/decisions/0033-licensing-split-surface-and-license-manifest.md
@@ -1,0 +1,204 @@
+# ADR 0033: License The Protocol Surface Permissively And Define The Licensed Work By Manifest
+
+- Status: Accepted
+- Date: 2026-08-05
+- Owners: IOI Foundation (licensor) / architecture canon owners / conformance
+  and certification owners
+- Refines: ADR 0015
+- Unaffected: the Change Date (November 6, 2029); the Section 2 Use Limitation;
+  every technical contract, schema, and invariant in this canon
+- Confidence: settled as the licensing architecture and as the repair of two
+  drafting defects. **Not settled as legal advice.** See § Counsel Review below.
+
+## Counsel Review Is Advised Before Any Public Release Relies On This
+
+This ADR was drafted from the decision space in the R-03 track opener and from
+the license text at the bytes. **It has not been reviewed by external counsel.**
+The eight questions the track opener enumerated for review remain open questions
+for counsel, and three of them — the reach of the Section 2 Use Limitation
+against a redistributed modified L0, the pre-Change-Date patent posture, and
+contribution-intake formality — are answered here provisionally or not at all.
+
+Before any public release, marketing claim, certification programme, or
+third-party adoption relies on this ADR, counsel should review the amended
+`LICENSE-BBSL`, `LICENSE-MANIFEST.json`, and this decision. Landing it now
+resolves the *architecture* question that every downstream adoption property was
+waiting on; it does not convert that resolution into a legal opinion, and this
+ADR must not be cited as one.
+
+## Context
+
+Canon named this the single most load-bearing adopt-vs-fork input: may a third
+party legally implement and independently operate L0, and under exactly which
+terms for exactly which components? ADR 0015 and
+`foundations/economic-flywheel-and-pricing-boundaries.md` both required a
+dedicated licensing ADR; `foundations/web4-and-ioi-stack.md` listed its absence
+as open flank number one of its adoption calculus. Every downstream property —
+open protocol surface, offline verifiability, credible neutrality, portable
+exit — was contingent on an answer that did not exist.
+
+Read at the bytes, `LICENSE-BBSL` is **more permissive than canon's framing
+implied**: BUSL-shaped, with a fixed conversion to Apache-2.0 on 2029-11-06 and
+a narrow restriction that reaches only competing blockchain development
+frameworks and SDKs, explicitly not sovereign chains, agentic networks, DePIN,
+contracts, services, consulting, hosting, validation, or private forks. The
+problem was never that the license was closed. It was two drafting defects that
+undermine the adoption calculus regardless of which licensing option is chosen,
+and one structural mismatch between a kernel-era license and a monorepo that now
+carries the daemon, Agentgres, product surfaces, marketplaces, schemas, and the
+conformance tree.
+
+## Decision
+
+### 1. Split the surface
+
+The protocol surface is licensed permissively **now**; the reference
+implementation remains under `LICENSE-BBSL` until the Change Date.
+
+| Class | License | Covers | Effective |
+| --- | --- | --- | --- |
+| `apache_2_0` | Apache-2.0 | registered contracts, JSON Schemas, cross-field invariants, fixtures, both generated projections, the conformance tree, client-facing protocol type libraries | now |
+| `cc_by_4_0` | CC BY 4.0 | specification and decision prose under `docs/` | now |
+| `bbsl_1_1` | BBSL 1.1 → Apache-2.0 | the reference implementation and its build configuration | now, converting 2029-11-06 |
+| `third_party` | per subtree | vendored material with its own `LICENSE` | now |
+| `reserved` | none granted | internal working material, evidence, marks, brand assets | now |
+
+The reasoning is the covenant canon already made: **anything a third party must
+read, implement, or run to verify IOI's honesty must be inspectable and
+independently operable.** A conformance suite an adopter may not legally run
+does not make them able to self-certify, and a schema registry under a
+competition-restricted license does not make a protocol surface open. Those are
+the artifacts that carry the openness claim, so those are the artifacts that get
+permissive terms today rather than in 2029.
+
+What the split does **not** give away is what the Use Limitation was actually
+protecting: the reference implementation stays under BBSL, and redistributing it
+as a competing blockchain development framework stays restricted until the
+Change Date. Publishing the specification has never been how a framework moat is
+lost.
+
+### 2. Define the Licensed Work by manifest
+
+`LICENSE-MANIFEST.json`, committed at the repository root, assigns **every**
+tracked path to exactly one license class by ordered, first-match glob rules. A
+new Section 0 in `LICENSE-BBSL` makes that manifest the definition of the
+Licensed Work, and gives the manifest control where the two disagree.
+
+Two properties are deliberate:
+
+- **Unmatched means reserved, never granted.** A path no rule matches is
+  licensed to no one. Silence has to fail closed in a license for the same
+  reason it fails closed everywhere else in this canon: an implied grant nobody
+  wrote is a grant nobody can bound.
+- **The manifest a copy carries governs that copy.** An adopter's rights are
+  determined by the manifest in the copy they received, not by whatever the
+  manifest later becomes.
+
+### 3. Fix the revocable grant (D-1)
+
+`LICENSE-BBSL` § 1 granted a *"revocable"* license while § 8 already terminated
+on breach. Read together, § 1 was revocable **at will** — and no rational
+institution builds on a grant the licensor can withdraw. One word contradicted
+"adopt is the rational move" at the root.
+
+The grant is now **perpetual and irrevocable**, terminable only under § 8 on the
+licensee's own breach, with an explicit statement that the licensor may not
+withdraw, revoke, suspend, or narrow the grant as to copies already distributed,
+and that no later version of the License or the manifest reduces rights already
+received under a version the licensee complied with.
+
+### 4. Marks and certification stay separate
+
+Neither the manifest nor any license class grants trademark, service mark, or
+logo rights; `LICENSE-BBSL` § 5's reservation is unchanged and is restated in
+the manifest and in both new license files. Separately: **a `CertificationClaim`
+never requires a mark licence, and mark reservation never encumbers an
+independent implementation.** Certification remains issued under
+`foundations/ecosystem-assurance-certification-liability.md`.
+
+This separation is not tidiness. `foundations/protocol-governance-neutrality.md`
+holds specification ownership, reference implementation, and
+certification-plus-marks apart as three roles precisely because a category owner
+who could withhold the name from a conforming implementation would have a veto
+over conformance that no conformance contract mentions.
+
+### 5. Supersession posture
+
+`LICENSE-BBSL` is **amended in place**, not superseded by a versioned successor.
+Amendment is correct here because both changes are repairs that can only widen
+or clarify a licensee's position — an irrevocable grant is strictly better than
+a revocable one, and a defined Licensed Work is strictly better than an
+undefined one — so no licensee's rights narrow. A change that could narrow
+rights would need a versioned successor and the change process in
+`protocol-governance-neutrality.md`.
+
+## Consequences
+
+- The adoption calculus's open flank number one closes as an *architecture*
+  question. `web4-and-ioi-stack.md` may state the license posture instead of
+  recording its absence, subject to the counsel caveat above.
+- The `foundations/economic-flywheel-and-pricing-boundaries.md` requirement for
+  a versioned open-protocol-surface manifest is discharged by the
+  `open_protocol_surface` block in `LICENSE-MANIFEST.json`.
+- R-05's reference-implementation contract gains a legal footing: a third party
+  proving parity against a named surface may now legally read, implement, and
+  run every artifact that surface consists of.
+- R-07's public conformance profile becomes legally runnable by an outsider. It
+  is still not *operationally* runnable — no runner exists — and this ADR does
+  not change that.
+- `crates/*/Cargo.toml` entries carrying `license-file = "LICENSE-BBSL"` remain
+  correct: those crates are `bbsl_1_1` under the manifest.
+- Contributions continue under § 4 with no CLA or DCO formality. This is
+  provisional and is one of the questions left for counsel.
+
+## Rejected Alternatives
+
+- **Option B — whole-repo BBSL with the defects fixed.** Cheapest legally, and
+  rejected because it leaves the conformance suite and schema registry
+  non-permissive. That directly contradicts the outsider-runnable certification
+  requirement and would have made the adoption calculus's own table read
+  "recorded gap" for a reason we had chosen.
+- **Option C — full permissive now.** Maximal adoption credibility, and
+  rejected as strictly more than the problem required: the defects and the
+  closed protocol surface are what damaged the calculus, not the Use Limitation,
+  which already permits every use an adopter actually needs and expires in 2029
+  regardless.
+- **Versioned successor license instead of amending in place.** Rejected because
+  both changes only widen a licensee's position; a successor would create a
+  two-license estate and an unnecessary question about which copy carries which
+  terms.
+- **Enumerating the Licensed Work inside the license text.** Rejected: it would
+  go stale on the first directory rename, and a stale definition of the Licensed
+  Work is the defect D-2 already is.
+
+## Cost Of Being Wrong And Reversal
+
+The two defect repairs are one-way and intended to be: an irrevocable grant
+cannot be walked back for copies already distributed, which is exactly the
+property that makes it worth granting. If counsel finds the split-surface
+boundary drawn in the wrong place, the manifest can move paths **toward**
+permissive without any licensee losing rights; moving a path from permissive
+back toward BBSL cannot retroactively affect copies already distributed under
+the permissive class, and would need the change process, a new manifest version,
+and a stated rationale. That asymmetry is deliberate — it means an error in this
+ADR costs IOI optionality and never costs an adopter their footing.
+
+## Canonical References
+
+- [`../../LICENSE-BBSL`](../../LICENSE-BBSL) — amended: Section 0 and the
+  irrevocable grant.
+- [`../../LICENSE-MANIFEST.json`](../../LICENSE-MANIFEST.json) — the definition
+  of the Licensed Work and the open-protocol-surface enumeration.
+- [`../../LICENSE-APACHE-2.0`](../../LICENSE-APACHE-2.0),
+  [`../../LICENSE-DOCS`](../../LICENSE-DOCS) — the permissive classes.
+- [`0015-bounded-distributed-autonomous-systems-and-network-enrollment.md`](./0015-bounded-distributed-autonomous-systems-and-network-enrollment.md)
+- [`../architecture/foundations/web4-and-ioi-stack.md`](../architecture/foundations/web4-and-ioi-stack.md)
+  — the adoption calculus and the reference-implementation contract.
+- [`../architecture/foundations/protocol-governance-neutrality.md`](../architecture/foundations/protocol-governance-neutrality.md)
+  — the three roles and the change process.
+- [`../architecture/foundations/ecosystem-assurance-certification-liability.md`](../architecture/foundations/ecosystem-assurance-certification-liability.md)
+  — certification and issuers.
+- [`../architecture/foundations/economic-flywheel-and-pricing-boundaries.md`](../architecture/foundations/economic-flywheel-and-pricing-boundaries.md)
+  — the open-L0 covenant and the protocol-surface manifest requirement.
+- [`../conformance/README.md`](../conformance/README.md) — the public
+  conformance profile this ADR makes legally runnable.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -47,3 +47,4 @@ through gate identifiers.
 - [ADR 0030: Rooms Are A Composition, Not A Primitive Family](./0030-rooms-are-a-composition-not-a-primitive-family.md) (refines ADRs 0003, 0015, 0020, and 0022)
 - [ADR 0031: GoalRun Execution Composes Thread Orchestration](./0031-goalrun-execution-composes-thread-orchestration.md) (refines ADRs 0017, 0022, 0029, and 0030)
 - [ADR 0032: Define "Independently Implemented Client" By Named Axes](./0032-independently-implemented-client-definition.md) (refines ADRs 0002 and 0013)
+- [ADR 0033: License The Protocol Surface Permissively And Define The Licensed Work By Manifest](./0033-licensing-split-surface-and-license-manifest.md) (refines ADR 0015; external counsel review advised before public release relies on it)


### PR DESCRIPTION
> ⚠️ **This PR changes a real license.** ADR 0033 states inside itself that external counsel review is advised before any public release relies on it. Please read that section first.

## R-item quoted

> **R-03 — Land the licensing ADR.** Owner: a dedicated accepted ADR with legal review. Both ADR 0015 and `foundations/economic-flywheel-and-pricing-boundaries.md` require it, and `web4-and-ioi-stack.md` names it the single most load-bearing adopt-vs-fork input: whether a third party may legally implement and independently operate L0 under `LICENSE-BBSL` versus the required permissive/standards-compatible open surface. Every adoption-calculus property downstream of this is contingent until it lands. Recorded gap today; it should not remain one.

## How this closes it

**Both defects byte-verified before drafting.** D-1 at `LICENSE-BBSL:12` — the grant read "royalty-free, and revocable" while § 8 already terminated on breach, which read together made § 1 revocable **at will**. D-2 at `LICENSE-BBSL:4` — "The IOI Blockchain Framework (the 'IOI Kernel') as defined in this repository", where no such definition exists anywhere in the repository, and the monorepo now carries the daemon, Agentgres, product surfaces, marketplaces, schemas, and the conformance tree.

**D-1 fixed.** The grant is now **perpetual and irrevocable**, terminable only under § 8 on the licensee's own breach, with explicit language that the licensor may not withdraw, revoke, suspend, or narrow the grant as to copies already distributed, and that no later License version and no later manifest version reduces rights already received under a version the licensee complied with. One word had contradicted "adopt is the rational move" at the root.

**D-2 fixed.** A new `LICENSE-BBSL` § 0 makes `LICENSE-MANIFEST.json` the definition of the Licensed Work, with the manifest controlling where the two disagree. Coverage is **measured, not asserted** — all 6,354 tracked files resolve to exactly one class: 3,866 `bbsl_1_1`, 1,276 `third_party`, 931 `apache_2_0`, 175 `cc_by_4_0`, 106 `reserved`, **zero unmatched**. Two properties are deliberate: unmatched means **reserved and never granted**, because an implied grant nobody wrote is a grant nobody can bound; and **the manifest a copy carries governs that copy**, so an adopter's rights do not move when ours do.

**Split surface — the opener's Option A, as instructed.** Apache-2.0 **now** for the protocol surface (registered contracts, schemas, cross-field invariants, fixtures, both generated projections, the conformance tree, client-facing protocol type libraries); CC BY 4.0 **now** for specification and decision prose; BBSL retained for the reference implementation until the 2029-11-06 Change Date; marks and certification separate. The reasoning is the covenant canon already made: anything a third party must read, implement, or run to verify IOI's honesty must be inspectable and independently operable — a conformance suite an adopter may not legally *run* does not let them self-certify, and a schema registry under a competition-restricted license is not an open protocol surface. What the split does *not* give away is what the Use Limitation actually protected; publishing the specification has never been how a framework moat is lost.

**Mechanical consequences applied.** `LICENSE-APACHE-2.0` (canonical text plus a scoping note), `LICENSE-DOCS`, the `open_protocol_surface` enumeration the flywheel doc has been owed since it was written, `docs/decisions/README.md` indexed, and the adoption-calculus table in `web4-and-ioi-stack.md` rewritten from "recorded gap" to what is now true — including that the remaining flank is the missing counsel review, not the missing decision.

## Counsel review — stated inside the ADR, as instructed

ADR 0033 **opens** with it rather than footnoting it: this has not been reviewed by external counsel; three of the track opener's eight questions are answered provisionally or not at all (the § 2 Use Limitation's reach against a redistributed modified L0, the pre-Change-Date patent posture, and contribution-intake formality); and no public release, marketing claim, certification programme, or third-party adoption should rely on it until review happens. Landing it resolves the **architecture** question every downstream adoption property was waiting on; it does not convert that into a legal opinion, and the ADR says it must not be cited as one.

**Reversal asymmetry, recorded in the ADR.** The manifest can always move paths *toward* permissive without any licensee losing rights; moving one back cannot retroactively affect copies already distributed under the permissive class and would need the change process in `protocol-governance-neutrality.md`. An error here costs IOI optionality and never costs an adopter their footing.

## Defaults exercised

- **Use the opener's split-surface recommendation.** Done; Options B and C are recorded as rejected alternatives with the reason each was rejected.
- **Resolve the two byte-verified defects in the drafting.** Done, both, with the amendment made in place rather than by versioned successor — justified in the ADR because both repairs can only widen a licensee's position, so no licensee's rights narrow.
- **Apply the mechanical consequences.** License text amendment, manifest file, the two new license texts, the ADR index, and the adoption-calculus table.

## Verification

`LICENSE-MANIFEST.json` parses and covers every tracked path with zero unmatched (measured). All relative links in every touched doc resolve. `crates/*/Cargo.toml` entries carrying `license-file = "LICENSE-BBSL"` remain correct — those crates are `bbsl_1_1` under the manifest. No code or generated artifact touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)