### PR TITLE
W0.3: uniform read-projection client + CapabilityLease authority client

### DIFF
--- a/apps/hypervisor/surfaces/authority-client.mjs
+++ b/apps/hypervisor/surfaces/authority-client.mjs
@@ -1,0 +1,212 @@
+// W0.3 — the authority client. ONE encoding of the CapabilityLease authority-crossing
+// flow, exactly as the daemon gateway behaves at the bytes (`authorize_capability_lease`,
+// crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs:11899-11942):
+//
+//   1) 428 PRECONDITION_REQUIRED — the sealed backing credential did not resolve
+//      (body: { ok:false, decision:"blocked", reason, message, backing_provider }).
+//   2) 403 FORBIDDEN — owner wallet authority required (body carries the challenge:
+//      required_authority_scope, required_scopes, approval:{policy_hash, request_hash},
+//      authority_challenge — public commitments only; sign externally, resubmit the
+//      one-use grant as `wallet_approval_grant`).
+//   3) Success — the gateway issues + persists the lease (ioi.hypervisor.capability-lease.v1)
+//      and the route receipts the transition on the record's own history (`receipt_ref`).
+//
+// The invariant this client enforces: NO SILENT NO-OP. Every call resolves to exactly one
+// typed result — crossed-with-receipt, refusal, or failure — that a pane can render as a
+// named state. A 2xx WITHOUT a discoverable receipt ref fails CLOSED (`receipt_missing`),
+// matching the estate's governed-build idiom. The wallet grant is forwarded to the daemon
+// exactly once and is never retained, logged, or echoed by this module.
+//
+// Usable from BOTH lanes (serve-side readout + browser augmentation): no node: imports;
+// fetch and the daemon base are injectable.
+import { defaultDaemonBase } from "./read-client.mjs";
+
+const DEFAULT_TIMEOUT_MS = 15000; // crossings can mint fresh tokens server-side (network)
+const HASH_RE = /^sha256:[0-9a-f]{64}$/;
+
+const iso = () => new Date().toISOString();
+const trim = (value, max = 300) => String(value == null ? "" : value).slice(0, max);
+
+const failure = (code, message) => ({
+  ok: false,
+  kind: "failure",
+  code,
+  message: trim(message),
+  receipt_ref: "",
+  at: iso(),
+});
+
+const refusal = (stage, status, code, message, extra = {}) => ({
+  ok: false,
+  kind: "refusal",
+  stage,
+  status,
+  code,
+  message: trim(message),
+  receipt_ref: "",
+  at: iso(),
+  ...extra,
+});
+
+// Grant intake mirrors the governed-build pane: accept an object, or parse a pasted JSON
+// string; anything else is a typed refusal BEFORE the network — never a mangled forward.
+function normalizeGrant(grant) {
+  if (grant === undefined || grant === null || grant === "") return { grant: undefined };
+  if (typeof grant === "object" && !Array.isArray(grant)) return { grant };
+  if (typeof grant === "string") {
+    try {
+      const parsed = JSON.parse(grant);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { err: "the grant is not a JSON object" };
+      }
+      return { grant: parsed };
+    } catch {
+      return { err: "the grant is not valid JSON (was it truncated?)" };
+    }
+  }
+  return { err: "the grant must be a JSON object" };
+}
+
+// The 403 challenge, surfaced with its public commitments VERBATIM (hash-shape-checked,
+// like the governed-build pane) so a pane can name exactly what to sign. Never a secret.
+function walletChallenge(payload) {
+  const approval = payload?.approval || {};
+  return {
+    required_authority_scope: trim(payload?.required_authority_scope || "", 200),
+    required_scopes: Array.isArray(payload?.required_scopes) ? payload.required_scopes : [],
+    policy_hash: HASH_RE.test(approval.policy_hash || "") ? approval.policy_hash : "",
+    request_hash: HASH_RE.test(approval.request_hash || "") ? approval.request_hash : "",
+    authority_challenge: payload?.authority_challenge ?? null,
+  };
+}
+
+// Receipt discovery over the daemon's real success shapes: a top-level receipt_ref, a
+// nested record's `history[]` (latest entry carrying receipt_ref — how lifecycle records
+// receipt every transition), or a nested record's receipt_ref. Deterministic scan, no
+// guessing beyond these shapes — an undiscoverable receipt is receipt_missing, not "ok".
+function findReceiptRef(payload, extractReceiptRef) {
+  if (typeof extractReceiptRef === "function") {
+    const ref = extractReceiptRef(payload);
+    return typeof ref === "string" && ref.length > 0 ? ref : "";
+  }
+  if (!payload || typeof payload !== "object") return "";
+  if (typeof payload.receipt_ref === "string" && payload.receipt_ref) return payload.receipt_ref;
+  for (const value of Object.values(payload)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    if (typeof value.receipt_ref === "string" && value.receipt_ref) return value.receipt_ref;
+    const history = Array.isArray(value.history) ? value.history : [];
+    for (let i = history.length - 1; i >= 0; i--) {
+      const ref = history[i]?.receipt_ref;
+      if (typeof ref === "string" && ref.length > 0) return ref;
+    }
+  }
+  return "";
+}
+
+// Non-secret lease coordinates when the success payload carries them (descriptor fields /
+// the sealed-session labels). Labels only — the gateway never exports credential material.
+function leaseFacets(payload) {
+  if (!payload || typeof payload !== "object") return null;
+  const nodes = [payload, ...Object.values(payload).filter((v) => v && typeof v === "object" && !Array.isArray(v))];
+  for (const node of nodes) {
+    const candidates = [node, node.session, node.lease].filter((v) => v && typeof v === "object");
+    for (const c of candidates) {
+      const lease_id = c.lease_id || c.gateway_lease_id || "";
+      const grant_ref = c.grant_ref || "";
+      const policy_hash = c.policy_hash || "";
+      const request_hash = c.request_hash || "";
+      if (lease_id || grant_ref || policy_hash || request_hash) {
+        return {
+          lease_id: trim(lease_id, 120),
+          grant_ref: trim(grant_ref, 200),
+          policy_hash: HASH_RE.test(policy_hash) ? policy_hash : "",
+          request_hash: HASH_RE.test(request_hash) ? request_hash : "",
+        };
+      }
+    }
+  }
+  return null;
+}
+
+/// The crossing. POSTs to a gateway-guarded daemon route; `grant` (optional) rides the
+/// request exactly once as `wallet_approval_grant`. Result kinds:
+///   { ok:true,  kind:"crossed", status, receipt_ref, lease, payload, at }
+///   { ok:false, kind:"refusal", stage:"grant"|"credential"|"wallet_challenge"|"gateway",
+///     status?, code, message, challenge?, refusal?, at }
+///   { ok:false, kind:"failure", code ("daemon_unavailable"|"crossing_timeout"|"receipt_missing"), message, at }
+export async function crossWithLease(
+  { daemon = defaultDaemonBase(), fetchImpl = globalThis.fetch, timeoutMs = DEFAULT_TIMEOUT_MS } = {},
+  path,
+  { method = "POST", body = {}, grant, extractReceiptRef } = {},
+) {
+  const { grant: normalized, err } = normalizeGrant(grant);
+  if (err) return refusal("grant", 0, "grant_invalid_json", err);
+  const request = { ...body };
+  if (normalized !== undefined) request.wallet_approval_grant = normalized;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let response;
+  let payload = {};
+  try {
+    response = await fetchImpl(`${daemon}${path}`, {
+      method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    try { payload = text ? JSON.parse(text) : {}; } catch { payload = {}; }
+  } catch (error) {
+    const timedOut = error?.name === "AbortError";
+    return failure(
+      timedOut ? "crossing_timeout" : "daemon_unavailable",
+      timedOut
+        ? `the daemon did not answer the crossing within ${timeoutMs}ms — treat state as unknown and re-read the record`
+        : "the daemon did not answer — no crossing occurred",
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const status = response.status;
+  // Gateway step 1 — sealed credential unresolved. Fix the credential, then retry.
+  if (status === 428) {
+    return refusal("credential", status,
+      payload?.reason || "credential_unresolved",
+      payload?.message || "this crossing needs a resolvable sealed backing credential",
+      { refusal: payload });
+  }
+  // Gateway step 2 — owner wallet authority required; surface the challenge to sign.
+  if (status === 403) {
+    return refusal("wallet_challenge", status,
+      payload?.reason || "wallet_authority_required",
+      payload?.message || "this crossing requires independently resolved, atomically consumed owner authority",
+      { challenge: walletChallenge(payload), refusal: payload });
+  }
+  if (status >= 400) {
+    return refusal("gateway", status,
+      payload?.error?.code || payload?.reason || payload?.code || `http_${status}`,
+      payload?.error?.message || payload?.message || payload?.reason || "the gateway refused the crossing",
+      { refusal: payload });
+  }
+  // Gateway step 3 — the crossing happened iff a receipt names it. Fail closed otherwise.
+  const receipt_ref = findReceiptRef(payload, extractReceiptRef);
+  if (!receipt_ref) {
+    return failure("receipt_missing", "the crossing returned success without a receipt ref — failing closed");
+  }
+  return { ok: true, kind: "crossed", status, receipt_ref, lease: leaseFacets(payload), payload, at: iso() };
+}
+
+/// Bound-client convenience mirroring createReadClient.
+export function createAuthorityClient(options = {}) {
+  const client = {
+    daemon: options.daemon ?? defaultDaemonBase(),
+    fetchImpl: options.fetchImpl ?? globalThis.fetch,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
+  return {
+    ...client,
+    cross: (path, opts) => crossWithLease(client, path, opts),
+  };
+}

--- a/apps/hypervisor/surfaces/read-authority-clients.test.mjs
+++ b/apps/hypervisor/surfaces/read-authority-clients.test.mjs
@@ -1,0 +1,219 @@
+// W0.3 contract test — the uniform read-projection client + the CapabilityLease authority
+// client, exercised against a STUB gateway (never the real daemon). The stub speaks the
+// byte-verified gateway ladder (lifecycle_routes.rs:11899-11942): 428 sealed-credential →
+// 403 wallet challenge (approval.policy_hash/request_hash + authority_challenge) →
+// receipted success on the record's own history. Run: npm run test:hypervisor-app-clients
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { createReadClient, readProjections, defaultDaemonBase } from "./read-client.mjs";
+import { createAuthorityClient } from "./authority-client.mjs";
+
+const POLICY_HASH = `sha256:${"a".repeat(64)}`;
+const REQUEST_HASH = `sha256:${"b".repeat(64)}`;
+
+const seen = []; // every request the stub actually received: { method, path, body }
+
+const stub = createServer(async (req, res) => {
+  let raw = "";
+  for await (const chunk of req) raw += chunk;
+  const body = raw ? JSON.parse(raw) : null;
+  seen.push({ method: req.method, path: req.url, body });
+  const json = (status, payload) => {
+    res.writeHead(status, { "content-type": "application/json" });
+    res.end(JSON.stringify(payload));
+  };
+  if (req.url === "/v1/ok") {
+    return json(200, { ok: true, operations: [{ id: "op_1", status: "running" }] });
+  }
+  if (req.url === "/v1/missing") {
+    return json(404, { error: { code: "plane_not_found", message: "no such projection" } });
+  }
+  if (req.url === "/v1/refused") {
+    return json(503, { error: { code: "plane_degraded", message: "projection temporarily refused" } });
+  }
+  if (req.url === "/v1/slow") {
+    return; // never answers — exercises the deadline, socket reaped at teardown
+  }
+  if (req.url === "/v1/cross/credential-missing") {
+    return json(428, {
+      ok: false, decision: "blocked", reason: "scm_credential_required",
+      message: "This lease needs a resolvable backing credential before the crossing.",
+      backing_provider: "github", host_mutation: false,
+    });
+  }
+  if (req.url === "/v1/cross/guarded") {
+    if (!body?.wallet_approval_grant) {
+      return json(403, {
+        ok: false, decision: "blocked", reason: "odk_connector_session_authority_required",
+        message: "This crossing requires independently resolved, atomically consumed owner authority.",
+        required_scopes: ["tools/call"],
+        required_authority_scope: "scope:hypervisor.live-route.hypervisor-odk-connector-session",
+        approval: { policy_hash: POLICY_HASH, request_hash: REQUEST_HASH },
+        authority_challenge: { challenge_kind: "wallet.approval-grant.v1" },
+        host_mutation: false,
+      });
+    }
+    return json(200, {
+      ok: true,
+      connector_session: {
+        id: "cs_1", status: "session_obtained",
+        session: { gateway_lease_id: "lease_abc", grant_ref: "grant://g1", policy_hash: POLICY_HASH, request_hash: REQUEST_HASH },
+        history: [
+          { op: "created", receipt_ref: "receipt://created" },
+          { op: "session_obtained", receipt_ref: "receipt://obtained" },
+        ],
+      },
+    });
+  }
+  if (req.url === "/v1/cross/no-receipt") {
+    return json(200, { ok: true });
+  }
+  return json(404, { error: { code: "route_unknown", message: "stub has no such route" } });
+});
+
+let daemon = "";
+const DEAD = "http://127.0.0.1:9"; // discard port — connection always refused, nothing listens
+
+test.before(async () => {
+  await new Promise((resolve) => stub.listen(0, "127.0.0.1", resolve));
+  daemon = `http://127.0.0.1:${stub.address().port}`;
+});
+test.after(() => {
+  stub.closeAllConnections?.();
+  stub.close();
+});
+
+// ------------------------------ read-projection client ------------------------------
+
+test("read: success carries the payload verbatim plus fetched_at, nothing else invented", async () => {
+  const r = await createReadClient({ daemon }).read("/v1/ok");
+  assert.equal(r.ok, true);
+  assert.equal(r.kind, "read");
+  assert.equal(r.status, 200);
+  assert.deepEqual(r.payload.operations, [{ id: "op_1", status: "running" }]);
+  assert.ok(!Number.isNaN(Date.parse(r.fetched_at)));
+});
+
+test("read: daemon down is a typed unavailable with NO data field — nothing fabricated", async () => {
+  const r = await createReadClient({ daemon: DEAD, timeoutMs: 2000 }).read("/v1/ok");
+  assert.equal(r.ok, false);
+  assert.equal(r.kind, "unavailable");
+  assert.equal(r.status, 0);
+  assert.equal(r.code, "daemon_unavailable");
+  assert.ok(!("payload" in r), "degraded result must not carry a payload");
+  assert.ok(!("rows" in r), "degraded result must not carry fabricated rows");
+  assert.ok(!Number.isNaN(Date.parse(r.fetched_at)));
+});
+
+test("read: deadline exceeded is read_timeout, not a hang and not a fake empty", async () => {
+  const r = await createReadClient({ daemon, timeoutMs: 250 }).read("/v1/slow");
+  assert.equal(r.ok, false);
+  assert.equal(r.kind, "unavailable");
+  assert.equal(r.code, "read_timeout");
+  assert.ok(!("payload" in r));
+});
+
+test("read: typed refusal surfaces the daemon's own code/message and body verbatim", async () => {
+  const r = await createReadClient({ daemon }).read("/v1/refused");
+  assert.equal(r.ok, false);
+  assert.equal(r.kind, "refusal");
+  assert.equal(r.status, 503);
+  assert.equal(r.code, "plane_degraded");
+  assert.match(r.message, /temporarily refused/);
+  assert.equal(r.refusal.error.code, "plane_degraded");
+  assert.ok(!("payload" in r));
+});
+
+test("read: 404 is typed absence (not_found), distinct from refusal and from unavailable", async () => {
+  const r = await createReadClient({ daemon }).read("/v1/missing");
+  assert.equal(r.ok, false);
+  assert.equal(r.kind, "not_found");
+  assert.equal(r.status, 404);
+  assert.equal(r.code, "plane_not_found");
+});
+
+test("read: fan-out degrades independently — one down plane never poisons the rest", async () => {
+  const client = createReadClient({ daemon });
+  const map = await readProjections(client, { good: "/v1/ok", gone: "/v1/missing", down: "/v1/refused" });
+  assert.equal(map.good.ok, true);
+  assert.equal(map.gone.kind, "not_found");
+  assert.equal(map.down.kind, "refusal");
+});
+
+test("read: browser lane defaults to same-origin, serve lane to the daemon URL", () => {
+  assert.equal(defaultDaemonBase(), process.env.IOI_HYPERVISOR_DAEMON_URL?.replace(/\/$/, "") || "http://127.0.0.1:8765");
+  globalThis.window = {};
+  try {
+    assert.equal(defaultDaemonBase(), "");
+  } finally {
+    delete globalThis.window;
+  }
+});
+
+// ------------------------------ authority client ------------------------------
+
+test("authority: 428 sealed-credential step is a typed credential refusal, verbatim reason", async () => {
+  const r = await createAuthorityClient({ daemon }).cross("/v1/cross/credential-missing");
+  assert.equal(r.ok, false);
+  assert.equal(r.kind, "refusal");
+  assert.equal(r.stage, "credential");
+  assert.equal(r.status, 428);
+  assert.equal(r.code, "scm_credential_required");
+  assert.equal(r.receipt_ref, "");
+});
+
+test("authority: 403 wallet step surfaces the challenge's public commitments verbatim", async () => {
+  const r = await createAuthorityClient({ daemon }).cross("/v1/cross/guarded");
+  assert.equal(r.ok, false);
+  assert.equal(r.kind, "refusal");
+  assert.equal(r.stage, "wallet_challenge");
+  assert.equal(r.status, 403);
+  assert.equal(r.code, "odk_connector_session_authority_required");
+  assert.equal(r.challenge.policy_hash, POLICY_HASH);
+  assert.equal(r.challenge.request_hash, REQUEST_HASH);
+  assert.equal(r.challenge.required_authority_scope, "scope:hypervisor.live-route.hypervisor-odk-connector-session");
+  assert.deepEqual(r.challenge.required_scopes, ["tools/call"]);
+  assert.equal(r.challenge.authority_challenge.challenge_kind, "wallet.approval-grant.v1");
+});
+
+test("authority: grant resubmission completes the ladder — crossed, receipted, lease facets", async () => {
+  const grant = { grant_id: "g1", scope: "scope:hypervisor.live-route.hypervisor-odk-connector-session" };
+  const before = seen.length;
+  const r = await createAuthorityClient({ daemon }).cross("/v1/cross/guarded", { grant });
+  assert.equal(r.ok, true);
+  assert.equal(r.kind, "crossed");
+  assert.equal(r.status, 200);
+  assert.equal(r.receipt_ref, "receipt://obtained", "latest history receipt wins");
+  assert.equal(r.lease.lease_id, "lease_abc");
+  assert.equal(r.lease.grant_ref, "grant://g1");
+  assert.equal(r.lease.policy_hash, POLICY_HASH);
+  // the grant rode the wire exactly once, verbatim, under wallet_approval_grant
+  const wire = seen.slice(before).filter((q) => q.body?.wallet_approval_grant);
+  assert.equal(wire.length, 1);
+  assert.deepEqual(wire[0].body.wallet_approval_grant, grant);
+});
+
+test("authority: a pasted grant string is parsed; garbage refuses BEFORE the network", async () => {
+  const before = seen.length;
+  const r = await createAuthorityClient({ daemon }).cross("/v1/cross/guarded", { grant: "{not json" });
+  assert.equal(r.ok, false);
+  assert.equal(r.stage, "grant");
+  assert.equal(r.code, "grant_invalid_json");
+  assert.equal(seen.length, before, "an unparseable grant must never reach the daemon");
+});
+
+test("authority: 2xx without a discoverable receipt fails CLOSED (receipt_missing)", async () => {
+  const r = await createAuthorityClient({ daemon }).cross("/v1/cross/no-receipt");
+  assert.equal(r.ok, false);
+  assert.equal(r.kind, "failure");
+  assert.equal(r.code, "receipt_missing");
+});
+
+test("authority: daemon down is a typed failure — no silent no-op, no invented state", async () => {
+  const r = await createAuthorityClient({ daemon: DEAD, timeoutMs: 2000 }).cross("/v1/cross/guarded");
+  assert.equal(r.ok, false);
+  assert.equal(r.kind, "failure");
+  assert.equal(r.code, "daemon_unavailable");
+  assert.ok(!("payload" in r), "a failed crossing must not carry fabricated payload");
+});

--- a/apps/hypervisor/surfaces/read-client.mjs
+++ b/apps/hypervisor/surfaces/read-client.mjs
@@ -1,0 +1,125 @@
+// W0.3 — the uniform read-projection client. ONE way to read daemon truth (the ~20
+// `/overview` + projection endpoints and every other GET the product surfaces render).
+// Usable from BOTH lanes: the serve-side readout lane (Node) and browser augmentation
+// modules — no node: imports, fetch/daemon base are injectable, defaults resolve per lane.
+//
+// The contract (honesty first):
+//   - EVERY result is one of four kinds, always with `fetched_at`:
+//       { ok: true,  kind: "read",        status, payload, fetched_at }
+//       { ok: false, kind: "not_found",   status (404|410), code, message, fetched_at }
+//       { ok: false, kind: "refusal",     status (other 4xx/5xx), code, message, refusal, fetched_at }
+//       { ok: false, kind: "unavailable", status: 0, code ("daemon_unavailable"|"read_timeout"), message, fetched_at }
+//   - Degraded results carry NO data field — never a fabricated `[]`/`{}` default. A
+//     renderer that wants rows must check `ok` first; absence stays absent.
+//   - NO caching. Every result is a live fetch, stamped `fetched_at` (ISO). If a cache
+//     is ever added it must ride the result shape explicitly (its own kind + fetched_at),
+//     never silently re-serve a stale payload as live.
+//   - `refusal` on typed refusals is the daemon's own body VERBATIM (already-parsed JSON)
+//     so panes can render the daemon's reason/message instead of inventing one.
+//
+// Deadline mechanics live in plane-read.mjs (one deadline over headers AND body) — this
+// module owns the error taxonomy and result shape on top of it.
+import { readJsonWithDeadline } from "./plane-read.mjs";
+
+const DEFAULT_TIMEOUT_MS = 8000; // matches the estate's adapter/serve daemon deadline
+
+// Per-lane daemon base: serve lane honors IOI_HYPERVISOR_DAEMON_URL (adapter default
+// http://127.0.0.1:8765); the browser lane uses same-origin "" so reads ride the serve
+// layer's proxy exactly like the existing augmentation modules do.
+export function defaultDaemonBase() {
+  const env = globalThis.process?.env?.IOI_HYPERVISOR_DAEMON_URL;
+  if (typeof env === "string" && env.length > 0) return env.replace(/\/$/, "");
+  return typeof globalThis.window === "undefined" ? "http://127.0.0.1:8765" : "";
+}
+
+const iso = () => new Date().toISOString();
+const trim = (value, max = 300) => String(value == null ? "" : value).slice(0, max);
+
+function refusalCode(payload, status) {
+  return (
+    payload?.error?.code
+    || payload?.reason
+    || payload?.code
+    || `http_${status}`
+  );
+}
+
+function refusalMessage(payload, status) {
+  return trim(
+    payload?.error?.message
+    || payload?.message
+    || payload?.reason
+    || `the daemon answered ${status} without a typed body`,
+  );
+}
+
+/// One projection read. `path` is the daemon route (e.g. "/v1/hypervisor/operations").
+export async function readProjection(
+  { daemon = defaultDaemonBase(), fetchImpl = globalThis.fetch, timeoutMs = DEFAULT_TIMEOUT_MS } = {},
+  path,
+  init = {},
+) {
+  let response;
+  let payload;
+  try {
+    ({ response, payload } = await readJsonWithDeadline(fetchImpl, `${daemon}${path}`, timeoutMs, init));
+  } catch (error) {
+    const timedOut = error?.code === "plane_timeout";
+    return {
+      ok: false,
+      kind: "unavailable",
+      status: 0,
+      code: timedOut ? "read_timeout" : "daemon_unavailable",
+      message: timedOut
+        ? `the daemon did not answer ${path} within ${timeoutMs}ms`
+        : `the daemon could not be reached for ${path}`,
+      fetched_at: iso(),
+    };
+  }
+  const status = response.status;
+  if (response.ok) {
+    return { ok: true, kind: "read", status, payload, fetched_at: iso() };
+  }
+  if (status === 404 || status === 410) {
+    return {
+      ok: false,
+      kind: "not_found",
+      status,
+      code: refusalCode(payload, status),
+      message: refusalMessage(payload, status),
+      fetched_at: iso(),
+    };
+  }
+  return {
+    ok: false,
+    kind: "refusal",
+    status,
+    code: refusalCode(payload, status),
+    message: refusalMessage(payload, status),
+    refusal: payload && typeof payload === "object" ? payload : null,
+    fetched_at: iso(),
+  };
+}
+
+/// Fan-out over named paths — the composed-readout idiom (a cockpit that renders six
+/// planes). Each entry degrades INDEPENDENTLY: one down plane never poisons the others,
+/// and a down plane is a typed absence in the map, never an empty default.
+export async function readProjections(client, paths) {
+  const entries = Object.entries(paths);
+  const results = await Promise.all(entries.map(([, path]) => readProjection(client, path)));
+  return Object.fromEntries(entries.map(([key], index) => [key, results[index]]));
+}
+
+/// Bound-client convenience so call sites carry one handle, not three parameters.
+export function createReadClient(options = {}) {
+  const client = {
+    daemon: options.daemon ?? defaultDaemonBase(),
+    fetchImpl: options.fetchImpl ?? globalThis.fetch,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
+  return {
+    ...client,
+    read: (path, init) => readProjection(client, path, init),
+    readMany: (paths) => readProjections(client, paths),
+  };
+}

--- a/internal-docs/overhaul/2026-08-05-hypervisor-bring-to-life-run.md
+++ b/internal-docs/overhaul/2026-08-05-hypervisor-bring-to-life-run.md
@@ -195,7 +195,7 @@ unchecked row, refreshes its brief at the bytes, and executes.
 | C-1..C-4 canon layering fixes | ☑ 2026-08-05 | landed in core-clients-surfaces.md (#155); surviving daemon/UI named-field sites recorded in briefs, migrate at the PR that touches them |
 | W0.1 v2 route shell | ☑ 2026-08-05 | all 23 canonical routes + `/work/sessions` resolve from ONE table at `apps/hypervisor/scripts/v2-route-shell.mjs:29`; bare `/sessions` answers the daemon's typed 410; the home.md §3 `/automations` hijack retired (canonical route now renders the shell page, legacy readout linked) |
 | W0.2 surface compiler | ☐ | compiler route already exists (applications.md §2); gaps = grouping, policy filtering, system-interface join |
-| W0.3 read + authority clients | ☐ | lease-gateway order at bytes: 428 credential → 403 wallet → receipted (developer-console.md §1) |
+| W0.3 read + authority clients | ☑ 2026-08-05 | `apps/hypervisor/surfaces/read-client.mjs` (readProjection/readProjections/createReadClient) + `apps/hypervisor/surfaces/authority-client.mjs` (crossWithLease/createAuthorityClient); gateway order re-verified at lifecycle_routes.rs:11899-11942 (428 credential → 403 wallet → receipted); 13-check stub-gateway contract test at `test:hypervisor-app-clients` |
 | W0.4 event client (M5 plane) | ☐ | automation-scheduler owner namespace already fixtured in the M5 contract (automations.md §2) |
 | W0.5 identity truth | ☐ | fixture-RPC set corrected: 2 not 5 (settings.md §3, projects.md §3); +2 adapter lies to delete (environments.md §3) |
 | W0.6 backend enablers | ☐ | sessions/overview · unified inbox folds 4+2 decision planes (governance.md §2) · `GET /v1` index · scheduler gap = liveness only (automations.md §3) |

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dryrun:hypervisor-code-editor-adapter-host": "bash apps/hypervisor/scripts/dry-run-desktop.sh x11",
     "dryrun:hypervisor-code-editor-adapter-host:wayland": "bash apps/hypervisor/scripts/dry-run-desktop.sh wayland",
     "test:hypervisor-app-harness": "node --test scripts/lib/hypervisor-app-harness-contract.test.mjs",
+    "test:hypervisor-app-clients": "node --test apps/hypervisor/surfaces/read-authority-clients.test.mjs",
     "build:agent-sdk": "npm run build --workspace=@ioi/agent-sdk",
     "test:agent-sdk": "npm test --workspace=@ioi/agent-sdk",
     "build:wallet-protocol": "npm run build --workspace=@ioi/wallet-protocol",


### PR DESCRIPTION
Wave 0 item W0.3 of the Hypervisor bring-to-life run (stacks on #160, the W0.1 v2 route shell branch). What became operational: the estate now has ONE way to read daemon truth and ONE way to cross authority, consumable from both the serve-side readout lane and browser augmentation modules. `apps/hypervisor/surfaces/read-client.mjs` wraps every projection read in a single deadline with an honest four-kind result taxonomy (read / not_found / refusal / unavailable), stamps `fetched_at` on every result, adds no cache, and never fabricates defaults in degraded results; `apps/hypervisor/surfaces/authority-client.mjs` encodes the CapabilityLease gateway ladder exactly as `authorize_capability_lease` behaves at the bytes (`lifecycle_routes.rs:11899-11942`: 428 sealed-credential refusal → 403 wallet challenge with `approval.policy_hash`/`request_hash` + `authority_challenge` surfaced verbatim → receipted crossing), refuses to no-op silently (crossed-with-receipt_ref, typed refusal, or typed failure — 2xx without a discoverable receipt fails closed as `receipt_missing`), and forwards the wallet grant exactly once, never retaining it. A 13-check stub-gateway contract test lands as `test:hypervisor-app-clients` beside the existing harness lane; app build, source-neutral, token gate, ported-seed invariant (413/413), and the harness test (10/10) are all green. Wave 1/2 PRs consume these clients for read-first launches and receipted actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)