### PR TITLE
canon(C-1..C-4) + charter: subject_attachments layering; bring-to-life run + master guide

### DIFF
--- a/docs/architecture/components/hypervisor/core-clients-surfaces.md
+++ b/docs/architecture/components/hypervisor/core-clients-surfaces.md
@@ -2677,24 +2677,27 @@ persistent HypervisorOS node session
 terminal session
 editor session
 computer-use session
-Foundry / eval / training session
 provider / environment management session
 ```
+
+A training, evaluation, goal-pursuit, or room-participation session is not a
+distinct session kind: it is an ordinary session kind above carrying a typed
+subject attachment to the workload's owner object. Kinds are mechanical
+execution contexts; workloads are attachments.
 
 A Session binds:
 
 - user, organization, project, system, or worker context when applicable;
 - its explicit session mode;
-- AutomationRun or GoalRun refs when it executes part of standing behavior or
-  pursued intent;
-- work item and work run refs when the session is executing delegated agent
-  work;
+- typed subject attachments (owner-registered `subject_kind` + `subject_ref`)
+  for every piece of work the session serves — standing behavior, delegated
+  work items and runs, and application-owned subjects such as the ioi.ai
+  goal/room family — the platform never names an application family as a
+  dedicated field;
 - authority grants and capability leases;
 - policy and approval state;
 - runtime assignment;
 - context cell / task refs where applicable;
-- GoalRun plus optional OutcomeRoom, participant, claim, and attempt refs when
-  the session performs collaborative frontier work;
 - cTEE custody posture where applicable;
 - Agentgres refs and receipt obligations;
 - adapter targets;
@@ -3313,6 +3316,16 @@ GoalRun and OutcomeRoom views may project those refs and derived status; they do
 not own a parallel execution graph. Harness-to-harness coordination is therefore
 a bounded Core/daemon request over these primitives, not direct peer authority
 or application-local runtime truth (ADR 0031).
+
+Layering rule for the execution substrate itself: thread, thread-fork,
+managed-session, session-launch-recipe, and harness-session-binding records
+are ONE daemon-internal execution substrate generation-in-consolidation, and
+the Session is the single platform-level object over it. Product surfaces
+compose these records by read; no surface, application, or new route may
+treat the thread plane as a second public spine or write to it outside the
+daemon's own execution path. Consolidation onto the durable event substrate
+is the standing thread-orchestration seam obligation and completes this rule
+rather than amending it.
 
 For a persistent collective outcome, Work / Room detail is graph-first:
 
@@ -3947,17 +3960,28 @@ HypervisorSession:
   session_kind:
     local_workspace | remote_vm_workspace | browser_sandbox |
     hosted_worker | hypervisoros_node | terminal | editor |
-    computer_use | foundry_eval_training | provider_management |
-    environment_management
+    computer_use | provider_management | environment_management
+    # session_kind is the platform-mechanical execution context ONLY.
+    # Workload identity (training, evaluation, goal pursuit, room work)
+    # comes from subject_attachments, never from a kind value. The former
+    # foundry_eval_training kind was a product workload wearing a platform
+    # enum value and is retired.
   daemon_ref: daemon://...
   runtime_assignment_ref: runtime-assignment://... | null
-  automation_run_ref: automation-run://... | null
-  work_item_ref: work_item://... | null
-  goal_run_ref: goal://... | null
-  outcome_room_ref: outcome-room://... | null
-  room_participant_lease_ref: participant-lease://... | null
-  work_claim_lease_ref: work-claim://... | null
-  attempt_ref: attempt://... | null
+  subject_attachments:
+    # The ONLY way a Session names the work it serves. Typed, generic, and
+    # owner-registered — the same subject discipline Work rows use. The
+    # platform session schema names no application-layer family: platform
+    # kinds (automation_run, work_item, work_run) are registered here by
+    # Hypervisor owners, and application kinds (goal_run, outcome_room
+    # participant/claim/attempt — the ioi.ai family, per ADR 0022) are
+    # registered by the owning application's canon, exactly as event
+    # classes are declared per owner namespace. Adding an application
+    # never edits this schema.
+    - subject_kind: owner-registered kind (e.g. automation_run | work_item |
+        work_run | app-registered kinds)
+      subject_ref: typed ref resolved by the subject's canonical owner
+      attachment_role: executes | contributes_to | manages | observes
   authority_refs:
     - grant://...
     - lease://...

--- a/internal-docs/overhaul/2026-08-05-hypervisor-bring-to-life-run.md
+++ b/internal-docs/overhaul/2026-08-05-hypervisor-bring-to-life-run.md
@@ -1,0 +1,200 @@
+# Hypervisor Bring-To-Life Run — multi-session starter prompt
+
+This file IS the starter prompt. Any fresh session begins by reading this file
+top to bottom, then the master guide, then the Run State ledger at the bottom
+of this file, and resumes at the first unchecked item. No other context is
+required or assumed. Update the ledger in every landing PR — the file is the
+handoff channel between sessions.
+
+## Mission
+
+Bring the currently mostly-shell Hypervisor product to life: every canonical
+surface operational, logic wired to UI, per canon. **This run CREATES its own
+master guide first, then executes it.**
+
+**Phase A — author the per-surface implementation briefs (first sessions).**
+The guide is not one large file. It is one markdown file PER APPLICATION
+SURFACE under `internal-docs/implementation/surfaces/`:
+
+```
+internal-docs/implementation/surfaces/
+  studio.md · automations.md · ontology.md · data.md · governance.md ·
+  provenance.md · evaluations.md · improvement.md · foundry.md ·
+  packages.md · developer-workspace.md · developer-console.md ·
+  environments.md · operations.md
+  home.md · systems.md · projects.md · applications.md ·
+  work.md (owns the Sessions view) · settings.md
+  _index.md (one-page map: file list, wave assignments, shared plumbing)
+```
+
+Each surface file has the same five sections, all derived from bytes:
+
+1. **Canon digest** — what this surface owns/must display/may never do, with
+   `file:line` cites into `core-clients-surfaces.md` and owner docs.
+2. **Schema map** — the canon objects and registered contracts this surface
+   projects (registry entries, `_meta/schemas/*`, canon object blocks), each
+   mapped to the daemon route(s) that carry it today, or marked
+   `route-missing` (feeds the backend build-list).
+3. **UI seed map** — what is traversable TODAY but not functional: the
+   shell captures/registered surface/native readouts serving this surface,
+   every pane and control cluster, classified wired / partial / dead, from
+   the live tree (v0 census as starting point, bytes win).
+4. **Schema→UI binding table** — the heart: each traversable UI element ↦
+   the schema+route that must back it ↦ current state ↦ target state
+   (wired-read | wired-action-receipted | disabled-named-gap | delete).
+   Session-serving elements bind through `subject_attachments`, never named
+   app fields (C-1..C-4).
+5. **Ordered PR list** — smallest viable wiring steps, read-first then
+   actions, with cutover/410 retirement last.
+
+Seed input, verified at the bytes and absorbed or corrected — never trusted
+blind: `internal-docs/overhaul/2026-08-05-hypervisor-full-functionality-master-guide.md`
+(v0 synthesis of the 2026-08-05 three-lane audit: canon requirements,
+~663-route daemon inventory, UI wiring census). Where v0 and the bytes
+disagree, the bytes win and the surface file records the correction. Phase A
+ends when `_index.md` and all twenty surface files are landed and the Run
+State ledger below is regenerated to one row per surface file.
+
+**Phase B — execute the briefs.** Before building each surface, the session
+refreshes that surface's file against the bytes, then executes its PR list.
+Each landing PR updates the surface file's binding table — the files grow
+from map to record as the run proceeds.
+
+## Ground truths (do not re-litigate; re-verify bytes when relied on)
+
+- Target taxonomy: 12 owner applications (Studio, Automations, Ontology,
+  Data, Governance, Provenance, Evaluations, Improvement, Foundry, Packages,
+  Developer Workspace, Developer Console) + substrate Environments and
+  Operations + 6 core workspaces (Home, Systems, Projects, Applications,
+  Work, Settings) on the 23 canonical v2 routes
+  (`docs/architecture/components/hypervisor/core-clients-surfaces.md:874-906`).
+  Legacy app names (Approvals, Issues, Pipeline, Upgrade Assistant,
+  Connections, Missions-as-app) are retired labels for tool surfaces or Work
+  views.
+- Sessions = `/work/sessions`, a typed Work view, never a peer application.
+  Bare `/sessions` gets the typed 410 the daemon already emits; the shell
+  stops advertising it.
+- Settings = core workspace at `/settings`, projection-only,
+  writes-through-owners. Its panes project canonical owner records.
+- Strategy is REHOME, NOT REBUILD: existing wired planes (24 governed
+  controls, ODK planes, goal-orchestration reads, the workbench) move into
+  their canonical owners. The ported-seed-preservation invariant
+  (`apps/hypervisor/ported-seed-preservation.v1.json`) and the 6-step per-app
+  cutover rule (`apps/hypervisor/AGENTS.md`) are in force.
+- New UI event consumption rides the M5 plane (`/v1/event-streams`,
+  `/v1/subscriptions`); per-resource SSE is legacy, wrapped not extended.
+- All authority-crossing actions go through the CapabilityLease client flow
+  (403 wallet challenge → 428 credential → receipted lease); reads go through
+  the uniform read-projection client.
+
+## Regime — fully preauthorized, no stops
+
+Ordinary branches off master, small PRs, `gh pr merge --auto --squash` at
+open; if auto-merge is refused, leave the PR open and continue — open PRs are
+never blockers. Per-PR bar: build + test + lint green; description names the
+wave item and states in one paragraph what became operational. No proof
+apparatus of any kind is built. Every contingency maps to a default action;
+none is a stop:
+
+| Contingency | Default action |
+|---|---|
+| Guide/audit claim stale at the bytes | Trust the bytes, correct the guide in the same PR, continue |
+| A control's backing route doesn't exist | Disabled-with-named-gap in UI; add the route to the Wave 3 build-list in the guide; continue |
+| A change would contradict accepted canon or a recorded owner ruling | Canon wins automatically; implement the remainder; note the deviation in the PR |
+| Test failure you caused | Fix it |
+| Test failure not attributable after ≤30 min | Record as pre-existing with evidence; continue |
+| `hypervisor-daemon.rs` merge conflict (central flat router) | Backend-route PRs serialize; rebase and continue |
+| Fixture/mock data encountered | Replace with daemon truth or honest absence — never fixture presented as runtime truth |
+| Anything else ambiguous | Resolve with the guide + canon text, record the choice in the PR, continue |
+
+Standing surface rules on every PR: read truth or honest absence · local UI
+state stays local · existing authority only, with receipts · every other
+control disabled with a named gap · serve with no test flags · one
+daemon-backed lane per capability, no forked truth.
+
+## Layering rulings already landed in canon (2026-08-05 — implement, don't re-decide)
+
+Four schema/canon conflations between the sessions platform, the thread
+orchestration primitives, and the ioi.ai products (GoalRuns, OutcomeRooms)
+were FIXED in `core-clients-surfaces.md` on 2026-08-05:
+
+- **C-1/C-2 — app-family fields out of the platform schema.**
+  `HypervisorSession` no longer names `goal_run_ref`, `outcome_room_ref`,
+  `room_participant_lease_ref`, `work_claim_lease_ref`, `attempt_ref` (nor
+  `automation_run_ref`/`work_item_ref` as dedicated fields). The one
+  mechanism is `subject_attachments[]` — owner-registered `subject_kind` +
+  `subject_ref` + `attachment_role`, the same typed-subject discipline Work
+  rows use; application kinds (the ioi.ai goal/room family per ADR 0022)
+  register in the owning application's canon. Adding an application never
+  edits the platform schema. The must-bind list matches.
+- **C-3 — one execution substrate.** Thread/thread-fork/managed-session/
+  launch-recipe/harness-binding records are declared one daemon-internal
+  generation-in-consolidation with Session as the single platform object
+  over them; product surfaces compose by read; nothing treats the thread
+  plane as a second public spine. Consolidation remains the standing M5
+  thread-orchestration seam obligation — not this run's job.
+- **C-4 — kinds are mechanical, workloads are attachments.**
+  `foundry_eval_training` is retired from `session_kind`; training/eval/
+  goal/room workloads are subject attachments on ordinary kinds.
+
+Run consequences: every session view, route, and record this run builds uses
+`subject_attachments` — never a named app field; Wave 3's session
+overview/lineage backend is designed against the attachment model from day
+one; any daemon/UI code still carrying the old named fields gets migrated at
+the PR that touches it, with the guide recording remaining sites.
+
+## The waves (full definitions in the master guide §2–§6)
+
+- [ ] **Wave 0 — plumbing**: W0.1 v2 route shell · W0.2 product-surface
+  compiler v1 · W0.3 read client + authority client · W0.4 event client on
+  the M5 plane · W0.5 identity truth (delete adapter constants,
+  IDENTITY_REWRITES, 5 fixture-only RPCs) · W0.6 backend enablers
+  (sessions/overview, unified approvals inbox, /v1 index, scheduler status).
+- [ ] **Wave 1 — read-first launches**: Work + Sessions views · Provenance ·
+  Environments · Operations · Governance reads + inbox · Ontology · Data ·
+  Automations · Foundry · Developer Workspace rehome. Exit per app: canonical
+  route renders daemon truth end-to-end, honest empty/degraded states, zero
+  fixture data.
+- [ ] **Wave 2 — actions**: authority-crossing controls via the lease client
+  across Governance, Data, Ontology, Automations, Foundry, Developer Console,
+  Environments/Operations. Exit: every enabled control receipted; the rest
+  disabled-with-named-gap.
+- [ ] **Wave 3 — backend builds + UIs**: Packages registry family · Studio
+  blueprints · Evaluations epochs/holdouts/challenges · Improvement
+  agendas/campaigns · session lineage (after L-1) · anything accumulated on
+  the Wave 3 build-list.
+- [ ] **Wave 4 — cutover + execution loop**: Sessions execution loop (daemon
+  "Cut #2") · per-app legacy `/__ioi/*` retirement with typed 410s · delete
+  server.cjs mocks, fixture API lane, duplicate static copy · Settings
+  completion · canon nits (5-vs-6 workspace count, Settings section).
+
+## Session protocol
+
+1. Read this file, the master guide, `git log master -15`, and the Run State
+   ledger below.
+2. Take the first unchecked item (or continue a partially-checked wave's next
+   sub-item). In Phase A that means authoring the next missing surface file;
+   in Phase B, refresh the target surface's file against the bytes before
+   building it.
+3. Execute in small auto-merging PRs. Every PR that completes a ledger item
+   also updates the ledger in this file (same PR).
+4. Before context runs out: land what's landable, update the ledger with a
+   one-line handoff note per in-flight item, stop cleanly. Never leave the
+   ledger claiming more than the bytes show.
+
+## Run State ledger
+
+| Item | State | Handoff note |
+|---|---|---|
+| Phase A: per-surface briefs at `internal-docs/implementation/surfaces/` (20 files + `_index.md`) | ☐ | v0 seed = the 2026-08-05 overhaul guide; verify at bytes; on completion regenerate this ledger to one row per surface |
+| C-1..C-4 canon layering fixes | ☑ 2026-08-05 | landed in core-clients-surfaces.md; implementation migrates per-PR |
+| W0.1 v2 route shell | ☐ | |
+| W0.2 surface compiler | ☐ | |
+| W0.3 read + authority clients | ☐ | |
+| W0.4 event client (M5 plane) | ☐ | |
+| W0.5 identity truth | ☐ | |
+| W0.6 backend enablers | ☐ | sessions/overview + lineage designed against subject_attachments |
+| Wave 1 (10 app launches) | ☐ | per-app checkmarks added when wave opens |
+| Wave 2 (action lighting) | ☐ | |
+| Wave 3 (backend builds) | ☐ | |
+| Wave 4 (cutover + Cut #2) | ☐ | |

--- a/internal-docs/overhaul/2026-08-05-hypervisor-full-functionality-master-guide.md
+++ b/internal-docs/overhaul/2026-08-05-hypervisor-full-functionality-master-guide.md
@@ -1,0 +1,232 @@
+# Hypervisor Full-Functionality Master Guide — every surface operational
+
+Goal: take every Hypervisor application surface from its current seed state to
+operational — logic wired to UI — per canon, including Sessions and Settings.
+Regime: post-overhaul light. Ordinary branches/PRs; per-PR bar = build + test +
+lint + the standing surface rules (read truth · local UI state · existing
+authority with receipts · disabled-named-gap for everything else; serve with no
+test flags). No proof apparatus is rebuilt by this program.
+
+Grounded in a three-lane audit (2026-08-05): canon requirements
+(`core-clients-surfaces.md` 4,834 lines + owner docs), daemon capability
+inventory (~663 routes), and UI wiring state (14 registered surfaces, 97-RPC
+adapter, ~100 native readouts, 563-control census). Verified corrections to
+prior beliefs: **Settings IS canonically owned** (core workspace `/settings`,
+projection-only, writes-through-owners; the 2026-07-30 "ownerless" finding is
+stale — the residue is a five-vs-six count drift in 5 canon locations and no
+dedicated canon section). **Sessions is `/work/sessions`**, a typed Work view,
+never a peer app; bare `/sessions` must die with a typed 410 (the daemon
+already refuses it — `handle_retired_hypervisor_route`; it's the UI shell that
+soft-404s and still advertises the dead route in tiles). **The legacy app
+names are retired**: Approvals, Issues, Pipeline, Upgrade Assistant,
+Connections, Missions-as-app are tool surfaces or Work views inside the twelve
+owners.
+
+## 1. The two ground trees
+
+**Target (canon):** 12 owner applications — Studio, Automations, Ontology,
+Data, Governance, Provenance, Evaluations, Improvement, Foundry, Packages,
+Developer Workspace, Developer Console — plus substrate Environments and
+Operations, conditional Embodied Systems (planned, nonlaunchable), and six
+core workspaces (Home, Systems, Projects, Applications, Work, Settings) on 23
+canonical routes. One product-surface compiler feeds nav/catalog/palette/
+search; six-record registration family; ten independent state dimensions;
+effectful tooling requires contract refs + authority posture + receipt
+obligations; lifecycle strip on every capability detail page.
+
+**Actual (estate):** a T1 SPA shell (29 vendor captures + 97-RPC adapter — 3
+backing classes: daemon-projected, local-constant identity lies, app-local
+prefs — plus 5 fixture-only RPCs), ~100 wired native `/__ioi/*` readouts, and
+14 registered T3 surfaces named for the retired taxonomy (6 with governed
+mutations, 8 read-only; 24 of 563 controls governed-receipted). Sessions
+route absent; Settings = 20 capture panes, reads mostly daemon-backed, writes
+partial, identity partly fabricated (`IDENTITY_REWRITES`). Ported-seed
+preservation invariant + 6-step per-app cutover rule are in force
+(`apps/hypervisor/ported-seed-preservation.v1.json`, `AGENTS.md`).
+
+**Strategy: rehome, don't rebuild.** Every wired plane survives by moving into
+its canonical owner; every rebuilt-parallel shell is forbidden by the seed
+invariant. v2 cutover deletes legacy routes with typed 410s (ADR 0022), one
+app at a time, per the existing cutover rule.
+
+## 2. Wave 0 — shared plumbing (everything else stacks on this)
+
+| W0 item | Content |
+|---|---|
+| W0.1 v2 shell + router | The 23 canonical routes as the shell's route table; legacy `/__ioi/*` kept serving until each app's cutover; typed-410 retirement per route at cutover. |
+| W0.2 Product-surface compiler v1 | One projection feeding nav/catalog/palette/launch from registration records (daemon: `surface-descriptors`, `product-surface-projections`, `domain-apps` routes exist). Policy filtering before aggregation. Kills the three hand-maintained catalogs. |
+| W0.3 Read client + authority client | Uniform read-projection fetch (the ~20 `/overview` + projections) and the authority-crossing client encoding the CapabilityLease flow (403 wallet challenge, 428 credential, receipt refs on completion). |
+| W0.4 Event client on the M5 plane | UI subscriptions ride `/v1/event-streams` + `/v1/subscriptions` (durable, checkpointed, resumable); legacy per-resource SSE wrapped, not extended. |
+| W0.5 Identity truth | Delete the adapter's local-constant identity (`GetOrganization`, `GetAccount`, policies, ToS) and `IDENTITY_REWRITES`; back by daemon identity/whoami/org routes or render honest absence. Kill the 5 fixture-only RPCs (Project/Insights/RunnerConfiguration) by wiring or by disabled-named-gap. |
+| W0.6 Backend enablers (small routes, one PR each) | `GET /v1/hypervisor/sessions/overview`; unified approvals-inbox projection (folds the 4 disjoint approval systems); `GET /v1` capability index; scheduler read surface (`/v1/hypervisor/scheduler/status`). Central-router file is a merge hotspot — sequence these serially. |
+
+## 3. Per-application plan (canon → assets → gaps)
+
+Format: **owner — route — inherits (rehomed assets) — backend state — work**.
+
+1. **Studio `/studio`** — inherits `designer` + `machinery` surfaces (worst
+   ratio: 7/51 implemented). Backend: `state-machines`, ODK reads exist; no
+   blueprint/canvas persistence plane. Work: typed-canvas read view over
+   Systems/agents; draft blueprint objects (new daemon family
+   `studio/blueprints` CRUD + promote-through-gates); Canvas stays inside
+   Studio, never a peer app.
+2. **Automations `/automations`** — inherits `monitors` + the Home
+   automations redirect. Backend rich: automations CRUD/start/runs/webhooks +
+   placement + warm pools; scheduler in-process. Work: wire spec/version list,
+   trigger entrypoints, run history with GoalRun/Session refs (routes exist);
+   step-family graph view over Workflow Compositor contracts; needs W0.6
+   scheduler read surface; AutomationRun → result/Session/GoalRun lineage rows.
+3. **Ontology `/ontology`** — inherits `schema` (deepest wired surface, 13
+   governed controls) + `explorer` (read-only, currently degenerate "Loan"
+   rows). Backend: ODK domain-ontologies/projections/mappings/views complete.
+   Work: rehome both under `/ontology`; fix explorer's object-set reads
+   (`materialized-object-sets` routes exist); enable the disabled
+   proposal/branch plane through the authority client.
+4. **Data `/data`** — inherits `pipeline` (8 receipted actions; 40 disabled
+   controls = largest dead cluster) + `sources` (3 of 4 tabs empty). Backend:
+   ODK transformation/materializing/connector-session routes complete;
+   `data-sources` CRUD partial (no update/delete). Work: rehome; light up the
+   40 via authority client where routes exist (deploy/scheduler plane defers
+   to Automations); finish sources CRUD backend; consent-posture badges from
+   policy-bound-data-views.
+5. **Governance `/governance`** — inherits `approvals` surface. Backend:
+   governance approval-requests, kill-switches, release-controls, cohorts,
+   improvement-gates all exist; capability-leases + authority
+   grants/posture/receipts exist. Work: the unified inbox (W0.6) as the
+   Approvals tool; release/change cockpit facet (promotion/rollout/rollback/
+   kill-switch/cohort views over existing routes); authority-scope and lease
+   browser; `reviewer_ref` becomes a principal, not free text.
+6. **Provenance `/provenance`** — inherits work-ledger/lineage/run-timeline/
+   run-replay readouts (all wired T2). Backend: receipts read surfaces ×5
+   families, replay routes, outcome-room replay/graph projections. Work:
+   unify into one receipt-stream + lineage graph surface with the
+   waterfall/detail-drawer contract (D6); work-first display rule (hashes only
+   behind proof drilldowns).
+7. **Evaluations `/evaluations`** — inherits `evalsuites` (has the estate's
+   known receiptless-mutation defect — fix against the effectful-tooling
+   gate). Backend: eval-suites CRUD exists; epochs/holdouts/challenges absent.
+   Work: 12-section IA as read-first over suites + runs; file backend families
+   (epochs, sealed-holdout custody, challenges) as the app's build-list;
+   receipts on every mutation.
+8. **Improvement `/improvement`** — inherits `changes`. Backend:
+   improvement-proposals + approve/reject/apply/simulate, improvement-gates,
+   intelligence graph/review-queue/outcome-mining exist. Work: agenda/campaign
+   objects are backend gaps (file family); wire proposals inbox + what-if
+   simulation views now; no "Self-improve" button, ever.
+9. **Foundry `/foundry`** — inherits `models` surface + model-mount plane
+   (45 routes!) + model-routes + foundry specs/run-plans + intelligence
+   memory/skills. Work: platform IA (Discover/Build/Train/Evaluate/Optimize/
+   Deploy/Govern) as read-first over the huge existing surface; wire
+   probe/enable/select-default via authority client; training/dataset
+   families largely exist under foundry+model-mount; learning-boundary badge
+   is a projection, never ambient permission.
+10. **Packages `/packages`** — nearest assets: `listings` surface (highest
+    decorative ratio) + marketplace routes + worker-package-install-admissions.
+    Backend gap: no package/release/install/recall registry — the biggest
+    single backend build in the program (file: `packages/*` family with
+    releases, installs, deprecation, revocation, recall + compiler hook so
+    recall removes launches). Marketplace becomes the optional mode at
+    `/packages/marketplace` over existing listing routes.
+11. **Developer Workspace `/developer-workspace`** — inherits the wired
+    workbench (`/details/:env`, EnvironmentService 14 RPCs, AgentService 10,
+    terminals, editor-services/leases/targets). Work: rehome under the
+    canonical route; adapter-connection-profile rule (editor = adapter
+    target); wire editor-service lifecycle controls that exist server-side.
+12. **Developer Console `/developer-console`** — backend rich (connectors,
+    secrets, OAuth flows, MCP, api-tokens, SSO/SCIM/OIDC config, domain
+    verifications), UI absent (only the BYOA connect button + `/__ioi/
+    connections`). Work: registration-estate UI over existing routes:
+    connectors + credential + invoke-test, MCP gateway tools, API tokens,
+    conformance placeholder; owns integration *registrations*, never provider
+    runtime (that's Environments/Operations).
+
+**Substrate:** **Environments `/environments`** — env CRUD/lifecycle/logs/
+ports/snapshots + provider accounts/candidates/placement/failover all exist;
+UI = env readouts today; build the lifecycle cockpit read-first, actions via
+authority client. **Operations `/operations`** — operations reads, storage
+backends/archives/incidents, spend reconciliation, warm pools, autonomous-
+systems projections exist; build the jobs/capacity/custody cockpit read-first.
+
+**Embodied Systems** — reserved route only; nonlaunchable registration row in
+the compiler; no UI work.
+
+## 4. Sessions chapter (`/work/sessions` — a Work view, not an app)
+
+Backend today: create/list/get/teardown/execute/events (+ ports/revoke);
+"positive execution loop is Cut #2" per the daemon's own comment; the live
+I/O plane is session-execution-bindings (input/stop/archive/restore/events)
+plus managed-sessions + session-turns; no overview/lineage/transition routes.
+
+1. `/work` shell with typed views: goals, sessions, rooms, queues, reviews,
+   incidents, history (routes + subject_kind/subject_ref rows; policy filter
+   before counts).
+2. Sessions list = `/v1/hypervisor/sessions` + W0.6 overview; detail =
+   D4 object fields + D5 view contract (transcript, step graph, tool/model
+   calls, authority gates, receipts, replay availability) composed from
+   session + execution-binding + thread + workrun reads; D7 WorkRun view; D8
+   room-participant drilldown (claim/lease/heartbeat/spend/evidence — routes
+   exist in the room-participation plane).
+3. Lineage: file the backend gap (session lineage/fork/children projection)
+   — the one first-class family with none of overview/transition/history.
+4. Retirement: shell stops advertising `/__ioi/sessions` (tile + vendor
+   sidebar tab); `/sessions` renders the typed 410 the daemon already emits.
+5. Execution loop Cut #2 (turn loop on session-execution-bindings) is the
+   product milestone that turns the view live; sequence after W0.4.
+
+## 5. Settings chapter (`/settings` — core workspace, projection-only)
+
+Canon: panes project canonical owner records; Settings persists only admitted
+preferences + owner-backed administrative mutations; transient UI state stays
+client-local. Today: 20 capture panes; reads mostly daemon-backed
+(members/secrets/PATs/billing/SSO/SCIM/OIDC/service accounts); org identity +
+policies + ToS are adapter constants; runners/integrations lists are local
+lies; preferences backend is GET+PUT-by-id only.
+
+1. Replace constant-backed panes with owner routes or honest absence (W0.5).
+2. User pane set: connected apps (Developer Console records), memory/skill
+   prefs (intelligence routes exist), delivery channels, BYOK/BYOA defaults.
+3. Org pane set: connectors/service accounts, allowlists + provider policies,
+   SSO/SCIM/retention (routes exist), learning-boundary defaults (projection
+   + governed-upgrade-proposal on change), workspace defaults.
+4. Backend: keep `preferences` for admitted preferences; add scope+schema
+   listing so panes render generically; every administrative mutation routes
+   to its owner and returns that owner's receipt.
+5. File the canon nit: five-vs-six core-workspace count drift (5 locations)
+   + missing dedicated Settings section — one-line canon PR.
+
+## 6. Launch ladder
+
+- **Wave 0** — plumbing W0.1–W0.6. Exit: v2 shell serves all 23 routes
+  (bodies may be read-first), compiler feeds nav, identity honest.
+- **Wave 1 (read-first launches)** — apps whose backends are rich today:
+  Work+Sessions views, Provenance, Environments, Operations, Governance
+  (reads + unified inbox), Ontology, Data, Automations, Foundry,
+  Developer Workspace rehome. Exit per app: canonical route renders daemon
+  truth end-to-end with honest empty/degraded states; zero fixture data.
+- **Wave 2 (actions)** — authority-crossing controls via the lease client:
+  Governance cockpit verbs, Data/Ontology mutations, Automations lifecycle,
+  Foundry route/mount controls, Developer Console registrations, env/ops
+  actions. Exit: every enabled control is receipted; everything else is
+  disabled-with-named-gap; the 24 governed controls become hundreds only as
+  fast as routes actually exist.
+- **Wave 3 (backend builds + their UIs)** — Packages registry family (the
+  big one), Studio blueprints, Evaluations epochs/holdouts/challenges,
+  Improvement agendas/campaigns, session lineage, approvals-inbox if not in
+  W0. Each lands backend-first, then UI in the same wave.
+- **Wave 4 (cutover + execution loop)** — Sessions execution loop Cut #2;
+  per-app legacy `/__ioi/*` retirement with typed 410s per the 6-step rule;
+  delete the mock branches in `server.cjs`, the fixture API lane, and the
+  second static copy (`product-ui/public`); Settings completion; the two
+  remaining canon-file nits.
+
+## 7. Standing rules for every PR in this program
+
+Read truth or show honest absence — never fixture data presented as runtime
+truth (the Home fallback-fixture rule generalizes: visible fixture source or
+nothing). Local UI state stays local. Existing authority only, with receipts
+— no effectful control without contract refs + authority posture + receipt
+obligation; otherwise disabled with a named gap. One daemon-backed lane per
+capability — no forked truth, no parallel shells (seed-preservation invariant
+stands until each app's cutover). Serve with no test flags. The central
+router file is a serialization point — backend-route PRs touching
+`hypervisor-daemon.rs` don't parallelize.


### PR DESCRIPTION
Wave item: run charter + C-1..C-4 canon layering (pre-Phase-A prerequisite).

What became operational: the four session-layering conflations are fixed in canon — HypervisorSession now carries typed subject_attachments[] instead of named app-family fields (C-1/C-2), the thread plane is declared one daemon-internal substrate under Session (C-3), and foundry_eval_training is retired from session_kind (C-4). The bring-to-life run charter (preauthorized regime + Run State ledger) and the v0 master guide it executes are now on master, making the ledger the cross-session handoff channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)