### PR TITLE
briefs(Phase A): owner-app briefs I — studio, automations, ontology, data, governance, provenance

### DIFF
--- a/internal-docs/implementation/surfaces/automations.md
+++ b/internal-docs/implementation/surfaces/automations.md
@@ -1,0 +1,219 @@
+# Automations — implementation brief
+
+Canonical route: `/automations` · Owner: Automations (owner application)
+Brief status: authored 2026-08-05 from bytes at `21ae389fe` · v0 seed corrected where noted
+
+Canon cites are `docs/architecture/components/hypervisor/core-clients-surfaces.md` unless
+prefixed. Daemon cites: `crates/node/src/bin/hypervisor-daemon.rs` (router) or
+`hypervisor_daemon_routes/*.rs`. UI cites: `apps/hypervisor/...`. `census:` cites:
+`internal-docs/audits/2026-07-30-hypervisor-surface-end-state-audit/inventory.v1.json`
+(2026-07-30; spot-verified against the live tree where load-bearing).
+
+## 1. Canon digest
+
+- Automations owns reusable workflow, trigger, schedule, monitor, API/service, approval-flow,
+  queue, and process-graph **definitions plus their activations**; core grammar =
+  condition-over-object-set → governed effect (:1308-1311). Route `/automations`; shell
+  placement and application identity resolve to the same registration (:893).
+- It is the reusable-standing-behavior surface over Hypervisor Core and the Workflow
+  Compositor (:2300-2301) — for work the user wants to save, run again, trigger, schedule,
+  publish as an internal service, or expose through an API/webhook (:2303-2304).
+- May own product projections for: specs and versions; trigger/schedule/webhook/queue/API
+  entrypoints; workflow/service graphs backed by Workflow Compositor contracts; review points
+  and approval gates; change plans, rollout gates, canary, recall, remediation;
+  **AutomationRun history with resulting GoalRun/Session/WorkRun refs, receipt views, replay
+  links**; service templates; Canvas editor state (:2306-2317). Graph node vocabulary
+  :2319-2336.
+- Does NOT own: execution semantics; wallet authority or secret release; Agentgres truth,
+  receipts, archive refs; model private reasoning; Foundry training; the selected harness's
+  internal step loop (:2338-2345). Room participation / shared-frontier admission stay
+  room-level contracts (:2390-2396).
+- Objects: durable reusable `AutomationSpec`; one activation = `AutomationRun`;
+  scope enablement = exact `AutomationInstallationBinding` (:2361-2381, :3283-3285). A run may
+  finish directly, request bounded Sessions/WorkRuns, explicitly create/link GoalRuns, or
+  contribute typed room work; it never becomes a GoalRun by being long-running (:2362-2365).
+  Relationship model :3296-3303; an AutomationRun may finish without a GoalRun and, with no
+  managed execution, without a Session (:3307-3309).
+- Modes: manual/scheduled/event-webhook/PR-issue/monitor/approval-flow/service-API/
+  queue-worker/marketplace-recipe (:2347-2359). Durable automations must not silently
+  duplicate an existing name/project trigger match (:2408-2413).
+- Step families: `agent`, `task`, `approval`, `pull_request`, `report`, `deployment`,
+  `remediation`, `webhook/API`; agent resolves through HarnessProfile/adapter; task through
+  daemon-owned env task execution; a PR step is a delivery contract, not proof; **every
+  consequential step emits receipts and Agentgres-backed run history** (:2415-2420).
+- Canvas: default home for durable workflows/services is Automations (:2427-2428);
+  `HypervisorCanvasView.owner_surface` includes `automations` (:3944-3953); Canvas never owns
+  execution/authority/semantics (:2443-2445). Tool placement: Process Graphs (legacy
+  Machinery) → Automations / Process Graphs; Monitors (legacy Automate) → Automations /
+  Monitors (:1416-1417).
+- Minimal objects: `HypervisorAutomationSpec` (:3856-3883, revisioned + content-hashed, kind
+  enum :3863-3866, WorkflowTemplate refs :3867-3869, registry_status :3883);
+  `HypervisorAutomationInstallationBinding` (:3885-3897);
+  `HypervisorAutomationRun` (:3899-3942) — carries `goal_run_refs[]`, `work_item_refs[]`,
+  `work_run_refs[]`, **`session_refs[]`** (:3916-3924), resolution receipt (:3912), status
+  enum (:3940-3942). `WorkflowTemplateEnvelope` is compositor-owned, immutable,
+  content-addressed; a template never runs itself (:2588-2591).
+- C-1..C-4 layering (implement, never re-decide): a session serving an automation names it via
+  `subject_attachments` with owner-registered `subject_kind: automation_run` +
+  `attachment_role` — the platform never names an app family as a dedicated session field
+  (:3971-3984, :2683-2687). New Session may carry an optional typed AutomationRun attachment
+  (:1490). Lineage FROM the run side uses the run's own `session_refs[]`/`goal_run_refs[]`
+  (:3916-3924) plus receipts — both directions are reads, never a named session field.
+
+## 2. Schema map
+
+| Canon object / contract | Canon block / registry | Daemon route today | Wave |
+| --- | --- | --- | --- |
+| HypervisorAutomationSpec | :3856-3883; registry: none — daemon persists ad-hoc `ioi.hypervisor.automation-workflow.v1` (orchestration_routes.rs:193) | `GET/POST /v1/hypervisor/automations` (hypervisor-daemon.rs:1268-1271); `GET/PATCH/DELETE /:id` (:1273-1277). Flat mutable record: project_ref required (orchestration_routes.rs:160-169), trigger/steps/limits/schedule_spec/agent+harness+model config (:192-243); **no revisions, no content_hash, no registry_status** | wired; revisioning gap → W3 |
+| AutomationInstallationBinding | :3885-3897 | **route-missing** — no binding plane; `project_ref` on the spec is the only scope | **W3** |
+| HypervisorAutomationRun | :3899-3942 | executions: `POST /:id/start` (:1279-1282), `GET/POST /:id/runs` (:1284-1288), `GET /v1/hypervisor/automation-executions/:id` + `/cancel` (:2076-2084). Record `ioi.hypervisor.automation-execution.v1` carries `environment_id`, `step_results`, counts (orchestration_routes.rs:1171-1176) — **no session/goal/work refs, no resolution receipt** | wired; lineage fields → W3 |
+| Webhook entrypoint + audit | :2309, :2352 | `POST /:id/webhook` (:1291-1293, own-token auth, gate-exempt — orchestration_routes.rs:57), `POST /:id/webhook-rotate` (:1295-1297, plaintext token returned once — orchestration_routes.rs:236-252), `GET /:id/webhook-events` (:1299-1301; receipted `webhook-trigger-events` rows with `receipt_id`) | wired |
+| Schedule plane | :2309, scheduler mode :2111 | `schedule_spec` on the spec + **in-process scheduler**: `tokio::spawn(automation_scheduler(...))` (hypervisor-daemon.rs:3481-3486), 15s tick (:4207, :4430-4437), fires due automations through the manual-run path, never fires on create (:4440-4470); `GET /v1/hypervisor/cron-preview` (:1304-1306) | wired |
+| Scheduler read surface | — | **partial**: `GET /v1/hypervisor/operations` projects a `scheduler` block (count + per-automation enabled/trigger/schedule/next_run_at/last_run_at/policies) from records (orchestration_routes.rs:403-435; route hypervisor-daemon.rs:1314-1316). No liveness truth (tick heartbeat, catch-up/misfire decisions) | **W0.6** — `GET /v1/hypervisor/scheduler/status` (liveness only; the schedule projection exists) |
+| Run/webhook proof stream | :2314-2315 | `GET /v1/hypervisor/work-ledger` (:1309-1311) — unified runs+webhook receipts with state_root; run timeline refs `/__ioi/run-timeline/{exec}` (orchestration_routes.rs:475) | wired |
+| WorkflowTemplateEnvelope / step-family graph | :2588-2591; registry `workflow-template.v1.schema.json` (`schema://ioi/foundations/workflow-template/v1`, architecture-contract-registry.v1.json) | **route-missing** — no workflow-template family; the spec stores an opaque `workflow_graph_ref` (orchestration_routes.rs:206) | **W3** — template read/derive family + graph view |
+| Step families beyond agent/task | :2415-2420 | executor implements `agent` (agentops conversation), `command`, `proposal` only (orchestration_routes.rs:1236-1330) | **W3** — `approval`/`pull_request`/`report`/`deployment`/`remediation`/`webhook` step kinds over existing owner planes |
+| Monitor grammar (condition-over-object-set → effect) | :1311, :2354, :1417 | **route-missing** — trigger kinds are manual/schedule/webhook only (create default orchestration_routes.rs:172-186; census monitors missing-authority); no object-set/threshold/metric trigger authority. Object sets themselves exist: `/v1/hypervisor/odk/materialized-object-sets` (:1580) | **W3** — object-set trigger family |
+| Process-graph definitions (ex-Machinery) | :1416; process-graph defs owned here :1308-1311 | `/v1/hypervisor/state-machines{,/overview,/:id}` (:1939-1953) — **definitions only by explicit design**: "NO run/step/execution, no scheduling, and no automation binding here — that is a later authority-crossing cut" (:1935-1938; state_machine_routes.rs:417) | wired read; **W3** — run/step/bind family (activations are canon-owned here) |
+| AutomationRun→Session lineage | C-1..C-4 (:3971-3984, :3916-3924) | **route-missing** — `subject_attachments` appears nowhere in daemon bin code (grep clean); executions carry `environment_id` only; agent steps run agentops conversations, not HypervisorSessions (orchestration_routes.rs:1237-1260) | **W3** — lineage build (see §4 row) |
+| Warm pools | orchestration/scale substrate (router comment :1266) | `GET/POST /v1/hypervisor/warm-pools`, `POST /:id/claim` (:2674-2681) | wired (Operations-facing projection; link only) |
+| Placement | — | `/v1/hypervisor/placement/{resolve,metrics,venues,venue-policy,preview,decisions[,/:id]}` (:2591-2620) | wired (surface as run-placement facet, read) |
+| Event plane | W0.4 rule | `/v1/event-streams` + `/v1/subscriptions` (:2350-2372); the contract already fixtures an `automation-scheduler` owner namespace with `schedule.fired` / `trigger.suppressed` classes (docs/architecture/_meta/schemas/fixtures/event-stream-v1/positive-automation-scheduler-namespace.json) | W1/W2 consumption |
+| Automation affinities (intelligence, read-adjacent) | — | `/v1/hypervisor/automation-affinities[/:id]` (:1677-1686) | wired read (projection band only; intelligence-owned) |
+
+## 3. UI seed map
+
+**T1 shell:** `/automations` **resolves today** (census:canonical_target_routes) — it is a
+vendored-SPA route with a left-rail tab (census README T1 table). Its data plane is adapter
+stubs: `WorkflowService/ListWorkflows|ListWorkflowExecutions|GetWorkflowExecutionSummary`
+return honest-empty constants (ioi-api-adapter.mjs:865-872), as do
+`EnvironmentAutomationService` lists (:874-882). The serve file declares the SPA's org-scoped
+WorkflowService surface **NOT canonical** (serve-product-ui.mjs:703-706). Classification:
+traversable, dead data plane.
+
+**T2 native readouts (the wired owner substrate):**
+- `/__ioi/automations` cockpit (serve:8328 list, POST create :8369-8401): project-first spec
+  cards over daemon truth (:802, :812), New form with cron preview (:985-1035; proxy :8361 →
+  daemon cron-preview). Detail dispatch (:8443-8494): **Run now** (→ `POST /:id/runs`, :8452),
+  **Pause/Resume** (→ `PATCH {enabled}`, :8459), inline **patch** editor (:8464-8467),
+  **webhook rotate** with show-once token + URL (:8471-8476; UI band :899-906), **Delete**
+  (:8491-8494). Classification: wired (reads + direct daemon actions; no lease client, no
+  receipts surfaced on spec mutations).
+- `/__ioi/automations/monitors` (serve:8434-8441 → `renderMonitorsPort` :4455-4574): the
+  certified "Automate" landing — a **read-only projection over the real automation plane**
+  (stats/paused/user-executed derived from real fields :4467-4473; honest-0 notification lane;
+  authoring stays on the owner substrate, foot :4574). Classification: wired read.
+- `/__ioi/operations` (serve:8802 → daemon `/v1/hypervisor/operations`): execution-health
+  cockpit with per-run drawer + **Re-run / Pause / Resume** actions (:1986-1991).
+- Home readout tile "Automations" → `/__ioi/automations` (:1457); project cards cross-link
+  (:1410); GoalRun views link the plane via "Automation readiness" affinities band (:2751).
+- Incoming from Studio at rehome: `/__ioi/studio/machinery` (serve:9616-9622, reads
+  `/v1/hypervisor/state-machines`; `renderMachineryPort` definition detail with named-gap
+  footer :4761 — run/step/execute, scheduling, binding, simulation, versioning all named).
+
+**T3 registered surfaces:**
+- `monitors` — registry `scripts/surface-registry.mjs:61`: owner "Automations", title
+  **"Automate"**, route `/__ioi/automations/monitors`, capabilities `["browse"]`,
+  operational_state `browse`. Census: 29 controls / 20 implemented (8 daemon_read, 3
+  local_view, 0 governed, 9 disabled_missing_authority, 1 unsupported, 8 reference_data_only)
+  (census:tier_t3_registered_applications.monitors). Missing-authority contracts: object-set
+  trigger catalog, effect library, notification-subscription plane, marketplace install
+  binding, monitor settings (expiration/permission-scoped visibility).
+- `machinery` — registry :60 (owner-in-code "Studio") — canonical target **Automations /
+  Process Graphs** (:1416; census `canon_target_name`); census 30 controls / 17 implemented,
+  0 governed, 12 disabled. Transfers here (paired PR with studio.md).
+
+**Mock lane:** `product-ui/server.cjs` still ships an "Automate" catalog fixture (:895) —
+deleted at W4 per the master ladder.
+
+### Corrections vs v0
+
+- v0 said: "scheduler in-process with NO read surface (W0.6: `/v1/hypervisor/scheduler/status`)"
+  — bytes show `GET /v1/hypervisor/operations` already projects the scheduler's schedule state
+  (count, per-automation enabled/trigger/spec/next_run_at/last_run_at/concurrency/policy)
+  (orchestration_routes.rs:403-435; route hypervisor-daemon.rs:1314-1316). The real W0.6 gap
+  narrows to scheduler **liveness** (tick heartbeat, catch-up/misfire decisions) — today's
+  projection is records-derived, not loop-derived.
+- v0 said: "wire … run history with GoalRun/Session refs (routes exist)" — bytes show run rows
+  are `automation-executions` carrying `environment_id` + `step_results` with **no
+  session/goal refs** (orchestration_routes.rs:1171-1176); the `agent` step drives an agentops
+  conversation, not a HypervisorSession (:1237-1260). Lineage refs are a Wave-3 build, not a
+  wiring task.
+- v0 (and the census `owner_family_in_code`) placed `machinery` under Studio — canon places
+  Process Graphs (legacy Machinery) under **Automations** (:1416), and Automations owns
+  process-graph definitions *plus activations* (:1308-1311); machinery rehomes here with the
+  state-machines backend (definitions-only today, hypervisor-daemon.rs:1935-1938).
+- Surviving `automation_run_ref` sites: **none in daemon or UI code** (repo-wide grep clean).
+  All remaining sites are docs and canon-legal — `HypervisorWorkItem`/`HypervisorWorkRun`
+  (:4197, :4227), product-surface projection request context
+  (daemon-runtime/api.md:1099), admission response (api.md:1565), and
+  `AutomationRunResolutionReceipt` (daemon-runtime/events-receipts-delivery-bundles.md:1869).
+  There is no code-migration debt; the C-1..C-4 work is purely additive (`subject_attachments`
+  exists in no daemon code yet — grep clean).
+- v0 said Automations inherits "the Home automations redirect" — bytes show two distinct
+  inheritances: the T1 SPA rail route `/automations` over non-canonical WorkflowService stubs
+  (ioi-api-adapter.mjs:865-872) and the Home readout tile → `/__ioi/automations`
+  (serve:1457). No redirect exists; the T1 page is a live route with a dead data plane.
+
+## 4. Schema→UI binding table
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+| --- | --- | --- | --- |
+| Spec list + project filter | AutomationSpec; `GET /v1/hypervisor/automations[?project_ref]` (:1268) | wired at `/__ioi/automations` (serve:8328-8348) | `wired-read` at `/automations` (read-projection client) |
+| Spec detail (trigger, steps census, limits, agent/harness/model config, schedule) | spec record fields (orchestration_routes.rs:192-243) | wired (serve detail :857-961) | `wired-read`; version strip appears with W3 revisioning |
+| Create automation (form + cron preview) | `POST /v1/hypervisor/automations` (:1268-1271) + `GET /v1/hypervisor/cron-preview` (:1304-1306) | wired direct POST (serve:8369-8401) | `wired-action-receipted` via lease client (403 wallet → 428 credential → receipt); duplicate name/project trigger guard per :2412-2413 |
+| Run now | `POST /:id/runs` (:1284-1288) | wired direct (serve:8452) | `wired-action-receipted` (transcript state_root already recorded — orchestration_routes.rs:1361-1382) |
+| Pause / Resume schedule | `PATCH /:id {enabled}` (:1273-1277) | wired direct (serve:8459) | `wired-action-receipted` |
+| Edit (patch) / Delete | `PATCH`/`DELETE /:id` (:1273-1277) | wired direct (serve:8464, :8491) | `wired-action-receipted`; delete refuses when enabled schedule/webhook active (named refusal) |
+| Webhook enable/rotate + show-once token + events feed | `POST /:id/webhook-rotate`, `GET /:id/webhook-events` (:1295-1301) | wired (serve:8471-8476, band :899-906) | `wired-action-receipted` (rotate); events feed `wired-read` (rows already carry `receipt_id`) |
+| Run history list + run drawer (status, env, timeline ref) | automation-executions; `GET /:id/runs` (:1284), `GET /v1/hypervisor/automation-executions/:id` (:2076) | wired (list + operations drawer :1986-1991) | `wired-read` with D6 waterfall/detail-drawer contract (:2712-2718) |
+| Cancel running execution | `POST /v1/hypervisor/automation-executions/:id/cancel` (:2080-2083) | route exists, no UI control | `wired-action-receipted` |
+| Run detail → serving Session(s)/GoalRun(s) lineage rows | `HypervisorAutomationRun.session_refs/goal_run_refs` (:3916-3924) + sessions filtered by `subject_attachments{subject_kind: automation_run, subject_ref, attachment_role: executes}` (:3971-3984) | absent (executions carry `environment_id` only) | `disabled-named-gap` until W3 lineage lands; then `wired-read`. **Never a named session field** |
+| Scheduler pane (what's scheduled, next/last fire) | operations `scheduler` block (orchestration_routes.rs:419-434; scheduled table serve:1767) | wired read | `wired-read`; liveness badge binds to W0.6 `/v1/hypervisor/scheduler/status` when it lands (`disabled-named-gap` until) |
+| Monitors overview bands (active/paused stats, recently-viewed, recently-triggered) | real spec/execution fields (serve:4467-4473) | wired read | `wired-read` as `/automations/monitors` view |
+| "New automation" monitor wizard (condition catalog → effects → settings) | none — object-set trigger + effect-library authority missing (census) | disabled in place | `disabled-named-gap` until W3 monitor-grammar family; then `wired-action-receipted` |
+| Notification "For you" tile / subscription filter | no notification-subscription plane (census) | honest 0 | `disabled-named-gap` |
+| Marketplace install lanes / template docs / wizard illustrations | vendor reference content (census: reference_data_only ×8) | decorative | `delete` at cutover |
+| Process-graph (machinery) table + definition detail (states/transitions/guards/IO/history) | state-machines (:1939-1953) | wired read at `/__ioi/studio/machinery` (serve:9616) | `wired-read` at `/automations` Process Graphs view (rehome) |
+| Process-graph create/edit/delete (form-based) | `POST/PATCH/DELETE /v1/hypervisor/state-machines[/:id]` (:1943-1953; history[] appended per census) | absent in UI (daemon CRUD exists) | `wired-action-receipted` |
+| Process-graph run/step/monitor, simulate, version/branch, bind-to-automation | none — explicitly deferred (:1935-1938) | named gaps in footer (serve:4761) | `disabled-named-gap` until W3 activation family |
+| Step-family graph view (Canvas read) | WorkflowTemplate registry schema; no daemon family | absent (`workflow_graph_ref` opaque) | `disabled-named-gap` until W3 template family; Canvas stays inside the app (:2427-2428) |
+| Live updates (runs firing, schedule ticks) | `/v1/event-streams` `automation-scheduler` namespace (:2350-2361 + registry fixture) | absent (no SSE here today) | `wired-read` via W0.4 event client (M5 plane; per-resource SSE is legacy, wrapped not extended) |
+| T1 SPA `/automations` WorkflowService page | adapter stubs (ioi-api-adapter.mjs:865-872) | dead data plane | `delete` at cutover (owner route replaces the rail tab; W0.5 kills the stub lane) |
+
+## 5. Ordered PR list
+
+1. **W1** — `/automations` v2 route renders spec list + detail read-first over the W0.3 read
+   client (rehome the `/__ioi/automations` reads; zero fixture data; honest-empty states).
+2. **W1** — Rehome the monitors "Automate" overview as the `/automations/monitors` view
+   (read-only projection; gaps stay named in place, converted to `data-ioi-disabled-reason`).
+3. **W1** — Rehome machinery as the Process Graphs view (read over state-machines); registry
+   owner-family transfer paired with studio.md PR 4.
+4. **W1** — Run-history pane adopts the D6 drawer over runs + work-ledger + run-timeline reads.
+5. **W0.6** (serialized on the central router) — `GET /v1/hypervisor/scheduler/status`
+   liveness surface (tick heartbeat, last catch-up/misfire decisions); UI badge binds after.
+6. **W2** — Lifecycle actions through the CapabilityLease client: create/patch/enable/disable/
+   delete/run-now/webhook-rotate/cancel (routes :1268-1301, :2076-2084); every enabled control
+   receipted; duplicate-trigger guard on create.
+7. **W2** — Process-graph form-based CRUD via the authority client (daemon CRUD exists;
+   :1943-1953); visual authoring stays disabled-named-gap.
+8. **W2** — Event client subscribes to the `automation-scheduler` namespace on
+   `/v1/event-streams` for live run/schedule updates (W0.4 plane).
+9. **W3 backend** — AutomationRun lineage: execution admission stamps
+   `session_refs`/`goal_run_refs`/`work_run_refs` on the run record and writes the serving
+   session's `subject_attachments` row (`automation_run`, `executes`) inside the daemon
+   execution path; read projections both directions; UI lineage rows go live.
+10. **W3 backend** — Spec revisioning + `AutomationInstallationBinding` plane per :3856-3897
+    (content-hashed revisions, registry_status, scope bindings); UI version strip + binding
+    panel follow in-wave.
+11. **W3 backend** — Monitor grammar: object-set trigger family over materialized-object-sets
+    (+ threshold/metric/time-series conditions) and the effect/step families
+    `approval`/`pull_request`/`report`/`deployment`/`remediation` (:2415-2420); wizard UI
+    lands in-wave.
+12. **W3 backend** — WorkflowTemplate read/derive family + step-family graph (Canvas read
+    view, layout via CanvasView `layout_ref`); process-graph activation/binding family (the
+    deferred authority-crossing cut, :1935-1938).
+13. **W4** — Cutover per the 6-step rule: typed 410s for `/__ioi/automations*`,
+    `/__ioi/automations/monitors`, `/__ioi/studio/machinery`; delete the SPA WorkflowService
+    stub surface and the `server.cjs` "Automate" fixture (:895); rail/nav rows come from the
+    product-surface compiler only.

--- a/internal-docs/implementation/surfaces/data.md
+++ b/internal-docs/implementation/surfaces/data.md
@@ -1,0 +1,181 @@
+# Data — implementation brief
+
+Canonical route: `/data` · Owner: Data (owner application)
+Brief status: authored 2026-08-05 from bytes at `21ae389fe` · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Owner job: "supply the world-model: sources/syncs, data recipes, datasets, time-series
+  and media sets — nothing enters a system's view without a governed recipe, and every
+  data object carries its consent posture; consumes connector bindings from Connections,
+  never owns them" (core-clients-surfaces.md:1319-1323). Connector/integration
+  *registrations* are Developer Console inventory (:1392-1397); Data only consumes.
+- Nav identity: "Data (supply the world-model: sources, syncs, data recipes, datasets,
+  media sets, consent posture — Data/Knowledge family)" (core-clients-surfaces.md:839-840);
+  route `/data` in the v2 ledger, no aliases per ADR 0022 (:876-880, :895).
+  `Data / Knowledge` is an alias label, never a surface (:1744-1745, :2142).
+- Two tool surfaces rehome here: Pipeline Builder / Recipe Builder → `Data / Recipes`,
+  Data Connections → `Data / Sources` (core-clients-surfaces.md:1408-1409); tools launch
+  under the owner with typed context, never as peer identities (:1428-1433).
+- ODK is not an app; "data recipes and sources [surface] through Data" (:935-938).
+- Learning boundary: Data (with Ontology) exposes "source-rights, consent, intended-use,
+  recipe, and derivative-impact posture" (:1079-1080); Build lifecycle verb (:1121);
+  System Design mode participant (:1648).
+- Durable workflow/schedule truth belongs to Automations — "Scheduled services,
+  workflow graph truth … belong to the top-level Automations surface" (:1029-1034);
+  a pipeline scheduler is therefore not a Data build-list item.
+- May never: separate runtime truth (:1470-1473); write canonical truth outside the
+  daemon path (:4541-4543); no private runtime loop (:4543-4544); no credential material
+  in declared truth — the daemon rejects plaintext secrets and credential-bearing
+  endpoints outright (data_source_routes.rs:9-11, :288-304, :340-347).
+- Layering (C-1..C-4): nothing on this surface serves a HypervisorSession. ODK
+  `connector-sessions` are sealed substrate ladder records (hypervisor-daemon.rs:1538-1540),
+  not HypervisorSessions — no `subject_attachments` binding arises; no named app-family
+  session fields exist in the inherited modules (checked at the bytes).
+
+## 2. Schema map
+
+No Data-plane contract has an entry in
+`docs/architecture/_meta/schemas/architecture-contract-registry.v1.json` (grep evidence:
+no `data-source`/`odk`/`transformation`/`materializing` contract ids). The daemon
+self-declares schema_versions per plane (e.g.
+`ioi.hypervisor.odk.policy-bound-data-view.v1`, policy_bound_data_view_routes.rs:28-30).
+
+| Canon object / contract | Registry / canon anchor | Daemon route(s) today |
+|---|---|---|
+| DataSource (declared registry record; kind vocabulary + credential POSTURE, never a secret) | canon :1319-1323; registry-absent; receipt `ioi.hypervisor.data-source-receipt.v1` (`surfaces/sources/index.mjs:75`) | list/create hypervisor-daemon.rs:2159-2163; overview :2164-2167; get :2168-2171. **No PATCH/DELETE — verified partial CRUD** → `route-missing` **W3** |
+| DataRecipe ("nothing enters a system's view without a governed recipe" :1321) | canon :1906-1909 (DataRecipe refs in registration posture) | ODK CRUD :1592-1601; compatibility alias `GET /v1/hypervisor/data-recipes` :1629-1632 (retire W4) |
+| ConnectorMapping (source fields → typed properties; the per-source semantic join) | registry-absent | :1372-1394 (CRUD + overview + health + history) |
+| PolicyBoundDataView (authority envelope: allowed operations/subjects/property scope + retention/export/training/evaluation/publish postures; high-risk ops require named receipt obligations) | the byte-level carrier of canon consent posture (:1322); enums at policy_bound_data_view_routes.rs:35-56 | :1397-1419 (CRUD + overview + health + history) |
+| TransformationRun (auditable PLAN/DRY-RUN contract; "executed/materialized are reserved for a future connector-adapter cut" — daemon's own comment :1420-1421) | registry-absent | list/create :1422-1426; overview :1427-1430; get/patch/delete :1431-1436; history :1437-1440; dry-run :1441-1444; cancel :1445-1448 |
+| CapabilityLeasePlan (declares the exact lease scope; mints nothing, :1478-1480) | registry-absent | :1481-1503 (CRUD + overview + history + revoke) |
+| MaterializingRun (the live authority crossing: real wallet-gated lease from the one gateway) | registry-absent; receipt `ioi.hypervisor.odk.materializing-run-receipt.v1` (`surfaces/pipeline/index.mjs:89`) | :1507-1537 (CRUD + overview + history + acquire-lease + release-lease + cancel); execute :1575-1578 |
+| ConnectorSession (sealed credential crossing, `credential_required:true`, labels only) | registry-absent; receipt `ioi.hypervisor.odk.connector-session-receipt.v1` (`pipeline/index.mjs:90`) | :1541-1571 (CRUD + overview + history + open + release + cancel) |
+| MaterializedObjectSet (output of one bounded receipted read; shared read with Ontology) | see ontology.md §2 | :1579-1591 (list/overview/get/DELETE — delete receipted, connector_execution_routes.rs:1112-1151) |
+| Ingestion / extraction / connection-test authority (live source contact beyond the one bounded ladder read) | the daemon's own named boundary: "ingestion/extraction is not wired: an effectful pull requires a future wallet/authority crossing bound to admitted substrate (named, not built)" (data_source_routes.rs:252-254) | `route-missing` → **W3** |
+| Syncs (canon names "syncs" :839) | nearest existing truth: materializing-run records (the sources module already counts them as sync activity, `sources/index.mjs:126-130`) | read view over :1507-1517 — no new family needed |
+| Datasets / time-series / media sets (:1319-1321) | no daemon plane under Data (Foundry has its own dataset lanes, canon :2505) | `route-missing` → **W3** (file only after an owner ruling on Data-vs-Foundry split; do not duplicate Foundry truth) |
+| Vendor connector catalog (reference's ~219-connector gallery) | daemon kind vocabulary is a fixed enum: 10 SOURCE_KINDS + 4 CREDENTIAL_POSTURES (data_source_routes.rs:40-57) | Developer Console connector registrations exist (:3022-3065) — projectable read, not a Data-owned build |
+
+## 3. UI seed map
+
+Registered T3 surfaces:
+
+- **Pipeline Builder** — slug `pipeline`, route `/__ioi/pipeline`
+  (`apps/hypervisor/surfaces/pipeline/index.mjs:17-19`). The governed-build workhorse:
+  8 declared receipted runtime actions — admit-run, submit-lease-grant, cancel-run,
+  release-lease, admit-session, submit-session-grant, release-session, execute
+  (:93-102) — over the existing ODK authority only; the wallet grant rides one bounded
+  opaque field, forwarded once, never persisted (:83-91). The handlers already encode
+  the full authority grammar: 403 → typed challenge with public commitment hashes only
+  (:123-130, :161, :201), 428 credential-unresolved (:200, :225), receipt-or-fail-closed
+  on every stage (:151-152, :164-165, :228-229), idempotent resume from record status
+  (:143-146, :181-183). Command table: Preview + Build enabled as read-navigation;
+  Schedule + Deploy disabled with named reasons (:76-81). Control matrix at the bytes:
+  83 entries — 12 daemon_action, 20 local_view, **40 disabled_reason** (the estate's
+  largest dead cluster), 11 unsupported, every disabled/unsupported entry carrying its
+  reason, malformed matrix fails serve boot (`pipeline/control-matrix.mjs:15-125`).
+- **Data Connection** — slug `sources`, route `/__ioi/data/sources`
+  (`surfaces/sources/index.mjs:24-29`). One receipted mutation: `declare`
+  (POST `/v1/hypervisor/data-sources`, confirm-required, `dsr_` receipt fail-closed,
+  :69-105). Declare form derives kinds/postures from daemon vocabulary
+  (`overview.source_kinds`), fails closed when unreachable (:176-197); no secret field
+  exists by design. Header tab row: **Sources active + 4 disabled named-gap tabs**
+  (Syncs, Agents, Listeners, External stacks — :239-245). Selected-source panel renders
+  real per-source connector mappings and 4 disabled record mutations with exact missing
+  contracts (Edit/Delete/Test/Extract, :204-209). Sync counters are real materializing-run
+  states (:126-130, :250-254). Census: 31 controls — 6 daemon_read, 3
+  governed_receipted_action, 11 disabled_missing_authority (census: t3 `sources`).
+- T2 native readouts feeding this owner: `/__ioi/odk` (the substrate authoring ladder),
+  `/__ioi/lineage`, `/__ioi/vertex` (census t2: live 200s); work-ledger provenance links
+  from every ladder record.
+- T1 adapter carries no data-plane RPCs (grep `ioi-api-adapter.mjs`: only `recipes` →
+  `/v1/hypervisor/recipes`, the session-launch-recipe plane, unrelated to DataRecipe).
+- Live population note: the estate's one executed ladder produced the demo loan set
+  (census pipeline workflow: Preview rows L-1/L-2/L-3 citing mset_18c15c5d9d5bfc0f /
+  mrun_18c15c5cd7095669 / csn_18c15c5d306798fa) — the surfaces render honest empties
+  otherwise.
+
+### Corrections vs v0
+
+- v0 said: `sources` has "3 of 4 tabs empty" — bytes show 5 tabs: Sources is live and
+  the other **4 of 5** (Syncs/Agents/Listeners/External stacks) are disabled named-gap
+  spans rendered in place with reasons, not empty panes (`sources/index.mjs:239-245`).
+  And Syncs is not authority-missing like the others: the estate's sync truth already
+  exists as materializing-run records the same module counts (:126-130).
+- v0 said: "`data-sources` CRUD partial (no update/delete)" — **confirmed** at the bytes:
+  GET list + POST create + GET overview + GET `:id` only (hypervisor-daemon.rs:2159-2171);
+  the UI already names both absent routes verbatim in its disabled controls
+  (`sources/index.mjs:205-206`).
+- v0 said: "light up the 40 via authority client where routes exist" — at the bytes most
+  of the 40 have **no** backing route (deploy, build-settings, branching/proposal,
+  graph/node authoring, unit tests, favorites/organizations/color-grouping —
+  `control-matrix.mjs`), and canon assigns scheduling to Automations (:1029-1034). The
+  honestly wireable subset today: transform-plan authoring (TransformationRun CRUD +
+  dry-run exists, :1422-1448 — the matrix reason "requires a TransformationRun authoring
+  authority" is satisfiable as PLAN authoring), and `out.more-options` reset (DELETE
+  `/odk/materialized-object-sets/:id` exists and is receipted, :1587-1591 — the census
+  claim "GET-only … no retire/delete" is stale at the bytes).
+- v0 said: "consent-posture badges from policy-bound-data-views" — bytes: PBV records
+  carry no literal `consent` field; the carriers are the posture enums
+  (retention/export/training/evaluation/publish-route) + allowed operations/subjects/
+  property scope (policy_bound_data_view_routes.rs:35-56) plus the DataSource
+  `credential_posture` vocabulary (data_source_routes.rs:52-57). Badges must project
+  these named postures, not an invented "consent" scalar.
+
+## 4. Schema→UI binding table
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| Sources: declared-source table + census (kinds, postures, wired:false boundary) | DataSource list/overview (hypervisor-daemon.rs:2159-2167) | wired read | `wired-read` |
+| Sources: `declare` (New source / Connect card) | POST `/v1/hypervisor/data-sources` → `dsr_` receipt (`sources/index.mjs:69-105`) | wired-action-receipted | `wired-action-receipted` — move onto the W0.3 lease client encoding (403/428 paths currently unused on this plane; daemon refusals already typed) |
+| Sources: Edit / Delete source | PATCH/DELETE `:id` | disabled named gap (routes absent) | `disabled-named-gap` → after W3 PR 6, `wired-action-receipted` with confirm |
+| Sources: Test connection / Extract | ingestion authority (daemon's named gap, data_source_routes.rs:252-254) | disabled named gap | `disabled-named-gap` → W3 ingestion family; extract remains the governed ladder until then |
+| Sources: Syncs tab | MaterializingRun list/overview (:1507-1517) | disabled named gap | `wired-read` (W1 — the module already computes the counters from this plane) |
+| Sources: Agents / Listeners / External stacks tabs | none; reference-only lanes | disabled named gaps | `delete` at cutover |
+| Sources: creator/edited-by/viewed columns + Favorites | registry lacks principal/view fields | named-gap dashes (`sources/index.mjs:142-144`) | `disabled-named-gap` → optional W3 field add on the registry record |
+| Sources: connector gallery (source-type picker) | daemon SOURCE_KINDS vocabulary (served via overview :2164-2167) | wired (10 kinds) | `wired-read`; optionally enrich with a Developer Console connector-registration read projection (routes :3022-3065) — display only, Data never owns registrations (:1322-1323) |
+| Sources/Recipes: consent-posture badges | PBV postures + DataSource credential_posture (§2) | partial (posture text in rows) | `wired-read` badge vocabulary shared with Ontology inspectors (W1) |
+| Pipeline: ladder graph, node inspectors, file tree, warnings, preview rows | the seven ladder reads (mappings, policy views, transformation-runs, lease plans, materializing-runs, connector-sessions, sets) | wired read | `wired-read` (read-projection client W0.3; build-stage updates via `/v1/event-streams` + `/v1/subscriptions`, no new per-resource SSE) |
+| Pipeline: governed Build — 8 stage actions | MaterializingRun/ConnectorSession POST lanes (§2) with `mrr_`/`csr_` receipts | wired-action-receipted, resumable, fail-closed | `wired-action-receipted` — re-encode through the shared CapabilityLease client (the 403-challenge/428-credential/receipt grammar it hand-rolls today, `pipeline/index.mjs:123-130, :200-201`) |
+| Pipeline: transform strip (Transform/Join/Union/Split/Edit) | TransformationRun create/patch/dry-run (:1422-1448) | disabled named gap | `wired-action-receipted` (W2 — PLAN authoring only; execution stays reserved per :1420-1421) |
+| Pipeline: `out.more-options` reset / re-materialize | DELETE `/odk/materialized-object-sets/:id` receipted (:1587-1591) | disabled named gap (stale census reason) | `wired-action-receipted` (W2, confirm; projection reset is server-side) |
+| Pipeline: Schedule cmd + `rail.schedules` | Automations owns schedule truth (:1029-1034) | disabled named gap | `delete` on this surface at cutover; replace with a link to the owning Automations view |
+| Pipeline: Deploy cmd + `rail.deploy` + build-settings | no daemon plane; no canon Data requirement | disabled named gap | `delete` at cutover unless a canon change names a Data deploy object |
+| Pipeline: Proposals/branch tabs + `rail.changes` + Propose | ontology proposal/branch family (route-missing, ontology.md §2) | unsupported/disabled | `disabled-named-gap` → read view after the W3 family lands (shared with Ontology) |
+| Pipeline: graph/node authoring, annotations, marquee, layout, import-model, LLM/AIP lanes, unit tests | no daemon planes; unit tests owned by Evaluations, models by Foundry | disabled/unsupported with reasons | `delete` at cutover (keep the owner cross-links) |
+| Recipes view (new under `/data/recipes`) | ODK DataRecipe CRUD (:1592-1601) | daemon-complete, UI only in `/__ioi/odk` readout | `wired-read` list/detail in W1; `wired-action-receipted` create/patch in W2 |
+
+No element binds a HypervisorSession; nothing requires `subject_attachments` (§1).
+
+## 5. Ordered PR list
+
+1. **W1** — Mount `/data` in the v2 shell: Sources at `/data/sources`, Pipeline/Recipe
+   Builder at `/data/recipes` (canon placement :1408-1409), modules rehomed unchanged
+   (seed-preservation invariant); legacy `/__ioi/pipeline` + `/__ioi/data/sources` keep
+   serving until step 9.
+2. **W1** — Syncs tab becomes a real read view over materializing-runs; recipes
+   list/detail read view over ODK DataRecipe; honest empties everywhere.
+3. **W1** — Consent-posture badge vocabulary: project PBV
+   retention/export/training/evaluation/publish postures + DataSource
+   credential_posture onto source rows, recipe details, and ladder nodes (shared
+   component with Ontology inspectors).
+4. **W1** — Reads move to the W0.3 read-projection client; build-stage/run updates
+   subscribe on the M5 event plane (`/v1/event-streams` + `/v1/subscriptions`).
+5. **W2** — The 8 Build-ladder actions and `declare` re-encode through the shared
+   CapabilityLease authority client (uniform 403 wallet challenge → 428 credential →
+   receipted); zero behavior change to daemon contracts.
+6. **W2** — Light the honestly wireable dead controls: transform-PLAN authoring
+   (create/patch/dry-run TransformationRun) and materialized-set reset (receipted
+   DELETE); both confirm-gated.
+7. **W3 (backend)** — DataSource PATCH + DELETE (receipted, fail-closed, same
+   plaintext-secret rejections), optional principal fields; then enable Edit/Delete
+   source. Serialize on `hypervisor-daemon.rs` (router merge hotspot).
+8. **W3 (backend)** — Ingestion/extraction authority crossing (the daemon's own named
+   gap: wallet/authority-bound effectful pull on admitted substrate); then Test
+   connection/Extract and true sync scheduling **in Automations** (Data links, never
+   owns the schedule). Proposal/branch read view follows the Ontology-owned W3 family.
+9. **W4** — Cutover: typed 410s for `/__ioi/pipeline` + `/__ioi/data/sources` per the
+   6-step rule; delete the `delete`-marked lanes (§4); retire the daemon alias
+   `GET /v1/hypervisor/data-recipes` (hypervisor-daemon.rs:1629-1632); captures stay
+   dormant seeds per `ported-seed-preservation.v1.json`.

--- a/internal-docs/implementation/surfaces/governance.md
+++ b/internal-docs/implementation/surfaces/governance.md
@@ -1,0 +1,203 @@
+# Governance — implementation brief
+
+Canonical route: `/governance` · Owner: Governance (owner application)
+Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Governance is the authority and control surface: approvals inbox, authority
+  scopes and capability leases, release gates, cohorts, kill switches, budgets,
+  retention/marking policy, justification checkpoints; constitution and
+  protected-amendment history, ordering/finality, oracle policy,
+  successor/guardian paths, migration/fork/adoption, dissolution/decommission,
+  and IOI Network enrollment/assurance are explicit high-assurance facets
+  (core-clients-surfaces.md:1325-1331; rail summary :841).
+- Canonical route `/governance`, no aliases; legacy paths die with typed
+  refusals at cutover (core-clients-surfaces.md:896, :876-880).
+- Lifecycle "Govern" verb: wallet.network, authority scopes, capability leases,
+  approvals, secrets, policy gates, privacy, declassification, risk, semantic
+  governance, registries (core-clients-surfaces.md:1128-1131); Governance also
+  owns activation, canary/cohort, rollback, recall, and recovery decisions in
+  the Improve verb (:1143).
+- Release/change controls are a Governance facet — the primary cockpit for
+  capability promotion, release, rollout, pause, rollback, recall, kill-switch,
+  remote-config, release-target, gate, cohort, and deployment-risk
+  coordination (core-clients-surfaces.md:1164-1168). They may appear as an
+  Open Application view, panel, or detail drawer but never become a permanent
+  shell rail item or separate peer product (:1176-1179). `Release Controls` /
+  `Authority / Govern` are facet aliases, not products (:2143-2146).
+- Approvals is a tool surface placed at Governance / Approvals; direct launch
+  opens it under the owner and current context, never as a peer product
+  identity (core-clients-surfaces.md:1412, :1428-1431).
+- Enterprise Learning Boundary: Governance owns boundary policy, exceptions,
+  declassification, export, deletion, revocation, incident, and system-upgrade
+  review; boundary is primarily configured in Governance + settings
+  (core-clients-surfaces.md:1077-1078, :1052-1053).
+- Governance decides activation and effect recovery; Improvement coordinates;
+  the lifecycle projection is never a new truth store — Agentgres admits truth,
+  wallet.network authorizes, the daemon executes
+  (core-clients-surfaces.md:1249-1254, :1354, :4808).
+- May never: own runtime truth (application surfaces are governed projections
+  over Core/daemon/Agentgres/wallet.network — core-clients-surfaces.md:1470-1473);
+  execute enforcement from the UI without an existing daemon authority route;
+  masquerade Work views (reviews/incidents) as Governance-owned tools (:1421-1426).
+- Systems workspace "Govern" mode projects Governance authority, budgets,
+  protected change, learning boundary, lifecycle, enrollment
+  (core-clients-surfaces.md:1650).
+
+## 2. Schema map
+
+Daemon-local record schemas exist for every governance control object
+(`ioi.hypervisor.governance.*.v1`, minted in governance_routes.rs — e.g. :585);
+NONE of them are in the schema registry (`docs/architecture/_meta/schemas/
+architecture-contract-registry.v1.json` carries no governance control-object
+contracts — only authority-grant-envelope v1/v2, authority-effect-admission-
+receipt v1, declassification-approval v1 among the related set). Registry
+admission for the governance family is program debt, tracked here but not a
+route gap.
+
+| Canon object / contract | Canon block / registry | Daemon route(s) today | Wave |
+| --- | --- | --- | --- |
+| GovernanceOverview (read projection over authority/identity/lease/admission substrate, names missing controls) | core-clients-surfaces.md:1325-1331 | `GET /v1/hypervisor/governance/overview` hypervisor-daemon.rs:1955-1958 (comment :1953-1954) | — |
+| ApprovalRequest (record-only transitions, receipted) | :1326 approvals inbox | `GET/POST /v1/hypervisor/governance/approval-requests` hypervisor-daemon.rs:1962-1966; `GET/PATCH/DELETE …/:id` :1967-1971 | — |
+| ApprovalTransitionReceipt (`ioi.hypervisor.governance.approval-transition-receipt.v1`) | :2737-2749 receipts doctrine | **route-missing** — persisted write-only under `governance-approval-transition-receipts` (governance_routes.rs:372, :691-699); no read route anywhere | W3 |
+| ReleaseControl | :1164-1168 | `GET/POST /v1/hypervisor/governance/release-controls` + `:id` GET/PATCH/DELETE hypervisor-daemon.rs:1984-1993 | — |
+| KillSwitch (+ enforcement after trip, domain-app runtimes only) | :1327 | CRUD hypervisor-daemon.rs:1995-2003; `POST …/:id/enforce` :2006-2008 | — |
+| ImprovementGate | :1327-1328 (release gates) | CRUD hypervisor-daemon.rs:2010-2018 | — |
+| Cohort | :1327, :1143 | CRUD hypervisor-daemon.rs:1973-1982 | — |
+| CapabilityLease (browser: every issued use-only lease, 9-field shape, never a credential) | :1327 | `GET /v1/hypervisor/capability-leases` hypervisor-daemon.rs:2975-2977 (lifecycle_routes.rs:12064-12070); list only — detail/revoke **route-missing** (scoped revokes exist: editor-access-leases :3179-3184, principal lease-grants DELETE :3383-3390) | W3 |
+| AuthorityGrantEnvelope v1/v2 | registry `authority-grant-envelope.v1/v2.schema.json` | `POST /v1/hypervisor/authority/grant` :2736-2738, `POST …/revoke` :2740-2742, `GET …/grants` :2744-2746 | — |
+| Authority posture / evaluate / preflight / providers | :1128-1131 | hypervisor-daemon.rs:2722-2724, :2726-2728, :2748-2750, :2732-2734 | — |
+| AuthorityEffectAdmissionReceipt | registry `authority-effect-admission-receipt.v1.schema.json` | `GET /v1/hypervisor/authority/receipts` :2752-2754 (authority_routes.rs:882-886, `authority-receipts` dir) | — |
+| Thread/tool-exec approvals (approval plane #2) | :2706-2710 authority gates in session view | `POST /v1/threads/:id/approvals` + `:approval_id/decision|approve|reject|revoke` hypervisor-daemon.rs:932-951 | — |
+| ImprovementProposal decisions (approval plane #3; owner Improvement, inbox projects) | :1348-1354 | `…/improvement-proposals/:id/approve|reject|apply` hypervisor-daemon.rs:1716-1726 (list/get/simulate :1698-1713) | — |
+| MemoryMutationProposal decisions (approval plane #4) | :949-1048 memory placement | `…/memory-mutation-proposals/:id/approve|reject` hypervisor-daemon.rs:1748-1759 | — |
+| Marketplace AdmissionReview (decision-shaped, `reviewer_ref` free text) | :1380-1384 | `GET/POST /v1/hypervisor/marketplace/admission-reviews` + `:id` hypervisor-daemon.rs:2053-2062 (marketplace_routes.rs:861, :905) | — |
+| Unified approvals-inbox projection (one queue over the four decision planes) | :1326 | **route-missing** | W0.6/W3 |
+| Rollout promote/rollback (policy canary) | :1143 | `POST /v1/goal-orchestration/ioi-agent/launch-policies/:id/rollout/promote|rollback` hypervisor-daemon.rs:1789-1795 | — |
+| Budgets | :1327 | `GET/POST /v1/hypervisor/resource/budgets` :2762-2764; `/v1/hypervisor/budget` + `/reconcile` :3007-3013 | — |
+| Retention/marking policy, justification checkpoints, constitution/amendment history, network enrollment | :1328-1331 | **route-missing** — zero daemon routes match constitution/enrollment/retention/justification (grep verified); constitution schemas exist registry-side only | W3 (file as named gaps; build only if ruled in) |
+
+## 3. UI seed map
+
+- **Registered T3 surface `approvals`** (`apps/hypervisor/surfaces/approvals/index.mjs`,
+  272 lines; meta route `/__ioi/governance/approvals`, verifier + pixel
+  certification, index.mjs:44-49). Wired read over
+  `/v1/hypervisor/governance/approval-requests` (:51-54) plus the estate's
+  action-runtime pilot: approve / reject / revoke declared with authority
+  plane, expected receipt family, and confirm rules (:72-74); success without
+  the declared `approval-transition-receipt.v1` FAILS CLOSED (:87-91).
+  Classification: wired-read + 3 receipted actions. census: 40 controls, 35
+  implemented, 9 daemon_read, 3 governed_receipted, 13 disabled_missing_authority.
+- **Native readout `/__ioi/governance`** — control cockpit
+  (serve-product-ui.mjs:9901-9932): reads all five governance control families
+  + domain-apps + marketplace candidates/listings + foundry specs/plans in one
+  page; tabbed. Record-only POST mutation forms per family at
+  `/__ioi/governance/<fam>` (serve-product-ui.mjs:9937-9944). Classification:
+  wired (reads + record-only transitions). census: 23 controls, 0 disabled.
+- **Approvals deep links from other readouts**: home/ops surfaces link
+  `/__ioi/governance?tab=approvals` (serve-product-ui.mjs:1062); agent-studio
+  improvements embed approve/request-approval forms
+  (serve-product-ui.mjs:2704-2705). Classification: wired.
+- **Authority / lease browsing: absent.** No UI over
+  `/v1/hypervisor/authority/{posture,grants,receipts,providers}` or
+  `/v1/hypervisor/capability-leases` — daemon reads exist, zero panes serve
+  them. Classification: dead (backend-live, UI-absent).
+- **Shell SPA**: no governance route; census `/governance` `resolves: false`.
+  The 97-RPC adapter carries no approvals/governance RPCs (approvals surfacing
+  named only as future work, ioi-api-adapter.mjs:1294).
+
+### Corrections vs v0
+
+- v0 said: "the unified inbox (W0.6) … folds the 4 disjoint approval systems" —
+  bytes show exactly four decision planes to fold (governance
+  approval-requests hypervisor-daemon.rs:1962-1971; thread/tool-exec approvals
+  :932-951; improvement-proposal approve/reject/apply :1716-1726;
+  memory-mutation-proposal approve/reject :1748-1759) **plus** two more
+  decision-shaped planes v0 didn't count: marketplace admission-reviews
+  (:2053-2062) and the POST-only `*-admissions` planner family (:1076-1104).
+  The inbox folds the four; the extras get named rows, not silent absorption.
+- v0 said: "`reviewer_ref` becomes a principal, not free text" — verified at
+  the bytes, and it is worse than free text: any JSON value is accepted
+  verbatim on transition (governance_routes.rs:718, :644-654; created null
+  :592) AND `reviewer_ref` is patchable after decision through the
+  non-transition metadata lane with no receipt and no revision bump
+  (governance_routes.rs:739-751) — a decided approval's reviewer can be
+  silently rewritten. Two defects, not one. Principals routes exist to bind
+  against (`/v1/hypervisor/principals` hypervisor-daemon.rs:3369-3374).
+- v0 said: Governance backend families "all exist" — true for the six control
+  families, but their transition receipts are write-only (no read route,
+  governance_routes.rs:372) and the approvals surface's own success banner
+  links "proof stream" → `/__ioi/work-ledger`
+  (surfaces/approvals/index.mjs:186-187), whose backing aggregate does NOT
+  join `governance-approval-transition-receipts`
+  (orchestration_routes.rs:532-951 enumerates every joined family; grep
+  confirms absence) — the receipt drilldown dangles.
+- census said `/__ioi/governance` 23 controls / approvals 40 controls
+  (2026-07-30) — spot-verified both surfaces still exist and bind the same
+  routes at the live tree (serve-product-ui.mjs:9901-9932;
+  surfaces/approvals/index.mjs:51-54); counts not re-measured.
+
+## 4. Schema→UI binding table
+
+Authority-crossing actions run through the W0.3 CapabilityLease client (403
+wallet challenge → 428 credential → receipt refs on completion). Reads use the
+uniform read-projection client. Rows naming session-serving data bind through
+`subject_attachments` (core-clients-surfaces.md:3971-3990), never a named app
+field.
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+| --- | --- | --- | --- |
+| Governance overview header (posture, counts, named missing controls) | governance overview · hypervisor-daemon.rs:1955-1958 | wired at `/__ioi/governance` | wired-read |
+| Approvals inbox — unified queue (4 planes, one list, policy-filtered) | W0.6 inbox projection · route-missing | absent | disabled-named-gap until W0.6 lands, then wired-read |
+| Approvals inbox — governance ApprovalRequest rows + detail | approval-requests · :1962-1971 | wired (T3 surface) | wired-read |
+| Approve / Reject / Revoke | PATCH transition · :1967-1971 · receipt `approval-transition-receipt.v1` | wired, receipted, fail-closed (index.mjs:87-91) | wired-action-receipted (via lease client) |
+| Reviewer field | `reviewer_ref` (free text today) | wired, defective | wired-action-receipted — principal ref validated against :3369-3374; metadata-lane rewrite closed |
+| Receipt drilldown from decision banner | transition receipts · route-missing | dangling link to work-ledger | wired-read after W3 receipt read route (Provenance coordinates) |
+| Thread/tool-exec approval rows in inbox | thread approvals · :932-951 | absent from any inbox | wired-action-receipted (decide via each plane's own route) |
+| Improvement-proposal rows in inbox (decide deep-links to Improvement) | :1716-1726 | wired only in agent-studio readout (serve:2704-2705) | wired-read + cross-owner deep link |
+| Memory-mutation-proposal rows in inbox | :1748-1759 | absent | wired-action-receipted |
+| Release cockpit — ReleaseControl list/detail + record transitions | :1984-1993 | wired (record-only forms, serve:9937-9944) | wired-action-receipted |
+| Release cockpit — KillSwitch list/detail | :1995-2003 | wired | wired-read |
+| Kill-switch Enforce | `POST …/enforce` :2006-2008 | wired (form) | wired-action-receipted (lease flow; blast-radius confirm) |
+| Release cockpit — rollout promote/rollback | :1789-1795 | absent | wired-action-receipted |
+| Release cockpit — Cohorts, ImprovementGates | :1973-1982, :2010-2018 | wired (cockpit tabs) | wired-read + record transitions receipted |
+| Authority browser — posture / providers / grants / receipts | :2722-2754 | dead (no UI) | wired-read |
+| Authority browser — grant / revoke | :2736-2742 | dead | wired-action-receipted |
+| Authority browser — evaluate / preflight (what-would-happen) | :2726-2728, :2748-2750 | dead | wired-read (POST, non-effectful) |
+| Lease browser — capability-leases list | :2975-2977 | dead | wired-read |
+| Lease browser — lease detail / generic revoke | route-missing | absent | disabled-named-gap (+ W3 row if ruled in) |
+| Budgets facet | :2762-2764, :3007-3013 | dead | wired-read |
+| High-assurance facets (constitution history, enrollment, retention/marking, justification checkpoints) | route-missing | absent | disabled-named-gap |
+
+## 5. Ordered PR list
+
+Router-file PRs (#1, #7, #8) are serial — the central router is a merge
+hotspot (master guide standing rule; not re-decided here).
+
+1. **W0.6** — `GET /v1/hypervisor/governance/approvals-inbox`: one projection
+   folding the four decision planes (each row: plane, subject_ref, status,
+   decide-route ref); policy filter before counts. Backend-only.
+2. **W1** — `/governance` canonical route in the v2 shell: overview +
+   control-family read panes rehomed from `/__ioi/governance` (rehome, don't
+   rebuild; seed stays serving until step 9).
+3. **W1** — Approvals tool at `/governance` embedding the existing T3
+   approvals surface content; inbox list switches to the W0.6 projection when
+   present, else governance approval-requests only.
+4. **W1** — Authority-scope + lease browser: read panes over
+   posture/providers/grants/receipts/capability-leases + budgets facet.
+5. **W2** — Approve/reject/revoke + thread-approval + memory-proposal
+   decisions through the authority client (403/428/receipt); improvement rows
+   deep-link to Improvement's own decide surface.
+6. **W2** — Release cockpit verbs: kill-switch enforce, rollout
+   promote/rollback, receipted record transitions for
+   release-controls/cohorts/gates; everything without a route stays
+   disabled-named-gap.
+7. **W3** — `reviewer_ref` → principal: validate against
+   `/v1/hypervisor/principals`, refuse non-principal values, delete
+   `reviewer_ref` from the receiptless metadata-patch allowlist
+   (governance_routes.rs:739-751).
+8. **W3** — Approval-transition-receipt read route + fold into the unified
+   receipt stream (joint PR with Provenance brief step 6).
+9. **W4** — Cutover: `/__ioi/governance*` retired with typed 410s per the
+   6-step per-app rule; shell stops advertising the legacy paths.

--- a/internal-docs/implementation/surfaces/ontology.md
+++ b/internal-docs/implementation/surfaces/ontology.md
@@ -1,0 +1,187 @@
+# Ontology — implementation brief
+
+Canonical route: `/ontology` · Owner: Ontology (owner application)
+Brief status: authored 2026-08-05 from bytes at `21ae389fe` · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Owner job: "the semantic world-model systems act on: ontologies (object/link/action
+  types), functions, value types, object exploration and saved object sets, ontology
+  health and history — every semantic object carries its consent/visibility ladder"
+  (core-clients-surfaces.md:1313-1317). Saved object sets are canon-required inventory,
+  not a nice-to-have (:1315).
+- Route `/ontology` is in the v2 target-route ledger; no compatibility aliases — retired
+  paths fail with a typed refusal per ADR 0022 (core-clients-surfaces.md:876-880, :894).
+- Two tool surfaces rehome here: Ontology Manager → `Ontology / Schema`, Object
+  Explorer → `Ontology / Explore` (core-clients-surfaces.md:1410-1411). Tools stay
+  owner-bound, launch under the owner and current context, and never become peer product
+  identities (:1428-1433); a tool has exactly one primary owner (:1913-1916, anti-pattern
+  :4731).
+- ODK is NOT an application: its object planes are substrate; "ontologies and value
+  types [surface] through Ontology" (core-clients-surfaces.md:935-938).
+  `OntologySurfaceDescriptor` is registration input, never a launchable app (:1928-1929).
+- Surface registrations carry ontology posture: DomainOntology refs,
+  CanonicalObjectModel refs, DataRecipe refs, PolicyBoundDataView refs,
+  OntologyProjection refs, OntologySurfaceDescriptor refs (core-clients-surfaces.md:1906-1909).
+- Ontology (with Data) exposes "source-rights, consent, intended-use, recipe, and
+  derivative-impact posture" as learning-boundary projections (core-clients-surfaces.md:1079-1080);
+  it sits in the Build lifecycle verb (:1121) and in a System workspace's Design mode (:1648).
+- `Ontology Studio` is a retired alias label, never a surface (core-clients-surfaces.md:1744-1747, :2142).
+- May never: separate runtime truth ("governed projections and control surfaces" only,
+  :1470-1473); no client writes canonical truth outside the daemon path (:4541-4543); no
+  private runtime loop beside the daemon (:4543-4544). Action-type declarations carry no
+  execution authority — execution is a daemon authority crossing that does not exist yet
+  (census, and the surface's own standing boundary: `surfaces/object-explorer/index.mjs:27-29`).
+- Layering (C-1..C-4, implement-never-re-decide): no element on this surface serves a
+  `HypervisorSession`; ODK "connector sessions" are substrate ladder records, not
+  HypervisorSessions, so no `subject_attachments` binding arises here. No named
+  app-family session fields exist in the four inherited modules (checked at the bytes).
+
+## 2. Schema map
+
+No ODK/ontology contract has an entry in
+`docs/architecture/_meta/schemas/architecture-contract-registry.v1.json` (grep: no
+`odk`/`ontology`/`domain-ontology` contract ids; only autonomous-system materialization
+families match). The daemon self-declares `ioi.hypervisor.odk.*` schema_versions in the
+route modules. Registering these is part of the known M6 surface-record gap, not this
+surface's build-list.
+
+| Canon object / contract | Registry / canon anchor | Daemon route(s) today |
+|---|---|---|
+| DomainOntology (draft + CanonicalObjectModel: object/link/action/value types, functions) | canon :1313-1317, :1906-1909; registry-absent (daemon `ioi.hypervisor.odk.ontology-receipt.v1`, `surfaces/ontology-manager/index.mjs:54`) | list/create hypervisor-daemon.rs:1352-1355; get/patch/delete :1356-1361; health :1362-1365; history :1366-1369 |
+| OntologyProjection (declared explorer/search shape) | canon :1908; daemon comment "the explorer/search/read SHAPE" hypervisor-daemon.rs:1449-1450 | list/create :1451-1455; overview :1456-1459; get/patch/delete :1460-1465; history :1466-1469; recheck :1470-1473; retire :1474-1477 |
+| MaterializedObjectSet (the only object-instance carrier; canon "saved object sets" nearest existing plane) | canon :1315; registry-absent | list :1579-1582; overview :1583-1586; get/DELETE :1587-1591 (delete is receipted + resets the tied projection, connector_execution_routes.rs:1112-1151) |
+| ConnectorMapping (source fields → typed object properties; read-only in Manager) | registry-absent | list/create :1372-1376; overview :1377-1380; get/patch/delete :1381-1386; health :1387-1390; history :1391-1394 |
+| ODK overview + edit vocabulary (`odk_vocabulary`) | daemon truth only | GET :1348-1351 |
+| Ontology proposal/branch/merge plane (Proposals tab, History-as-branch, Propose, branch selector/actions) | no canon object named; product need per inherited seeds | `route-missing` — grep of hypervisor-daemon.rs finds no ontology proposal/branch routes (only threads/intelligence/memory/scm proposals, :885-889, :1699-1725, :1749-1759, :3098) — **W3** |
+| Object-instance search plane (full-text + facets over instances) | census gap; canon "object exploration" :1315 | `route-missing` — **W3** |
+| Per-principal saved explorations/lists/favorites | canon-required "saved object sets" :1315 | `route-missing` — **W3** |
+| Action-type execution against instances | declarations only in COM; execution = daemon authority | `route-missing` — **W3** (sequenced behind the TransformationRun/writeback authority; see data.md) |
+| Compatibility list alias `GET /v1/hypervisor/ontologies` | ADR 0022 no-alias rule :876-880 | hypervisor-daemon.rs:1623-1628 — retire at W4 cutover |
+
+## 3. UI seed map
+
+Registered T3 surfaces (registry slugs `schema`, `explorer`; module dirs differ):
+
+- **Ontology Manager** — slug `schema`, route `/__ioi/ontology/manager`
+  (`apps/hypervisor/surfaces/ontology-manager/index.mjs:12-17`). The estate's deepest
+  wired surface: census 60 controls — 21 daemon_read, 13 governed_receipted_action, 15
+  disabled_missing_authority, 5 unsupported, 3 reference_data_only (census:
+  inventory.v1.json t3 `schema.control_census`). Seven declared receipted actions at the
+  bytes: create-ontology, update-metadata, upsert-value-type, upsert-object-type,
+  upsert-property, upsert-link-type, upsert-action-type — all through POST/PATCH
+  `/odk/domain-ontologies` under optimistic concurrency (`expected_revision`), each
+  returning `ioi.hypervisor.odk.ontology-receipt.v1` and failing closed on a missing
+  receipt (`ontology-manager/index.mjs:53-64, :80-141`). Eleven-section IA (discover,
+  object-types, properties, value-types, link-types, action-types, functions, health,
+  resources, configuration, create — `surfaces/ontology-context.mjs:23`); unknown
+  section fails closed. Wired: authoring + section nav + health/history + resource
+  inspectors (connector-mappings + policy views loaded read-only, index.mjs:22-31).
+  Dead/disabled: deletion lanes, Proposals/branch, shared-property/groups/interfaces,
+  in-Manager datasource authoring, global search/palette, OaC repo (census
+  `missing_authority_contracts`).
+- **Object Explorer** — slug `explorer`, route `/__ioi/ontology/explorer`
+  (`object-explorer/index.mjs:12-17`). Read-only by declared contract: `actions = []`
+  (:29). Census 35 controls — 9 daemon_read, 0 receipted, 8 disabled, 12 unsupported.
+  Wired reads: object-type catalog with working server-side `?q=` filter, shortcuts =
+  real top materialized sets, object-set catalog, semantic type/set inspectors with real
+  row preview + provenance refs (pre_output_receipt_ref, run/session refs, redacted
+  source origin) (:52-107, :187-243). Every reference per-user/instance lane is a
+  disabled named gap in place (:112-176). Loads real daemon truth via the shared model:
+  `/odk/overview` + `/odk/domain-ontologies` + `/odk/ontology-projections` +
+  `/odk/materialized-object-sets` (`ontology-context.mjs:91-107`).
+- Shared semantic context kit: URL-carried typed context (14 keys, bounded values,
+  fail-closed parsing) + owner link builders across
+  Manager/Explorer/Pipeline/lineage/vertex/work-ledger (`ontology-context.mjs:18-62`).
+- T2 native readouts feeding this owner: `/__ioi/odk` (substrate ladder, census: 36
+  controls), `/__ioi/lineage`, `/__ioi/vertex` (census: t2 `nat-odk`, `nat-lineage`,
+  `nat-vertex`; live 200s). Vendor captures `/__apps/schema`, `/__apps/explorer` are
+  secondary reference grammars, never rebound surfaces (serve-product-ui.mjs:3453, :5571-5574).
+- T1 adapter carries no ontology RPCs (grep of `ioi-api-adapter.mjs`: only `recipes` →
+  `/v1/hypervisor/recipes`, a launch-recipe plane) — the SPA shell reaches this family
+  only through the T3/T2 lanes above.
+
+### Corrections vs v0
+
+- v0 said: explorer is "read-only, currently degenerate 'Loan' rows" and the work is to
+  "fix explorer's object-set reads (`materialized-object-sets` routes exist)" — bytes
+  show the reads are already wired and fail-closed: the Explorer loads
+  `/v1/hypervisor/odk/materialized-object-sets` and renders real sets, counts, and row
+  previews (`ontology-context.mjs:91-107`, `object-explorer/index.mjs:97-107, :218-243`).
+  The "Loan" rows are the estate's one real demo materialized set (census pipeline
+  workflow: rows L-1/L-2/L-3 "First/Second/Third Loan", mset_18c15c5d9d5bfc0f), i.e., a
+  data-population fact, not a read defect. The actual gap is the missing
+  instance-search/exploration plane (route-missing, §2).
+- v0 said: "enable the disabled proposal/branch plane through the authority client" —
+  impossible as stated: no ontology proposal/branch daemon routes exist (grep evidence,
+  §2). This is a W3 backend build, not a W2 wiring task.
+- census (2026-07-30) said: "Deletion authority: DELETE /v1/hypervisor/odk/domain-ontologies/{id}
+  … not yet contracted" and "materialized-object-sets exposes GET-only routes … no POST
+  retire/delete exists" — bytes show both DELETEs exist today:
+  hypervisor-daemon.rs:1356-1361 (`.delete(handle_odk_ontology_delete)`) and
+  :1587-1591 (`.delete(handle_set_delete)`). Set delete is receipted
+  (`materialized_output_removed`) and resets the projection
+  (connector_execution_routes.rs:1112-1151); ontology delete is a bare unreceipted
+  `json_del` (odk_routes.rs:253-256, :1063-1068) — an effectful mutation with no receipt,
+  a defect to fix before any UI enables it.
+- v0 said: "Backend: ODK domain-ontologies/projections/mappings/views complete" —
+  confirmed at the bytes, with the additions that projections also carry
+  recheck/retire actions (hypervisor-daemon.rs:1470-1477) and mappings a full
+  CRUD+health+history set (:1372-1394).
+
+## 4. Schema→UI binding table
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| Manager ontology picker + 11 section nav + definition selection | DomainOntology list/get (hypervisor-daemon.rs:1352-1361); URL context (`ontology-context.mjs:18-42`) | wired | `wired-read` (read-projection client, W0.3) |
+| Manager 7 authoring actions (create/update-metadata/5 upserts) | POST/PATCH `/odk/domain-ontologies` + `ioi.hypervisor.odk.ontology-receipt.v1` (`ontology-manager/index.mjs:53-64`) | wired, receipted, fail-closed on missing receipt | `wired-action-receipted` — re-plumb through the W0.3 CapabilityLease client (this plane today mutates without a wallet challenge; keep daemon truth, adopt uniform 403/428/receipt encoding) |
+| Manager health + history panes | `:id/health`, `:id/history` (hypervisor-daemon.rs:1362-1369) | wired read | `wired-read` |
+| Manager resources pane (connector-mappings, policy views, projections, sets) | mappings :1372-1394; policy views :1397-1419; projections :1451-1477; sets :1579-1591 | wired read (loaded in `ontology-manager/index.mjs:22-31`) | `wired-read` |
+| Projection recheck / retire controls | POST `:id/recheck`, `:id/retire` (:1470-1477) | not surfaced (substrate readout only, `/__ioi/odk`) | `wired-action-receipted` (W2, lease client) |
+| Cleanup / delete-ontology / delete-definition lanes | DELETE `:id` exists but unreceipted (odk_routes.rs:1063-1068, :253-256); definition-delete-in-COM has no route | disabled named gap (census) | `disabled-named-gap` until the W3 receipt fix + definition-delete land; then `wired-action-receipted` with confirm |
+| Manager Proposals tab, History-as-branch, Propose, branch selector | none — route-missing (§2) | disabled named gap | `disabled-named-gap` → wire after W3 proposal/branch family |
+| New → Shared property / Group / Interface / OaC repo | no canon object, no route | disabled named gap | `delete` at cutover (reference-only lanes; canon COM has no groups/interfaces, :1313-1317) |
+| Header Search resources / ctrl+K palette | product-surface compiler + search projection (W0.2) | disabled named gap | `wired-read` after W0.2 |
+| Explorer type catalog + `?q=` filter + shortcuts + set catalog | the four shared reads (`ontology-context.mjs:91-107`) | wired read | `wired-read` |
+| Explorer semantic type/set inspectors (props, links, action declarations, row preview, provenance refs) | DomainOntology + MaterializedObjectSet reads | wired read | `wired-read` |
+| Explorer "All Ontologies" scope selector | DomainOntology list exists | disabled named gap (`object-explorer/index.mjs:116`) | `wired-read` (W1 — scoped catalog param; the data already loads) |
+| Explorer WAYF "Search for objects", Filter-by facets, Search instances | object-instance search plane | disabled named gap (:123-124, :214) | `disabled-named-gap` → W3 family |
+| Explorer Explorations/Lists/Recents/Favorites/"Your object sets"/New exploration | per-principal saved-set plane | disabled named gap (:113-115, :139-144, :167-172) | `disabled-named-gap` → W3 family (canon-required, :1315) |
+| Explorer / Manager "Execute action" / "Evaluate function" | execution authority | disabled named gap (:214, census) | `disabled-named-gap` → W3 (behind TransformationRun/writeback authority) |
+| Cross-links: Pipeline node / Lineage / Vertex / Provenance / Sources per record | link builders (`ontology-context.mjs:50-62`) | wired navigation | `wired-read` (retarget hrefs to v2 routes at cutover) |
+| Consent/visibility ladder on every semantic object (canon :1316-1317) | nearest carriers: PBV postures + policy view refs (see data.md §2) | absent as a rendered ladder | `wired-read` badge row (W1: project PBV postures + credential postures onto type/set inspectors); honest absence where no policy view binds |
+
+No element on this surface serves a HypervisorSession; nothing binds
+`subject_attachments` (see §1 layering note).
+
+## 5. Ordered PR list
+
+1. **W1** — Mount `/ontology` in the v2 shell: Manager at `/ontology/schema`, Explorer
+   at `/ontology/explore`, both rehomed modules unchanged (seed-preservation invariant);
+   legacy `/__ioi/ontology/*` keeps serving until step 8.
+2. **W1** — Explorer ontology-scope selector goes live (scoped catalog over the already
+   loaded DomainOntology list); wire the consent/visibility badge row from bound policy
+   views onto the type/set inspectors (honest absence when none binds).
+3. **W1** — Manager reads move to the shared read-projection client (W0.3); no behavior
+   change; status updates for long ladders subscribe via `/v1/event-streams` +
+   `/v1/subscriptions` (M5 plane), never new per-resource SSE.
+4. **W2** — Manager authoring actions re-encode through the CapabilityLease authority
+   client (403 wallet challenge → 428 credential → receipted); receipts still
+   `ioi.hypervisor.odk.ontology-receipt.v1`; surface projection recheck/retire as
+   receipted controls.
+5. **W3 (backend, small)** — Receipt the DomainOntology DELETE (today `json_del`,
+   odk_routes.rs:253-256) and add definition-delete-in-COM; then enable the Cleanup
+   lanes with confirm. Serialize with other `hypervisor-daemon.rs` PRs (router is a
+   merge hotspot).
+6. **W3 (backend)** — Ontology proposal/branch family (propose/review/merge + branch
+   refs on DomainOntology); then the Manager Proposals tab and Pipeline `rail.changes`
+   read view (shared consumer, see data.md PR 8).
+7. **W3 (backend)** — Per-principal saved object-set/exploration plane (canon :1315);
+   then Explorer Lists/Favorites/New-exploration lanes. Object-instance search plane
+   follows as its own family (or an explicit canon narrowing if instance search is
+   ruled out-of-scope for bounded materialized sets).
+8. **W4** — Cutover: shell stops advertising `/__ioi/ontology/*`; typed 410 per the
+   6-step rule; delete the reference-only lanes marked `delete` in §4; retire the
+   daemon alias `GET /v1/hypervisor/ontologies` (hypervisor-daemon.rs:1623-1628);
+   `/__apps/schema` + `/__apps/explorer` captures remain dormant seeds per
+   `ported-seed-preservation.v1.json`.

--- a/internal-docs/implementation/surfaces/provenance.md
+++ b/internal-docs/implementation/surfaces/provenance.md
@@ -1,0 +1,210 @@
+# Provenance — implementation brief
+
+Canonical route: `/provenance` · Owner: Provenance (owner application)
+Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Provenance is the proof plane: chronological receipt stream, lineage graph
+  of runs/artifacts/authority where every edge is a receipt, state roots,
+  replay entries, custody receipts; exposes editable domain object →
+  immutable source snapshot → derived export including the exact
+  tool/workflow revision, transformation run, and receipt per derived edge;
+  evolves the former Work Ledger card (core-clients-surfaces.md:1333-1339;
+  rail summary :842). Agentgres is the Provenance work-ledger substrate
+  (:366). Canonical route `/provenance` (:897).
+- Lifecycle "Observe" verb: receipts, replay, traces, logs, lineage, state
+  roots (core-clients-surfaces.md:1133-1134). Provenance inspects evidence
+  and owns transition trace, receipt, proof, settlement, and replay
+  inspection; the dependency/provenance/impact graph is shared with Ontology
+  (:1238-1239, :1235-1236, :1254).
+- Receipts/replay must answer: what happened, why, under whose authority,
+  against which policy, with which artifacts, whether it can be replayed,
+  challenged, improved, packaged, or settled
+  (core-clients-surfaces.md:2737-2749); surfaces expose the improvement loop
+  without owning runtime truth (:2751-2767).
+- **Work-first display rule** (the canon cite): the default UX stays
+  work-first — show the event, authority, policy, receipt, replay, artifact,
+  and proof state first; show raw transaction hashes, chain IDs, contract
+  refs, bridge refs, or gas details only when the receipt is anchored/settled
+  or the user opens proof, settlement, dispute, governance, developer, or
+  evidence-export detail (core-clients-surfaces.md:2771-2776). A proof
+  explorer for deep inspection across runs is allowed (:2771-2772).
+- **Waterfall/detail-drawer contract**: one coherent trace/replay path — open
+  a session, workrun, automation run, or workflow node; inspect grouped turns
+  or run segments; scan a waterfall of agent/model/tool/connector/MCP/browser/
+  terminal/environment/authority/eval/settlement spans; open a detail drawer
+  for overview, event, request, response, graph, logs, authority, receipts,
+  proof/settlement, artifacts. Proof/settlement is a drilldown from work
+  inspection, never a chain-first default (core-clients-surfaces.md:2712-2718).
+- Learning boundary: Provenance derives a metadata-safe learning-flow graph
+  from source through eligibility, use, derivative, promotion, egress/export,
+  and revocation (core-clients-surfaces.md:1089-1090).
+- Every capability detail page's lifecycle strip deep-links receipts, replay,
+  and proof refs back to Provenance (core-clients-surfaces.md:1170-1173,
+  :1242-1247); Systems "Evidence" mode projects Provenance + Evaluations
+  (:1651). `Receipts / Replay` as a family label is a facet alias, not a
+  separate product surface (:2143-2146).
+- May never: become runtime truth or a second truth store (application
+  surfaces are governed projections — core-clients-surfaces.md:1470-1473);
+  default to chain-first display (:2717-2718); own the room graph (Work / Room
+  detail owns the graph-first shared view; a session is one
+  participant drilldown — :2729-2733).
+
+## 2. Schema map
+
+The registry carries the envelope contracts (`receipt-envelope.v1`,
+`receipt-proof-bundle.v1`, `receipt-checkpoint.v1`,
+`authority-effect-admission-receipt.v1` in
+`docs/architecture/_meta/schemas/architecture-contract-registry.v1.json`);
+no daemon receipt route returns these envelope shapes today — every family
+returns its own ad-hoc record shape. Convergence is registry/program debt,
+noted per row, not a separate route gap.
+
+| Canon object / contract | Canon block / registry | Daemon route(s) today | Wave |
+| --- | --- | --- | --- |
+| Chronological receipt stream (Work Ledger aggregate) | core-clients-surfaces.md:1334, :366 | `GET /v1/hypervisor/work-ledger[?project]` hypervisor-daemon.rs:1307-1311; handler joins ~16 record families — automation runs (orchestration_routes.rs:583-622), provider crossings (:624-651), storage custody (:652-666), placement decisions (:667-681), failover runs (:682-700), webhook trigger receipts (:701-730), harness executions + goal-run invocations/reconciliations (:738-800), memory projections/lifecycle, simulation/rollout/policy/improvement receipts, goal runs, domain-app mounts, marketplace publishes, kill enforcements, ODK materializations (:806-951) | — |
+| Receipt read family 1: authority receipts | :2771-2776 | `GET /v1/hypervisor/authority/receipts` hypervisor-daemon.rs:2752-2754 (authority_routes.rs:882-886) | — |
+| Receipt read family 2: resource receipts | :1242-1247 | `GET /v1/hypervisor/resource/receipts` :2782-2785 (resource_routes.rs:504) | — |
+| Receipt read family 3: provider receipts (+ spend backlink) | :1334 custody | `GET /v1/hypervisor/provider-receipts` :2821-2824 (provider_routes.rs:6436); `GET /v1/hypervisor/provider-spend/reconciliation` :2829-2832 | — |
+| Receipt read family 4: storage/custody receipts | :1336 custody receipts | `GET /v1/hypervisor/storage-receipts` :2874-2877 (storage_backend_routes.rs:1430); archives :2866-2869; incidents :2870-2873 | — |
+| Receipt read family 5: model-mount receipts (+ per-receipt replay) | :1334 | `GET /v1/model-mount/receipts` + `/:id` hypervisor-daemon.rs:738-739; `…/:id/replay` :740-742 | — |
+| Governance approval-transition receipts | :2737-2749 | **route-missing** — write-only records (governance_routes.rs:372, :691-699); absent from the work-ledger join (grep verified over orchestration_routes.rs:532-951) | W3 |
+| Unified receipt-stream projection with principal ownership coordinates | :1334; work-first :2771-2776 | **route-missing** — the aggregate exists but refuses everything except `local_development` (orchestration_routes.rs:537-566) and omits the authority/resource/model-mount/approval-transition families | W3 |
+| State roots | :1334 | carried on transcripts + ledger rows: `GET /v1/hypervisor/agent-run-transcripts` + `/:id` hypervisor-daemon.rs:2952-2957 (comment :2950: Agentgres-backed Run Timeline truth) | — |
+| Replay entries (run replay = one-shot event SSE) | :1334, :2712-2718 | `GET /v1/runs/:id/replay` hypervisor-daemon.rs:3299-3303 (alias of `/events` :3295-3298); run sub-projections usage/conversation/trace/inspect :3304-3320; `GET /v1/hypervisor/dev-replay/status` :613-616 | — |
+| Outcome-room replay + graph projections (Work owns the room view; Provenance deep-links) | :2729-2733 | `GET /v1/goal-orchestration/outcome-rooms/:id/replay` hypervisor-daemon.rs:2413-2416; `…/collaborative-work-graph` :2417-2420; discussion/product projections :2421-2428 | — |
+| GoalRun proof trail | :2751-2763 | `GET /v1/goal-orchestration/goal-runs` + `/:id` + `/:id/events` hypervisor-daemon.rs:1820-1851 | — |
+| Lineage graph projection (one daemon-side graph over sources→recipes→sets→receipts) | :1334-1336, :1235-1236 | **route-missing** as a projection — today the serve composes 9 separate reads client-side (serve-product-ui.mjs:9645-9655); every constituent read exists | W3 (optional — composition via read client is a valid target) |
+| Metadata-safe learning-flow graph | :1089-1090 | **route-missing** | W3 (named gap; build only if ruled in) |
+| Event consumption for live stream updates | M5 plane | `/v1/event-streams/*` + `/v1/subscriptions/*` hypervisor-daemon.rs:2349-2382 (durable, checkpointed); legacy per-run SSE `/v1/runs/:id/events` wrapped, not extended | — |
+
+## 3. UI seed map
+
+All four inherited native readouts verified live in the tree (census seed
+confirmed at the bytes):
+
+- **`/__ioi/work-ledger`** — the owned proof stream
+  (serve-product-ui.mjs:8748-8774): daemon work-ledger read + auth-posture
+  read, honest typed unavailable/403 states, `renderWorkLedger`
+  (serve-product-ui.mjs:1551) with `?receipt=`/`?objectSet=` selection context
+  (:8771-8772) and per-kind deep links into ontology/pipeline/lineage/vertex
+  surfaces (:1673-1686). Estate index tile "Provenance" points here
+  (:1462); page header brands the surface Provenance and links the lineage
+  canvas seed + graph lenses (:1578). Wired. census: 42 controls, 0 disabled.
+- **`/__ioi/run-replay`** — replay index over three run sources (serve
+  registry runs + daemon agent-run-transcripts + goal-runs), kind chips,
+  state-root column, per-row replay link (serve-product-ui.mjs:7254-7310).
+  Wired. census: 66 controls.
+- **`/__ioi/run-timeline[/:runId|/goal-run/:id|/env/:id|/draft/:id]`** — the
+  owned transcript primitive (serve-product-ui.mjs:7311-7460; goal-run proof
+  page :7317-7360; env/draft branches :7381-7390): grouped turns, a
+  **turn waterfall positioned from recorded timestamps only**, lineage row
+  (env → session → run → turns → artifacts), receipts/artifact counts, deep
+  links to the proof stream (:6535-6546). This is the estate's seed for the
+  D6 waterfall/detail-drawer contract. Wired. census: 66 controls.
+- **`/__ioi/lineage`** and **`/__ioi/vertex`** — graph lenses composing 9 and
+  5 daemon reads respectively, work-ledger as `provenance_stream` input
+  (serve-product-ui.mjs:9643-9671, :9623-9642; comment :9662: "the surface is
+  Provenance"). Wired. census: 21 + 22 controls.
+- **Serve-side allowlist**: work-ledger/run-timeline/run-replay are
+  internally-owned managed GET routes (serve-product-ui.mjs:337-356) but each
+  fails closed outside `local_development` posture (:7278-7283, :8764-8768) —
+  matching the daemon-side refusal (orchestration_routes.rs:537-566).
+- **T4 dormant seed**: `/__apps/lineage` — lineage canvas capture, explicitly
+  "adopting" (serve-product-ui.mjs:1578); preserved under the seed invariant.
+- **Shell SPA**: no provenance route; census `/provenance` `resolves: false`.
+  The 97-RPC adapter maps only model-mount receipts
+  (ioi-api-adapter.mjs:322); no other provenance RPCs.
+
+### Corrections vs v0
+
+- v0 said: "Backend: receipts read surfaces ×5 families" — bytes show the 5
+  standalone GET families (authority :2752, resource :2782, provider :2821,
+  storage :2874, model-mount :738) **plus** the work-ledger aggregate joining
+  ~16 record families (orchestration_routes.rs:583-951), **plus** at least one
+  receipt family with no read route at all (governance approval-transition
+  receipts, governance_routes.rs:372) and one that is POST-admission only
+  (service-composition-receipt-bundles, hypervisor-daemon.rs:1111-1113). The
+  aggregate also OMITS the authority/resource/model-mount standalone families
+  — "one receipt stream" does not exist yet at any route.
+- v0 said: "inherits work-ledger/lineage/run-timeline/run-replay readouts (all
+  wired T2)" — verified wired, but every core readout is a local-operator
+  projection that fails closed outside `local_development` (daemon
+  orchestration_routes.rs:537-566; serve :7278-7283, :8764-8768) because the
+  joined families lack principal ownership coordinates. "Wired" ≠ deployable;
+  the principal-coordinates gap is the W3 build, not more UI.
+- v0 said: "outcome-room replay/graph projections" under Provenance backend —
+  the routes exist (hypervisor-daemon.rs:2413-2428) but their consumer is the
+  `/__ioi/goal-space` Work readout (serve-product-ui.mjs:8735-8746), and canon
+  gives the room graph to Work / Room detail (:2729-2733). Provenance
+  deep-links room replay; it does not rehome that pane.
+- Layering note (C-1..C-4 record-the-site rule): ledger/timeline code still
+  reads named app-family fields — `e.goal_run_ref` in ledger entry links
+  (serve-product-ui.mjs:1673) and goal_run rows minted by the aggregate
+  (orchestration_routes.rs:880-899 region); session identity on timeline rows
+  is `sessionRef`/env lineage (serve-product-ui.mjs:6546). These are ledger
+  ENTRY fields, not Session records, so they are legal evidence fields — but
+  any new Provenance row that names what a SESSION serves must resolve via
+  `subject_attachments` (core-clients-surfaces.md:3971-3990), and these sites
+  migrate at the PR that touches them.
+
+## 4. Schema→UI binding table
+
+Reads use the uniform read-projection client (W0.3); live updates ride
+`/v1/event-streams` + `/v1/subscriptions` (W0.4), wrapping the legacy per-run
+SSE. Provenance is read-only — it has NO authority-crossing verbs; the only
+"actions" are navigation, filters, and export drilldowns. Session-serving rows
+bind through `subject_attachments` (core-clients-surfaces.md:3971-3990).
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+| --- | --- | --- | --- |
+| Receipt stream pane (chronological, kind/project filters) | work-ledger aggregate · hypervisor-daemon.rs:1307-1311 | wired at `/__ioi/work-ledger` (local-dev only) | wired-read |
+| Stream facets: authority / resource / provider / storage / model-mount receipts | :2752-2754, :2782-2785, :2821-2824, :2874-2877, :738-742 | dead (no pane serves the standalone families) | wired-read |
+| Approval-transition receipt rows | route-missing (write-only records) | absent (dangling refs in Governance banners) | disabled-named-gap → wired-read after W3 read route |
+| Receipt detail drawer (overview/event/authority/receipts/proof/artifacts tabs per D6) | ledger entry + per-family `:id` reads · :2712-2718 | partial — `?receipt=` selection context exists (serve:8771-8772), no drawer tabs | wired-read |
+| Proof drilldown (state roots, commitments, anchors) — hashes ONLY here | work-first rule :2771-2776; state roots on transcripts :2950-2957 | partial — roots truncated inline in rows (serve:2276, :7299) | wired-read (rows stay work-first; hashes move behind the drawer's Proof tab) |
+| Run waterfall (turn spans from recorded timestamps) | run-timeline projection · serve:6535-6546; transcripts :2950-2957 | wired | wired-read |
+| Replay index + per-run replay | `/v1/runs/:id/replay` :3299-3303; transcripts; goal-run events :1849-1851 | wired at `/__ioi/run-replay` | wired-read |
+| Live stream tail (new receipts appear without reload) | M5 event plane :2349-2382 | absent (readouts are static renders) | wired-read (subscription client) |
+| Lineage graph pane (sources → recipes → sets → receipts; every edge a receipt) | 9 composed reads · serve:9645-9655 | wired at `/__ioi/lineage` | wired-read (rehomed composition; daemon projection optional W3) |
+| Vertex/object-neighborhood lens | 5 composed reads · serve:9625-9631 | wired at `/__ioi/vertex` | wired-read |
+| Room replay / room graph deep links (Work owns the pane) | :2413-2428; canon :2729-2733 | wired via `/__ioi/goal-space` | wired-read deep link (never rehomed) |
+| Session/work subject chips on stream rows | `subject_attachments` resolution · :3971-3990 | partial — legacy `goal_run_ref`/env refs (serve:1673, :6546) | wired-read (typed subject chips; legacy field sites migrate when touched) |
+| Learning-flow graph | route-missing · :1089-1090 | absent | disabled-named-gap |
+| Evidence-export / settlement detail | route-missing (no export route) | absent | disabled-named-gap |
+
+## 5. Ordered PR list
+
+Router-file PRs (#5, #6) are serial with all other backend-route PRs (central
+router = merge hotspot; standing rule).
+
+1. **W1** — `/provenance` canonical route in the v2 shell: receipt-stream pane
+   rehomed from `/__ioi/work-ledger` via the read client; honest
+   typed-unavailable states preserved; zero fixture data. Seeds keep serving
+   until step 8.
+2. **W1** — Waterfall + detail drawer: rehome run-timeline/run-replay under
+   `/provenance` as the D6 contract (drawer tabs: overview, event, authority,
+   receipts, proof, artifacts); hashes/state roots move behind the Proof tab
+   per the work-first rule (core-clients-surfaces.md:2771-2776).
+3. **W1** — Lineage graph pane: rehome the `/__ioi/lineage` + `/__ioi/vertex`
+   composition; adopt the `/__apps/lineage` canvas seed for rendering
+   (adopt→rebrand→rebind, never rebuild).
+4. **W1** — Standalone receipt families as stream facets: authority, resource,
+   provider (+spend backlinks), storage (+incidents/archives), model-mount
+   (+per-receipt replay) over their existing GETs.
+5. **W0.4/W1** — Live tail: subscription client on `/v1/event-streams` +
+   `/v1/subscriptions`; legacy `/v1/runs/:id/events` SSE wrapped for the open
+   drawer only.
+6. **W3** — Unified receipt-stream projection with principal ownership
+   coordinates: fold the standalone families + approval-transition receipts
+   (read route lands here — joint with Governance brief step 8) into one
+   daemon projection, retiring the `local_development`-only refusal
+   (orchestration_routes.rs:537-566) by fixing its cause, not its gate.
+7. **W3 (optional, only if ruled in)** — daemon lineage-graph projection and
+   metadata-safe learning-flow graph; until then both stay
+   composition/named-gap per section 4.
+8. **W4** — Cutover: `/__ioi/work-ledger`, `/__ioi/run-timeline`,
+   `/__ioi/run-replay`, `/__ioi/lineage`, `/__ioi/vertex` retired with typed
+   410s per the 6-step rule; estate tiles/headers stop advertising the legacy
+   paths.

--- a/internal-docs/implementation/surfaces/studio.md
+++ b/internal-docs/implementation/surfaces/studio.md
@@ -1,0 +1,193 @@
+# Studio — implementation brief
+
+Canonical route: `/studio` · Owner: Studio (owner application)
+Brief status: authored 2026-08-05 from bytes at `21ae389fe` · v0 seed corrected where noted
+
+All canon cites are `docs/architecture/components/hypervisor/core-clients-surfaces.md` unless
+prefixed. Daemon cites are `crates/node/src/bin/hypervisor-daemon.rs` (router) or a
+`hypervisor_daemon_routes/*.rs` module. UI cites are `apps/hypervisor/...`. Census cites
+(`census:`) are `internal-docs/audits/2026-07-30-hypervisor-surface-end-state-audit/inventory.v1.json`
+(2026-07-30; spot-verified against the live tree where load-bearing).
+
+## 1. Canon digest
+
+- Studio is the system/agent composition surface: a typed canvas over real substrate objects —
+  agents (model + harness + tools + memory + policies), the connections between them, and the
+  system boundary (authority scopes, tool allow-lists via capability leases, budgets); it saves
+  draft blueprints and promotes them through governed gates; it absorbs the former Agent Studio
+  as its agent-level lens (core-clients-surfaces.md:1300-1306).
+- Tool placement: System Designer (legacy Solution Designer) → **Studio / System Design**
+  (:1415). Process Graphs (legacy Machinery) → **Automations**, not Studio (:1416) — see
+  Corrections; the machinery surface leaves Studio at rehome.
+- Canonical route `/studio` (:892). Application surfaces are governed projections and control
+  surfaces — never separate runtime truth (:1470-1473).
+- The bounded-system builder journey runs through Studio: describe → **Studio compiles one
+  inspectable package/genesis proposal** → validate with typed blockers → preview
+  authority/policy/cost/topology/evidence/lifecycle → simulate → propose/approve through the
+  existing owner paths → instantiate one System (:2062-2074). Visual Studio, declarative files,
+  ADK/SDK/CLI are editors over ONE source-neutral build representation — same compiled
+  contracts, no hidden defaults, no forked truth (:2076-2082). Fast composition is a product
+  acceptance contract, not permission for Studio to absorb owner state or authority
+  (:2090-2094). Templates prefill but never pre-authorize effects or create live state
+  (:2086-2088).
+- Surface modes classified under Studio: "blueprint / generated-surface builder (Studio;
+  kit-scaffolded)" and "system designer / architecture planner (Studio)" (:2104, :2113, owner
+  classification :2138-2141).
+- **Surface Generate** (Studio, scaffolded by the developer kit) is the product path for
+  object-aware application shells, widgets, forms, dashboards, operator consoles,
+  autonomous-system blueprints, and generated domain apps (:2217-2221). Builder paths are
+  proposal/packaging paths over Hypervisor Core — they own no runtime, authority, semantic, or
+  storage truth; effectful actions ride Operator Plane + daemon admission + authority gates +
+  receipts (:2223-2226).
+- Studio authors interface descriptors; the kit may scaffold them; Packages admits and versions
+  them; the product-surface compiler exposes eligible installed bindings (:1435-1441). ODK
+  surface descriptors surface through Studio (:935-939, esp. :939).
+- `GoalRunProfile`: Studio may author and compare profile revisions; Packages
+  versions/distributes; none of the surfaces becomes a second runtime owner (:2645-2652).
+- Embodied Systems: Studio authors graph source; Foundry produces candidates; Governance owns
+  consequential admission; daemon + Agentgres own execution (:1374-1377).
+- Canvas is a visual builder/editor **inside** Studio, Automations, Developer Workspace, or
+  Foundry — never a separate product plane or runtime owner (:1399-1402); Canvas owns no
+  execution, authority, state truth, receipts, or workflow semantics (:2443-2445). Canon nit:
+  the `HypervisorCanvasView` minimal object's `owner_surface` enum is
+  `automations | developer_workspace | foundry` (:3946-3947) and :2427 also omits Studio —
+  internal drift vs :1399-1401; flag with the program's canon-nit PRs, do not re-decide here.
+- May never: absorb owner state/authority (:2093-2094), own runtime truth (:1470-1473), let a
+  reference capture determine taxonomy (:1296-1297).
+
+## 2. Schema map
+
+| Canon object / contract | Canon block (cite) | Daemon route today | Wave |
+| --- | --- | --- | --- |
+| Draft blueprint object ("saves draft blueprints and promotes them through governed gates") | :1304-1305; :2104; no minimal-object block, no `_meta/schemas` registry entry exists (registry grep clean) | **route-missing** — deliberate: router comments say "/blueprints stays 404" twice (hypervisor-daemon.rs:1624, :1639) | **W3** — new family `studio/blueprints`: draft CRUD + layout artifact + promote-through-gates |
+| Blueprint promotion gate target | promote "through the existing owner paths" :2069, :2073-2074 | governance approval-requests exist: `/v1/hypervisor/governance/approval-requests[/:id]` (hypervisor-daemon.rs:1963-1970) | W3 (promotion endpoint composes existing governance/packages paths; no new authority kind) |
+| Studio intent frame (compile-a-frame projection) | builder journey :2062-2066 | `POST /v1/studio/intent-frame` (hypervisor-daemon.rs:631-634) — pure kernel projection, no persistence (lifecycle_routes.rs:1511-1529). **No UI consumer** (grep clean in apps/hypervisor/scripts) | W1 (wire into the /studio composer read path) |
+| Agent estate (agent-level lens, ex-Agent Studio) | :1305-1306; simple-label config Agent/Model/Reasoning :1443-1462 | `GET /v1/agents` (:775), `GET /v1/hypervisor/agent-runner-profiles` (:1237), model-routes registry + model-mount reads (aggregated by the T2 lens, serve-product-ui.mjs:9012-9035) | W1 |
+| System-composition truth (typed canvas read view) | typed canvas over real substrate objects :1301-1304 | ODK reads complete: domain-ontologies (:1353-1371), connector-mappings (:1373-1396), policy-bound-data-views (:1398-1421), ontology-projections (:1452-1479), materialized-object-sets (:1580), domain-apps (:1854-1897) | W1 |
+| OntologySurfaceDescriptor (interface descriptors Studio authors) | :1435-1441; :939 | `/v1/hypervisor/odk/surface-descriptors[/:id]` (:1613-1622) + list alias `/v1/hypervisor/surface-descriptors` (:1634) | W1 read; authoring W2 (CRUD exists on the ODK plane) |
+| GoalRunProfile authoring/compare lens | :2645-2652 | launch-policies family incl. clone/promote/rollback (:1775-1795) | W1 read, W2 actions |
+| Session launch from Studio previews | two-phase wallet relay | `/v1/goal-orchestration/ioi-agent/launch-preview` + `/launch` (:1643, :1647; "Two-phase launch relays the wallet challenge" router comment :1640-1641) | W2 |
+| Process-graph / state-machine definitions | :1416 places them under Automations | `/v1/hypervisor/state-machines*` (:1939-1953) — definitions only by design (:1935-1938) | moves with machinery → see `automations.md` |
+| Diagram/node layout persistence | `layout_ref: artifact://...` on CanvasView :3951 | route-missing (part of the blueprints family) | W3 |
+
+`route-missing` rows feed Wave 3: the single Studio backend build is the **`studio/blueprints`
+family** (draft blueprint CRUD, content-addressed revisions, canvas layout artifact,
+promote-through-gates composing governance approval-requests / Packages admission, receipts on
+every mutation).
+
+## 3. UI seed map
+
+**T1 shell:** no `/studio` route — census: `/studio` `resolves: false`
+(census:canonical_target_routes). The vendored SPA has no Studio page; nothing to preserve.
+
+**T2 native readouts (wired, the real Studio seed):**
+- `/__ioi/agent-studio` (serve-product-ui.mjs:9007-9040) — the "Studio" landing (h1 "Studio",
+  :2849): the agent estate lens, aggregating **22 daemon reads** in one Promise.all
+  (:9012-9035): agents, runner profiles, model-mount routes/providers, agentops conversations,
+  run transcripts, model-routes, launch-policies, memory/skill entries, automation-affinities,
+  connectors, capability-leases, memory proposals/projections, intelligence
+  review-queue/outcome-mining/improvement-proposals, release-controls, cohorts, ODK
+  overview + surface-descriptors. Sub-readouts `/__ioi/agent-studio/intel/{graph,memory,skills}`
+  and `/__ioi/agent-studio/launch-policies` (census:tier_t2_native_readouts). Home tile
+  "Studio" → `/__ioi/agent-studio` (:1456). Classification: wired (read).
+- `/__ioi/studio/designer` (serve:9593-9615) — reads 6 families (ODK domain-ontologies,
+  connector-mappings, policy-bound-data-views, ontology-projections, materialized-object-sets,
+  domain-apps — :9595-9602); renders the vendor landing splash + a below-fold **read-only
+  composition map** (Concepts/Components/Resources columns of real ODK refs, ontology switcher
+  :3858, :3890). Named gaps disabled in place, footer names them (:3910). Classification:
+  partial (reads wired; all authoring dead).
+
+**T3 registered surfaces:**
+- `designer` — registry entry `scripts/surface-registry.mjs:59`: owner "Studio", title
+  "Solution Designer", route `/__ioi/studio/designer`, capabilities `["browse"]`,
+  operational_state `browse`, interaction_parity `none`; metadata-only (no extracted
+  `surfaces/designer/` module — the handler lives in the serve file). Census control census:
+  **51 controls / 7 implemented** (7 daemon_read, 17 local_view_interaction, 0
+  governed_receipted_action, 20 disabled_missing_authority, 3 unsupported_reference_session,
+  4 reference_data_only) — the worst implemented ratio in the estate
+  (census:tier_t3_registered_applications.designer). The 20 disabled controls are the vendor
+  authoring canvas: New Diagram / Open Diagram / Save / Group / Add Text / diagram title /
+  drag-to-reference. Census missing-authority contracts: diagram-persistence plane (the core
+  gap → W3 blueprints), AIP Architect/Critic NL-planning authority, favorites plane,
+  principal/view-tracking, template library (vendor reference content only).
+- `machinery` — registry `surface-registry.mjs:60` says owner "Studio", but its canonical
+  target is **Automations / Process Graphs** (:1416; census `canon_target_name`). It leaves
+  Studio at rehome; its seed map and bindings live in `automations.md`.
+
+**T4 / vendor:** `/__apps/designer` capture is a documented-insufficient proxy lane
+(cross-origin :9225 chunk fetches; serve:3910); workshop and module-builder captures are
+reference-only sibling seeds (serve:3910). Template cards / reference diagrams are verbatim
+vendor content (census: reference_data_only).
+
+**Stale labels in bytes:** the designer/machinery footers name "Owner: Agent Studio"
+(serve:3910, :4761) — a pre-canon label; canon retired Agent Studio into Studio's agent lens
+(:1305-1306). Gap reasons are encoded in `title=` attributes, not the machine-readable
+`data-ioi-disabled-reason` convention (0 present; census:atlas_blockers).
+
+### Corrections vs v0
+
+- v0 said: "Studio `/studio` — inherits `designer` + `machinery` surfaces (worst ratio: 7/51
+  implemented)." — bytes show: 7/51 is **designer alone** (census designer control_census);
+  machinery is 17/30 and its canonical target is **Automations / Process Graphs**
+  (core-clients-surfaces.md:1416; census machinery `canon_target_name`) — only the code-side
+  registry says Studio (surface-registry.mjs:60). Studio inherits `designer` plus the
+  `/__ioi/agent-studio` T2 estate; machinery rehomes into Automations.
+- v0 said: "Backend: `state-machines`, ODK reads exist" — bytes show: state-machines is a
+  definitions-only plane that explicitly defers run/step/scheduling/binding
+  (hypervisor-daemon.rs:1935-1938; state_machine_routes.rs:417) and belongs to Automations per
+  canon :1416. Studio's wired backend is the ODK/domain-apps read estate **plus
+  `POST /v1/studio/intent-frame`** (hypervisor-daemon.rs:631-634), which v0 omits and no UI
+  calls today.
+- v0 said: "no blueprint/canvas persistence plane" — confirmed at the bytes, and it is a
+  deliberate refusal, not an accident: router comments "/blueprints stays 404"
+  (hypervisor-daemon.rs:1624, :1639). Registry has no blueprint schema (grep clean).
+- Canon-internal nit found while verifying: `HypervisorCanvasView.owner_surface` enum omits
+  `studio` (:3946-3947) while :1399-1401 includes Studio in Canvas's host list — file with the
+  program's canon-nit lane.
+
+## 4. Schema→UI binding table
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+| --- | --- | --- | --- |
+| Studio landing: agent-estate list + detail (model route, runtime posture, harness adapters, recent activity) | AgentRecord et al.; `/v1/agents`, `/v1/hypervisor/agent-runner-profiles`, model-routes/model-mount reads (serve:9012-9035) | wired at `/__ioi/agent-studio` | `wired-read` at `/studio` (read-projection client; rehome, don't rebuild) |
+| Intel sub-views (memory/skills/graph, launch policies) | intelligence + launch-policies routes (:1775-1795) | wired T2 sub-readouts | `wired-read` as Studio panes; launch-policy clone/promote/rollback `wired-action-receipted` via lease client (403 wallet → 428 credential → receipt refs) |
+| System Design composition map (Concepts/Components/Resources columns, refChips, ontology switcher) | ODK reads (:1353-1479, :1580) + domain-apps (:1854-1897) | wired reads at `/__ioi/studio/designer` (serve:9595-9602) | `wired-read` at `/studio` System Design view |
+| Composer "describe → compile frame" entry | `POST /v1/studio/intent-frame` (:631-634) | route wired, UI-orphaned | `wired-read` (projection call from the Studio composer; no authority crossing) |
+| Canvas authoring: New Diagram / Open / Save / title / Group / Add Text / node add (Concept/Component/Resource) | none — W3 `studio/blueprints` (draft CRUD + `layout_ref` artifact, CanvasView :3944-3953) | disabled_missing_authority ×20 (census) | `disabled-named-gap` until W3 lands; then `wired-action-receipted` (blueprint mutations receipted) |
+| Promote blueprint through gates | W3 family composing governance approval-requests (:1963-1970) / Packages admission | absent | `wired-action-receipted` after W3 (lease flow; Governance decides, Studio proposes) |
+| New Session / launch from a composed agent | ioi-agent launch-preview/launch (:1643, :1647) | absent in designer; "Use in Automation →" cross-link exists (serve:2909) | `wired-action-receipted` (two-phase wallet relay already daemon-side) |
+| AIP Architect / AIP Critic / "Start planning" | no daemon contract (census missing-authority) | disabled in place | `disabled-named-gap` (no route → no target implying authority) |
+| Favorites pill / per-row star; Creator / Last edited by / Last viewed | no favorites/principal/view plane (census) | honest em-dashes / disabled | `disabled-named-gap` |
+| Template library / Reference Diagrams / Browse all | vendor reference content (census: reference_data_only) | decorative | `delete` at cutover (never estate data) |
+| Machinery table + definition detail | state-machines (:1939-1953) | wired read under `/__ioi/studio/machinery` | `delete` from Studio — rehomes to `/automations` (see automations.md; paired PR) |
+| Gap-reason encoding on disabled controls | `data-ioi-disabled-reason` convention | `title=` attrs only (census) | `disabled-named-gap` made machine-readable in the W1 rehome PR |
+
+Session-serving elements: Studio has no session views of its own; any session ref it displays
+(e.g. launch results) resolves through the session's `subject_attachments`
+(core-clients-surfaces.md:3971-3984), never a named app field. No surviving named-field sites
+exist in Studio UI bytes (grep clean).
+
+## 5. Ordered PR list
+
+1. **W1** — Register `/studio` in the v2 shell; rehome the `/__ioi/agent-studio` agent-estate
+   lens as the `/studio` landing over the W0.3 read client (zero fixture data; honest-empty).
+2. **W1** — Rehome the designer composition map as the `/studio` System Design view; keep every
+   vendor-authoring control disabled with `data-ioi-disabled-reason`; retire the "Agent Studio"
+   owner label in footers.
+3. **W1** — Wire the composer to `POST /v1/studio/intent-frame` (projection only) as the
+   describe→compile read path.
+4. **W1** — Registry hygiene: transfer the `machinery` entry's owner family to Automations
+   (surface-registry.mjs:60) — paired with automations.md PR 3; Studio's registration row keeps
+   `designer` only.
+5. **W2** — Authority actions via the CapabilityLease client: launch-policy clone/promote/
+   rollback (:1786-1795), ioi-agent launch from Studio (:1643, :1647), ODK surface-descriptor
+   authoring (:1613-1622). Everything else stays disabled-named-gap.
+6. **W3** — Backend: `studio/blueprints` family (draft blueprint CRUD with content-addressed
+   revisions, canvas `layout_ref` artifact, promote endpoint composing governance
+   approval-requests, receipts on every mutation; router PR serialized on
+   hypervisor-daemon.rs). Registry schema + fixtures land with it.
+7. **W3** — UI: canvas authoring (New/Open/Save/node-add/layout) binds to the blueprints
+   family; promote-through-gates flow surfaces typed blockers per :2066.
+8. **W4** — Cutover per the 6-step rule: typed 410 for `/__ioi/agent-studio` +
+   `/__ioi/studio/designer`; delete vendor template lanes and the `/__apps/designer` proxy
+   note; shell/nav rows come from the product-surface compiler only.


### PR DESCRIPTION
Wave item: Phase A per-surface implementation briefs (batch 1 of 4).

What became operational: the first six owner-application briefs now exist as byte-derived build maps — every canon claim cited to file:line, every daemon route verified against the 663-route table, every traversable UI element bound to its backing schema/route with an honest target state (wired-read / wired-action-receipted / disabled-named-gap / delete), and each file records where the v0 master guide was corrected at the bytes. Session-serving rows bind through subject_attachments per the C-1..C-4 canon rulings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)