### PR TITLE
briefs(Phase A): owner-app briefs II — evaluations, improvement, foundry, packages, developer-workspace, developer-console

### DIFF
--- a/internal-docs/implementation/surfaces/developer-console.md
+++ b/internal-docs/implementation/surfaces/developer-console.md
@@ -1,0 +1,233 @@
+# Developer Console — implementation brief
+
+Canonical route: `/developer-console` · Owner: Developer Console (owner application)
+Brief status: authored 2026-08-05 from bytes at `21ae389fe` · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Owner job: "extension surface: connector, connected-app, MCP, tool, and provider-
+  integration registrations; APIs and OAuth/service registrations; function, widget,
+  and extension registries; conformance; and developer-kit on-ramps (scaffolds,
+  templates, generated SDKs). Environments and Operations own provider lifecycle,
+  placement, health, capacity, and spend" (core-clients-surfaces.md:1392-1397).
+  Nav identity: "Developer Console (connectors, MCP, APIs, OAuth clients, SDK
+  on-ramps, conformance — Developer & Integrations family; UI touchpoint of the
+  developer kit)" (:853-854). Route `/developer-console`, no aliases (:876-880, :903).
+- "The primary product venue for the full integration estate is Developer Console"
+  — connectors and connected apps; MCP servers and surface MCPs; connector/tool/
+  provider-integration registrations; APIs, OAuth clients, SDKs, ADK, webhooks,
+  service registrations; conformance and developer app registration; developer-kit
+  on-ramps (:957-967).
+- **Registrations, never runtime**: "Developer Console defines and validates
+  integration/configuration registrations; it does not own provider runtime
+  lifecycle, placement, health, capacity, or spend. Environments and Operations own
+  those projections and actions, while settings own personal or organization
+  credential and policy defaults" (:970-974).
+- Records stay with their canonical owners: "Identity, membership, SSO/SCIM, secrets,
+  tokens, connectors, providers, policies … remain with their canonical owners";
+  Settings persists only admitted preferences + owner-backed administrative mutations
+  (:994-1000); user/org settings expose only scoped slices (:976-992). The
+  identity/access plane (principals, SSO/OIDC, SCIM, invites, domain verification,
+  secrets, API access tokens, principal lease-grants) has its own owner doc
+  (identity-access-and-metering.md:61-112).
+- MCP Gateway: authority-scoped profiles; exposes selected capabilities from
+  Applications/Projects/Sessions/Automations/Foundry/**Developer Console**/Provenance/
+  operator plane; every tool compiles to RuntimeToolContract or surface/operator
+  contract refs; fails closed on expired/revoked/quarantined bindings; "never a
+  durable API key or master MCP" (:597-635).
+- Tool / Function Builder is housed primarily in Automations and Developer Console;
+  outputs compile into RuntimeToolContract + authority scopes + receipt obligations
+  (:2210-2215). ODK is NOT an app — its "developer tooling [surfaces] through
+  Developer Console and the kit itself" (:935-940).
+- Contextual placements: Create/import wizard row (:301); Networks/storage/devices
+  row shared with Environments/Governance (:304); Systems "Interfaces" mode (:1653);
+  Build lifecycle verb (:1120-1122); learning-boundary facet — "Models and Developer
+  Console expose the registered bidirectional provider/customer learning terms,
+  retention, ZDR, custody, fallback, and provider-exposure configuration" (:1081-1083).
+  May project automation readiness but never cannibalize Automations (:1036-1042);
+  templates/snippets may appear (:1029-1034); integration primitives are not
+  permanent rail items (:951-955).
+- Data consumes connector bindings, never owns them (:1319-1323) — Console is the
+  registration inventory Data/Sources reads from.
+- Layering (C-1..C-4): nothing here serves a HypervisorSession — connector and
+  gateway records are registrations + leases, not sessions; no `subject_attachments`
+  rows arise and no named app-family session fields exist in these modules (checked:
+  lifecycle_routes connector/gateway families carry connector/lease/receipt refs
+  only).
+
+## 2. Schema map
+
+Registry: `RuntimeToolContract` is registered
+(`schema://ioi/components/connectors-tools/runtime-tool-contract/v1`, canon home
+`connectors-tools/contracts.md#runtimetoolcontract`) and `ScmPublicationEffect`
+v1+v2 likewise (architecture-contract-registry.v1.json). NO registry schema exists
+for connector-registration, MCP-server registration, OAuth flow records, or API
+tokens (grep: `editor|mcp|oauth|token` → zero registry hits) — those planes are
+daemon-declared shapes only. Extension-surface registration records DO have schemas:
+`hypervisor-application-surface-registration.v1`,
+`hypervisor-product-surface-projection.v1`, `hypervisor-surface-release-record.v1`,
+`hypervisor-surface-installation-binding.v1`, `hypervisor-surface-serving-binding.v1`.
+
+| Canon object / contract | Registry / canon anchor | Daemon route(s) today |
+|---|---|---|
+| Connector registration (generic estate: any service as use-only lease, declared tools only) | canon :962-964; registry-absent | list/register hypervisor-daemon.rs:3020-3025; delete :3031-3034; policy :3035-3038 |
+| Connector credential bind/revoke (sealed; value never returned) | canon :3232-3236 posture; registry-absent | :3026-3030 |
+| Connector invoke (the test/crossing lane; gateway order 428 credential → 403 wallet → receipted) | RuntimeToolContract (registry) carried in `allowed_tools`; gateway comment lifecycle_routes.rs:11899-11942 | :3039-3042 |
+| Connector MCP tool discovery (grant-free discovery; tools/call leased — lifecycle_routes.rs:13273-13274) | canon "MCP servers and surface MCPs" :963 | :3043-3046 |
+| OAuth-native connect (Authorization Code + PKCE, device flow, DCR discovery) | canon "OAuth clients" :853, :965 | discover :3047-3051; start :3052-3055; callback :3056-3059; device start/poll :3060-3067 |
+| BYOA GitHub App (user-owned app via manifest flow) | canon "connected-app … registrations" :1393 | scm-connect/github :3068-3071; github-app manifest :3072-3075; conversion :3076-3079; installation :3080-3083 |
+| SCM connector registry + credential + abandon-PR | canon :962-965 | :2960-2974 |
+| SCM destination bindings / publication proposals / effects (registration + proof rows; the publish crossing itself fires from an env — Developer Workspace brief §2) | ScmPublicationEffect v2 (registry) | bindings :3092-3096; proposals :3097-3100; effects :3101-3104 |
+| MCP gateway declared tool contracts + invoke | canon :597-635 | tools :2700-2703; tools/:tool invoke :2704-2707; discover status `/v1/mcp` :871 |
+| Capability leases (read roster — issued authority, the "Authority Clients" view) | canon :613-619 | list :2975-2978 |
+| API access tokens (inbound; hash+metadata, plaintext once) | identity-access-and-metering.md:109-112 (identity-owned; Console = developer-facing surface, Settings pane = projection) | list/create :2992-2997; delete :2998-3001 |
+| Secrets (sealed org/user/project) | identity-access-and-metering.md:103-108 — identity-owned; Settings projects; Console links only | :2979-2991 |
+| SSO/OIDC login config, SCIM provisioning, org-invite, domain verification, custom domain | identity-access-and-metering.md:81-93 — identity-owned, projected in Settings org panes (canon :985-991); NOT Console estate rows | oidc-config :3015-3019; sso :3392-3399; auth/oidc :3400-3407; scim config :3408-3417; scim server :3446-3469+; org-invite :3419-3427; domain-verifications :3428-3440; custom-domain :3441-3445 |
+| Principal-scoped lease grants (least-privilege ring per connector/tool) | identity-access-and-metering.md:95-101 | :3381-3390 |
+| Extension/surface registration reads (function/widget/extension registries' nearest existing truth) | the five surface-record schemas above; canon :1435-1441 | surface-descriptors :1634-1638 (+ ODK :1613-1618); product-surface-projections :1060-1063; domain-apps :1854-1894 |
+| Conformance / developer app registration | canon :966, :1395 | **`route-missing` → W3** (grep `conformance` in daemon: zero routes) |
+| Developer-kit on-ramps (scaffolds, templates, generated SDKs) | canon :966-967, :935-940 | **`route-missing` → W3** (no SDK/scaffold routes; `/v1/agent-sdk` endpoints info only, hypervisor-daemon.rs:3846-3871) |
+| Webhook/service registrations (inbound) | canon :965 | **`route-missing` → W3** (automation webhooks exist under Automations ownership; no Console-side inbound-service registry) |
+
+## 3. UI seed map
+
+Backend-rich / UI-thin, but NOT UI-absent. What serves today (bytes):
+
+- **T2 `/__ioi/connections` — the Connections cockpit** (census: 200, 10 controls,
+  `nat-connections`): composes SIX daemon reads — connectors, scm-connectors,
+  capability-leases, mcp-gateway/tools, auth/policy, SCIM ServiceProviderConfig probe
+  (serve-product-ui.mjs:10105-10121). Renderer (:549-700+):
+  - connector registry grouped by category with per-connector detail drawer — tool
+    contracts, auth posture, scopes, issued leases; sanitized ("sealed
+    credentials … never leave the daemon-side render", :553-556). **Wired read.**
+  - "Authority Clients" roster from lease records (credential source × authority
+    provider, active/expired/receipted/revocable) (:640-665). **Wired read.**
+  - a "Developer Console" card block already exists IN THIS READOUT — API spine
+    posture, MCP gateway declared tools, identity/SCIM endpoints, "every posture
+    pill is a live probe" (:666-681). **Wired read.**
+  - Tool Analytics facet: leased-vs-declared tool volume (:682-688). **Wired read.**
+  - The Home tile for this readout is already NAMED "Developer Console" (:1468).
+- **T2 `/__ioi/connections/add`** (census: 200, 4 controls): registration FORMS that
+  post real daemon mutations — add MCP server → `POST /v1/hypervisor/connectors`
+  (kind mcp) + auto `oauth/discover`; add API-key service → connector register +
+  sealed credential bind (serve:10123-10163). **Wired action (ungoverned POST —
+  no lease flow, see §4).**
+- **T2 OAuth connect lane**: `/__ioi/integrations/connect/:id` launcher +
+  `/__ioi/integrations/oauth/callback` driving connectors/:id/oauth/* (serve:8247-8319);
+  `/__ioi/slack/setup` (:571, :614). **Wired action.**
+- **T2 BYOA GitHub App flow**: `/__ioi/github-app/start` → manifest;
+  `/callback` → conversion; `/installed` → installation (serve:8181-8232). **Wired
+  action** — this is v0's "BYOA connect button".
+- **T1 Settings panes (adapter-backed, projections of these families)**:
+  PATs — `UserService/List|Create|DeletePersonalAccessTokens` → daemon api-tokens,
+  plaintext surfaced once (ioi-api-adapter.mjs:1237-1283); Secrets —
+  `SecretService/*` → daemon secrets (:1137-1206); Integrations panes —
+  `IntegrationService/*` projects daemon MCP connectors into the vendor shape
+  (:145-149, :1073-1131); `RunnerConfigurationService/ListSCMIntegrations` is a
+  CONSTANT (:832-839) — local lie. Census pane set: user
+  `git-authentications`/`personal-access-tokens`/`integrations`/`secrets`; org
+  `org-integrations`/`scim`/`security-oidc`/`login` (tier_t1_settings_panes).
+- **T4 dormant seed**: `ux-seeds/widgets` is census-assigned
+  `canonical_owner: "Developer Console"`, proposed route
+  `/__ioi/developer-console/widgets` (tier_t4_dormant_ux_seeds; tree at
+  `apps/hypervisor/ux-seeds/widgets/`).
+- Census deltas: `/developer-console` `resolves: false`; no T3 registered surface
+  (14 slugs, none console-shaped). Census "SSO/SCIM/domain-verification
+  deferred-as-epic" ceiling note is STALE — the daemon routes exist and serve
+  (§2), only SPA panes lag.
+
+### Corrections vs v0
+
+- v0 said: "UI absent (only the BYOA connect button + `/__ioi/connections`)" — bytes
+  show a substantially larger wired estate: the connections cockpit composes six
+  daemon reads with a per-connector contract/lease drawer, an Authority Clients
+  roster, live-probe Developer Console cards, and a Tool Analytics facet
+  (serve:549-700, 10105-10121); PLUS working registration forms
+  (`/__ioi/connections/add`, serve:10123-10163), a full OAuth connect/callback lane
+  (serve:8247-8319), Slack setup, and daemon-backed Settings panes for
+  PATs/secrets/MCP-integrations (adapter:1073-1283). The build is consolidation
+  under the canonical route, not first-light.
+- v0 listed "secrets, … SSO/SCIM/OIDC config, domain verifications" as Console
+  backend families — the routes exist as cited, but their canonical OWNER is the
+  identity/access plane (identity-access-and-metering.md:61-112) with Settings as
+  the projection surface (core-clients-surfaces.md:985-1000). Console's owned estate
+  is connector/MCP/OAuth-client/tool/extension registrations + conformance + kit
+  on-ramps (:1392-1397). The console links to identity records; it must not become
+  their second owner. (API tokens stay on the Console surface as the
+  developer-credential touchpoint, mirroring v0's target list, with the Settings
+  pane remaining the identity-owner projection.)
+- v0 said "MCP gateway" as one family — bytes split it in two: the estate's MCP
+  gateway (`/v1/hypervisor/mcp-gateway/tools[/:tool]` :2700-2707, canon :597-635)
+  vs Foundry's model-mount MCP import/invoke (`/v1/model-mount/mcp*` :754-756),
+  which is model-tooling and NOT Console estate. The census/cockpit probe uses only
+  the former.
+- Census-vs-bytes: census T2 lists the cockpit at 10 controls — the live renderer
+  now also carries the drawer script + three probe cards (serve:618-688), so the
+  census count is stale-low; verify at cutover.
+
+## 4. Schema→UI binding table
+
+Authority-crossing actions ride the W0.3 authority client (403 wallet challenge →
+428 credential → receipted; gateway order verified at
+lifecycle_routes.rs:11899-11942). Reads ride the W0.3 read client. No session-serving
+elements exist on this surface (no `subject_attachments` rows).
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| Connector registry (grouped list + drawer: tools, posture, scopes, leases) | connectors :3020-3025 + capability-leases :2975-2978 | wired (`/__ioi/connections`) | `wired-read` at `/developer-console` |
+| Register connector (MCP url / bearer service) | :3020-3025 (+ oauth/discover :3047-3051) | wired but ungoverned form POST (serve:10144-10163) | `wired-action-receipted` via authority client |
+| Bind / revoke credential (sealed) | :3026-3030 | wired (add-form binds; no revoke control) | `wired-action-receipted`; revoke control added |
+| Delete connector / set org policy | :3031-3038 | dead (server-only) | `wired-action-receipted` |
+| Invoke-test console (declared tool, live 428/403/receipt walk) | :3039-3042 | dead (server-only) | `wired-action-receipted` — the flagship registration-validation control (canon "defines and validates" :970) |
+| Connector MCP tools panel (discovered contracts) | :3043-3046 | dead | `wired-read` |
+| OAuth connect / device-code walk | :3047-3067 | wired (`/__ioi/integrations/connect/:id`) | `wired-action-receipted` |
+| BYOA GitHub App connect | :3068-3083 | wired (`/__ioi/github-app/*`) | `wired-action-receipted` |
+| SCM connector rows + credential posture | :2960-2974 | wired read (cockpit + `/__ioi/code`) | `wired-read`; credential bind/revoke `wired-action-receipted` |
+| SCM destination bindings / publication effects trail | :3092-3104 | partial (`/__ioi/code` shows publish trail) | `wired-read` (effects are proof rows; publish itself fires from Developer Workspace) |
+| MCP gateway tools + try-tool | :2700-2707 | read wired (cockpit probe card); invoke dead | tools `wired-read`; invoke `wired-action-receipted` (leased, canon :608-611) |
+| Authority Clients roster | leases :2975-2978 | wired | `wired-read` (lease browser deep-link → Governance, which owns authority scopes :1325-1331) |
+| API tokens panel (create/reveal-once/delete) | api-tokens :2992-3001 | wired via Settings PAT pane (adapter:1237-1283) | `wired-action-receipted` on Console; Settings pane remains the identity-owner projection |
+| Extension/surface registrations (read inventory) | surface-descriptors :1634-1638; product-surface-projections :1060-1063; domain-apps :1854-1894; five surface-record schemas | partial (odk/domain-app readouts elsewhere) | `wired-read` (registration browser; launch stays with Applications catalog :1435-1441) |
+| Conformance panel | none (§2 W3 row) | absent | `disabled-named-gap` — placeholder naming the missing family |
+| Developer-kit on-ramps (scaffold/template/SDK) | none (§2 W3 row) | absent | `disabled-named-gap` |
+| Webhook/service registration | none (§2 W3 row; Automations owns automation webhooks) | absent | `disabled-named-gap` |
+| Identity links block (SSO/SCIM/OIDC/domains status) | :3392-3469 etc. | wired probe pills (cockpit) | `wired-read` links out to Settings org panes — never owner-mutations here (canon :994-1000) |
+| `ListSCMIntegrations` constant (adapter:832-839) | none | local lie | `delete` (W0.5: wire to :2960-2963 or honest absence) |
+| Provider runtime state (health/capacity/spend) | Environments/Operations routes | not present | **stays absent by canon** (:970-974) — never build here |
+
+## 5. Ordered PR list
+
+1. **W1** — Register Developer Console + serve `/developer-console` read-first:
+   rehome the connections cockpit composition (six reads, drawer, Authority Clients,
+   probe cards, Tool Analytics) under the canonical route; Home tile repointed
+   (serve:1468 already carries the name). `/__ioi/connections` keeps serving until
+   cutover.
+2. **W1** — Registration browser read view: surface-descriptors +
+   product-surface-projections + domain-apps as the extension-registry inventory;
+   SCM bindings/effects trail folded in from `/__ioi/code`'s data contract.
+3. **W2** — Governed registration verbs via the authority client: register connector
+   (MCP/bearer), credential bind/revoke, delete, org policy — replacing the
+   ungoverned `/__ioi/connections/add` form POSTs; receipts surfaced on completion.
+4. **W2** — Invoke-test console: declared-tool picker → live crossing showing the
+   428 credential / 403 wallet-challenge / receipt sequence verbatim (the
+   registration-validation loop, canon :970).
+5. **W2** — MCP gateway panel: declared contracts + leased try-tool invoke
+   (:2704-2707); OAuth + device-code + BYOA flows rehomed onto the canonical route
+   (existing serve lanes reused, not rebuilt).
+6. **W2** — API tokens panel on Console (create/reveal-once/delete) over
+   :2992-3001; identity-links block reads SSO/SCIM/OIDC/domain status with
+   links out to Settings org panes (no owner-mutations here).
+7. **W3** — File the missing backend families from §2 with owner sign-off:
+   conformance/developer-app registration; developer-kit on-ramp records;
+   inbound webhook/service registry (scope against Automations' webhook ownership
+   :1029-1034 first). UI lands in the same wave, replacing the three
+   `disabled-named-gap` placeholders.
+8. **W3** — Adapter honesty: delete the `ListSCMIntegrations` constant
+   (adapter:832-839); IntegrationService projection reviewed so Settings
+   integrations panes read Console-owned records (master-guide Settings chapter
+   dependency, not owned here).
+9. **W4** — Cutover per the 6-step rule: `/__ioi/connections`,
+   `/__ioi/connections/add`, `/__ioi/integrations/*`, `/__ioi/github-app/*`,
+   `/__ioi/slack/setup` retired with typed 410s; ux-seeds/widgets disposition
+   (adopt under `/developer-console` or archive) decided in the same PR; census
+   control-count refresh recorded.

--- a/internal-docs/implementation/surfaces/developer-workspace.md
+++ b/internal-docs/implementation/surfaces/developer-workspace.md
@@ -1,0 +1,217 @@
+# Developer Workspace — implementation brief
+
+Canonical route: `/developer-workspace` · Owner: Developer Workspace (owner application)
+Brief status: authored 2026-08-05 from bytes at `21ae389fe` · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Owner job: "code, systems, workflow, workspace, editor, terminal, browser, and
+  debugging surface, including development environment recipes and lifecycle
+  observations where they help users start, inspect, restore, or tear down work"
+  (core-clients-surfaces.md:1386-1390). One-line identity: "Developer Workspace
+  develops, debugs, and operates systems and workspaces" (:98).
+- `Workbench` / `HypervisorWorkbench` are RETIRED labels, tolerated only in existing
+  routes/packages/saved links during migration — never a second product identity
+  (:2281-2284); "Workbench = retired label; the owner name is Developer Workspace"
+  (:4809). Route `/developer-workspace` in the v2 ledger, no aliases per ADR 0022
+  (:876-880, :902).
+- **The editor is an adapter target, not the product identity** (:2295-2296). The
+  implementable contract is `AdapterConnectionProfile`: connection mode, launch path,
+  required local/remote components, supported features, policy coverage, known limits;
+  "Editor choice is a session preference, not Hypervisor's product identity"
+  (:3168-3195). Surfaces it may appear in: App, Web, remote browser workspaces,
+  VS Code-family / Cursor / Windsurf / JetBrains adapters, terminal/tmux views
+  (:2286-2293).
+- Lives inside or attached to a Project — "The owner name is the IDE-grade
+  **Developer Workspace** inside or attached to a Project; the Project is the durable
+  context object" (:1600-1602); correct flow: "Open the Project. Use Developer
+  Workspace or an editor adapter to inspect and change it." (:1620-1622).
+- Consumes, never owns, the environment-ops substrate: daemon owns lifecycle
+  semantics, wallet.network owns authority/credential release, Agentgres owns admitted
+  state/receipts/restore truth (:3206-3209). Developer Workspace receives structured
+  outputs and exit codes — never durable secrets, plaintext custody, or authority
+  except through capability leases + receipts (:3232-3236).
+- Operator-expectation rows it serves: "Live console / machine window" and
+  "Snapshots / checkpoints / restore" (:302-303). Build-verb participant (:1120-1122);
+  Surface Generate may consume "Developer Workspace code" (:2217-2221); Canvas may
+  appear inside it (:1399-1401, :2427).
+- May never: be runtime truth (:4783); make one editor shell the parent product
+  (:4718-4719); treat an editor name string as the adapter contract (:4746); treat the
+  editor adapter as a full execution boundary (:4787) or the adapter target as a
+  secret vault (:4788); densify Home into its terminal/diff/file console (:4725).
+- Layering (C-1..C-4): sessions bind "typed subject attachments … the platform never
+  names an application family as a dedicated field" (:2683-2687, :2692-2696) and
+  "adapter targets" (:2703); the thread/managed-session/launch-recipe plane is ONE
+  daemon-internal substrate composed by read only (:3320-3328). The workbench's
+  sessions/runs panels are read-projections; any session-serving row binds through
+  `subject_attachments`.
+
+## 2. Schema map
+
+Registry (`docs/architecture/_meta/schemas/`): the environment/editor planes are the
+best-covered in the estate — `hypervisor-development-environment-recipe.v1` (+
+`-resolution.v1`), `hypervisor-environment-backup.v1`,
+`hypervisor-environment-route-binding.v1`, `harness-session-terminal-attach.v1`,
+`hypervisor-session-launch-recipe-admission.v1` all exist. `AdapterConnectionProfile`
+has NO registry schema; its byte-level carrier is the tracked manifest
+`packages/hypervisor-adapter-targets/editor-targets.manifest.json`
+(`ioi.hypervisor.editor_targets.manifest.v1`, doctrine block restates the canon rule)
++ per-editor profiles `code-editors/profiles/*.json` (vscode, vscode-browser,
+insiders, cursor, windsurf, devin), read by editor_routes.rs:40-53.
+
+| Canon object / contract | Registry / canon anchor | Daemon route(s) today |
+|---|---|---|
+| Environment object model (HypervisorEnvironmentClass / LifecycleState) | canon :3238-3253 | classes hypervisor-daemon.rs:1140-1143; list/create :1144-1148; summary projection :1150-1153; get :1154-1157; `:id/:action` (start/stop/delete/archive/restore) :1158-1161; logs :2688-2691; typed lifecycle projection :2228-2231 + `lifecycle/:op` :2232-2238 |
+| EnvironmentOpsService (files/git/terminal Connect contract; "the native Workbench consumes" — daemon's own comment :2912-2913) | canon env-ops contract list :3211-3230 | ops-lease :2914-2921; `/supervisor/:env/supervisor.v1.EnvironmentOpsService/:method` :2922-2925; methods ReadFile/WriteFile/Find/GetGitStatus/GetGitDiff*/ListTerminalProfiles/Exec/CancelExec (supervisor_routes.rs:347-594) |
+| HypervisorEnvironmentPort (+ preview gateway) | canon :3222, :3248 | ports :2928-2931; expose :2932-2935; unexpose :2936-2939 |
+| Watch/PR-draft (daemon-owned snapshot + governed proposal) | canon :3214, receipts obligation :3229 | watch-state :2942-2945; pull-request-drafts :2946-2949; env-files :2907-2911 |
+| HypervisorDevelopmentEnvironmentRecipe (+ resolution) | schema in registry; canon "development environment recipes" :1388 | recipes list/create :1221-1225; get :1226-1229 |
+| Snapshots / backups / restore (HypervisorEnvironmentBackup) | schema in registry; canon archive/restore doctrine :3255-3271 | snapshots list/create :1207-1212; restore :1213-1216; backups create :1217-1220. **No backup LIST / restore-prepare/apply/cancel ladder** (canon :3226) → `route-missing` **W3** (small) |
+| Interactive PTY terminals (T7-E, environment_ref-bound) | canon "terminal" :1387 | list/create :3105-3109; stream :3110-3113; input :3114-3117; resize :3118-3121; close :3122-3125 |
+| Editor-target registry (adapter targets, probed open posture) | manifest above; canon :3166-3195 | targets list :3129-3132; get :3133-3136 |
+| Editor services + host provisioning (WS-3/8; fail-closed `editor_runtime_not_provisioned`, editor_routes.rs:14-16) | canon "editor" :1387 | provisioning plans :3137-3144; services list/create :3145-3149; start :3150-3153; stop :3154-3157; rebuild :3158-3161; expose :3162-3165; status :3166-3169; logs :3170-3173; open-url :3174-3177 |
+| Editor access leases (capability leases via the EXISTING authority machinery — editor_routes.rs:4-6) | canon :3232-3236 | create :3178-3181; revoke :3182-3185. **No GET list** → `route-missing` **W3** (small; needed for the lifecycle strip) |
+| CodeEditorAdapterLaunchPlan admission | fixture family `hypervisor-session-launch-recipe-admission` (negative-workbench-without-adapter) | :1107-1110 |
+| HarnessSessionTerminalAttach admission | `harness-session-terminal-attach.v1` schema; canon :3060 | :1119-1122 |
+| Code WorkRun (materialized Git branch/worktree + patch branch, :4825-4826) | canon anti-pattern :4782 | workruns list/create :1162-1167; get :1168-1171; execute :1172-1175 |
+| ScmPublicationEffect (governed publish out of an env workspace) | `schema://ioi/components/connectors-tools/scm-publication-effect/v2` in registry | publish :3088-3091 (bindings/proposals/effects are Developer Console rows, see sibling brief) |
+| Session plane (read-compose only) | C-rulings; canon :3320-3328 | sessions :3189-3193; events :3194-3197; execute :3198-3201; get/teardown :3206-3210; session-turns :769-772; threads :783-798 (daemon-internal substrate — read-compose) |
+
+## 3. UI seed map
+
+The inherited workbench is THREE wired lanes, all serving today:
+
+- **T1 vendor SPA shell** (`apps/hypervisor/product-ui/owned/public/`; captures under
+  `details/<uuid>/index.html`, `workspaces/`; served by `serve-product-ui.mjs`, wired
+  through the adapter):
+  - `/details/:envId` — session detail (conversation + env panel). Adapter
+    `EnvironmentService`: **14 RPCs**, all daemon-backed
+    (ioi-api-adapter.mjs:399-486 → `/v1/hypervisor/environments*`); residues:
+    `CreateEnvironmentLogsToken` returns a fabricated local token (:479-480),
+    `MarkEnvironmentActive` is a no-op `{}` (:481-482). Adapter `AgentService`:
+    **10 RPCs** (CreateAgentSession :509-519, ListAgentExecutions :521-528,
+    GetAgentExecution :530-535, CreateAgentExecution/StartAgent :537-553,
+    SendToAgentExecution :555-580, StopAgentExecution :582-585,
+    DeleteAgentExecution :587-590, CreateAgentExecutionConversationToken :592-593
+    [local constant], ListPrompts :1288) — riding a serve-local run registry plus
+    daemon `/v1/threads*` writes (:526, :552, :579, :584, :589). Classified
+    **partial**: wired, but the run registry is serve-local state and the thread
+    writes are thread-plane write sites (see Corrections).
+  - `/workspaces/:envId` — the code-workspace IDE console ("the real console; NOT
+    iframed here. No owned terminal/editor" — serve-product-ui.mjs:2344). Its live
+    file/git/terminal I/O is the EnvironmentOpsService bridge: SPA opens
+    `ws://…/supervisor.v1.EnvironmentOpsService/` → serve WS transport
+    (serve-product-ui.mjs:10408-10581, unary delegated to the daemon contract home)
+    → daemon :2922-2925. Access token = real env-scoped ops lease
+    (adapter:472-477 → daemon :2914-2917). **Wired.**
+  - `EditorService/ListEditors` offers ONLY probed-openable targets from the daemon
+    editor-target registry (adapter:677-699). **Wired.**
+- **T2 native readouts** (serve-product-ui.mjs):
+  - `/__ioi/workbench` (census: 200, 266 controls — the estate's biggest single
+    readout) — environments-summary + editor-targets + sessions + goal-runs composed
+    (serve:8840-8851, renderer :2345-2460); per-env drawer links Workbench / Session /
+    Run Timeline (:2390-2435). **Wired read.**
+  - `/__ioi/editor/open?environmentId=…` — drives the FULL editor-service lifecycle
+    chain server-side: create service → mint access lease → start → expose → 302 to
+    `open_url`, fail-closed with the daemon's reason (serve:10328-10356). **Wired
+    action** (governed via capability lease).
+  - Terminals panel drives `/v1/hypervisor/terminals` create/stream/input/close
+    (serve:6905-6925, :6370-6397). **Wired action.**
+  - `/__ioi/code` (census: 24 controls) — repos + SCM binding posture + publish trail,
+    links back to Workbench (serve:1413). Read-only here; SCM registrations belong to
+    Developer Console.
+- **T4 dormant seed**: `ux-seeds/workspaces` is census-assigned
+  `canonical_owner: "Developer Workspace"` (inventory.v1.json
+  tier_t4_dormant_ux_seeds; tree at `apps/hypervisor/ux-seeds/workspaces/`) —
+  reference capture only, no registration.
+- Census deltas: `/developer-workspace` `resolves: false`
+  (census: canonical_target_routes); no T3 registered surface exists for this owner
+  (14 slugs, none workspace-shaped). Seed-preservation: serve/adapter/owned-public are
+  protected seed roots (`ported-seed-preservation.v1.json` seed_roots).
+
+### Corrections vs v0
+
+- v0 said: "inherits the wired workbench (route `/details/:env` …)" — bytes show the
+  workbench is three lanes, not one route: vendor SPA `/details/:id` (session detail)
+  AND `/workspaces/:id` (the IDE console, serve-product-ui.mjs:2344) AND the native
+  readout `/__ioi/workbench` (serve:8840-8851, 266 controls per census). The rehome
+  must carry all three or it strands the IDE lane.
+- v0 said: "wire editor-service lifecycle controls that already exist server-side" —
+  bytes show the create→lease→start→expose chain ALREADY has a wired consumer
+  (`/__ioi/editor/open`, serve:10328-10356); the genuinely unwired server-side
+  controls are stop / rebuild / status / logs / lease-revoke
+  (hypervisor-daemon.rs:3154-3173, :3182-3185). The work is narrower: surface the
+  running-service inventory + those five verbs.
+- v0 counts verified exact: EnvironmentService 14 RPCs (adapter:406-486), AgentService
+  10 (adapter:509-593 + :1288). But two of the 14 are dishonest residues
+  (fabricated logs token :479-480, no-op MarkEnvironmentActive :481-482) — v0's
+  "wired workbench" overstates by exactly these.
+- Thread-plane write sites to record per the C-rulings (migrate at the PR that touches
+  them, target = session-execution loop / `session-turns`): adapter POSTs
+  `/v1/threads` (:552), `/v1/threads/:id/turns` (:579), `/v1/threads/:id/cancel`
+  (:584), DELETE `/v1/threads/:id` (:589); serve-local run registry backs
+  ListAgentExecutions (:523-528). No named app-family session fields found in these
+  modules — the binding residue is the write path itself.
+
+## 4. Schema→UI binding table
+
+Lease flow = the standing gateway order: sealed credential (428) → wallet grant (403)
+→ receipted (lifecycle_routes.rs:11899-11942); editor access leases ride the same
+machinery (editor_routes.rs:4-6). Reads go through the W0.3 read client.
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| Environment inventory (list + counts + pager) | environments-summary :1150-1153 | wired (`/__ioi/workbench` + SPA list) | `wired-read` under `/developer-workspace` |
+| Env detail drawer (phase, class, project, links) | environments/:id :1154-1157 + lifecycle projection :2228-2231 | wired | `wired-read` |
+| Start / Stop / Archive / Restore / Delete env | `:id/:action` :1158-1161 | wired via adapter (SPA) | `wired-action-receipted` via authority client |
+| Create environment (from project / class) | :1144-1148 + classes :1140-1143 + recipes :1221-1229 | wired via adapter | `wired-action-receipted` |
+| File tree / editor buffer / git status / diff | EnvironmentOpsService :2922-2925 (WS bridge serve:10408-10581) | wired | `wired-read` (writes: `wired-action-receipted` behind ops lease) |
+| Terminal panes | terminals :3105-3125; ops-lease :2914-2917 | wired (serve:6905-6925) | `wired-action-receipted` (lease-scoped) |
+| Ports panel (observe / expose / unexpose) | :2928-2939 | wired via adapter UpdateEnvironment (:447-452) | `wired-action-receipted` |
+| Logs pane | :2688-2691 | wired | `wired-read` |
+| Editor picker ("Open in …") | editor-targets :3129-3136 + manifest profiles | wired, probed-only (adapter:689-696) | `wired-read`; default editor = org/user preference, never the contract (manifest doctrine) |
+| Open editor (VS Code Browser) | editor-services chain :3145-3181 | wired (`/__ioi/editor/open`) | `wired-action-receipted` |
+| Editor service strip (status/logs/stop/rebuild/lease-revoke) | :3154-3177, :3182-3185 | **dead — server-only, zero UI consumers** | `wired-action-receipted` (W2) |
+| Editor access-lease list on the strip | no GET list route | absent | `disabled-named-gap` → W3 row (§2) |
+| Snapshots / backups / restore panel | :1207-1220 | dead (no UI consumer found) | `wired-read` + restore `wired-action-receipted`; backup-list ladder `disabled-named-gap` → W3 row (§2) |
+| Agent conversation pane (`/details/:id`) | serve run registry + `/v1/threads*` (adapter:495-594) | partial (works; serve-local truth + thread-plane writes) | `wired-read` composed from session + execution-binding + turns reads; input rides the session execution loop (Cut #2, W4); session rows bind subjects via `subject_attachments` |
+| Sessions / IOI-Agent-runs panels on workbench | sessions :3189-3193 + goal-runs (serve:8840-8846) | wired read | `wired-read` (subject_attachments rows) |
+| WorkRun view (branch/patch/receipts) | workruns :1162-1175 + agent-run-transcripts :2950-2959 | partial (Run Timeline readout) | `wired-read` (D7 WorkRun view fields, canon :2720-2727) |
+| PR draft / publish out of env | pull-request-drafts :2946-2949; scm publish :3088-3091 | wired (governed) | `wired-action-receipted`; destination-binding registration UI lives in Developer Console |
+| Fabricated logs/conversation tokens (adapter:479-480, :592-593) | none | local lies | `delete` (W0.5 identity-truth rule: real token route or honest absence) |
+| `MarkEnvironmentActive` no-op (adapter:481-482) | activity signals canon :3227 | local lie (silent `{}`) | `delete` or wire to a real activity-signal route when one exists (`disabled-named-gap` until then) |
+
+## 5. Ordered PR list
+
+1. **W1** — Register Developer Workspace + serve `/developer-workspace`: env
+   inventory + detail read-first (environments-summary/get/lifecycle projection),
+   rehoming the `/__ioi/workbench` renderer's data contract; `Workbench` label
+   retired from nav copy (canon :2281-2284). No new truth.
+2. **W1** — Editor-target picker as read view (targets + manifest posture); default
+   editor exposed as preference, adapter-connection-profile rule stated in-surface
+   (canon :3195-3196).
+3. **W1** — Rehome the IDE lane: `/developer-workspace/:envId` mounts the existing
+   SPA workbench (EnvironmentOpsService WS bridge + terminals) unchanged under the
+   canonical route; legacy `/workspaces/:id`, `/details/:id` keep serving until
+   cutover (seed invariant).
+4. **W2** — Env lifecycle verbs (start/stop/archive/restore/delete/create) through
+   the W0.3 authority client with receipt refs surfaced; ports expose/unexpose
+   likewise.
+5. **W2** — Editor-service lifecycle strip: running services inventory
+   (list/status/logs) + stop/rebuild/lease-revoke wired to :3154-3185; open-chain
+   reuses the `/__ioi/editor/open` sequence server-side.
+6. **W2** — Snapshots/recipes panel: read + snapshot-create/restore receipted;
+   recipe list/get read-first.
+7. **W3** — Backend smalls from §2: editor-access-lease GET list; backup list +
+   restore-prepare/apply/cancel ladder (canon :3226). UI follows in the same wave
+   (replaces the two `disabled-named-gap` rows).
+8. **W3** — Adapter honesty pass: delete fabricated logs/conversation tokens +
+   MarkEnvironmentActive no-op; wire or honestly absent (W0.5 rule).
+9. **W4** — Conversation lane onto the session execution loop (Cut #2):
+   replace serve-local run registry + `/v1/threads*` writes with
+   session-execution-binding reads + `session-turns`; `subject_attachments` rows
+   throughout; event updates via `/v1/event-streams` subscriptions (W0.4), legacy
+   per-resource SSE wrapped.
+10. **W4** — Cutover per the 6-step rule: `/workspaces/:id`, `/details/:id`,
+    `/__ioi/workbench` retired with typed 410s; ux-seeds/workspaces disposition
+    decided (adopt or archive) at the same PR.

--- a/internal-docs/implementation/surfaces/evaluations.md
+++ b/internal-docs/implementation/surfaces/evaluations.md
@@ -1,0 +1,204 @@
+# Evaluations — implementation brief
+
+Canonical route: `/evaluations` · Owner: Evaluations (owner application)
+Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Evaluations is the **independent judgment surface**: it defines what evidence is
+  admissible for a declared decision, freezes that contract per epoch, accounts
+  for what adaptive search learned from protected tests, and keeps dependent
+  claims honest when an evaluator fails (evaluations.md:21-32). It does not
+  build the capability under test, execute effects, select campaign targets, or
+  authorize release (evaluations.md:31-32, :93-114).
+- Owns: suite definitions + **immutable released revisions**; portfolio lanes
+  (visible/sealed/transfer/adversarial/cross-play/external-reality/production/
+  reproduction); `EvaluationEpoch` lifecycle; holdout/evaluator custody posture;
+  `EvaluationExposureLedger`; evaluator dependency/validity graphs;
+  `VerifierChallenge` intake→disposition; re-verification plans; scorecards that
+  preserve uncertainty; feedback intake with evidence-eligibility posture
+  (evaluations.md:50-87). Summary registration in the suite tree:
+  core-clients-surfaces.md:1341-1346; route ledger row `/evaluations`
+  core-clients-surfaces.md:898; tool-surface row "Evaluation Suites (legacy AIP
+  Evals) → Evaluations / Suites" core-clients-surfaces.md:1419.
+- Epoch discipline: an epoch must never float on a mutable `latest` suite/judge/
+  dataset; lifecycle state appends around a frozen root; changed judgment ⇒
+  successor epoch (evaluations.md:203-212). Exposure/contamination must be
+  derived from an admitted append-only ledger head, never an unreceipted mutable
+  counter (evaluations.md:255-260, :419-420).
+- Every `VerifierPath`/acceptance profile declares a `verification_cost_class`
+  from the closed set negligible/sublinear/comparable/superlinear/
+  unverifiable_at_price; downward reclassification is a judgment-contract
+  mutation ⇒ successor epoch (evaluations.md:126-171).
+- Recommended 12-section IA: Overview · Suites/Revisions · Epochs ·
+  Runs/Scorecards · Sealed Holdouts · Exposure/Contamination ·
+  Evaluators/Dependencies · Challenges · Re-verification · Feedback/Evidence
+  Eligibility · Quality/Drift · Claims And Release Impact
+  (evaluations.md:350-363).
+- May never: nominate a campaign winner, issue an UpgradeDecision, activate/
+  roll back/recall production state (evaluations.md:433-434); treat a receipt as
+  evaluator correctness or a benchmark average as production fitness
+  (evaluations.md:449-451); treat feedback capture as learning permission — the
+  `InstitutionalLearningBoundaryProfile` and most-restrictive-boundary rule
+  govern eligibility (evaluations.md:378-394; core-clients-surfaces.md:1084-1097).
+- Effectful-tooling gate (the fix target for the inherited defect): "No
+  Hypervisor application surface may expose effectful operator tooling without
+  RuntimeToolContract or MCP contract refs, wallet authority posture, Agentgres
+  refs, and receipt obligations" (core-clients-surfaces.md:4610-4612).
+- Foundry boundary: Foundry builds/executes eval assets and admitted jobs;
+  Evaluations owns admissibility, exposure accounting, challenges, and never the
+  release decision (evaluations.md:325-339; core-clients-surfaces.md:2461-2475).
+
+## 2. Schema map
+
+| Canon object / contract | Canon block | Registry entry | Daemon route(s) today | Status |
+|---|---|---|---|---|
+| Eval-suite declaration (transitional draft object `ioi.hypervisor.eval-suite.v1`) | evaluations.md:55-58, :188-190 | none | `/v1/hypervisor/eval-suites` GET/POST, `/:id` GET/PATCH/DELETE, `/overview` (hypervisor-daemon.rs:1920-1933; handlers eval_suite_routes.rs:143-398) | exists — draft-only, receiptless (defect, §3/§4) |
+| **Released suite revision** (immutable) | evaluations.md:55-58, :203-206 | none | `route-missing` — bytes pin `status: "draft"` always (eval_suite_routes.rs:268-269) | **W3** (release/revision lifecycle) |
+| `EvaluationEpoch` (draft/freeze/activate/challenge/close/invalidate/successor) | evaluations.md:63-68, :191-212 | none | `route-missing` (no epoch route in the 663; grep clean) | **W3** |
+| Sealed-holdout custody contract | evaluations.md:239-253 | none | `route-missing` | **W3** |
+| `EvaluationExposureLedger` (append-only, chained entries) | evaluations.md:72-74, :255-266, :419-420 | none | `route-missing` | **W3** |
+| `VerifierChallenge` | evaluations.md:78-79, :268-301 | `verifier-challenge.v3` + envelope v1 (architecture-contract-registry.v1.json:819-871; schemas dir) | `/v1/goal-orchestration/verifier-challenges` GET/POST, `/overview`, `/:id`, `/:id/transition` (hypervisor-daemon.rs:2574-2588); hosted, receipted, lease-governed plane (verifier_challenge_routes.rs:1-5, :27-32, :69-70; governed completer hypervisor-daemon.rs:3578-3585) | exists — **rehome as projection**, not a rebuild |
+| Re-verification plan / affected-result discovery | evaluations.md:80-82, :288-299 | none | `route-missing` (challenge statuses include `reverifying`, verifier_challenge_routes.rs:50-60, but no epoch/claim impact walk) | **W3** (rides the epoch family) |
+| Evaluation run / Finding / scorecard | evaluations.md:197-201, :83-85 | none (Finding/Attempt v3 exist for goal-orchestration: registry:191, :981) | `route-missing` for eval execution — "no run/scoring/judge here" is the plane's own doctrine (eval_suite_routes.rs:13-18; hypervisor-daemon.rs:1915-1918) | **W3** (admitted-job read views only; execution is daemon/Foundry) |
+| Evaluator dependency/validity graph | evaluations.md:75-77, :270-281 | none | `route-missing` | **W3** |
+| `verification_cost_class` declaration | evaluations.md:126-144 | none | `route-missing` (declared on VerifierPath/acceptance profiles) | **W3** (field on suite-revision/epoch families) |
+| Feedback entry + evidence-eligibility consent | evaluations.md:87, :378-394 | none | `/v1/hypervisor/feedback/overview`, `/v1/hypervisor/feedback-entries` GET/POST, `/:id` GET/PATCH/DELETE (hypervisor-daemon.rs:1901-1914) | exists — consent ladder shared with eval-suites (eval_suite_routes.rs:53-59) |
+| Eval-suite mutation **receipt family** | required by core-clients-surfaces.md:4610-4612 | none | absent — create/patch/delete persist with no receipt (eval_suite_routes.rs:274, :388, :396-397); feedback plane likewise mints none (feedback_routes.rs — zero receipt records, 286 lines) | **W3** (small daemon addition; blocks W2 actions) |
+
+## 3. UI seed map
+
+Traversable today (bytes; census 2026-07-30 used as seed, labeled):
+
+- **T2 owner surface `/__ioi/evaluations`** (GET serve-product-ui.mjs:8569-8589;
+  renderEvaluations :1299-1372). Panes: stat banner (suites/declared/empty/
+  subjects, :1317-1319) — **wired-read**; "Declare an eval suite" form posting
+  to the daemon (:1323-1331 → POST handler :8590-8605) — **wired mutation,
+  receiptless** (the defect); suite library table with per-row Delete
+  (:1335-1347 → :8606-8611, which also swallows daemon errors via
+  `.catch(() => {})` at :8608) — **wired mutation, receiptless**; assessment
+  subjects pane over `/v1/hypervisor/operations` + goal-runs (:1349-1360,
+  fetches :8571-8577) — **wired-read**; consent-ladder + feedback + Foundry
+  `model_eval` drafts pane (:1362-1367) — **wired-read**; named-gaps note
+  (:1369) — honest absence.
+- **T2 sublane `/__ioi/feedback`** (renderFeedbackQueue :1252-1287): feedback
+  CRUD + consent-gated conversion PATCH (:8555-8564) — **wired mutation,
+  receiptless at the daemon**.
+- **T3 registered surface `evalsuites`**, registry title "AIP Evals", owner
+  Evaluations, route `/__ioi/evaluations/evalsuites`
+  (surface-registry.mjs:63; GET handler :8415-8420; renderEvalsuitesPort
+  :4045-4131). Pixel-faithful AIP Evals shell; Recents rows are real suites —
+  **wired-read**; Creator/Last-edited/Last-viewed columns render gap dashes (no
+  principal/view metadata on the plane, :4076-4078) — **dead (named gap)**;
+  "New evaluation suite" + "Help" header buttons disabled as named gaps
+  (:4105-4106) — **dead**; suite-library truth section (:4089-4097) —
+  **wired-read**. Census: 32 controls, 24 implemented, 3 daemon_read, 1
+  disabled_missing_authority (census: control_census).
+- **Vendor capture `/__apps/evalsuites`** (proxy fold of `/workspace/evals/`,
+  :7430) — renders no data, documented insufficient (#44 sweep note, :4048,
+  :4096). Keep as dormant seed only.
+- **v2 SPA shell**: no `/evaluations` route exists in `apps/hypervisor/src`
+  (grep clean); census agrees (census: `{"route": "/evaluations", "resolves":
+  false}`).
+- Seed-preservation: `evalsuites` is a protected route classed `daemon_wired`
+  (ported-seed-preservation.v1.json:30) — rehome, never rebuild.
+
+### Corrections vs v0
+
+- v0 said: "epochs/holdouts/challenges absent." Bytes show **challenges are not
+  absent**: a hosted, receipted, lease-governed VerifierChallenge plane exists
+  at `/v1/goal-orchestration/verifier-challenges` (hypervisor-daemon.rs:
+  2574-2588; verifier_challenge_routes.rs:1-5, :27-32) with a registered v3
+  schema contract (architecture-contract-registry.v1.json:819-871). Epochs,
+  sealed-holdout custody, and the exposure ledger remain route-missing.
+  Challenges become a rehome/projection, not a W3 from-scratch build — only the
+  epoch-linked affected-result discovery is new.
+- v0/census said: "the surface simply leaves the create button disabled"
+  (census: evalsuites primary_workflow). Bytes show the **create authority is
+  exercised today**: the owner surface `/__ioi/evaluations` posts create and
+  delete straight to the daemon (serve-product-ui.mjs:8590-8611). Only the AIP
+  Evals landing's "New evaluation suite" button is disabled (:4105). The
+  receiptless-mutation defect is therefore **live**, not latent.
+- v0 said: "eval-suites CRUD exists" — confirmed, but with a canon-relevant
+  narrowing v0 omits: the object is a **permanently draft, mutable declaration**
+  (`status: "draft"` unconditionally, eval_suite_routes.rs:268-269; PATCH edits
+  in place :291-390), so canon's immutable released revisions and "no mutable
+  `latest` supplies promotion evidence" rule (evaluations.md:203-212, :415-416)
+  have no substrate yet — a distinct W3 row from the epoch family.
+- Census counted 3 `governed_receipted_action` controls on evalsuites (census:
+  control_census); bytes show all eval-suite mutations emit no receipt
+  (eval_suite_routes.rs:274, :388, :396-397) — the census's own
+  `missing_authority_contracts[0]` names the receipt-family gap; the counter is
+  the stale side.
+
+## 4. Schema→UI binding table
+
+Reads use the W0.3 read-projection client; authority-crossing actions use the
+CapabilityLease client (403 wallet challenge → 428 credential → receipted).
+Suite `subject_scope` may name `session` subjects (eval_suite_routes.rs:38);
+any session-serving detail row binds through the session's
+`subject_attachments[]`, never a named app field (core-clients-surfaces.md:
+2683-2687, :3971-3990).
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| Overview stat banner | eval-suites `/overview` + list (daemon:1920-1927) | wired-read on T2 (:1317-1319) | `wired-read` at `/evaluations` Overview |
+| Suites/Revisions table + detail | eval-suite records (list/get) | wired-read (:1335-1347, :4068-4079) | `wired-read`; revision/release strip `disabled-named-gap` until W3 revision family |
+| Declare-suite form | POST `/v1/hypervisor/eval-suites` (daemon:1924-1927) | wired, receiptless (:8590-8605) | `wired-action-receipted` — blocked on receipt family (W3 row); until then keep enabled only with visible "no receipt" defect banner, or gate behind the fix PR |
+| Suite edit (PATCH) | `/:id` PATCH (daemon:1929-1932) | no UI control (daemon-only) | `wired-action-receipted` after receipt family |
+| Suite delete | `/:id` DELETE | wired, receiptless, error-swallowing (:8606-8611) | `wired-action-receipted`; surface daemon refusals |
+| AIP Evals "New evaluation suite" | same create route | disabled named gap (:4105) | `wired-action-receipted` (same lease flow as declare) |
+| Recents Creator/Last-edited/Last-viewed | principal/view metadata | dead gap-dashes (:4076-4078) | `disabled-named-gap` (principal attribution = W3 backlog row, census: missing_authority_contracts[1]) |
+| Epochs pane | `EvaluationEpoch` family | absent | `disabled-named-gap` until W3 epoch family, then `wired-read` + freeze/close via lease client |
+| Sealed Holdouts + Exposure/Contamination panes | custody + `EvaluationExposureLedger` | absent | `disabled-named-gap` until W3; ledger head is read-only projection, never a counter (evaluations.md:419-420) |
+| Challenges list/detail | verifier-challenges GET/`/overview`/`/:id` (daemon:2574-2586) | not rendered by any Evaluations surface | `wired-read` projection (W1) |
+| Challenge intake + transition | POST + `/:id/transition` (daemon:2574-2588; already governed, verifier_challenge_routes.rs:69-70) | no UI | `wired-action-receipted` via lease client (W2) |
+| Re-verification view | challenge `reverifying` status + epoch impact | absent | `disabled-named-gap` until epoch family; interim: status filter on challenge projection |
+| Runs/Scorecards pane | eval execution family | absent by doctrine (eval_suite_routes.rs:13-18) | `disabled-named-gap` (W3 family; render admitted-job truth only, never scores computed UI-side) |
+| Feedback/Evidence Eligibility pane | feedback overview/entries (daemon:1901-1914) | wired on T2 feedback lane (:1252-1287) | `wired-read` + conversion as `wired-action-receipted` once feedback mutations mint receipts (same W3 receipt row) |
+| Consent-ladder chips | overview `consent_ladder` (eval_suite_routes.rs:151-159) | wired-read (:1364-1366) | `wired-read` |
+| Assessment-subjects pane | operations runs + goal-run blockers (daemon:1314, :1821) | wired-read (:1349-1360) | `wired-read`; session-subject rows bind via `subject_attachments` |
+| Foundry `model_eval` drafts chips | `/v1/hypervisor/foundry/specs` (daemon:1325) | wired-read (:1367) | `wired-read` link-out to `/foundry` (Foundry boundary, evaluations.md:330-339) |
+| Quality/Drift, Claims And Release Impact panes | scorecard/claim families | absent | `disabled-named-gap` (W3; claims depend on epoch family) |
+| `/__apps/evalsuites` proxy lane | vendor capture | dead (renders no data, :4048) | `delete` at cutover (W4) |
+
+New event consumption (suite/epoch/challenge updates) rides `/v1/event-streams`
++ `/v1/subscriptions` (daemon:2350-2379); per-resource SSE is legacy, wrapped
+not extended.
+
+## 5. Ordered PR list
+
+1. **W1** — `/evaluations` read-first shell: Overview + Suites/Revisions over
+   eval-suites overview/list/get; 12-section IA rendered with honest
+   `disabled-named-gap` panes for the absent families; rehome the T2 subjects/
+   consent panes. No mutations exposed.
+2. **W1** — Challenges pane: read projection over
+   `/v1/goal-orchestration/verifier-challenges` (+overview, detail, status
+   filters incl. `reverifying`).
+3. **W1** — Feedback/Evidence Eligibility pane: read views over feedback
+   overview/entries with consent posture rendered per entry.
+4. **W3 (small daemon, serial on router)** — eval-suite + feedback mutation
+   receipt family: create/patch/delete/convert mint durable receipts and fail
+   closed without one; closes the inherited receiptless-mutation defect against
+   core-clients-surfaces.md:4610-4612.
+5. **W2** — suite mutations via the CapabilityLease client: declare/edit/delete
+   receipted end-to-end; enable AIP Evals "New evaluation suite"; delete stops
+   swallowing errors; every completed action displays its receipt ref.
+6. **W2** — challenge intake/transition actions through the lease client (the
+   daemon side is already governed).
+7. **W3** — released suite-revision lifecycle (immutability + revision roots +
+   `verification_cost_class` declaration field), backend first, then the
+   Revisions strip.
+8. **W3** — `EvaluationEpoch` family (draft/freeze/activate/challenge/close/
+   invalidate/successor; frozen roots per evaluations.md:63-68), then the
+   Epochs pane and challenge→affected-epoch discovery.
+9. **W3** — sealed-holdout custody + `EvaluationExposureLedger` (append-only,
+   chained, derived head), then Sealed Holdouts + Exposure/Contamination panes.
+10. **W3** — evaluator dependency/validity graph + re-verification projections;
+    Quality/Drift and Claims panes over scorecard/claim reads as those families
+    land.
+11. **W4** — cutover per the 6-step rule: `/__ioi/evaluations`,
+    `/__ioi/feedback`, `/__ioi/evaluations/evalsuites` retire with typed 410s
+    (pattern: hypervisor-daemon.rs:610-612); delete the `/__apps/evalsuites`
+    proxy fold; release the seed-preservation rows
+    (ported-seed-preservation.v1.json:30).

--- a/internal-docs/implementation/surfaces/foundry.md
+++ b/internal-docs/implementation/surfaces/foundry.md
@@ -1,0 +1,228 @@
+# Foundry — implementation brief
+
+Canonical route: `/foundry` · Owner: Foundry (owner application)
+Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Foundry is the candidate/evaluator asset builder and admitted experimental
+  executor for worker/model/eval/persistent-training/dataset/registry/endpoint/
+  package work over Hypervisor Core (core-clients-surfaces.md:2496-2498). It
+  produces what other surfaces use: model catalog entries/cards, registry
+  entries, model routes and model-mount candidates, WorkerPackages, datasets/
+  feature views/holdouts, dataset-factory runs, training pipelines, experiment
+  optimization cycles, artifact conversion, endpoints, batch inference,
+  eval-suite/world/scorer/verifier candidates, recipes, quality gates,
+  promotion proposals, and package publication proposals
+  (core-clients-surfaces.md:2500-2513).
+- Foundry never self-mutates the runtime. Its experiment optimizer is a
+  subordinate execution profile; it does not own the ImprovementCampaign,
+  freeze evaluation truth, select the release candidate, or make the release
+  decision. Durable improvements go through governed proposals, independent
+  eval gates, wallet approvals, and Agentgres admission
+  (core-clients-surfaces.md:2515-2522; ledger row :1356-1366 — "not campaign
+  owner, evaluation-epoch truth, candidate-selection authority, or release
+  owner").
+- Foundry binds the active `InstitutionalLearningBoundaryProfile`, individual
+  training-evidence eligibility, source rights, model-route rights, derivative
+  lineage, and revocation impact before consuming evidence or promoting a
+  derived artifact; a green learning-boundary projection is never ambient
+  permission to train (core-clients-surfaces.md:2524-2528). Foundry must show
+  the exact boundary, eligibility, source-rights, route-rights, destination
+  scope, and export disposition before a job begins (:1087-1088). The facet
+  never becomes a 14th app or a second privacy selector (:1055-1056).
+- Canonical route is `/foundry` (core-clients-surfaces.md:900); the legacy
+  Model Catalog tool resolves as `Foundry / Models` (:1413). `Model` is the
+  product label; `ModelRoute` remains the internal runtime object for
+  provider, custody, fallback, spend, privacy, eligibility, and invocation
+  policy (:1455-1458).
+- Owner doc IA: a platform IA, not a wizard — pane ledger foundry.md:173-217;
+  the stable conceptual split is Discover / Build / Train-Tune / Evaluate /
+  Optimize / Deploy-Route / Govern (foundry.md:219-257). Evaluations owns the
+  judgment contract, exposure, validity, and re-verification posture
+  (foundry.md:235-241); Governance owns activation decisions (foundry.md:254-257).
+- Object-first, not agent-first: control / data+metadata / execution /
+  serving+governance planes over immutable objects (foundry.md:259-296);
+  training artifacts and deployable artifacts are distinct lineage nodes,
+  conversion/packaging are governed downstream stages (foundry.md:297-303);
+  autonomous optimizers are advisory and may not directly mutate a registry
+  alias, model route, endpoint, approval state, or traffic split
+  (foundry.md:305-311). ~38 minimal objects at foundry.md:1131-2059
+  (FoundrySpec :1209, FoundryRunPlan :1263, FoundryDatasetFactoryRun :1707,
+  FoundryTrainingPipelineRun :1821, FoundryPromotionBundle :1973, etc.).
+- Pattern/example supply is upstream input; an example is never proof of
+  production readiness (foundry.md:845-866). ioi.ai coordination is not
+  Foundry and Foundry is not a chat room (core-clients-surfaces.md:2530-2532).
+- C-4 in force: `foundry_eval_training` is retired from `session_kind` —
+  workload identity comes only from `subject_attachments`
+  (core-clients-surfaces.md:3960-3990). Surviving byte sites: the token still
+  appears as a `profile_kind` enum value on the MCP-gateway profile contract —
+  docs/architecture/components/connectors-tools/contracts.md:162 and
+  doctrine.md:156. That is a different field (context-profile kind, not
+  session kind), but it names the retired workload-as-kind pattern; record
+  here, reconcile at the PR that touches those files. Zero code sites
+  (grep over *.rs/*.mjs/*.cjs: none).
+
+## 2. Schema map
+
+| Canon object / contract | Canon block | Daemon route(s) today |
+|---|---|---|
+| FoundrySpec (draft, kinds model_tune/model_eval/tool_build/inference_endpoint/ontology) | foundry.md:1209; `ioi.hypervisor.foundry-spec.v1` (foundry_routes.rs:31,35-41) | hypervisor-daemon.rs:1324-1333 (list/create/get/patch/delete) |
+| FoundryRunPlan (draft) | foundry.md:1263; `ioi.hypervisor.foundry-run-plan.v1` (foundry_routes.rs:32) | hypervisor-daemon.rs:1335-1345 |
+| Foundry overview projection (specs+plans+substrate) | foundry.md:173-176 | hypervisor-daemon.rs:1320-1323 (foundry_routes.rs:204) |
+| ModelRoute registry (probe/enable/disable/select-default/session-bindings) | core-clients-surfaces.md:1456-1458 | hypervisor-daemon.rs:2087-2124 |
+| Model-route mutation admission (planner-admitted mutation) | core-clients-surfaces.md:2515-2522 | hypervisor-daemon.rs:1076 |
+| Model weight custody admission | foundry.md:279-282 (data-plane custody refs) | hypervisor-daemon.rs:1080 |
+| Model-mount plane: server, tokens, providers, backends, endpoints, artifacts import, catalog import-url, downloads, instances/load, runtime engines/select, vault refs/status/health, receipts(+replay), projection, native-local, mcp, routes(+test), workflow nodes/receipt-gate — 48 routes | foundry.md:249-253 (Deploy/Route) | hypervisor-daemon.rs:635-766 |
+| OpenAI-compat inference + catalog reads (`/v1/models`, `/v1/models/routes`, `/v1/models/catalog/search`, `/v1/chat/completions`, `/v1/responses`, `/v1/messages`, `/v1/embeddings`) | foundry.md:249-253 | hypervisor-daemon.rs:617-618,681,750-753 |
+| Worker package install admission (kernel planner, 202+record) | core-clients-surfaces.md:2504 | hypervisor-daemon.rs:1099 (lifecycle_routes.rs:6615) |
+| Training-evidence sources: memory/skill entries + lifecycle + mutation proposals + projections (read for eligibility only) | core-clients-surfaces.md:2524-2526, :1024-1026 | hypervisor-daemon.rs:1651-1770; `/v1/skills` :1026 |
+| Eval-suite candidates (model_eval drafts feed Evaluations) | foundry.md:235-241 | eval-suites CRUD hypervisor-daemon.rs:1919-1930 (Evaluations-owned) |
+| InstitutionalLearningBoundaryProfile projection (per-job boundary/eligibility/rights readout) | core-clients-surfaces.md:1051-1056, :1087-1088; foundry.md:49-52 | `route-missing` — **W3** |
+| Dataset plane: FoundryDatasetFactoryRun/DatasetSnapshot/CandidateDataRecord/holdouts | foundry.md:1707,1235,1654; core-clients-surfaces.md:2505-2506 | `route-missing` — **W3** |
+| Training/tuning plane: FoundryTrainingPipelineRun/Trial/CheckpointArtifact/TeacherSession | foundry.md:1821,1285,1300,1374 | `route-missing` — **W3** |
+| Experiment optimization: FoundryExperimentOptimizationCycle (advisory) | foundry.md:1884,305-311 | `route-missing` — **W3** |
+| Deploy lineage: FoundryArtifactConversionRun/RegistryVersion/RouteBinding/PromotionBundle | foundry.md:1927,1344,1361,1973 | `route-missing` — **W3** |
+| Foundry-side eval assets: ExecutableEvalSuite/EvalWorld/EvalTrajectoryRun/TrajectoryScorecard | foundry.md:1398,1419,1438,1475 | `route-missing` — **W3** (judgment stays Evaluations) |
+
+No Foundry-family JSON Schema exists in `docs/architecture/_meta/schemas/`
+(158 files; zero model-route/foundry/model-mount entries) — the daemon schema
+strings above are the only registered shapes. Registry entries land with each
+W3 family.
+
+## 3. UI seed map
+
+- **T2 substrate readout `/__ioi/foundry`** (serve-product-ui.mjs:9496-9601
+  handlers; renderers :3021-3201): overview head + Model Catalog section over
+  `/v1/hypervisor/model-routes` (:3076-3108), FoundrySpec draft CRUD forms
+  (new/edit/patch/delete → daemon foundry routes; :3123-3166), FoundryRunPlan
+  draft CRUD (:3174-3201), Evals section listing `model_eval` drafts
+  (:3115). Deliberately inert: "Nothing here trains, evaluates, serves, or
+  promotes" (:3072). **wired** (reads + draft writes).
+- **T3 registered surface `models`** — surface-registry.mjs:57 (owner
+  "Foundry", title "Model Catalog", route `/__ioi/foundry/models`,
+  capabilities `["browse"]`). Renderer serve-product-ui.mjs:5212-5280,
+  handler :8785: one card per daemon model route with availability/probe
+  evidence/custody/credential posture. census: 39 controls — 20 implemented
+  (9 daemon-read, 9 local-view), **0 governed-receipted**, 6
+  disabled-missing-authority, 8 unsupported-reference, 7 reference-data-only.
+  Compare/playground, model detail, Registered-models import, facet search:
+  **dead** (named gaps, census `missing_authority_contracts`). **partial**.
+- **Model-route administration lives on Agent Studio, not the catalog**:
+  `#model-routes` tab (serve-product-ui.mjs:2983-2998, table :2488-2519)
+  posts probe/enable/disable/select-default to
+  `/__ioi/agent-studio/model-routes/:id/:act` which proxies to the daemon
+  verbs (serve-product-ui.mjs:9446-9449). **wired** (receipted,
+  planner-admitted). Known gotcha: stale probe evidence yields 412 on launch;
+  POST `:id/probe` refreshes.
+- **Intel readouts** `/__ioi/agent-studio/intel/memory`, `/intel/skills`,
+  `/intel/graph` (serve-product-ui.mjs:2567-2635, :9288): memory/skill entry
+  create + promote/dispute/mark_stale lifecycle forms over
+  hypervisor-daemon.rs:1651-1770. **wired**, but owned elsewhere (see
+  Corrections #4) — Foundry consumes reads only.
+- **T4 reference-only seeds**: `/__apps/models` (model-registry capture,
+  "familiar baseline, never a rebound surface"), `/__apps/modelstudio`,
+  `/__apps/inference` (serve-product-ui.mjs:3106). Preserved dormant per
+  ported-seed invariant.
+- Canonical `/foundry` does not resolve (census: `{"route": "/foundry",
+  "resolves": false}`); daemon-level `/sessions`/`/missions`/`/__ioi/*` are
+  already typed-410 (hypervisor-daemon.rs:610-612) — the serve process, not
+  the daemon, owns `/__ioi/foundry*` today.
+
+### Corrections vs v0
+
+- v0 said: "model-mount plane (45 routes!)" — bytes show **48** exact
+  `/v1/model-mount/*` registrations (hypervisor-daemon.rs:635-766), plus the
+  4 OpenAI-compat inference routes (:750-753) and 3 models/catalog reads
+  (:617,:618,:681) riding the same kernel (`model_mount`,
+  hypervisor-daemon.rs:200).
+- v0 said: "training/dataset families largely exist under foundry+model-mount"
+  — bytes show **no training, dataset, trial, checkpoint, registry-version,
+  or promotion route exists anywhere** (full 663-route sweep). The daemon
+  Foundry family is 5 registrations — overview + draft-only specs/run-plans
+  (hypervisor-daemon.rs:1320-1345), "deliberately inert … no training
+  execution, no eval execution, no promotion mutation"
+  (foundry_routes.rs:1-16). Model-mount covers weight custody/serving, not
+  training. Train/Build/Optimize IA sections therefore open read-first over
+  honest absence, with the section-2 W3 rows as their build-list.
+- v0 said: "inherits `models` surface" — the models registration is
+  browse-only with **0 governed controls** (census + surface-registry.mjs:57);
+  the actual receipted model-route verbs live on Agent Studio's
+  `#model-routes` tab (serve-product-ui.mjs:2491, 9446-9449). The rehome
+  source for Foundry's authority actions is Agent Studio, not the catalog.
+- v0 said: Foundry "inherits … intelligence memory/skills" — canon places
+  personal memory/skill preferences in Settings
+  (core-clients-surfaces.md:981), the durable memory substrate in Agent
+  Wiki/`ioi-memory` (:1044-1047), and gives Foundry only contextual
+  eligible-evidence/learning-flow/route-rights projections (:1024-1026,
+  :2524-2526). This brief binds memory/skill entries **read-only** as
+  training-evidence eligibility; the lifecycle verbs on the intel readout are
+  not rehomed under `/foundry` (cross-brief boundary — Improvement/Settings
+  own those panes).
+- Packet said the 14 registered surfaces live at `apps/hypervisor/surfaces/<slug>/`
+  — bytes: only 6 extracted module dirs exist there; `models`/`listings`
+  registration + render live in `scripts/surface-registry.mjs` and
+  `scripts/serve-product-ui.mjs` (census `module` fields are aspirational for
+  these slugs).
+
+## 4. Schema→UI binding table
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| Discover · catalog grid (one card per route: availability, probe evidence + staleness, custody, credential, lifecycle) | ModelRoute · GET /v1/hypervisor/model-routes (+ /overview :2092) | wired at /__ioi/foundry/models | wired-read (read client) |
+| Discover · catalog name/facet search | GET /v1/models/catalog/search (hypervisor-daemon.rs:681) + client filter | dead (census view-only gap) | wired-read |
+| Discover · model detail page (card, custody, admission trail) | GET /v1/hypervisor/model-routes/:id + /v1/model-mount/vault/refs,/vault/status | dead (named gap) | wired-read |
+| Discover · compare/playground (two routes → prompt → run) | no governed catalog workflow; raw /v1/chat/completions exists (:750) | dead | disabled-named-gap (census missing-authority row) |
+| Build · FoundrySpec list/create/edit/delete (5 kinds) | foundry-spec.v1 · hypervisor-daemon.rs:1324-1333 | wired draft CRUD on /__ioi/foundry | wired-action-receipted (draft writes must gain receipt refs — the eval-suites receiptless-mutation defect generalizes; else disabled-named-gap) |
+| Build · FoundryRunPlan list/create/delete | foundry-run-plan.v1 · hypervisor-daemon.rs:1335-1345 | wired draft CRUD | wired-action-receipted (same receipt obligation) |
+| Train/Tune · pipelines, teacher sessions, dataset factory, checkpoints | foundry.md:1707,1821,1374,1300 · route-missing | absent | disabled-named-gap now; wired after W3 |
+| Evaluate · model_eval drafts + link-out to Evaluations suites/runs | specs?kind=model_eval (foundry_routes.rs:270-277); eval-suites :1919-1930 | wired (drafts) / read link | wired-read; judgment stays Evaluations (foundry.md:235-241) |
+| Optimize · experiment cycles, attempt lineage | foundry.md:1884 · route-missing | absent | disabled-named-gap now; W3 (advisory-only rendering, foundry.md:305-311) |
+| Deploy · instances loaded/load, runtime engines/select, downloads(+cancel), storage cleanup, endpoints, artifacts import, catalog import-url, native-local | model-mount plane hypervisor-daemon.rs:635-766 | reads partial (adapter maps `model-routes`, `receipts` — ioi-api-adapter.mjs:322-330); actions unexposed | wired-read for state; actions wired-action-receipted via authority client (403 wallet challenge → 428 credential → receipt refs) |
+| Deploy · route admin verbs: probe / enable / disable / select-default | POST /v1/hypervisor/model-routes/:id/{probe,enable,disable,select-default} (:2102-2116) | wired on Agent Studio tab | wired-action-receipted, rehomed into /foundry Deploy pane |
+| Deploy · route create/patch/delete + mutation admission | :2087-2100 + admission :1076 | wired (Studio) | wired-action-receipted |
+| Deploy · session bindings rows (which sessions serve which route) | POST :id/session-bindings :2118; GET /v1/hypervisor/model-route-session-bindings :2122 | wired list | wired-read; session rows bind through `subject_attachments` only (C-1; core-clients-surfaces.md:3971-3990) — never a named app field |
+| Govern · receipts stream + replay drilldown | GET /v1/model-mount/receipts,/receipts/:id,/receipts/:id/replay (:738-743) | wired reads exist | wired-read (hashes behind proof drilldowns) |
+| Govern · learning-boundary badge on every job/spec/promotion pane | InstitutionalLearningBoundaryProfile projection · route-missing (W3) | absent | disabled-named-gap now; when wired, projection-only — **never ambient permission**, never a toggle (core-clients-surfaces.md:2527-2528, :1096-1099) |
+| Govern · promotion bundle queue / route-binding candidates | foundry.md:1973 · route-missing | absent | disabled-named-gap; W3 (activation decisions stay Governance) |
+| Govern · weight-custody + worker-package admission timelines | POST-only planners :1080, :1099 | invisible | wired-read over admission records (new read projection is part of the W3 row) |
+
+## 5. Ordered PR list
+
+1. **W0 (rides W0.2/W0.3)** — register Foundry in the product-surface
+   compiler feed; route `/foundry` in the v2 shell route table (bodies may be
+   read-first). No new daemon routes.
+2. **W1** — `/foundry` shell with the seven-section IA; Discover pane
+   wired-read over model-routes + overview + catalog search; honest-absence
+   panels (named, visible) for Train/Optimize/Promotion. Zero fixture data.
+3. **W1** — rehome the `/__ioi/foundry` specs/run-plans panes into
+   `/foundry` Build/Evaluate sections (read + draft forms preserved; seed
+   surfaces keep serving until cutover per the 6-step rule).
+4. **W1** — Govern pane read-first: model-mount receipts/replay reads,
+   projection, vault status; session-bindings list rendered via
+   `subject_attachments`.
+5. **W2** — Deploy pane authority actions via the CapabilityLease client:
+   route verbs (probe/enable/disable/select-default/create/patch/delete) and
+   model-mount lifecycle actions (downloads, instance load, runtime select,
+   storage cleanup, catalog import-url); every control receipted or
+   disabled-named-gap.
+6. **W2** — spec/run-plan mutation receipts: draft CRUD gains receipt refs
+   (or is demoted to disabled-named-gap until it does).
+7. **W3 (backend-first, serialized on hypervisor-daemon.rs)** — dataset
+   family (`foundry/dataset-factory-runs`, snapshots, candidate-data,
+   holdout custody); then training family (pipeline runs, trials,
+   checkpoints, teacher sessions); then deploy-lineage family (conversion
+   runs, registry versions, promotion bundles — read/propose only); then
+   optimizer cycles (advisory); each lands routes + registry schema + UI in
+   the same wave.
+8. **W3** — learning-boundary projection route + badge wiring across every
+   Foundry job/promotion pane (projection-only).
+9. **W4** — event consumption for probe/receipt/run updates moves to
+   `/v1/event-streams` + `/v1/subscriptions`; legacy model-mount SSE
+   (`/v1/model-mount/server/events` :642) wrapped, not extended.
+10. **W4** — cutover: `/__ioi/foundry*`, `/__ioi/foundry/models`, and the
+    Agent Studio `#model-routes` tab retire with typed 410s; `models` row
+    exits surface-registry; `/__apps/models`/`modelstudio`/`inference`
+    captures remain dormant T4 evidence; reconcile the two
+    `foundry_eval_training` profile_kind byte sites (connectors-tools
+    contracts.md:162, doctrine.md:156) in whichever PR touches those files.

--- a/internal-docs/implementation/surfaces/improvement.md
+++ b/internal-docs/implementation/surfaces/improvement.md
@@ -1,0 +1,208 @@
+# Improvement — implementation brief
+
+Canonical route: `/improvement` · Owner: Improvement (owner application)
+Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Improvement is the **safe-change cockpit**: it helps an accountable owner
+  decide what should improve, coordinate bounded work, compare immutable
+  candidates, and hand a supported change to the target owner's ordinary
+  governance path. It does not execute work, decide evaluation truth, possess
+  target authority, or activate a candidate (improvement.md:21-28). Suite-level
+  summary: core-clients-surfaces.md:2477-2492, :1348-1354; route ledger row
+  `/improvement` core-clients-surfaces.md:899; tool-surface row "Change Inbox
+  (legacy Upgrade Assistant) → Improvement / Changes"
+  core-clients-surfaces.md:1418.
+- Two proportionate paths, both canonical: **ordinary direct change** (evidence
+  → `UpgradeProposal` → `UpgradeDecision` → target-owner activation) and
+  **adaptive/multi-epoch improvement** (released `ImprovementAgenda` revision →
+  admitted `ImprovementCampaign` → GoalRuns → frozen `EvaluationEpoch`s →
+  attributable nomination → `UpgradeProposal`) (improvement.md:38-57). A
+  campaign is optional; the product must not force one around a one-shot patch
+  (improvement.md:59-64, :361-362).
+- Owns: immutable-by-revision agenda portfolios; campaign admission drafts and
+  workspaces; target/order graphs (seven non-collapsible coordinates,
+  improvement.md:194-208); candidate ancestry incl. rejected/inconclusive/
+  exploit attempts and negative knowledge; nomination bound to one frozen
+  epoch; `ImprovementOrderCutoffReceipt` synchronization; `UpgradeProposal`
+  construction; qualified `ImprovementEvidenceClaim`s; background-work
+  visibility (improvement.md:95-126).
+- Does not own: GoalRun/Session execution, candidate assets, evaluation truth,
+  wallet authority, Governance admission/activation/rollback/recall, Agentgres
+  truth, package release truth, or "a universal optimizer, recursive harness,
+  new runtime, new authority plane, or generic self-rewriting object"
+  (improvement.md:132-153).
+- Search/Judgment/Authority are separated rings: Search proposes, Judgment
+  freezes/applies contracts, Authority admits and activates; no coalition may
+  control the evaluator, meter, promotion authority, and recovery path that
+  canonicalize it (improvement.md:257-279).
+- Recommended IA: Overview · Agendas · Campaigns · Targets/Order Graph ·
+  Candidate Map · Plateaus/Negative Knowledge · Evaluation Posture (projection
+  from Evaluations) · Cutoffs/Synchronization Waves · Changes/Proposal Handoff ·
+  Release And Effect Recovery (projection from Governance) ·
+  Claims/Reproductions · History/Receipts (projection from Provenance)
+  (improvement.md:288-303).
+- **"Do not ship a universal Self-improve button."** Advanced views may expose
+  epochs, exposure, ancestry, order, and qualified claims "without presenting
+  them as ambient power" (improvement.md:317-319). Product copy must never
+  collapse the claim ladder into unqualified `RSI`/`self-improving` language
+  (improvement.md:349-353).
+- Implementation status per canon: a "narrow transitional improvement-proposal
+  and simulation/rollout slice" that must not be described as a general
+  recursive-improvement substrate (improvement.md:14-17).
+- Effectful-tooling gate applies to every cockpit verb
+  (core-clients-surfaces.md:4610-4612).
+
+## 2. Schema map
+
+| Canon object / contract | Canon block | Registry entry | Daemon route(s) today | Status |
+|---|---|---|---|---|
+| `ImprovementAgenda` (immutable revisions) | improvement.md:98-100, :408 | none | `route-missing` (grep clean for agenda/campaign) | **W3** |
+| `ImprovementCampaign` (frozen contract, owner, ceilings, coordinating GoalRun) | improvement.md:101, :155-183, :357-360 | none | `route-missing` | **W3** |
+| `UpgradeProposal` handoff (freezes campaign/epoch/candidate/diff/recovery) | improvement.md:120-122 | none | `route-missing` | **W3** |
+| `ImprovementOrderCutoffReceipt` | improvement.md:117-119, :245 | none | `route-missing` | **W3** (campaign family) |
+| `ImprovementEvidenceClaim` | improvement.md:123-125 | none | `route-missing` | **W3** |
+| ImprovementProposal (transitional slice, `ioi.hypervisor.improvement-proposal.v1`) | improvement.md:14-17 sanctions the slice | none | `/v1/hypervisor/intelligence/improvement-proposals` GET/POST (daemon:1699), `/:id` GET/PATCH (:1704), `/:id/approve` (:1717), `/:id/reject` (:1721), `/:id/apply` (:1725) | exists — approve/reject are **receiptless** state changes (ioi_intelligence_routes.rs:2531-2565, :2568-2601); apply mints `receipt://hypervisor/improvement/{id}` (:3170-3208) |
+| What-if simulation + report | improvement cockpit "what-if simulations" core-clients-surfaces.md:1352 | none | `/:id/simulate` (daemon:1709), `/simulation-reports/:id` (:1713); deterministic replay, `save:true` persists a receipted report (ioi_intelligence_routes.rs:3210-3217) | exists |
+| Apply gate (fresh simulation + approved ApprovalRequest + open ReleaseControl) | Governance gates and decides, core-clients-surfaces.md:1353-1354 | none | enforced inside apply via live-loaded gate inputs + proposal fingerprint (ioi_intelligence_routes.rs:2603-2625, :2940-2948) | exists — enforced |
+| `ImprovementGate` governance records | Governance owns admission (improvement.md:83-85) | none | `/v1/hypervisor/governance/improvement-gates` GET/POST, `/:id` GET/PATCH/DELETE (daemon:2011-2019) | exists — **records only, bounds not enforced** (governance_routes.rs:321) |
+| Candidate ancestry substrate (Attempt/Finding/WorkResult/OutcomeDelta) | improvement.md:106-111, :169-173, :211-216 | attempt.v3, finding fixtures (registry:191, :981) | attempts (daemon:2540-2553), findings (:2557-2570), work-results (:2328-2337), outcome-deltas (:2341-2346, per-goal-run :1834) | exists — read-first Candidate Map needs **no new backend** |
+| Outcome mining / review queue / intelligence graph | cockpit inputs; "background-work visibility" improvement.md:126 | none | `/v1/hypervisor/intelligence/outcome-mining` (:1695), `/review-queue` (:1729), `/graph` (:1733) | exists |
+| Release/effect-recovery projection | improvement.md:300, :329 | none | governance release-controls/approval-requests/kill-switches (daemon:2010 region; used by UI :9209, :9214) | exists — projection from Governance, never owned here |
+| Receipts on approve/reject transitions | core-clients-surfaces.md:4610-4612 | none | absent (only apply is receipted) | **W3** (small daemon addition; blocks W2 rehome of those verbs) |
+
+## 3. UI seed map
+
+- **T3 registered surface `changes`**, registry title "Upgrade Assistant",
+  owner Improvement, route `/__ioi/improvement/changes`
+  (surface-registry.mjs:62; GET handler serve-product-ui.mjs:8423-8431;
+  renderChangesPort :4215-4310). Pixel-faithful Upgrade Assistant inbox whose
+  DATA region is real improvement-proposal truth: one row per proposal with
+  kind pill, state + gate posture, and approval/release/simulation refs as the
+  proof trail (:4222-4228, :4282). Lanes Active/Past-due/Archived are live
+  `?lane=` links; Past-due is **honestly empty** — no due-date concept on the
+  plane (:4271-4275); UPGRADE-PROGRESS filter radios wired to `?filter=`
+  (:4227 comment block). **Read-only by design**: "no apply, no approve/reject,
+  no deploy, no release-gate mutation" (:4226-4228). Dead/named-gap chrome:
+  organization scoping, Admin/Assignee view toggles, search, sort
+  (:4291-4298). Census: 47 controls, 39 implemented, 12 daemon_read, 1
+  governed_receipted_action, 0 disabled_missing_authority (census:
+  control_census).
+- **The action lane lives in the wrong owner today**: Agent Studio's
+  `#improvement-proposals` panel (renderImprovementProposals :2677-2727)
+  carries Propose-from-mining (:2683), Simulate impact (:2689), Approve/Reject
+  (:2694), Apply (:2692), and the high-impact governance lanes
+  request-approval/open-release/attach (:2702-2710). POST handlers: propose
+  :9156-9178, simulate :9105-9110 (sends `save:true`), approve/reject/apply
+  :9251-9260, governance lanes :9198-9231 — all plain daemon fetches, fail
+  closed on refusal. Governance PATCH hardcodes
+  `reviewer_ref: "principal://operator"` (:9238) — free text, not a principal.
+- **Home tile** "Improvement" links into Agent Studio, not an Improvement route
+  (:1464).
+- **v2 SPA shell**: no `/improvement` route in `apps/hypervisor/src` (grep
+  clean); census agrees (census: `{"route": "/improvement", "resolves":
+  false}`).
+- Seed-preservation: `changes` is a protected route classed `daemon_wired`
+  (ported-seed-preservation.v1.json:37) — rehome, never rebuild.
+
+### Corrections vs v0
+
+- v0 said: backend = "improvement-proposals + approve/reject/apply/simulate,
+  improvement-gates, intelligence graph/review-queue/outcome-mining exist."
+  Bytes confirm, but v0 flattens **two distinct gate planes**: the
+  governance `improvement-gates` family is records-only — "bounds are
+  captured, not enforced" (governance_routes.rs:321) — while the *enforced*
+  gate is the intelligence apply path (fresh simulation fingerprint + approved
+  ApprovalRequest + open ReleaseControl, live-loaded at apply,
+  ioi_intelligence_routes.rs:2603-2625, :2940-2948). The cockpit must render
+  the enforced gate and not present the records plane as enforcement.
+- v0 said: "agenda/campaign objects are backend gaps (file family); wire
+  proposals inbox + what-if simulation views now." Confirmed for agendas/
+  campaigns (no routes, grep clean), but v0 omits that the **candidate-map/
+  negative-knowledge substrate already exists**: attempts, findings,
+  work-results, and outcome-deltas are live daemon planes
+  (hypervisor-daemon.rs:2540-2570, :2328-2346), so the Candidate Map and
+  Plateaus/Negative Knowledge IA sections are W1 read views, not W3 builds.
+- v0 implied the proposal verbs are ready to rehome as-is. Bytes: **approve and
+  reject are receiptless** state mutations (ioi_intelligence_routes.rs:
+  2531-2565, :2568-2601) — only apply mints a receipt (:3170-3208) and only
+  simulate persists a receipted report (:3210-3217). Rehoming approve/reject
+  under the effectful-tooling gate (core-clients-surfaces.md:4610-4612) needs
+  the small receipt addition first. Related census-vs-bytes note: the census
+  claim "every route + receipt already exists" (census:
+  missing_authority_contracts[0] for changes) is correct for routes, stale for
+  approve/reject receipts.
+
+## 4. Schema→UI binding table
+
+Reads use the W0.3 read-projection client; authority-crossing verbs use the
+CapabilityLease client (403 wallet challenge → 428 credential → receipted).
+Coordinating/child GoalRun and Session rows are projections; any
+session-serving row binds through `subject_attachments[]`
+(core-clients-surfaces.md:2683-2687, :3971-3990) — the improvement plane's own
+refs (`proposal_ref`, `target_ref`, evidence refs) stay on proposal records.
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| Changes/Proposal-handoff inbox (rows, lanes, gate posture, proof-trail refs) | improvement-proposals list w/ `gate` projection (daemon:1699; gate merge ioi_intelligence_routes.rs:2464-2474) | wired-read at `/__ioi/improvement/changes` (:8423-8431) | `wired-read` at `/improvement` |
+| Lane tabs + progress filter | query params, local | wired local view (:4301-4306) | local UI state (stays client-local) |
+| Past-due lane | due-date concept | honestly empty named gap (:4271-4275) | `disabled-named-gap` (no canon requirement; do not invent the field) |
+| Org / Admin / Assignee toggles, search, sort | principal-assignment + org planes | dead named-gap chrome (:4291-4298) | `disabled-named-gap` (principal plane is a separate program) |
+| Propose from mined candidate | POST improvement-proposals (daemon:1699; evidence_refs required, ioi_intelligence_routes.rs:2493-2500) | wired via Agent Studio (:9156-9178), unreceipted create | `wired-action-receipted` at `/improvement` via lease client |
+| Simulate impact | POST `/:id/simulate` `save:true` (daemon:1709) | wired via Agent Studio (:9105-9110); receipted report | `wired-action-receipted` (rehome) |
+| Simulation report drilldown | `/simulation-reports/:id` (daemon:1713) | not rendered | `wired-read` |
+| Approve / Reject | POST `/:id/approve`, `/:id/reject` (daemon:1717, :1721) | wired via Agent Studio (:9251-9260); **receiptless transitions** | `wired-action-receipted` after the W3 receipt row lands; until then `disabled-named-gap` on `/improvement` (defect named visibly) |
+| Apply | POST `/:id/apply` (daemon:1725; gate-enforced :2940-2948; receipt :3170-3208; protected seeds cloned never mutated :2996-3000, :3091-3113; canary/cohort variant + rollout provenance :3002-3075) | wired via Agent Studio | `wired-action-receipted` (rehome; render the gate decision and receipt ref) |
+| High-impact gate lanes (request approval / open release / attach refs) | POST governance approval-requests + release-controls + proposal PATCH (:9209, :9214, :9225) | wired via Agent Studio (:9198-9231) | `wired-action-receipted`; `reviewer_ref` becomes a real principal (today hardcoded `principal://operator`, :9238) |
+| Candidate Map + Plateaus/Negative Knowledge | attempts/findings/work-results/outcome-deltas (daemon:2540-2570, :2328-2346, :1834) | not rendered by any Improvement surface | `wired-read` (immutable DAG projection; archive never erased per improvement.md:365-366) |
+| Review queue pane | `/review-queue` (daemon:1729) | rendered inside Agent Studio panel data | `wired-read` (rehome) |
+| Outcome-mining pane | `/outcome-mining` (daemon:1695) | wired via Agent Studio (:2683) | `wired-read` + propose action per above |
+| Intelligence graph (proposal↔evidence↔receipt edges) | `/graph` (daemon:1733) | not rendered on an Improvement route | `wired-read` (shared plane; Improvement shows its slice) |
+| Agendas pane | `ImprovementAgenda` family | absent | `disabled-named-gap` until W3, then `wired-read` + authoring via lease client |
+| Campaigns pane (posture, ceilings, coordinating GoalRun, cutoffs) | `ImprovementCampaign` + `ImprovementOrderCutoffReceipt` | absent | `disabled-named-gap` until W3 |
+| Targets/Order graph | campaign order-assignment receipts (improvement.md:206-209) | absent | `disabled-named-gap` until W3 |
+| Evaluation Posture pane | projection from Evaluations (improvement.md:297; epoch family missing — see evaluations brief §2) | absent | `wired-read` over verifier-challenges projection now; epoch posture `disabled-named-gap` until the Evaluations W3 epoch family |
+| Release And Effect Recovery pane | governance release-controls/kill-switches reads | absent here (routes exist) | `wired-read` projection + deep link to `/governance`; never mutation from this pane |
+| Claims/Reproductions pane | `ImprovementEvidenceClaim` | absent | `disabled-named-gap` until W3 |
+| History/Receipts pane | receipts read surfaces (Provenance) | absent here | `wired-read` projection (proposal receipt refs already on records, :3193-3199) |
+| "Self-improve" affordance | improvement.md:317-319 | absent | never — `delete` on sight; no PR may add an ambient-power verb |
+
+New event consumption (proposal/gate state changes) rides `/v1/event-streams` +
+`/v1/subscriptions` (daemon:2350-2379); legacy per-resource SSE wrapped, not
+extended.
+
+## 5. Ordered PR list
+
+1. **W1** — `/improvement` read-first shell: Overview + Changes/Proposal-handoff
+   inbox rehoming the `renderChangesPort` truth (rows, lanes, gate posture,
+   proof-trail refs); IA panes for absent families rendered as named gaps; Home
+   tile retargeted from Agent Studio to `/improvement`.
+2. **W1** — Candidate Map + Plateaus/Negative Knowledge read views over
+   attempts/findings/work-results/outcome-deltas (immutable DAG projection,
+   archive preserved).
+3. **W1** — Review-queue, outcome-mining, graph-slice, and simulation-report
+   read views on `/improvement`; Release And Effect Recovery + History/Receipts
+   projection panes (governance + receipts reads, deep links out).
+4. **W3 (small daemon, serial on router)** — receipts on approve/reject
+   transitions (and proposal create), matching the apply receipt pattern
+   (ioi_intelligence_routes.rs:3170-3208); closes the effectful-tooling-gate
+   gap for those verbs.
+5. **W2** — action rehome via the CapabilityLease client: propose, simulate,
+   approve, reject, apply, and the high-impact governance lanes move from
+   `/__ioi/agent-studio` to `/improvement`; `reviewer_ref` becomes a principal;
+   every completed verb shows its receipt ref; Agent Studio panel reduced to a
+   link.
+6. **W3** — `ImprovementAgenda` family (immutable revisions), backend first,
+   then the Agendas pane.
+7. **W3** — `ImprovementCampaign` family (frozen contract, inherited ceilings,
+   coordinating-GoalRun ref, order-assignment receipt) +
+   `ImprovementOrderCutoffReceipt` + `UpgradeProposal` handoff object; then
+   Campaigns, Targets/Order Graph, and Cutoffs panes. Nomination must bind one
+   frozen `EvaluationEpoch` — sequence after the Evaluations epoch family.
+8. **W3** — `ImprovementEvidenceClaim` authoring + Claims/Reproductions pane
+   (qualified-claim language rules, improvement.md:338-353).
+9. **W4** — cutover per the 6-step rule: `/__ioi/improvement/changes` and the
+   Agent Studio improvement panels retire with typed 410s (pattern:
+   hypervisor-daemon.rs:610-612); release the seed-preservation row
+   (ported-seed-preservation.v1.json:37).

--- a/internal-docs/implementation/surfaces/packages.md
+++ b/internal-docs/implementation/surfaces/packages.md
@@ -1,0 +1,202 @@
+# Packages — implementation brief
+
+Canonical route: `/packages` · Owner: Packages (owner application)
+Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected where noted
+
+## 1. Canon digest
+
+- Packages is the **mandatory local lifecycle owner for reusable release
+  material**: package candidates, immutable admitted releases, dependencies,
+  installation bindings, serving eligibility, affected-System impact,
+  deprecation, disable, recall, revocation, rollback inputs, and the receipts
+  connecting those transitions (core-clients-surfaces.md:2536-2540). A package
+  may carry an application, RuntimeToolContract, Worker, GoalRunProfile
+  revision, WorkflowTemplate revision, HarnessProfile revision, SkillManifest
+  revision, AutomationSpec revision, ontology/DataRecipe bundle, System
+  profile, or generated interface without erasing that artifact's own
+  canonical contract (:2540-2545).
+- Packages contain immutable definitions, requirements, compatibility pins,
+  templates — **never** SkillEntries, ActiveSkillSetSnapshots, concrete MCP
+  gateway profiles, ContextLeases, RuntimeAssignments, authority grants,
+  connector credentials, or subject/session/run-scoped bindings (:2547-2553).
+- Package admission grants **no** runtime authority, live System, or
+  launchability. Installation and serving are explicit bindings evaluated
+  against org/Project/System/policy/capability/dependency/environment/
+  authority context. Agentgres retains admitted package/install truth;
+  daemon/Core executes admitted effects; wallet.network governs protected
+  authority; Packages supplies the lifecycle projection and requests owners
+  admit transitions (:2555-2561).
+- **Marketplace is an optional Packages mode** and distribution channel; a
+  private/air-gapped deployment retains complete package/release/install/
+  disable/recall/revocation semantics without it; a `Marketplace` entry point
+  resolves to `Packages / Marketplace` and never becomes a second package
+  owner (:2563-2568; route rule :901 — Marketplace mode at
+  `/packages/marketplace`; tool placement :1414).
+- **Recall and revocation are not cosmetic**: the product-surface compiler
+  must immediately remove ineligible launches, expose affected installs and
+  Systems, and route protected stop/rollback/migration/remediation through
+  their canonical owners; Packages must not silently mutate or terminate a
+  live System because one release changes state (:2570-2574; compiler rule
+  "Disable, recall, and revocation remove launch eligibility immediately"
+  :1982-1985).
+- Implementation status per canon itself: target owner; the unified Packages
+  workspace, admitted install registry, compiler integration, and
+  Marketplace-as-mode migration are **not yet shipped** (:2576-2579).
+- The normalized surface record family Packages projects: registration →
+  `HypervisorSurfaceReleaseRecord` (one immutable release; `package://.../release/...`)
+  → `HypervisorSurfaceInstallationBinding` (`install://...`) →
+  `HypervisorSystemInterfaceBinding` → `HypervisorSurfaceServingBinding`
+  (:1865-1875; object shapes :3561-3584, :3586-3605, :3607-3624, :3626-3639).
+  Ten independent state dimensions — a degraded install never becomes
+  uninstalled/unadmitted/recalled by inference (:1842-1851).
+- Adjacent ownership: extension applications are admitted and versioned by
+  Packages, distributed possibly by Marketplace (:1436-1439); GoalRunProfile
+  released revisions are versioned/distributed/recalled/revoked by Packages
+  (:2647-2649); ODK manifests surface through Packages (:935-939); the
+  Learning/Examples facet may appear inside Packages when a recipe can become
+  governed work (:2230-2233).
+
+## 2. Schema map
+
+| Canon object / contract | Canon block | Daemon route(s) today |
+|---|---|---|
+| Package (candidate → admitted immutable release) | core-clients-surfaces.md:2536-2545 | `route-missing` — **W3** (`/v1/hypervisor/packages` family) |
+| Release record (`package://.../release/...`, distribution, admission, disposition, capability depth) | :3561-3584 (HypervisorSurfaceReleaseRecord); census: 0 crates / 0 apps / 0 contract-registry (docs-only) | `route-missing` — **W3** |
+| Installation binding (`install://...`, install/enablement states, audience, allowed objects/actions) | :3586-3605 | `route-missing` — **W3** (worker-package admission below is a planner, not a registry) |
+| Deprecation / disable / recall / revocation transitions + receipts + affected-install/System impact | :2537-2540, :2570-2574 | `route-missing` — **W3** |
+| Compiler hook: recall/disable/revocation removes launch eligibility immediately | :1982-1988 | GET /v1/hypervisor/product-surface-projections exists (hypervisor-daemon.rs:1059) but consumes no package state — hook is part of **W3** |
+| Worker-package install **admission** (kernel planner: manifest/ontology/requirements/policy/receipt refs + wallet approval + gates; 202+record) | :2555-2558 | POST /v1/hypervisor/worker-package-install-admissions (hypervisor-daemon.rs:1099; lifecycle_routes.rs:6611-6631) |
+| Managed-worker lifecycle admission (state machine + authority/archive/restore/deletion controls) | :2555-2561 | POST /v1/hypervisor/managed-worker-lifecycle-admissions (hypervisor-daemon.rs:1103) |
+| MarketplaceListingDraft (kinds agent/domain_app/ontology_pack/data_recipe/foundry_capability) | :2563-2568 | hypervisor-daemon.rs:2027-2036 (list/create/get/patch/delete) |
+| MarketplacePublishCandidate + publish (invariant: domain_app + admitted review + open ReleaseControl + serving DomainAppRuntime) | :2563-2568 | :2038-2052; invariant enforced in marketplace_routes.rs:4-9, 264-291 |
+| MarketplaceAdmissionReview | :2570-2574 (admission before distribution) | :2053-2062 |
+| ManagedInstanceOffer (runtime_posture instantiated:false — no instance lifecycle) | :2555-2556 | :2064-2073; marketplace_routes.rs:13-18,48 |
+| Marketplace install/draft/job plane, product .zip upload/ingest, remote-store federation, cross-store search | :2563-2568 (distribution channel duties) | `route-missing` — **W3** (census `missing_authority_contracts`, 4 rows) |
+| Domain-app substrate backing publishable listings (mount/serve ladder) | :1853-1859 context | hypervisor-daemon.rs:1853-1884 |
+| ODK manifests (packaged through Packages) | :935-939 | hypervisor-daemon.rs:1602-1610 (reads); surface-descriptors :1633 |
+| GoalRunProfile released revisions (Packages versions/recalls/revokes) | :2647-2649 | `route-missing` — **W3** (no goal-run-profile routes exist; lands as a package payload kind, not a parallel registry) |
+
+`docs/architecture/_meta/schemas/` (158 files) contains **zero**
+package/release/install/marketplace schemas; the census's
+`registration_contract_implementation_status` shows all six surface-record
+families at 0 in crates/apps/contract-registry. Every W3 row above ships its
+JSON Schema + registry entry with the routes.
+
+## 3. UI seed map
+
+- **T3 registered surface `listings`** — surface-registry.mjs:58 (owner
+  "Marketplace", title "Marketplace", route `/__ioi/marketplace/listings`,
+  capabilities `["browse"]`). Storefront renderer serve-product-ui.mjs:
+  5345-5400 (handler :8779): store row is daemon truth (listing count /
+  published count); the install wizard band is reference chrome with the
+  honest note "Installing from this surface is a reference-only lane (named
+  gap)" (:5389). census: 33 controls — 16 implemented (4 daemon-read, 4
+  local-view), **0 governed-receipted**, 15 disabled-missing-authority, 9
+  reference-data-only — the estate's highest decorative ratio, confirmed.
+  **partial** (reads wired, all install/upload/federation/search lanes dead).
+- **T2 substrate readout `/__ioi/marketplace`** (renderer
+  serve-product-ui.mjs:6180-6275; handlers :9989-10120): store facets +
+  listing search (:6182-6189), listing draft create/edit/patch/delete
+  (:10004-10047), publish-candidate create (:10067-10087, auto-create on
+  publish-request :10037), admission-review create/delete (:10088-10095),
+  runtime-backed Publish button rendered only when the daemon says
+  `publishable` (:6247), managed-offer create/delete (:10096-…). All proxied
+  to the daemon marketplace family. **wired** (the one governed publish
+  ladder).
+- **T4 seed**: `/__apps/listings` vendor capture (store→product→detail→
+  Install ladder), preserved dormant; serve pins
+  `isUploadFromMarketplaceEnabled=false` (census). Work-ledger backlinks
+  resolve `marketplace-*` refs to `/__ioi/marketplace`
+  (serve-product-ui.mjs:5844, :1518-1519).
+- **No Packages UI exists at all**: no pane anywhere renders package,
+  release, install, deprecation, or recall state (the words exist only as
+  Foundry/worker admission copy). Canonical `/packages` and
+  `/packages/marketplace` do not resolve (census `canonical_target_routes`:
+  both `resolves: false`).
+- Daemon-side marketplace substrate is empty in the live estate (census
+  atlas: 0 listings / 0 published / 1 admitted review), so the storefront's
+  real-data path shows the honest empty state.
+
+### Corrections vs v0
+
+- v0 said: "no package/release/install/recall registry — the biggest single
+  backend build" — confirmed at the bytes (663-route sweep: no
+  `/v1/hypervisor/packages/*`), with one sharpening: **an install-admission
+  planner already exists** (POST /v1/hypervisor/worker-package-install-
+  admissions, hypervisor-daemon.rs:1099 — pure kernel planner, 202 + record,
+  wallet approval + policy gates, lifecycle_routes.rs:6611-6631). W3 must
+  build the durable registry (packages/releases/installs/recall + reads)
+  *around* this admission gate, not a second admission path.
+- v0 said: "marketplace routes" flatly — bytes show the marketplace plane is
+  10 routes with a **sharpened publish invariant already enforced**: a
+  `domain_app` listing publishes only with an admitted MarketplaceAdmissionReview
+  + an OPEN ReleaseControl + a backing DomainAppRuntime `mounted:true` and
+  `serving:true`; published = read-only distribution metadata, never
+  install/hire (marketplace_routes.rs:4-9, 264-291; hypervisor-daemon.rs:
+  2047-2052). The rehome must carry this ladder intact — it is the estate's
+  only working release-shaped flow and the seed for release-control wiring.
+- v0 said: "inherits `listings` surface (highest decorative ratio)" — census
+  bytes agree (15/33 disabled-missing-authority + 9/33 reference-data-only,
+  0 governed), but the *substrate sibling* `/__ioi/marketplace` is the real
+  inheritance: wired draft→candidate→review→publish→offer actions
+  (serve-product-ui.mjs:9989-10120). Both move under `/packages/marketplace`.
+- Packet said registered surfaces live at `apps/hypervisor/surfaces/<slug>/` —
+  bytes: `listings` has no module dir; registration + renderer live in
+  `scripts/surface-registry.mjs:58` and `scripts/serve-product-ui.mjs`.
+
+## 4. Schema→UI binding table
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| Packages catalog (all packages, disposition badges active/deprecated/superseded/recalled) | packages family · route-missing (W3) | absent | disabled-named-gap now → wired-read after W3 |
+| Release detail + lifecycle strip (immutable release, pins, dependencies, capability depth, admission state) | HypervisorSurfaceReleaseRecord :3561-3584 · route-missing (W3) | absent | wired-read after W3; lifecycle strip per canon :1156-1256 |
+| Installs view (org/project bindings, enablement, audience, affected Systems) | HypervisorSurfaceInstallationBinding :3586-3605 · route-missing (W3) | absent | wired-read after W3 |
+| Install action (bind release into org/project) | worker-package-install-admissions :1099 today; full family W3 | invisible (POST-only, no UI, no read-back list) | wired-action-receipted via authority client (403 wallet challenge → 428 credential → receipted 202 record); read-back list is part of W3 |
+| Deprecate / disable / recall / revoke verbs | recall transitions :2570-2574 · route-missing (W3) | absent | wired-action-receipted after W3; recall MUST drive the compiler hook (launch eligibility removed immediately, affected installs exposed; :1982-1985) — never silent System mutation (:2573-2574) |
+| Rollback / remediation handoffs from a recalled release | :2572-2573 | absent | disabled-named-gap (actions route to canonical owners — Governance/Operations — not executed by Packages) |
+| Marketplace mode `/packages/marketplace` · storefront browse + store facets + listing search | MarketplaceListingDraft · GET /v1/hypervisor/marketplace/listings, /overview (:2023-2036) | wired (storefront + substrate) | wired-read |
+| Marketplace · draft listing create/edit/delete (5 kinds, subject_ref resolved against real substrate) | :2027-2036; kind validation marketplace_routes.rs:40-46,155-190 | wired | wired-action-receipted |
+| Marketplace · publish candidate create + readiness reasons | :2038-2046; publishable computation marketplace_routes.rs:264-291 | wired | wired-action-receipted |
+| Marketplace · Publish (runtime-backed, domain_app-only) | POST :id/publish (:2047-2052) + publish receipts (`marketplace-publish-receipts`, marketplace_routes.rs:35) | wired | wired-action-receipted (the ladder is the seed for release-control integration) |
+| Marketplace · admission review create/decide | :2053-2062 | wired | wired-action-receipted (`reviewer_ref` becomes a principal per Governance brief) |
+| Marketplace · managed-instance offers | :2064-2073; instantiated:false invariant marketplace_routes.rs:13-18 | wired (draft only) | wired-action-receipted; instantiation stays out (no instance lifecycle here) |
+| Marketplace · Install-a-product flow (drafts/installed/jobs), .zip upload, remote stores, cross-store search | route-missing (census 4 missing-authority rows) | dead (reference chrome) | disabled-named-gap; install re-enters through the W3 packages install plane, not a marketplace-side install runtime |
+| Package payload drill-ins (GoalRunProfile / WorkflowTemplate / HarnessProfile / SkillManifest / AutomationSpec revisions, ODK manifests) | :2540-2545; odk manifests reads :1602-1610 | absent | wired-read links to payload owners after W3 (a package never erases the payload's own contract) |
+| Session/run-scoped rows (if any pane lists work serving a package) | C-1: `subject_attachments` only (:3971-3990) | n/a | any session-serving row binds through `subject_attachments`; packages never contain such bindings at rest (:2548-2553) |
+
+## 5. Ordered PR list
+
+1. **W0 (rides W0.2/W0.3)** — register Packages + the Marketplace-mode route
+   in the v2 shell + compiler feed (`/packages`, `/packages/marketplace`).
+2. **W1** — `/packages` read-first shell: honest-absence Packages catalog
+   (named gap panel citing the missing registry), plus working reads that
+   exist today — marketplace overview/listings, domain-apps, ODK manifests,
+   admission-record raw views where readable. Zero fixture data.
+3. **W1** — rehome the storefront + substrate under `/packages/marketplace`:
+   one surface, storefront browse + governed ladder together (reads first;
+   legacy `/__ioi/marketplace*` keeps serving until cutover).
+4. **W2** — marketplace ladder actions through the authority client with
+   receipts surfaced inline: draft/patch/delete, candidate create, review
+   decide, publish, offer draft; every other control disabled-named-gap.
+5. **W3.a (backend, serialized on hypervisor-daemon.rs)** — `packages/*`
+   family cut 1: Package + Release CRUD (draft → admitted immutable release),
+   JSON Schemas + contract-registry entries, receipts on every transition.
+6. **W3.b** — install plane: durable install bindings with read-backs,
+   fronted by the existing worker-package-install-admission planner as the
+   admission gate; enablement + audience + affected-System projection.
+7. **W3.c** — deprecation/disable/recall/revocation transitions + the
+   **compiler hook**: product-surface-projections (:1059) consumes package
+   state so recall removes launch eligibility immediately and exposes
+   affected installs/Systems; remediation verbs route to owners.
+8. **W3.d** — UI for W3.a-c in the same wave: catalog, release detail with
+   lifecycle strip, installs view, recall cockpit (read-first, then verbs).
+9. **W3.e** — Marketplace federation/install-visibility gaps re-filed over
+   the new registry (marketplace install views project `install://` truth;
+   upload/ingest lands as package-candidate intake, not a storefront `.zip`
+   lane).
+10. **W4** — package/release/install/recall event classes ride
+    `/v1/event-streams` + `/v1/subscriptions` (no per-resource SSE).
+11. **W4** — cutover: `/__ioi/marketplace` + `/__ioi/marketplace/listings`
+    retire with typed 410s; `listings` row exits surface-registry.mjs;
+    `/__apps/listings` capture stays dormant T4 evidence; Marketplace
+    resolves only as `Packages / Marketplace` (:2567-2568).


### PR DESCRIPTION
Wave item: Phase A per-surface implementation briefs (batch 2 of 4).

What became operational: the remaining six owner-application briefs now exist as byte-derived build maps with the same five-section contract as batch 1 — canon digests cited to file:line, schema maps marking route-missing families for the Wave 3 build-list (Evaluations epochs/holdouts/exposure ledger, Improvement agendas/campaigns, the full packages/* registry family, Foundry training/dataset families), binding tables with honest target states, and ordered PR lists. v0-guide corrections are recorded in each file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)