### PR TITLE
briefs(Phase A complete): work + home, surfaces _index, ledger regeneration

### DIFF
--- a/internal-docs/implementation/surfaces/_index.md
+++ b/internal-docs/implementation/surfaces/_index.md
@@ -1,0 +1,147 @@
+# Surface implementation briefs — index
+
+One brief per canonical surface under `internal-docs/implementation/surfaces/`.
+Each has the same five byte-derived sections: canon digest · schema map ·
+UI seed map (with corrections vs v0) · schema→UI binding table · ordered PR
+list. Authored 2026-08-05 (Phase A of the bring-to-life run,
+`internal-docs/overhaul/2026-08-05-hypervisor-bring-to-life-run.md`); each
+brief is refreshed against the bytes before its surface is built (Phase B).
+
+## File list and wave assignments
+
+| Brief | Route | Kind | Primary waves |
+|---|---|---|---|
+| [home.md](home.md) | `/home` | core workspace | W0.1 · W1 |
+| [systems.md](systems.md) | `/systems` | core workspace | W1 |
+| [projects.md](projects.md) | `/projects` | core workspace | W1 |
+| [applications.md](applications.md) | `/applications` | core workspace | W0.2 · W1 |
+| [work.md](work.md) | `/work` (owns `/work/sessions`) | core workspace | W0.6 · W1 · W3 (lineage) · W4 (Cut #2) |
+| [settings.md](settings.md) | `/settings` | core workspace | W0.5 · W4 |
+| [studio.md](studio.md) | `/studio` | owner application | W1 · W3 (blueprints) |
+| [automations.md](automations.md) | `/automations` | owner application | W0.6 (scheduler read) · W1 · W2 |
+| [ontology.md](ontology.md) | `/ontology` | owner application | W1 · W2 |
+| [data.md](data.md) | `/data` | owner application | W1 · W2 · W3 (sources CRUD) |
+| [governance.md](governance.md) | `/governance` | owner application | W0.6 (inbox) · W1 · W2 |
+| [provenance.md](provenance.md) | `/provenance` | owner application | W1 |
+| [evaluations.md](evaluations.md) | `/evaluations` | owner application | W1 · W3 (epochs/holdouts/challenges) |
+| [improvement.md](improvement.md) | `/improvement` | owner application | W1 · W2 · W3 (agendas/campaigns) |
+| [foundry.md](foundry.md) | `/foundry` | owner application | W1 · W2 |
+| [packages.md](packages.md) | `/packages` | owner application | W3 (registry family — biggest build) |
+| [developer-workspace.md](developer-workspace.md) | `/developer-workspace` | owner application | W1 |
+| [developer-console.md](developer-console.md) | `/developer-console` | owner application | W2 |
+| [environments.md](environments.md) | `/environments` | substrate | W1 · W2 |
+| [operations.md](operations.md) | `/operations` | substrate | W1 · W2 |
+
+Embodied Systems (`/embodied-systems`) is a reserved, nonlaunchable
+registration row in the compiler (planned) — no brief, no UI work.
+
+## Shared plumbing every brief assumes (Wave 0)
+
+- **W0.1** v2 route shell: the 23 canonical routes as the shell route table;
+  legacy `/__ioi/*` serves until each app's cutover; typed-410 per route at
+  cutover.
+- **W0.2** product-surface compiler v1: one projection feeding
+  nav/catalog/palette/launch from registration records; kills the
+  hand-maintained catalogs; Applications workspace is its first consumer.
+- **W0.3** read-projection client + authority client (CapabilityLease flow:
+  403 wallet challenge → 428 credential → receipted lease).
+- **W0.4** event client on the M5 plane (`/v1/event-streams`,
+  `/v1/subscriptions`); per-resource SSE wrapped, not extended.
+- **W0.5** identity truth: delete adapter identity constants +
+  `IDENTITY_REWRITES`; wire or kill the 5 fixture-only RPCs.
+- **W0.6** backend enablers (serialize — central router is a merge hotspot):
+  sessions/overview · unified approvals inbox · `GET /v1` capability index ·
+  scheduler status read.
+
+## Layering (C-1..C-4, canon 2026-08-05)
+
+Session-serving UI binds through `subject_attachments[]` (owner-registered
+`subject_kind`/`subject_ref`/`attachment_role`) — never a named app-family
+field; `foundry_eval_training` is retired; the thread plane is daemon-internal
+with Session as the single platform object over it. Byte sites still carrying
+retired fields are recorded in the briefs that own them and migrate at the PR
+that touches them.
+
+## Wave 3 build-list rollup (route-missing families found in Phase A)
+
+One line per surface; full detail in each brief's §2. W0.5/W0.6 items are
+marked — they land in Wave 0, not Wave 3.
+
+- **studio** — `studio/blueprints` draft CRUD + layout artifact +
+  promote-through-gates (composes governance approval-requests).
+- **automations** — AutomationInstallationBinding + spec revisioning ·
+  AutomationRun→Session/GoalRun lineage (daemon writes session
+  `subject_attachments` in the execution path) · object-set monitor triggers +
+  effect/step families · WorkflowTemplate read family + step-graph view ·
+  process-graph run/step/bind · **W0.6**: scheduler liveness status (schedule
+  posture already projected via `/v1/hypervisor/operations`).
+- **ontology** — proposal/branch/merge plane · object-instance search ·
+  per-principal saved explorations/object sets · action-type execution ·
+  receipt-on-delete fixes (domain-ontology delete is unreceipted today).
+- **data** — DataSource PATCH/DELETE · ingestion/extraction/connection-test
+  authority (daemon's own named `wired:false` boundary) ·
+  datasets/time-series/media-sets plane (needs Data-vs-Foundry owner ruling).
+- **governance** — **W0.6**: unified approvals-inbox (folds 4+2 decision
+  planes) · approval-transition-receipt read route · capability-lease
+  detail/revoke · reviewer-as-principal validation · retention/marking policy,
+  justification checkpoints, constitution/amendment history, network
+  enrollment (all zero-route today).
+- **provenance** — unified receipt-stream projection with principal
+  coordinates (today's readouts are local-operator-only) · optional
+  lineage-graph / learning-flow-graph projections.
+- **evaluations** — released suite-revision lifecycle (+
+  `verification_cost_class`) · EvaluationEpoch · sealed-holdout custody ·
+  EvaluationExposureLedger · evaluator dependency/validity graph ·
+  re-verification / affected-result discovery · run/scorecard family ·
+  mutation-receipt family (defect: live receiptless creates/deletes).
+- **improvement** — ImprovementAgenda · ImprovementCampaign +
+  order-assignment receipts · ImprovementOrderCutoffReceipt · UpgradeProposal
+  handoff object · ImprovementEvidenceClaim · approve/reject/create receipt
+  family (approve/reject are receiptless today).
+- **foundry** — datasets (factory runs/snapshots/candidate data/holdouts) ·
+  training/tuning (pipeline runs, trials, checkpoints, teacher sessions) ·
+  experiment-optimization cycles · deploy lineage (conversion runs, registry
+  versions, promotion bundles) · Foundry-side eval assets · learning-boundary
+  projection route. (No training/dataset routes exist anywhere today.)
+- **packages** — the whole `packages/*` registry family (package, immutable
+  release, install bindings, deprecation/disable/recall/revocation +
+  receipts) building around the existing install-admission planner · compiler
+  recall hook into product-surface-projections · marketplace
+  install/upload/federation/search lanes re-filed over the registry.
+- **developer-workspace** — editor-access-lease GET list · environment backup
+  list + restore-prepare/apply/cancel ladder.
+- **developer-console** — conformance / developer-app registration ·
+  developer-kit on-ramps · inbound webhook/service registry (scope against
+  Automations' webhook ownership first).
+- **environments** — HypervisorEnvironmentRouteBinding routes ·
+  service/task start-stop · `mark_active` + activity signals · evidenced
+  project discovery + `create_from_context_url` · cleanup-obligation verbs ·
+  env-scoped ScmAuthRequirement · **W0.5**: two adapter lies
+  (CreateEnvironmentLogsToken fabrication, MarkEnvironmentActive no-op).
+- **operations** — unified infrastructure-jobs projection (subjects via
+  `subject_attachments`) · capacity/utilization overview · RPO/RTO +
+  degraded/partition rollup · **W0.6**: scheduler read surface.
+- **systems** — System interface-binding plane (schema exists, zero rows/
+  routes/compiler join) · registry entry for the read-projection contract.
+- **projects** — HypervisorProjectDiscoveryProposal family · project
+  PATCH/update plane · receipts on create/delete.
+- **applications** — dynamic registration/admission family (extension+tool
+  CRUD, install/enable/recall verbs, durable storage replacing
+  `include_str!`) · compiler grouping + policy filtering + system-interface
+  join (sequenced with the Packages registry build).
+- **settings** — **W0.5**: org identity read record (whoami exists, org
+  record doesn't) · org-policy defaults family · preference scope+schema
+  listing · delivery-channels family (Automations-owned) · learning-boundary
+  org default (Governance-owned, governed-upgrade-proposal on change).
+- **work** — **W0.6**: sessions/overview · session
+  lineage/fork/children/transition/history family (the one first-class family
+  with none) · `subject_attachments` field on daemon session records (C-1
+  backend; three retired named-field sites recorded) ·
+  HypervisorWorkQueue/WorkItem object family · unified work-subject/facet
+  projections · `hypervisor-session` JSON Schema registry gap · execution
+  loop Cut #2 (W4).
+- **home** — `home-cockpit` + `session-operations` projections (documented in
+  daemon-runtime/api.md, absent from the daemon; Home composes 7 per-family
+  reads client-side today). Note: the live `/automations` redirect hijacks a
+  canonical v2 route into `/__ioi/automations` — deleted at Automations
+  cutover.

--- a/internal-docs/implementation/surfaces/home.md
+++ b/internal-docs/implementation/surfaces/home.md
@@ -1,0 +1,191 @@
+# Home — implementation brief
+
+Canonical route: `/home` · Owner: core workspace Home
+Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected where noted
+
+Canon cites are `docs/architecture/components/hypervisor/core-clients-surfaces.md` unless
+prefixed (`api.md:` = `docs/architecture/components/daemon-runtime/api.md`), and resolve against
+the blob at commit `21ae389fe` (branch `overhaul/bring-to-life-charter`); daemon and
+`apps/hypervisor/` bytes are identical between `21ae389fe` and master `1ff32a1a3`. Daemon cites are
+`crates/node/src/bin/hypervisor-daemon.rs`. UI cites are under `apps/hypervisor/`. Census cites
+(`census:`) are the 2026-07-30 inventory and are seed only; bytes win.
+
+## 1. Canon digest
+
+- Home is the default command and resume surface (core-clients-surfaces.md:1545-1547) on
+  canonical route `/home` (:884; workspace row with `canonical_route: "/home"` served in the
+  core-taxonomy contract, api.md:1014).
+- Home may accept goal prompts, show recent typed Work subjects, surface waiting approvals, and
+  route the user into a System, Project, Automation, Application, GoalRun, OutcomeRoom, Session,
+  receipt, or replay. Home may draft work but must NOT become the durable owner of systems,
+  goals, automations, projects, or sessions (:1565-1569). Avoid: durable automation owner,
+  ioi.ai chat replacement, default deploy-as-service funnel (:1584-1590); Home ≠ dense
+  terminal/diff/file console — dense panes belong in Project / Developer Workspace / Session /
+  Open Application contexts (:1571-1574; anti-pattern :4725).
+- Correct behaviors: Home starts or resumes governed work; Home can ask Core to create a New
+  Session; Home can draft an Automation or Foundry job for review (:1576-1582).
+- Home registers as a core workspace, never an application (:4545-4546);
+  `HypervisorCoreWorkspaceRegistration` is projection-only + writes-through-owners (:3468-3478);
+  no second "Home" entry in the Applications launcher (:1562-1563).
+- Canon's own implementation-status paragraph records today's Home: an owned EXPLORER over the
+  shell at `/ai` (rail Home destination), built from shell design tokens
+  (`renderExplorer`/`applyAiViews` in `apps/hypervisor/scripts/augmentation/`, "owns no truth"):
+  welcome hero with live summary; get-started actions (New Session / Applications / Automations);
+  first-class governed-work rows (approvals waiting, runs parked at a wallet gate incl.
+  `awaiting_authority_*` failover runs, failed runs — each opening the OWNING surface, collapsing
+  to one all-clear line, naming a daemon outage rather than papering over it); Recent tabs
+  (sessions/projects/runs) with honest empty states; the Applications estate grid; expanding
+  into the owned full readout `/__ioi/home` (:1549-1563).
+- The composer is deliberately NOT the home page — it is New Session (:1562-1563). New Session
+  is a one-click action whose canonical route is `/work/new-session` (:885, "remains a one-click
+  action"); it may create only a bounded Session, never an implicit Goal/Automation/System
+  (:1478-1482; conformance :4549-4551; anti-pattern :4765). The composer carries two explicit
+  semantic acts: ordinary submission = New Session; a separately labelled **Activate Goal**
+  affordance may draft/review/submit a `GoalRunActivationEnvelope` with
+  `source_kind: ioi_goal_draft` — typing, submission, correlation, or attachment is never the
+  activation act (:1530-1543).
+- **Fallback-fixture rule (the canon cite):** "Client fallback fixtures may keep the UI usable
+  while the daemon is offline, but the fixture source must be visible and must not be presented
+  as admitted runtime truth" — api.md:167-169, stated inside the Home-cockpit projection
+  contract. The projection contract itself: `GET /v1/hypervisor/home-cockpit` returns
+  `ioi.hypervisor.home_cockpit_projection.v1` with `boundary_invariant: "Home renders daemon
+  evidence projections; it does not become runtime truth."` and metrics whose `detail_route`
+  targets canonical routes (example `/work/sessions/…`) (api.md:132-164). A sibling
+  `GET /v1/hypervisor/session-operations` projection is specified at api.md:171-181.
+- Home's client class: read models only; "these endpoints are read models for clients; they do
+  not move runtime truth into the client" (api.md:127-129).
+
+## 2. Schema map
+
+| Canon object / contract | Registry / canon block | Daemon route(s) today | Gap wave |
+|---|---|---|---|
+| HypervisorCoreWorkspaceRegistration (home row) | canon :3468-3478; taxonomy row api.md:1014 | `GET /v1/hypervisor/core-taxonomy` hypervisor-daemon.rs:1056 | — |
+| `ioi.hypervisor.home_cockpit_projection.v1` | api.md:132-169 (no JSON Schema in `_meta/schemas/`) | route-missing — zero `home-cockpit`/`home_cockpit` hits in `crates/` | **W3** (W0.6-class small route; serial on the router file) |
+| `hypervisor_session_operations` projection | api.md:171-181 | route-missing — zero `session-operations` hits | **W3** |
+| Product-surface projection (Applications grid) | `hypervisor-product-surface-projection.v1.schema.json`; canon :1964-2009 | `/v1/hypervisor/product-surface-projections` :1060; surface-descriptors :1634 | — (compiler wiring = W0.2) |
+| Governed-work row sources | — | approval-requests :1963; failover runs :2630; operations :1314 | — |
+| Recents sources | — | sessions :3190; projects :1128; work-ledger :1309; automations/:id/runs :1284 | — |
+| Identity for the hero/summary | — | `/v1/hypervisor/auth/whoami` :3352 | — |
+| New Session create | canon :1478-1521 | `POST /v1/hypervisor/sessions` :3190 | — |
+| Activate Goal affordance | canon :1530-1543; `goal-run-activation.v1.schema.json` (+ receipt schema) | goal-run-activations :1809; `:id` :1813; `:id/submit` :1817 | — |
+| Home event freshness | M5 plane | `/v1/event-streams/...` :2350-2360 + `/v1/subscriptions/...` :2363-2379 | — (W0.4 client) |
+| Retired-route refusal (`/__ioi/*` at daemon) | `ioi.hypervisor.route_retirement_refusal.v1` | `/__ioi/*path` typed 410 at the daemon :612 (the UI serve process still serves `/__ioi/home` itself) | — |
+
+## 3. UI seed map
+
+- **`/home`: absent everywhere.** census: `/home` `resolves: false`; grep finds no `/home`
+  handler in `scripts/serve-product-ui.mjs`, the augmentation modules, or `src/`. The Home graft
+  has NOT moved to `/home` — it still lives at `/` + `/ai`.
+- **Owned explorer Home (wired, read-first):** `augmentation/40-home-explorer.js` — identity
+  comment "THE Home (rail Home, /ai with no hash) is an owned EXPLORER … The explorer owns no
+  truth: every affordance routes to the owning surface, missing projections are named, nothing
+  is fabricated" (:1-8). Composes SEVEN daemon reads client-side: approval-requests,
+  failover/runs, operations, work-ledger, sessions, projects, whoami (:14-21, 15s cache :11).
+  Governed-work rows: pending approvals → Governance, `awaiting_authority_*` failover runs →
+  Operations, failed runs → Operations (:45-60). Honest degradation: "Projection unavailable —
+  the daemon did not answer" (:94) and "Daemon unreachable — governed-work status unavailable.
+  Nothing is shown rather than fixtures." (:119) — the fallback-fixture rule already implemented.
+  Goal-prompt submit POSTs `/v1/hypervisor/sessions` (:328). "Sessions →" deep link still targets
+  `/__ioi/sessions` (:303 — retirement site, see work.md). census: 87 controls, 1 disabled.
+- **Full readout `/__ioi/home` (wired):** `renderHome` (serve-product-ui.mjs:1050; route
+  :8675-8683) reads operations, work-ledger, sessions, approval-requests, failover-runs;
+  "Fetches fail to null (NOT {}) so the renderer can distinguish daemon-down" (:8669-8671
+  comment). census: 27 controls, 0 disabled. Standing verifier:
+  `scripts/verify-hypervisor-home-surface.mjs`.
+- **New Session composer:** the SPA's polished composer page at `/ai#new-session`; the rail's
+  create-session button and Ctrl+O are intercepted and routed there
+  (60-shell-wiring.js:18-22, `goComposer()`); the Advanced-launch affordance opens the owned
+  governed launcher modal — registry-fed harness/model options DISABLED WITH THEIR REASON, launch
+  preview naming admission/receipts/isolation/restore before the effectful call
+  (50-new-session.js:1-24). census: composer 29 controls.
+- **Home automations redirect (inherited BY Automations, carried in Home's shell):**
+  `80-automations.js:4-18` — a capture-phase click handler hijacks every `a[href="/automations"]`
+  and rewrites navigation to `/__ioi/automations` ("beat the SPA router" :16). `/automations` is
+  one of only TWO canonical routes that resolve today (census: `/projects`, `/automations`).
+- **Applications estate grid:** hand-maintained 15-tile list `IOI_APPS`
+  (30-shell.js:5-20) still using the retired taxonomy — "Missions" → `/__ioi/sessions` (:11),
+  "Marketplace" (:15), "Workbench" (:16) — one of the three hand-maintained catalogs the W0.2
+  compiler kills.
+- **Fixture lane:** `product-ui/server.cjs` mock branches exist estate-wide (deleted at W4 per
+  the master ladder); the explorer/readout Home paths above do not read them.
+
+### Corrections vs v0
+
+- v0 treats the Home fallback-fixture rule as a standing generalization without a cite — bytes
+  locate the canon rule at **api.md:167-169** (inside the home-cockpit projection contract), and
+  it is already implemented verbatim in the live explorer (40-home-explorer.js:119 "Nothing is
+  shown rather than fixtures."). It is NOT in core-clients-surfaces.md (grep: no Home-rule
+  "fixture" hit there).
+- The documented Home read surface is unimplemented: `GET /v1/hypervisor/home-cockpit`
+  (api.md:132) and `GET /v1/hypervisor/session-operations` (api.md:172) have ZERO route hits in
+  `crates/` — the live Home instead composes 7 per-family reads client-side
+  (40-home-explorer.js:14-21). v0's W0 list does not name this route-missing pair; they feed the
+  Wave 3 build list.
+- The explorer-Home graft has not moved: it is still `/` + `/ai` via augmentation
+  (40-home-explorer.js:1-8), `/home` resolves nowhere (census + grep), and canon's own Home
+  implementation-status paragraph still names `/ai` (:1549-1550) while the route ledger demands
+  `/home` (:884) — the brief's job is a rehome at W0.1, plus a one-line canon status refresh at
+  cutover.
+- v0 says Automations "inherits … the Home automations redirect" — bytes sharpen this: the
+  redirect (80-automations.js:4-18) actively hijacks the CANONICAL `/automations` route (one of
+  the only two resolving v2 routes, census) into `/__ioi/automations`. At the v2 cutover this
+  augmentation must be deleted or it will fight the v2 shell's own router; recorded here because
+  the code rides Home's shell augmentation stack.
+
+## 4. Schema→UI binding table
+
+Reads use the W0.3 read-projection client; the only effectful controls on Home are launches
+routed to owners (New Session create; Activate Goal submit), which cross through the
+CapabilityLease client (403 wallet challenge → 428 credential → receipted). Recent-session rows
+are session-serving display: their subject chips bind through `subject_attachments` once the W3
+C-1 row lands (see work.md) — never a named app field.
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| `/home` route + workspace chrome | core-taxonomy workspace row :1056 / api.md:1014 | absent (`/ai` only) | wired-read (W0.1 rehome) |
+| Welcome hero + live summary | whoami :3352 + composed counts | wired at `/ai` (40-home-explorer.js) | wired-read (keep; swap onto read client) |
+| Home-cockpit metrics strip | `home_cockpit_projection.v1` api.md:143-164 | route-missing | disabled-named-gap → wired-read after W3 route |
+| Get-started: New Session | :885, :1478-1482; composer + modal | wired to `/ai#new-session` (60-shell-wiring.js:18-22) | wired-read link → `/work/new-session` |
+| Get-started: Applications | product-surface-projections :1060 | modal over hand list (30-shell.js:5-20) | wired-read (compiler projection, W0.2) |
+| Get-started: Automations | `/automations` canonical | redirect hijack (80-automations.js:4-18) | wired-read link to canonical route; delete the hijack at Automations cutover |
+| Governed row: approvals waiting | approval-requests :1963 | wired (:45-53), deep-link `/__ioi/governance` | wired-read; deep-link → `/governance` at cutover |
+| Governed row: runs parked at wallet gate | failover runs :2630 (`awaiting_authority_*`) | wired (:48, :54-57) | wired-read; deep-link → `/operations` |
+| Governed row: failed runs | operations :1314 | wired (:49, :58-60) | wired-read |
+| All-clear line / daemon-outage line | fallback-fixture rule api.md:167-169 | wired (:94, :119) | wired-read (KEEP behavior; it is the canon rule) |
+| Recent tabs: sessions / projects / runs | sessions :3190; projects :1128; work-ledger :1309 | wired with honest empties; "Sessions →" → `/__ioi/sessions` (:303) | wired-read; deep-links → `/work/sessions`, `/projects`, `/work/history` |
+| Goal prompt (ordinary submit) | POST sessions :3190 (bounded Session only :1478-1482) | wired (:328) | wired-action-receipted (lease client; provision receipt exists) |
+| Activate Goal affordance | :1530-1543; goal-run-activations :1809-1817 | absent (explorer has no activation act) | wired-action-receipted (W2; must show normalized intent, profile revision/hash, principal, authority posture, review requirement, source binding BEFORE submit :1536-1540) |
+| Applications estate grid | product-surface projection :1060; canon :1964-2009 | hand list w/ retired names, "Missions" tile → `/__ioi/sessions` (30-shell.js:11) | delete hand list; wired-read from compiler (W0.2); retired-name tiles die with it |
+| `/__ioi/home` strips (decisions/blocked/resume/newest-proof) | renderHome :1050, :8675-8683 | wired | wired-read rehomed into `/home` body; readout retired at W4 |
+| Live freshness (row updates) | event plane :2350-2379 | absent (15s poll cache, 40-home-explorer.js:11) | wired-read via W0.4 event client |
+| Session-operations pane | api.md:171-181 | route-missing | disabled-named-gap → W3 |
+
+## 5. Ordered PR list
+
+1. **W0.1** — v2 shell serves `/home` rendering the owned explorer body (rehome from `/ai`;
+   `/ai` keeps serving until cutover per the seed-preservation invariant). Honest
+   empty/degraded states carry over unchanged.
+2. **W0.2** — Applications grid + get-started tiles read the product-surface compiler projection
+   (`/v1/hypervisor/product-surface-projections` :1060); delete the `IOI_APPS` hand list
+   (30-shell.js:5-20) — this also removes the "Missions" tile advertising `/__ioi/sessions`.
+3. **W1** — Governed-work rows + Recent tabs onto the W0.3 read client with canonical deep-links
+   (`/governance`, `/operations`, `/work/sessions`, `/projects`, `/work/history`); the
+   `/__ioi/*` deep-links die per-app as each owner cuts over.
+4. **W1** — Rehome the `/__ioi/home` readout strips (decisions / blocked / resume / newest-proof,
+   renderHome :1050) into the `/home` body as a second read-first band; keep the readout
+   serving until W4.
+5. **W0.4 rider** — Home rows subscribe on `/v1/event-streams` + `/v1/subscriptions`
+   (:2350-2379) replacing the 15s poll; per-resource SSE not extended.
+6. **W2** — New Session one-click: `/home` action routes to `/work/new-session` (:885); launch
+   crosses via the CapabilityLease client; Advanced-launch keeps the owned governed modal
+   (50-new-session.js) as the single daemon-backed launch lane.
+7. **W2** — Activate Goal affordance over goal-run-activations :1809-1817 with the full
+   pre-submission disclosure contract (:1536-1540); receipted; never triggered by ordinary
+   submission.
+8. **W3** — Backend: `GET /v1/hypervisor/home-cockpit` per api.md:132-169 (+ optional
+   `session-operations` api.md:171-181); then wire the metrics strip. Serial on
+   hypervisor-daemon.rs (router hotspot). Register the projection schema in `_meta/schemas/`.
+9. **W4** — Cutover: `/ai` alias retired with the typed refusal pattern; `/__ioi/home` retired
+   after parity + no-fallback proof (6-step rule); delete the `/automations` click hijack
+   (80-automations.js:4-18) in the same wave as the Automations cutover; refresh the canon Home
+   implementation-status paragraph (:1549-1563) to name `/home`.

--- a/internal-docs/implementation/surfaces/work.md
+++ b/internal-docs/implementation/surfaces/work.md
@@ -1,0 +1,254 @@
+# Work — implementation brief
+
+Canonical route: `/work` · Owner: core workspace Work (owns the Sessions view at `/work/sessions`)
+Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected where noted
+
+All canon cites are `docs/architecture/components/hypervisor/core-clients-surfaces.md` unless
+prefixed, and resolve against the blob at commit `21ae389fe` ("canon(C-1..C-4) + charter",
+branch `overhaul/bring-to-life-charter`) — a master working tree that lags that commit will not
+contain the C-1..C-4 blocks (verified: daemon + `apps/hypervisor/` bytes are identical between
+`21ae389fe` and master `1ff32a1a3`; only the canon .md differs). Daemon cites are
+`crates/node/src/bin/hypervisor-daemon.rs` (router) and
+`crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs` (handlers). UI cites are under
+`apps/hypervisor/`. Census cites (`census:`) are the 2026-07-30 inventory
+(`internal-docs/audits/2026-07-30-hypervisor-surface-end-state-audit/inventory.v1.json`) and are
+seed only; bytes win.
+
+## 1. Canon digest
+
+- Work is the unified core workspace for starting, supervising, inspecting, intervening in,
+  reviewing, replaying, and resuming heterogeneous work — a policy-filtered read model, never a
+  canonical `Work` object or one universal lifecycle (core-clients-surfaces.md:1675-1680;
+  anti-pattern "Work = universal canonical status" :4761; object table row :3282).
+- Eight typed views: Active, Goals, Sessions, Rooms, Queues, Reviews, Incidents, History
+  (:1682-1691) on routes `/work` (= Active), `/work/goals`, `/work/sessions`, `/work/rooms`,
+  `/work/queues`, `/work/reviews`, `/work/incidents`, `/work/history` (:1711-1720). Route-ledger
+  rule: "typed views only; Sessions is `/work/sessions`" (:889).
+- Every row declares typed `subject_kind` + canonical `subject_ref` and deep-links to the
+  type-specific owner; Work derives display facets but never writes one common status back; policy
+  filtering occurs BEFORE search, counts, recents, aggregation, and caching (:1693-1697). Row and
+  facet contracts: `HypervisorWorkSubjectProjection` (:4325-4344, `read_model_only: true`) and
+  `HypervisorWorkFacetProjection` (:4346-4369 — a policy-filtered cross-owner pointer only).
+- No `/sessions` or `/missions` alias routes; retired paths are deleted, not aliased (ADR 0022
+  Decision 2) (:1722-1725, :877-879). Typed details resolve beneath views:
+  `/work/queues/{work_queue_id}`, `/work/reviews/{facet_projection_id}`,
+  `/work/incidents/{facet_projection_id}`; a review/incident detail is a read-only facet that
+  deep-links to its owner and mints no generic subject (:1726-1731; conformance :4589-4592).
+- Work registers as a core workspace, not an application; Sessions remains a typed execution
+  object and Work view, never a peer application registration (:4545-4548). Registration is
+  projection-only + writes-through-owners (`HypervisorCoreWorkspaceRegistration` :3468-3478);
+  route resolution fails typed, `accepts_retired_route_spellings: false` (:3480-3487).
+- Sessions canon: bounded governed interactive|headless|supervisory execution/control contexts
+  (:2663-2667); kinds are mechanical execution contexts, workloads are typed subject attachments
+  (:2683-2686). The C-1..C-4 spine:
+  - C-1 `subject_attachments[]` (owner-registered `subject_kind` + `subject_ref` +
+    `attachment_role`) is the ONLY way a Session names the work it serves; the platform never
+    names an application family as a dedicated field (:2692-2696, :3971-3984).
+  - C-2 `foundry_eval_training` is retired from `session_kind` (:3960-3968).
+  - C-3 thread/thread-fork/managed-session/session-launch-recipe/harness-session-binding records
+    are ONE daemon-internal execution substrate; product surfaces compose them by read only; no
+    surface may treat the thread plane as a second public spine (:3320-3328; ADR 0031 :3311-3318).
+  - C-4 any UI/daemon bytes still carrying named app fields migrate at the PR that touches them
+    (sites recorded in section 4).
+- The master guide's D-labels resolve to these canon blocks (the guide is seed, these are the
+  authority): D4 = the "A Session binds" field list (:2688-2704, minimal object :3955-4010);
+  D5 = the Session view contract — transcript, step graph, tool/model calls, terminal/browser
+  activity, authority gates, privacy posture, provider/environment state, logs, traces, receipts,
+  state roots, replay availability, promotion options (:2706-2710); D6 = one coherent
+  trace/replay path — waterfall of spans + detail drawer, proof as drilldown not default
+  (:2712-2718); D7 = the stable `HypervisorWorkRun` view (:2720-2727, object :4222-4284);
+  D8 = OutcomeRoom participant/claim/attempt drilldown — claim, lease, heartbeat/wake, spend,
+  evidence, verification, blocker, cancellation/quarantine projections, never only transcript
+  tokens (:2729-2733).
+- Work / Room detail is graph-first (objective/frontier/participants/claims/evidence/lineage/
+  replay); live feed or chat is a social projection over the graph (:3330-3343). Mission is
+  retired as an owner: optional label/preset resolving to exactly one typed GoalRun or OutcomeRoom
+  subject, no independent id/lifecycle/receipts (:3343-3352); new writes must not create
+  `HypervisorMission` or `mission://` (:4638; anti-pattern :4766).
+- Relationship model: GoalRun → zero or more Sessions; Session → zero or more WorkRuns; WorkRun →
+  results/evidence/receipts (:3295-3309). A direct Session may exist without a GoalRun (:3305-3307).
+- New Session is a one-click action at `/work/new-session` (:885) and may create only a bounded
+  Session (:1478-1482; conformance :4549-4551; anti-pattern :4765). Composer identity and the
+  separate Activate Goal affordance: :1523-1543 (advertised from Home — see `home.md`).
+- Supporting Work objects: `HypervisorWorkQueue` (:4175-4190), `HypervisorWorkItem` (:4192-4220),
+  `HypervisorWorkRunConversationProjection` (:4286-4298), `HypervisorWorkRunIntegrationStatus`
+  (:4300-4310), `HypervisorWorkRunReviewState` (:4312-4323), `HypervisorOutcomeRoomProjection`
+  (:4376-4388). Note: WorkItem/WorkRun legitimately carry `goal_run_ref`/`outcome_room_ref`/
+  `automation_run_ref` (:4197-4199, :4227-4231) — the C-1 retirement is of named app fields on
+  the SESSION object, not on WorkItem/WorkRun contracts.
+- Implementation status per canon: target contract — "the existing Sessions root, jobs, GoalRun
+  views, automation-run views, and issue/blocker aggregates are migration inputs" (:1704-1706).
+
+## 2. Schema map
+
+| Canon object / contract | Registry / canon block | Daemon route(s) today | Gap wave |
+|---|---|---|---|
+| HypervisorCoreWorkspaceRegistration (work row) | canon :3468-3478; served in core taxonomy | `/v1/hypervisor/core-taxonomy` hypervisor-daemon.rs:1056; workspace row w/ `/work` documented daemon-runtime/api.md:1018 | — |
+| HypervisorSession | canon :3955-4010; NO schema in `docs/architecture/_meta/schemas/` (no `hypervisor-session.*.schema.json`) | `/v1/hypervisor/sessions` GET+POST :3190; `:id/events` :3195; `:id/execute` :3199; `:id/ports/revoke` :3203; `:id` GET+DELETE :3207 | schema-registry gap (W3, one-file PR) |
+| Sessions overview | none | route-missing (only ODK connector-sessions have `/overview` :1547; pattern exists: work-results/overview :2333, outcome-rooms/overview :2388) | **W0.6** (`GET /v1/hypervisor/sessions/overview`) |
+| Session lineage / fork / children / transition / history | none | route-missing (grep: no `sessions/:id/{lineage,fork,children,transition,history}`) | **W3** |
+| `subject_attachments` on session records | canon :3971-3984 | field-missing — zero `subject_attachments` hits across `hypervisor_daemon_routes/*.rs` | **W3** (C-1 backend) |
+| SessionExecutionBinding (session/env/thread/work_run composition) | daemon comment "T7-2" hypervisor-daemon.rs:2878 | create :2880; get :2884; events :2888; input :2892; stop :2896; archive :2900; restore :2904 | — |
+| Session launch recipe admission | `hypervisor-session-launch-recipe-admission.v1.schema.json`; canon :2957-2973 | POST `/v1/hypervisor/session-launch-recipe-admissions` :1084 | — |
+| HarnessSessionBinding (+admission, readiness, spawn, terminal-attach) | `harness-session-binding{,-admission,-readiness,-spawn,-terminal-attach}` schemas; canon :2905-3060 | binding-admissions :1088; terminal-attachments :1120; harness-bindings :1232 | — |
+| Thread substrate (read-compose only, C-3) | canon :3320-3328 | `/v1/threads` + `:id`/turns/usage/approvals/snapshots/artifacts family :783-1041; managed-sessions GET :961, control POST :965; session-turns POST :770 | — |
+| HypervisorWorkRun | canon :4222-4284 | workruns GET+POST :1164; `:id` :1169; `:id/execute` :1174 | — |
+| HypervisorWorkQueue / HypervisorWorkItem | canon :4175-4220 | route-missing (`/v1/hypervisor/resource/work-queue` :2775 is the resource-scheduler read, NOT this object) | **W3** |
+| HypervisorWorkSubjectProjection (unified Work rows) | canon :4325-4344 | route-missing as one projection; W1 composes per-family list reads client-side | **W3** (optional unified projection) |
+| HypervisorWorkFacetProjection (reviews/incidents) | canon :4346-4369 | route-missing as such; nearest reads: incidents :1195, recovery-attempts :1199, approval-requests :1963, thread workspace-change-reviews :969, intelligence review-queue :1729 | **W3** |
+| GoalRun (Goals view subjects) | `goal-run.v1.schema.json` + activation schemas | goal-runs :1821; `:id` :1826; results :1830; outcome-deltas :1834; start :1838; reconcile :1842; lifecycle-recovery :1846; events :1850; activations :1809-1817 | — |
+| OutcomeRoom (Rooms view subjects) | `outcome-room.v2.schema.json`, `collaborative-work-graph.v1` | outcome-rooms :2383; overview :2388; `:id` :2392; transition :2396; lifecycle :2402; attach/detach-goal-run :2406/:2410; replay :2414; collaborative-work-graph :2418; discussion :2422; product-projection :2426 | — |
+| Room participation plane (D8) | `room-participant-lease-envelope.v1`, `work-claim-lease.v3`, `work-frontier-item.v3`, `attempt.v3`, `work-result.v3` | participation-requests :2430-2443; participant-leases :2447-2456; work-frontier-items :2459-2474; work-claim-leases :2476-2491; resource-offers :2493; capability-offers :2510; eligibility-matches :2527; attempts :2540-2554; findings :2557-2571; verifier-challenges :2574-2587; work-results :2328-2337 | — (no heartbeat/spend endpoints — see Corrections) |
+| AutomationRun (Active/History facets) | canon :3283-3285 | automations :1268; `:id/runs` :1284 | — |
+| History sources | `work-lifecycle-record.v1` | work-ledger :1309; work-results :2328 + overview :2333 | — |
+| Incident sources | — | incidents :1195; recovery-attempts :1199; failover runs :2630-2634 | — |
+| Event consumption | M5 plane | `/v1/event-streams/...` :2350-2360; `/v1/subscriptions/...` :2363-2379 (per-resource SSE `:id/events` wrapped, not extended) | — |
+| Retired-route refusal | `ioi.hypervisor.route_retirement_refusal.v1` | `/sessions`, `/missions`, `/__ioi/*path` → typed 410 :610-612; handler lifecycle_routes.rs:6451-6478 already names `canonical_replacement_route` `/work/sessions` and `/work` (:6453-6456) | — |
+
+Backend state note: the session surface is "Lane A, Cut #1: real workspace provisioning +
+environment-status/diff/readiness/receipt surfacing + fail-closed honest gates. The positive
+execution loop is Cut #2" — the daemon's own comment, hypervisor-daemon.rs:3186-3188. Session
+create accepts `initial_input` (validated, ≤ max bytes) + `project_ref` + optional `session_ref`;
+owner is daemon-resolved and client-supplied `owner_ref` is rejected
+(lifecycle_routes.rs:11166-11225). List rows: session_ref, project_ref, environment_ref,
+lifecycle_state, workspace_root, editor_target_ref, slim harness_binding, latest_receipt_refs,
+created_at — owner-filtered before count/truncation (lifecycle_routes.rs:17849-17890); no
+partial list on registry failure (:17838-17847).
+
+## 3. UI seed map
+
+- **`/work` and all 8 typed views: absent.** census: `/work`, `/work/sessions`,
+  `/work/new-session` all `resolves: false`; no `/work` handler exists in
+  `scripts/serve-product-ui.mjs` or the augmentation modules (grep). The v2 shell (W0.1) is the
+  precondition.
+- **Bare `/sessions`:** the daemon already refuses it typed (hypervisor-daemon.rs:610;
+  lifecycle_routes.rs:6451-6478). census: the shell rail's "Sessions (rail item)" destination
+  `/sessions` renders the SPA 404 page (`renders_404_page: true`, finding "rail item whose
+  destination renders the SPA 404 page"). The rail item could not be pinned to a greppable
+  literal in the minified vendor captures (`product-ui/owned/public/static/assets/`) — it is
+  vendor-runtime-rendered; retirement lands via shell wiring, not a capture edit.
+- **Sessions root readout (wired, read-only):** `/__ioi/sessions` → `renderSessionsRoot`
+  (serve-product-ui.mjs:1424-1447; route :8659-8667) reads `/v1/hypervisor/sessions` +
+  `/v1/hypervisor/environments-summary`; per-lifecycle-state chips, admitted-harness-binding
+  column ("selection is session truth recorded at create, never UI state" :1443), links to
+  `/workspaces/:env` (workbench), `/details/:env` (vendor session detail), `/__ioi/run-timeline`.
+  census: 157 controls, 0 disabled.
+- **Session detail today:** the vendor workbench `/details/:env` plus the injected IOI-native
+  cockpit panel + owned Run Timeline, which deliberately replaces the seeded transcript in-pane
+  (augmentation/00-core.js:1-15) — WorkRun patch branch, model-driven turns, scoped terminal,
+  receipts already surface there (00-core.js:3-7). This is the D5/D7 seed to rehome, not rebuild.
+- **`missions` T3 surface (absorbed → Work / Rooms):** registered read_only_by_contract at
+  `/__ioi/missions` (scripts/surface-registry.mjs:50); module `surfaces/missions/index.mjs` reads
+  13 goal-orchestration route families (goal-runs, outcome-rooms, participation-requests,
+  participant-leases, work-frontier-items, work-claim-leases, resource-offers, capability-offers,
+  eligibility-matches, attempts, findings, verifier-challenges, work-results — grep of the
+  module). census: 10 controls, 6 implemented, 4 daemon_read, 0 governed. Protected seed
+  (`ported-seed-preservation.v1.json` protected_routes: slug `jobs`, `/__ioi/missions`,
+  substrate_bound).
+- **`incidents` (Issues) T3 surface (absorbed → Work / Incidents):** registered at
+  `/__ioi/missions/incidents` (surface-registry.mjs:56); handler reads `/v1/hypervisor/operations`
+  + `/v1/goal-orchestration/goal-runs` and derives a run-failure + goal-blocker inbox with
+  open/closed/all lanes (serve-product-ui.mjs:8791-8801, lanes :5071, global rail :5130).
+  Protected seed (protected_routes: `daemon_wired`).
+- **Advertisement sites to retire (shell stops advertising `/__ioi/sessions`):** estate tile
+  "Missions … sessions root live" → `/__ioi/sessions` (augmentation/30-shell.js:11); Open
+  Application slot wiring maps `/__ioi/sessions` to "Missions" (60-shell-wiring.js:35,39); Home
+  explorer "Sessions →" link (40-home-explorer.js:303); search-palette Sessions group hrefs
+  (serve-product-ui.mjs:8630); build rows openUrl (serve-product-ui.mjs:7660).
+- **Adjacent wired readouts feeding views:** `/__ioi/run-timeline` (10-run-timeline.js),
+  `/__ioi/work-ledger`, `/__ioi/lineage`, `/__apps/jobs` + `/__apps/incidents` rebinds
+  (serve-product-ui.mjs:1443). census T2: work-ledger 42 controls, run-timeline 66, lineage 21.
+
+### Corrections vs v0
+
+- v0 said the `/work` shell has "typed views: goals, sessions, rooms, queues, reviews, incidents,
+  history" — bytes show canon defines EIGHT views: `Work / Active` is the `/work` root view and
+  is part of the contract (core-clients-surfaces.md:1682-1691, :1712); v0 omitted Active.
+- v0 said the D8 drilldown routes "exist in the room-participation plane" for
+  "claim/lease/heartbeat/spend/evidence" — bytes: lease/claim/frontier/attempt/finding/challenge
+  route families exist (hypervisor-daemon.rs:2430-2587) but there is NO heartbeat/wake or spend
+  endpoint (grep); heartbeat/spend are record fields/projections to read off leases and
+  participation records, not routes. The drilldown composes what exists; anything else is a named
+  gap.
+- v0 said bare `/sessions` "renders the typed 410 the daemon already emits" as future work —
+  bytes show the daemon refusal ALREADY carries the forward map:
+  `canonical_replacement_route: "/work/sessions"` for `/sessions` and `"/work"` for `/missions`
+  (lifecycle_routes.rs:6453-6456); the UI only needs to stop swallowing it into the SPA 404.
+- census listed 14 registered T3 surfaces implying per-slug module dirs — bytes: all 14 register
+  in scripts/surface-registry.mjs:50-63, but only 6 have extracted `surfaces/<slug>/` module dirs
+  (approvals, missions, object-explorer, ontology-manager, pipeline, sources — ls); the other 8
+  (incl. `incidents`) bind implementations inside serve-product-ui.mjs.
+- v0's "no overview/lineage/transition routes" — confirmed for `/v1/hypervisor/sessions`; the
+  overview *pattern* is already daemon-idiomatic elsewhere (odk connector-sessions :1547,
+  work-results :2333, outcome-rooms :2388), so W0.6 is a pattern-conformant small route, not a
+  new invention.
+
+## 4. Schema→UI binding table
+
+Reads use the W0.3 read-projection client; authority-crossing actions use the CapabilityLease
+client (403 wallet challenge → 428 credential → receipt refs on completion). Session-serving
+elements bind through `subject_attachments` (C-1) — never a named app field.
+
+| UI element (pane/control) | Backing schema + route | Current state | Target state |
+|---|---|---|---|
+| `/work` shell + 8 view tabs + breadcrumb | HypervisorCoreWorkspaceRegistration (:3468-3478) via core-taxonomy :1056 + compiler (W0.2) | absent | wired-read (W0.1) |
+| Work/Active rows (cross-kind) | subject rows :4325-4344 composed from sessions :3190 + goal-runs :1821 + automations/:id/runs :1284 + workruns :1164 + outcome-rooms :2383; policy filter before counts (:1696-1697; owner-filter precedent lifecycle_routes.rs:17849-17857) | absent | wired-read |
+| Work/Goals list + detail | goal-runs family :1821-1852 + activations :1809 | absent (missions surface reads these at `/__ioi/missions`) | wired-read (rehome) |
+| Work/Sessions list | sessions :3190 + overview (W0.6) | wired at `/__ioi/sessions` (renderSessionsRoot :1424) | wired-read (rehome) |
+| Session detail — D4 object fields | canon :2688-2704 / :3955-4010; session GET :3207 | partial (vendor `/details/:env` + cockpit panel 00-core.js) | wired-read |
+| Session detail — D5 view (transcript, step graph, tool/model calls, gates, receipts, replay) | :2706-2710 composed from execution-binding GET/events :2884/:2888 + thread GET :787 + turns + workruns :1169 — read-only composition per C-3 (:3320-3328) | partial (Run Timeline iframe replaces transcript, 00-core.js:9-13) | wired-read (events via W0.4 event client; `:id/events` SSE wrapped) |
+| Session detail — D6 waterfall + detail drawer | :2712-2718; run-replay/work-ledger reads :1309, :2328 | wired as separate readouts (`/__ioi/run-timeline`, `/__ioi/work-ledger`) | wired-read (compose; proof behind drilldown) |
+| Session detail — subject chips/filter | `subject_attachments` :3971-3984 | field-missing in daemon records (0 grep hits); C-4 sites: retired named fields `goal_run_ref`/`goal_run_activation_ref` (null non-grants) in session initial-input projection + receipt lifecycle_routes.rs:9928-9929, :9943-9944, :10361 — migrate at the PR that touches them | disabled-named-gap → wired-read after W3 C-1 row |
+| D7 WorkRun view (phase, harness, usage, conversation, review, delivery) | :2720-2727 / :4222-4284; workruns :1164-1176 | partial (cockpit panel WorkRun pane) | wired-read |
+| WorkRun execute control | workruns/:id/execute :1174 | wired in cockpit panel | wired-action-receipted (lease client) |
+| Work/Rooms list + graph-first room detail | outcome-rooms :2383-2427 (graph :2418, discussion :2422, replay :2414) | wired read-only at `/__ioi/missions` (surface-registry.mjs:50) | wired-read (rehome) |
+| D8 participant drilldown (claim/lease/attempt/finding/challenge/evidence) | participation plane :2430-2587 + work-results :2328 | wired read-only at `/__ioi/missions` | wired-read; heartbeat/spend panes disabled-named-gap (no routes) |
+| Room verbs (transition, attach/detach goal-run) | :2396-2410 | absent in UI (read_only_by_contract registration) | wired-action-receipted (W2, lease client) |
+| Work/Queues list + `/work/queues/{id}` | HypervisorWorkQueue :4175-4190 | route-missing; `/__ioi/…` has no queue UI (resource/work-queue :2775 is scheduler truth, label honestly if shown) | disabled-named-gap → W3 |
+| Work/Reviews + `/work/reviews/{facet_projection_id}` | facet projection :4346-4369; nearest reads approval-requests :1963, workspace-change-reviews :969, review-queue :1729 | absent as a view | wired-read (composed, W1) → unified facet projection W3 |
+| Work/Incidents + `/work/incidents/{facet_projection_id}` | facet projection :4346-4369; incidents :1195 + recovery-attempts :1199 + failover :2630 | wired derived inbox at `/__ioi/missions/incidents` (serve :8791-8801) | wired-read (rehome the derivation) |
+| Work/History | work-ledger :1309 + work-results :2328/:2333 | wired readouts (`/__ioi/work-ledger`) | wired-read (rehome) |
+| New Session action (`/work/new-session`) | :885, :1478-1482; POST sessions :3190 (provision receipt lifecycle_routes.rs:9915) | composer lives at `/ai#new-session` (see home.md) | wired-action-receipted (route rehome W0.1/W2) |
+| Session execute / teardown / ports-revoke | :3199 / :3207 DELETE / :3203 | wired via cockpit/adapter lanes | wired-action-receipted (Cut #1 gates; positive loop = Cut #2, W4) |
+| Execution-binding input/stop/archive/restore | :2892-2905 | not surfaced | wired-action-receipted (W2; live turn loop W4) |
+| Session lineage pane | none (route-missing) | absent | disabled-named-gap → W3 family |
+| Bare `/sessions` + `/missions` in shell | refusal contract lifecycle_routes.rs:6451-6478 | shell soft-404s (census) | render the daemon's typed 410 + replacement link; then delete rail/tile ads (W4) |
+| Tile/palette ads of `/__ioi/sessions` | 30-shell.js:11, 60-shell-wiring.js:35+:39, 40-home-explorer.js:303, serve :8630, :7660 | live | delete (W4, per-app cutover rule) |
+
+## 5. Ordered PR list
+
+1. **W0.6** — `GET /v1/hypervisor/sessions/overview` (counts by lifecycle_state/kind, newest
+   refs; owner-filtered before counts). Serial: touches hypervisor-daemon.rs (merge hotspot).
+2. **W0.1** — v2 shell `/work` + the 8 typed-view routes render read-first skeletons with honest
+   empty/degraded states; breadcrumb + back-stack identity per :1724-1725.
+3. **W1** — Work/Sessions list rehomed from `renderSessionsRoot` semantics onto the read client
+   (sessions + overview); zero fixture data.
+4. **W1** — Session detail read composition: D4 fields + D5 view + D6 waterfall from session GET
+   + execution-binding GET/events + thread GET + workrun GET (read-only, C-3); events through the
+   W0.4 event client, legacy `:id/events` SSE wrapped.
+5. **W1** — Work/Goals + Work/Rooms + D8 participant drilldown: rehome the `missions` surface's
+   13 goal-orchestration reads under `/work/goals` and `/work/rooms` (seed-preservation: adopt
+   the module, don't rebuild).
+6. **W1** — Work/Incidents: rehome the derived run-failure + goal-blocker inbox
+   (serve :8791-8801) under `/work/incidents`; Work/History over work-ledger + work-results;
+   Work/Reviews composed read (approval-requests + workspace-change-reviews + review-queue);
+   Work/Queues renders disabled-named-gap.
+7. **W2** — Session actions through the CapabilityLease client: create (from `/work/new-session`),
+   execute, teardown, ports-revoke; execution-binding input/stop/archive/restore; room
+   transition/attach/detach verbs. Every enabled control receipted; everything else
+   disabled-named-gap.
+8. **W3** — C-1 backend: `subject_attachments[]` on daemon session records (+ list/get/overview
+   projection + filter); migrate the three named-field sites (lifecycle_routes.rs:9928, :9943,
+   :10361) in the same PR that touches them; then Work row subject chips go live.
+9. **W3** — Session lineage family (lineage/fork/children projection routes + the lineage pane);
+   register the missing `hypervisor-session` schema in `_meta/schemas/`.
+10. **W3** — HypervisorWorkQueue/WorkItem backend family ONLY if an implemented contract pulls
+    it (queue standing rule); otherwise the named gap stands. Optional unified
+    work-subject/facet projection routes.
+11. **W4** — Execution loop Cut #2: positive turn loop on session-execution-bindings
+    (hypervisor-daemon.rs:3186-3188), after W0.4; the Sessions view turns live.
+12. **W4** — Retirement per the 6-step cutover rule (AGENTS.md, ported-seed-preservation):
+    shell renders the typed 410 for `/sessions`+`/missions`; delete the `/__ioi/sessions`
+    advertisements (30-shell.js:11, 60-shell-wiring.js:35/:39, 40-home-explorer.js:303,
+    serve :8630/:7660); retire `/__ioi/sessions`, `/__ioi/missions`,
+    `/__ioi/missions/incidents` with typed refusals + no-fallback proof.

--- a/internal-docs/overhaul/2026-08-05-hypervisor-bring-to-life-run.md
+++ b/internal-docs/overhaul/2026-08-05-hypervisor-bring-to-life-run.md
@@ -184,17 +184,39 @@ the PR that touches it, with the guide recording remaining sites.
 
 ## Run State ledger
 
+Per-surface rows cover that surface's full Phase B execution (its brief's §5
+PR list, W1 read-first through its cutover). Surface rows are ordered by the
+guide's Wave 1 launch order, then the remainder. A session takes the first
+unchecked row, refreshes its brief at the bytes, and executes.
+
 | Item | State | Handoff note |
 |---|---|---|
-| Phase A: per-surface briefs at `internal-docs/implementation/surfaces/` (20 files + `_index.md`) | ☐ | v0 seed = the 2026-08-05 overhaul guide; verify at bytes; on completion regenerate this ledger to one row per surface |
-| C-1..C-4 canon layering fixes | ☑ 2026-08-05 | landed in core-clients-surfaces.md; implementation migrates per-PR |
-| W0.1 v2 route shell | ☐ | |
-| W0.2 surface compiler | ☐ | |
-| W0.3 read + authority clients | ☐ | |
-| W0.4 event client (M5 plane) | ☐ | |
-| W0.5 identity truth | ☐ | |
-| W0.6 backend enablers | ☐ | sessions/overview + lineage designed against subject_attachments |
-| Wave 1 (10 app launches) | ☐ | per-app checkmarks added when wave opens |
-| Wave 2 (action lighting) | ☐ | |
-| Wave 3 (backend builds) | ☐ | |
-| Wave 4 (cutover + Cut #2) | ☐ | |
+| Phase A: per-surface briefs at `internal-docs/implementation/surfaces/` (20 files + `_index.md`) | ☑ 2026-08-05 | landed via PRs #155–#159; briefs pin canon cites to blob 21ae389fe (C-1..C-4 canon commit) |
+| C-1..C-4 canon layering fixes | ☑ 2026-08-05 | landed in core-clients-surfaces.md (#155); surviving daemon/UI named-field sites recorded in briefs, migrate at the PR that touches them |
+| W0.1 v2 route shell | ☐ | delete the live `/automations`→`/__ioi` redirect hijack at cutover (home.md §3) |
+| W0.2 surface compiler | ☐ | compiler route already exists (applications.md §2); gaps = grouping, policy filtering, system-interface join |
+| W0.3 read + authority clients | ☐ | lease-gateway order at bytes: 428 credential → 403 wallet → receipted (developer-console.md §1) |
+| W0.4 event client (M5 plane) | ☐ | automation-scheduler owner namespace already fixtured in the M5 contract (automations.md §2) |
+| W0.5 identity truth | ☐ | fixture-RPC set corrected: 2 not 5 (settings.md §3, projects.md §3); +2 adapter lies to delete (environments.md §3) |
+| W0.6 backend enablers | ☐ | sessions/overview · unified inbox folds 4+2 decision planes (governance.md §2) · `GET /v1` index · scheduler gap = liveness only (automations.md §3) |
+| work build (owns `/work/sessions`; Cut #2 is its W4 leg) | ☐ | surfaces/work.md §5 |
+| provenance build | ☐ | surfaces/provenance.md §5 |
+| environments build | ☐ | surfaces/environments.md §5 |
+| operations build | ☐ | surfaces/operations.md §5 |
+| governance build | ☐ | surfaces/governance.md §5 (reviewer_ref defects; transition-receipt read route) |
+| ontology build | ☐ | surfaces/ontology.md §5 (unreceipted deletes fix early) |
+| data build | ☐ | surfaces/data.md §5 |
+| automations build | ☐ | surfaces/automations.md §5 (receives machinery from Studio, paired PR) |
+| foundry build | ☐ | surfaces/foundry.md §5 |
+| developer-workspace build | ☐ | surfaces/developer-workspace.md §5 (three lanes, not one route) |
+| studio build | ☐ | surfaces/studio.md §5 |
+| evaluations build | ☐ | surfaces/evaluations.md §5 (live receiptless-mutation defect fixed first) |
+| improvement build | ☐ | surfaces/improvement.md §5 (approve/reject receipts gate the W2 verb rehome) |
+| packages build | ☐ | surfaces/packages.md §5 (biggest backend build; around existing install-admission planner) |
+| developer-console build | ☐ | surfaces/developer-console.md §5 |
+| home build | ☐ | surfaces/home.md §5 |
+| systems build | ☐ | surfaces/systems.md §5 |
+| projects build | ☐ | surfaces/projects.md §5 |
+| applications build | ☐ | surfaces/applications.md §5 |
+| settings build | ☐ | surfaces/settings.md §5 |
+| Wave 4 shared cutover | ☐ | server.cjs mocks · fixture API lane · duplicate static copy · canon 5-vs-6 nit (settings.md pins the 5 locations) |


### PR DESCRIPTION
Wave item: Phase A per-surface implementation briefs (batch 4 of 4 — completes Phase A). Stacked on #155 (shares the charter commit; merge #155 first and this reduces to the four brief files).

What became operational: Phase A is complete — all twenty surface briefs plus `_index.md` exist as byte-derived build maps, and the Run State ledger in the run charter is regenerated to one build row per surface in Wave 1 launch order, so any fresh session can boot from the charter and take the first unchecked row. The work brief encodes the subject_attachments session discipline end-to-end (including the three surviving named-field daemon sites to migrate); the home brief records that the live /automations redirect hijacks a canonical v2 route and must die at Automations cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)