### PR TITLE
plan: SCM transition-chain epic (P0 defects first) + repo-wide UX disposition ledger

### DIFF
--- a/internal-docs/implementation/repo-ux-disposition.md
+++ b/internal-docs/implementation/repo-ux-disposition.md
@@ -1,0 +1,34 @@
+# Repository-wide UX surface disposition ledger
+
+Companion to `scm-transition-chain-epic.md` (2026-08-05 audit absorption).
+One row per user-facing surface in the estate OUTSIDE the twenty briefed
+hypervisor surfaces. "What it is" is byte-verified (existence + whether it
+talks to the hypervisor daemon, checked by grepping for `/v1/hypervisor`).
+Dispositions: adopt · integrate · retain-static · demo-label · retire ·
+UNDISPOSITIONED-needs-owner-ruling. Rows the owner has not ruled and canon
+does not decide are UNDISPOSITIONED — candidates are recorded as candidates,
+never as rulings. The run charter carries one ledger row to rule the
+UNDISPOSITIONED set.
+
+| Surface | What it is (byte-verified) | Disposition | Next action |
+|---|---|---|---|
+| `apps/hypervisor` (product UI, serve lane, scripts, surfaces/ clients) | The hypervisor product estate; daemon-backed throughout; subject of the bring-to-life run | **adopt** (already the run's subject) | Continue the run; epic P0 defects 1-3 live here/daemon |
+| Rust CLI + agent TUI (`crates/cli`, incl. `src/commands/agent_tui.rs`, `agent_tui_loop.rs`, `agent_event_stream.rs`) | Exists; daemon-backed; the most functional non-web interface; has no web-parity brief | **integrate** (per epic P3 parity, C13) | Parity lane for inspect/verify/watch/preflight/reconcile/export at epic P3 |
+| Editor extension targets (`packages/hypervisor-adapter-targets/`: `code-editors/vscode-extension`, `jetbrains`, `ssh`) | Exist as adapter targets with a manifest (`editor-targets.manifest.json`) | UNDISPOSITIONED-needs-owner-ruling | Owner rules whether editor targets carry epic C13 parity obligations (the audit's parity list is UI/API/CLI/TUI/MCP — editors are not named) |
+| `apps/hypervisor-web` | Exists; static Vite scaffold "browser-facing Hypervisor product and marketing surface" (its README); zero `/v1/hypervisor` calls | UNDISPOSITIONED-needs-owner-ruling | Candidate retain-static (marketing); owner confirms + a sweep for any governed-state renderings that would need demo-labels |
+| `apps/developers-ioi-ai` (developers.ioi.ai) | Exists; static curated developer-experience site; zero `/v1/hypervisor` calls | UNDISPOSITIONED-needs-owner-ruling | Candidate retain-static; epic P1 contracts may later pull reference docs onto it |
+| `apps/benchmarks` | Exists; static React benchmark surface; zero `/v1/hypervisor` calls | UNDISPOSITIONED-needs-owner-ruling | Candidate retain-static; verify benchmark claims stay sourced, not fabricated |
+| `apps/aiagent-xyz` (aiagent.xyz) | Exists; static marketing surface ("composable autonomous supply"); zero `/v1/hypervisor` calls | UNDISPOSITIONED-needs-owner-ruling | Candidate retain-static (marketing) |
+| `apps/sas-xyz` (sas.xyz, `/v2` SPA) | Exists; static in-browser React demo (CDN React + Babel); zero daemon calls; renders FABRICATED signed/hash-linked receipts (`v2/receipt.jsx:230-231` Math.random chain; `v2/app.jsx:285-302` client-synthesized live contract) | **demo-label** (ruled by epic P0-5) | Quarantine or unmistakable demo-fixture labeling in the P0 PR; owner may later upgrade to retire |
+| `apps/ioi-ai` (QM: web/admin/portal/auth plugins, Slack surfaces `src/surfaces/slack-*.ts`, deployment CLI `cli/`) | Exists; separate product on its OWN Postgres authority boundary; not hypervisor-daemon-backed | UNDISPOSITIONED-needs-owner-ruling (held) | Out of epic scope; QM adoption is governed by the M-sequencer program (dormant adoption gates M5 exit per owner ruling) — UX disposition rides that ruling, not this run |
+| `apps/hypervisor/ux-seeds/` (workspaces · widgets · lineage) | Exists; DORMANT ported-seed evidence preserved by PRs #93-#95 under `ported-seed-preservation.v1.json` | **retain-static** (already ruled: preserved dormant) | Per-seed adopt-or-archive decided at each owner's W4 cutover PR (already in the briefs) |
+| `packages/hypervisor-workbench` | Exists; TypeScript workbench package consumed by the product UI; mounted-preview adapter honesty is tracked in `surfaces/developer-workspace.md`, not here | **adopt** (part of the briefed estate) | No separate row-level action; epic P0-1/P0-2 touch its publish/code lanes |
+
+Notes:
+
+- The audit lists this exact surface set as "surfaces with NO disposition" —
+  UNDISPOSITIONED here is therefore the owner's own current state, not a gap
+  this ledger invented. Ruling the UNDISPOSITIONED rows is a single
+  owner-scope pass (charter ledger row).
+- `retire` appears in no row yet: no surface has an owner ruling to delete,
+  and this ledger never guesses one.

--- a/internal-docs/implementation/scm-transition-chain-epic.md
+++ b/internal-docs/implementation/scm-transition-chain-epic.md
@@ -1,0 +1,169 @@
+# SCM / Agentgres transition-chain epic — cross-surface brief
+
+Absorbs the owner-delivered research audit of 2026-08-05 into the
+bring-to-life run (`../overhaul/2026-08-05-hypervisor-bring-to-life-run.md`).
+Scope: the Git/provider workflow experience — inbound provider events,
+Agentgres-admitted repository state, publication, and its projection across
+the EXISTING owner surfaces. Same discipline as the surface briefs: every
+cite below was re-verified at the bytes on 2026-08-05; where the audit's
+`file:line` drifted, the correction is recorded inline (bytes win).
+
+Reuse note: the M5 event plane (`/v1/event-streams`, `/v1/subscriptions`) and
+the SCM publication machinery (`scm_publication_routes.rs` — outbound
+publication effects behind the registered contract) are foundations this epic
+builds ON. Neither models inbound provider workflow state today: the daemon's
+only inbound webhook lane is the automation trigger webhook
+(token-hash-authenticated, session-less, per-automation —
+`orchestration_routes.rs:235-245`); there is no signed provider-event
+ingestion anywhere.
+
+## §1 The five P0 current-interface defects
+
+Repair or disable each BEFORE any surface presents the Git workflow
+experience as governed. One PR per defect is fine; the ledger row
+`P0: SCM truthfulness defects` in the run charter covers all five.
+
+**P0-1 — Publish PR uses the wrong contract (lane is dead as wired).**
+Daemon: `handle_scm_publish` requires `destination_binding_ref` +
+`proposal_ref` and refuses otherwise, returning `publication_effect` +
+receipts (`crates/node/src/bin/hypervisor_daemon_routes/scm_publication_routes.rs:1773`,
+refusal at `:1798`; audit cited :1771 — corrected). UI: `publishRunViaConnector`
+sends `{ connector_id, title }` and expects the older `receipt`/`remote_ref`
+shape (`apps/hypervisor/scripts/ioi-agent-runs.mjs:450`; payload `:482`/`:495`;
+expectation `:501-503`; audit cited :446 — corrected). Every UI publish
+therefore hits the typed refusal. Disposition: REPAIR — rewire the client to
+the registered contract (resolve destination binding + bound proposal, render
+`publication_effect` + receipts). Owning surface: Developer Workspace
+(workbench/run publish lane), daemon side already correct.
+
+**P0-2 — `/__ioi/code` publication trail is substring-matched, not queried.**
+`renderCodeRepositories` filters work-ledger rows on
+`String(e.kind||"").includes("publish")`
+(`apps/hypervisor/scripts/serve-product-ui.mjs:1400`, function `:1396`,
+handler `:8682`; audit's path `product-ui/serve-product-ui.mjs:8681` does not
+exist — corrected to `scripts/`, handler at `:8682`). The work-ledger emits
+`kind: "marketplace_publish"` rows
+(`crates/node/src/bin/hypervisor_daemon_routes/orchestration_routes.rs:908-916`,
+handler `:529-532`; audit cited :897 — corrected), so marketplace publication
+renders as code publication. Disposition: REPAIR-OR-DISABLE — query SCM
+publication effects (P2 projection) or, until then, restrict the pane to the
+SCM publication-effect record family / remove the trail. Owning surface:
+Developer Workspace (`/__ioi/code` folds into the workbench per its own
+header comment).
+
+**P0-3 — PR draft synthesizes an `agentgres://` ref without admission.**
+`POST /v1/hypervisor/environments/:id/pull-request-drafts` writes a plain
+record and answers
+`proposal_ref: "agentgres://pull-request-draft/{pid}"`
+(`crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs:916`
+route doc, handler `:921`, plain `persist_record` `:1033`, ref synthesis
+`:1035` — audit cite verified). No exact-head admission, no authority proof,
+no durable receipt — an `agentgres://` ref implying admitted chain state that
+never crossed admission. Disposition: REPAIR — until owner-controlled
+Agentgres exact-head admission exists (P1 contract, P2 wiring), the response
+must stop minting `agentgres://` refs; return an honestly-named local
+proposal ref. Owning surface: Work (agent-run → draft lane,
+`ioi-agent-runs.mjs:416` `createLocalPullRequestDraft`), daemon route repair.
+
+**P0-4 — GitHub App setup registers no webhook and subscribes to no events.**
+`handle_github_app_manifest` deliberately omits `hook_attributes` and sets
+`default_events: []`
+(`crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs:16948`
+handler, explicit no-webhook comment `:16972-16975`, empty events `:16984`;
+audit cited :16937 — corrected). Deliberate for the localhost BYOA flow, but
+the consequence stands: workflow events cannot be ingested, so no surface may
+present provider workflow state as live. Disposition: REPAIR at P2 (signed
+webhook registration + event subscription, Developer Console); until then any
+UI copy implying live provider events is disabled-with-named-gap. Owning
+surface: Developer Console.
+
+**P0-5 — apps/sas-xyz/v2 displays fabricated signed/hash-linked receipts.**
+`synthesizeReceipt` mints `chain.thisHash`/`prevHash` from `Math.random()`
+with "Receipt signed and chained" copy
+(`apps/sas-xyz/v2/receipt.jsx:229-231`, trace copy `:223`; audit cite :229
+verified), and `onDraftGoLive` synthesizes a "live" contract client-side
+(`apps/sas-xyz/v2/app.jsx:285-302`, fabricated `receipts30d` `:296`; audit
+cite :285 verified). The app makes zero daemon calls (no `/v1/hypervisor`
+references). Disposition: DEMO-LABEL or quarantine — unmistakable demo-fixture
+labeling on every fabricated-proof rendering, in the same P0 PR. Owning
+surface: none of the nine (estate app) — see `repo-ux-disposition.md`.
+
+## §2 Missing Git/Agentgres interface coverage, by EXISTING owner
+
+Never a new top-level app. Each row lands inside the named brief's waves;
+the brief carries a matching `### Git/Agentgres transition-chain interfaces
+(epic)` pointer back to this table.
+
+| Owner (brief) | Missing interface coverage |
+|---|---|
+| Projects (`surfaces/projects.md`) | Repo/installation/ref/workflow enrollment; typed Git OIDs (algorithm-tagged); workflow policy; latest admitted state; chain health per project |
+| Developer Console (`surfaces/developer-console.md`) | Signed webhook registration; secret rotation; provider permissions/events; repo selection; delivery/reconciliation health |
+| Developer Workspace (`surfaces/developer-workspace.md`) | Commit/PR check timeline; provider-observed vs IOI-admitted state; policy preflight; receipt links; reconcile/retry; stale/fork/unknown states |
+| Automations (`surfaces/automations.md`) | Provider-event mapping; workflow revision/run-attempt identity; legal transition graph; reconciliation; receipted outbound check projection |
+| Work (`surfaces/work.md`) | Repository/ref/commit/check subjects + integration transition history on WorkRun; `HypervisorWorkRunIntegrationStatus` is named in work.md §1 (`work.md:74`, canon `core-clients-surfaces.md:4300-4310`) but mapped in neither §2 nor §4 — closed by this epic at P2 |
+| Governance (`surfaces/governance.md`) | Admission + required-check policy; authority freshness; policy version/revocation; override justification; reconciliation approval; witness policy |
+| Provenance (`surfaces/provenance.md`) | Transition-chain search/timeline; head/predecessor/gap/fork verification; integrity vs currentness; checkpoint verification; proof export |
+| Operations (`surfaces/operations.md`) | Signature failures; ingest lag; duplicates/out-of-order; Agentgres conflicts; dead letters; backfill/reconciliation; provider outages; checkpoint health |
+| Settings / Home / Systems (`surfaces/settings.md`, `home.md`, `systems.md`) | Preferences + read-only summaries/deep links ONLY — never competing truth owners |
+
+## §3 Missing contracts beneath the UI — build-list with owner assignment
+
+Kinds: **daemon** = daemon route/record family · **schema** = schema-registry /
+canon contract entry · **client** = shared client (`apps/hypervisor/surfaces/*`,
+route shell) work.
+
+| # | Contract | Kind | Owner | Phase |
+|---|---|---|---|---|
+| C1 | Registered provider-neutral transition profile + legal state machine (state vocabulary) | schema | Governance (canon) + registry | P1 |
+| C2 | Owner-qualified repository/workflow bindings + algorithm-tagged Git OIDs | schema + daemon | Projects | P1/P2 |
+| C3 | Delivery / workflow / run / check / attempt identities | schema | Automations | P1 |
+| C4 | Signed, replay-protected, idempotent webhook ingestion with tenant/repository binding | daemon | Developer Console | P2 |
+| C5 | Owner-controlled Agentgres exact-head admission | daemon | Projects (admission), Governance (policy) | P1 contract / P2 wiring |
+| C6 | List / head / detail / history / filtered projections over the chain | daemon | each owner's read family | P2 |
+| C7 | Duplicate / omission / out-of-order / force-push / outage reconciliation | daemon | Operations (health) + Governance (approval) | P2/P3 |
+| C8 | Policy / override / revocation / authority-freshness objects | schema + daemon | Governance | P1/P3 |
+| C9 | Receipt / checkpoint verification + export routes | daemon | Provenance | P3 |
+| C10 | Domain event namespace for live UI updates (rides the M5 plane) | daemon + client | event plane (W0.4 client already landed) | P2 |
+| C11 | Principal/policy filtering + redaction before counts/search/exports | daemon (cross-cutting) | every projection above | P2/P3 |
+| C12 | Stable cross-surface deep-link grammar | client | route shell (`v2-route-shell.mjs:328` is exact root lookup today) | P1 (W1 addendum) |
+| C13 | UI/API/CLI/TUI/MCP parity for inspect/verify/watch/preflight/reconcile/export | client + `crates/cli` | parity lane | P3 |
+
+## §4 Sequencing — P0→P3, interleaved with the run's waves
+
+- **P0 — truthfulness (lands FIRST).** The five §1 defects, before any
+  surface presents the Git workflow as governed and before the `work build`
+  ledger row starts. Interleave: alongside W0.5/W0.6; no P1-P3 item and no
+  surface's Git-facing pane ships while a P0 defect is live on that lane.
+- **P1 — contracts.** Ownership map (§2), schemas + state vocabulary (C1-C3),
+  threat model for the ingestion boundary, admission + reconciliation
+  contracts (C5, C8), deep-link grammar (C12). Interleave: rides the W1
+  window; every P1 contract that a P2 wiring item consumes must be registered
+  before that wiring lands (contracts before wiring, the run's standing
+  8-step discipline).
+- **P2 — ingestion + projections + owner wiring.** Provider ingestion (C4),
+  Agentgres projections (C5 wiring, C6, C10, C11), then wire Projects /
+  Developer Console / Developer Workspace / Automations / Work per §2 —
+  including closing Work's `HypervisorWorkRunIntegrationStatus`
+  named-but-unmapped gap. Interleave: W2 (authority-crossing registrations
+  via the lease client) and W3 (new backend families ride the W3 build-list
+  mechanism; `hypervisor-daemon.rs` route PRs serialize).
+- **P3 — proofs + parity + acceptance.** Governance/Provenance/Operations
+  actions + proofs (C7 approval leg, C8 actions, C9), CLI/TUI parity (C13),
+  a11y/security/observability/real-daemon-E2E acceptance for the Git
+  workflow lanes. Interleave: W3/W4; the cutover of any legacy Git-facing
+  readout (e.g. `/__ioi/code`) happens at its owner's W4 leg per the 6-step
+  rule.
+
+## §5 Non-goals
+
+- **No new top-level application.** All coverage lands in the nine existing
+  owners (§2); the taxonomy stays 12 owner apps + 2 substrate + 6 core
+  workspaces.
+- **Settings, Home, Systems stay read-only** for this domain: preferences,
+  summaries, deep links — never a competing truth owner over chain state.
+- **No proof apparatus** (run charter regime).
+- **QM (`apps/ioi-ai`) is out of scope** — separate Postgres authority
+  boundary; its surfaces are dispositioned (or held) in
+  `repo-ux-disposition.md`, not wired here.
+- **No re-decision of C-1..C-4**: chain subjects attach to sessions via
+  `subject_attachments`, never named app fields.

--- a/internal-docs/implementation/surfaces/_index.md
+++ b/internal-docs/implementation/surfaces/_index.md
@@ -35,6 +35,23 @@ brief is refreshed against the bytes before its surface is built (Phase B).
 Embodied Systems (`/embodied-systems`) is a reserved, nonlaunchable
 registration row in the compiler (planned) — no brief, no UI work.
 
+## Epics (cross-surface, 2026-08-05 audit absorption)
+
+- [`../scm-transition-chain-epic.md`](../scm-transition-chain-epic.md) — the
+  Git/Agentgres transition-chain epic: five P0 truthfulness defects (§1,
+  lands before any surface presents the Git workflow as governed), the
+  owner-by-owner missing-interface table (§2), the missing-contracts
+  build-list (§3), P0→P3 wave interleaving (§4). Coverage lands ONLY in
+  existing owners; the nine affected briefs (projects, developer-console,
+  developer-workspace, automations, work, governance, provenance, operations,
+  settings) each carry a final `### Git/Agentgres transition-chain interfaces
+  (epic)` pointer to their §2 row.
+- [`../repo-ux-disposition.md`](../repo-ux-disposition.md) — repository-wide
+  surface disposition ledger (estate surfaces outside these briefs: CLI/TUI,
+  editor targets, hypervisor-web, developers.ioi.ai, benchmarks, aiagent.xyz,
+  sas.xyz, QM); UNDISPOSITIONED rows await one owner-scope ruling pass
+  (charter ledger row).
+
 ## Shared plumbing every brief assumes (Wave 0)
 
 - **W0.1** v2 route shell: the 23 canonical routes as the shell route table;

--- a/internal-docs/implementation/surfaces/automations.md
+++ b/internal-docs/implementation/surfaces/automations.md
@@ -217,3 +217,14 @@ deleted at W4 per the master ladder.
     `/__ioi/automations/monitors`, `/__ioi/studio/machinery`; delete the SPA WorkflowService
     stub surface and the `server.cjs` "Automate" fixture (:895); rail/nav rows come from the
     product-surface compiler only.
+
+### Git/Agentgres transition-chain interfaces (epic)
+
+From the 2026-08-05 audit ([epic §2](../scm-transition-chain-epic.md)):
+Automations gains provider-event mapping, workflow revision/run-attempt
+identity, the legal transition graph, reconciliation views, and the
+receipted outbound check projection; it owns the delivery/workflow/run/
+check/attempt identity contracts (epic §3 C3, a P1 item). Its inbound lane
+today is only the token-hash automation webhook
+(`orchestration_routes.rs:235-245`) — provider ingestion arrives via
+Developer Console's C4, mapped here at P2.

--- a/internal-docs/implementation/surfaces/developer-console.md
+++ b/internal-docs/implementation/surfaces/developer-console.md
@@ -231,3 +231,13 @@ elements exist on this surface (no `subject_attachments` rows).
    `/__ioi/slack/setup` retired with typed 410s; ux-seeds/widgets disposition
    (adopt under `/developer-console` or archive) decided in the same PR; census
    control-count refresh recorded.
+
+### Git/Agentgres transition-chain interfaces (epic)
+
+From the 2026-08-05 audit ([epic §2](../scm-transition-chain-epic.md)):
+Developer Console gains signed webhook registration, secret rotation,
+provider permissions/events, repo selection, and delivery/reconciliation
+health; it owns signed, replay-protected, idempotent webhook ingestion
+(epic §3 C4). Epic P0-4 — the GitHub App manifest registers no webhook and
+subscribes to no events (`lifecycle_routes.rs:16948`, `:16984`) — is this
+owner's repair, wired at the epic's P2 leg.

--- a/internal-docs/implementation/surfaces/developer-workspace.md
+++ b/internal-docs/implementation/surfaces/developer-workspace.md
@@ -215,3 +215,14 @@ machinery (editor_routes.rs:4-6). Reads go through the W0.3 read client.
 10. **W4** — Cutover per the 6-step rule: `/workspaces/:id`, `/details/:id`,
     `/__ioi/workbench` retired with typed 410s; ux-seeds/workspaces disposition
     decided (adopt or archive) at the same PR.
+
+### Git/Agentgres transition-chain interfaces (epic)
+
+From the 2026-08-05 audit ([epic §2](../scm-transition-chain-epic.md)):
+Developer Workspace gains the commit/PR check timeline, provider-observed vs
+IOI-admitted state, policy preflight, receipt links, reconcile/retry, and
+stale/fork/unknown states. Epic P0-1 (UI publish sends `connector_id`+`title`
+against the daemon's `destination_binding_ref`+`proposal_ref` contract —
+`ioi-agent-runs.mjs:450/:482/:495` vs `scm_publication_routes.rs:1773/:1798`)
+and P0-2 (`/__ioi/code` substring-matched publish trail,
+`serve-product-ui.mjs:1400`) are this owner's repair-or-disable items.

--- a/internal-docs/implementation/surfaces/governance.md
+++ b/internal-docs/implementation/surfaces/governance.md
@@ -201,3 +201,13 @@ hotspot (master guide standing rule; not re-decided here).
    receipt stream (joint PR with Provenance brief step 6).
 9. **W4** — Cutover: `/__ioi/governance*` retired with typed 410s per the
    6-step per-app rule; shell stops advertising the legacy paths.
+
+### Git/Agentgres transition-chain interfaces (epic)
+
+From the 2026-08-05 audit ([epic §2](../scm-transition-chain-epic.md)):
+Governance gains admission + required-check policy, authority freshness,
+policy version/revocation, override justification, reconciliation approval,
+and witness policy over the transition chain; it owns the provider-neutral
+state vocabulary (epic §3 C1, P1) and the policy/override/revocation/
+authority-freshness objects (C8). Approval legs of reconciliation (C7) land
+at P3 through the unified inbox this brief already plans.

--- a/internal-docs/implementation/surfaces/operations.md
+++ b/internal-docs/implementation/surfaces/operations.md
@@ -117,3 +117,13 @@ Reads ride the W0.3 read-projection client; authority actions ride the W0.3 auth
 7. **W2** — Membership/writer/continuity operations pane: proposal → Governance-gated decision → receipted execution, rendered as the governed two-step it is.
 8. **W3** — Backend builds + UI same wave: unified infrastructure-jobs projection (subjects via `subject_attachments`), capacity/utilization overview, RPO/RTO + degraded/partition rollup (§2 route-missing rows).
 9. **W4** — Cutover: `/__ioi/operations` retired with typed 410 per the 6-step rule; catalog tile (`serve-product-ui.mjs:1472`) repointed by the compiler projection; incidents-port and work-ledger cross-links repointed to `/operations`.
+
+### Git/Agentgres transition-chain interfaces (epic)
+
+From the 2026-08-05 audit ([epic §2](../scm-transition-chain-epic.md)):
+Operations gains the ingestion-health plane: signature failures, ingest lag,
+duplicates/out-of-order, Agentgres conflicts, dead letters,
+backfill/reconciliation, provider outages, and checkpoint health; it owns
+the health half of the reconciliation contracts (epic §3 C7 — Governance
+owns the approval half). Lands P2/P3, riding this brief's existing
+unified-jobs and rollup projections.

--- a/internal-docs/implementation/surfaces/projects.md
+++ b/internal-docs/implementation/surfaces/projects.md
@@ -165,3 +165,12 @@ named-field sites were found in the Project lanes audited here.
    the import wizard UI in the same wave.
 7. **W4** — Cutover residue: remove the mock bundle's project fixtures with
    the fixture-lane deletion; confirm `/projects` carries zero fallthrough.
+
+### Git/Agentgres transition-chain interfaces (epic)
+
+From the 2026-08-05 audit ([epic §2](../scm-transition-chain-epic.md)):
+Projects gains repo/installation/ref/workflow enrollment, algorithm-tagged
+Git OIDs, workflow policy, latest-admitted-state and chain-health panes; it
+owns the owner-qualified repository/workflow binding contracts (epic §3 C2)
+and the Agentgres exact-head admission surface (C5). P1 contracts land
+before P2 wiring; no new top-level app.

--- a/internal-docs/implementation/surfaces/provenance.md
+++ b/internal-docs/implementation/surfaces/provenance.md
@@ -208,3 +208,12 @@ router = merge hotspot; standing rule).
    `/__ioi/run-replay`, `/__ioi/lineage`, `/__ioi/vertex` retired with typed
    410s per the 6-step rule; estate tiles/headers stop advertising the legacy
    paths.
+
+### Git/Agentgres transition-chain interfaces (epic)
+
+From the 2026-08-05 audit ([epic §2](../scm-transition-chain-epic.md)):
+Provenance gains transition-chain search/timeline, head/predecessor/gap/fork
+verification, the integrity-vs-currentness distinction, checkpoint
+verification, and proof export; it owns the receipt/checkpoint verification
++ export routes (epic §3 C9, a P3 leg) — these fold into the unified
+receipt-stream projection this brief already plans.

--- a/internal-docs/implementation/surfaces/settings.md
+++ b/internal-docs/implementation/surfaces/settings.md
@@ -287,3 +287,12 @@ authority client already encodes it. No row binds session-serving data (no
 11. **W4** — One-line canon PR: fix the five five-count locations (:819, :1793-1794,
     :4545-4546, :4582-4583, :4803) and add the dedicated `Hypervisor Settings` section
     beside the other core-workspace sections.
+
+### Git/Agentgres transition-chain interfaces (epic)
+
+From the 2026-08-05 audit ([epic §2](../scm-transition-chain-epic.md)):
+Settings — like Home and Systems — gains only preferences plus read-only
+summaries and deep links into the chain owners' surfaces, and may NEVER
+become a competing truth owner over transition-chain state (epic §5
+non-goal). Projection-only, writes-through-owners, exactly this brief's
+standing rule.

--- a/internal-docs/implementation/surfaces/work.md
+++ b/internal-docs/implementation/surfaces/work.md
@@ -257,3 +257,15 @@ elements bind through `subject_attachments` (C-1) — never a named app field.
     advertisements (30-shell.js:11, 60-shell-wiring.js:35/:39, 40-home-explorer.js:303,
     serve :8630/:7660); retire `/__ioi/sessions`, `/__ioi/missions`,
     `/__ioi/missions/incidents` with typed refusals + no-fallback proof.
+
+### Git/Agentgres transition-chain interfaces (epic)
+
+From the 2026-08-05 audit ([epic §2](../scm-transition-chain-epic.md)):
+Work gains repository/ref/commit/check SUBJECTS (via `subject_attachments`,
+never named fields) and integration transition history on WorkRun.
+Explicitly: `HypervisorWorkRunIntegrationStatus` is named in §1 above (:74,
+canon `core-clients-surfaces.md:4300-4310`) but mapped in neither §2 nor §4
+— that named-but-unmapped gap is CLOSED by the epic at P2. Epic P0-3 (the
+run→draft lane's synthesized `agentgres://pull-request-draft/...` ref,
+`environment_routes.rs:1035` via `ioi-agent-runs.mjs:416`) is this owner's
+truthfulness repair.

--- a/internal-docs/overhaul/2026-08-05-hypervisor-bring-to-life-run.md
+++ b/internal-docs/overhaul/2026-08-05-hypervisor-bring-to-life-run.md
@@ -150,6 +150,18 @@ the PR that touches it, with the guide recording remaining sites.
   the M5 plane · W0.5 identity truth (delete adapter constants,
   IDENTITY_REWRITES, 5 fixture-only RPCs) · W0.6 backend enablers
   (sessions/overview, unified approvals inbox, /v1 index, scheduler status).
+  - **W0 client addenda (from 2026-08-05 audit)** — gaps in the landed W0
+    clients, each closed in the wave that consumes it (the W0 checkmarks are
+    not re-opened): grant-ACQUISITION journey on the authority client
+    (connect/sign/resubmit; today `crossWithLease` only transports a supplied
+    grant — `apps/hypervisor/surfaces/authority-client.mjs:137`) → **W2**;
+    schema-version negotiation + pagination + cancellation on the read client
+    (untyped JSON transport today — `apps/hypervisor/surfaces/read-client.mjs:57`)
+    → **W1**; central dynamic deep-link grammar in the route shell (exact
+    root lookup today — `apps/hypervisor/scripts/v2-route-shell.mjs:328`)
+    → **W1** (epic C12); `/sign-in` has a shell route row
+    (`v2-route-shell.mjs:129`) but no binding/cutover row anywhere → **W2**
+    (identity/authority leg).
 - [ ] **Wave 1 — read-first launches**: Work + Sessions views · Provenance ·
   Environments · Operations · Governance reads + inbox · Ontology · Data ·
   Automations · Foundry · Developer Workspace rehome. Exit per app: canonical
@@ -216,6 +228,7 @@ unchecked row, refreshes its brief at the bytes, and executes.
 | W0.4 event client (M5 plane) | ☑ 2026-08-05 | `apps/hypervisor/surfaces/event-client.mjs` — durable `/v1/subscriptions` pull with typed live/resuming/daemon_unavailable/refused states, checkpoint-token resume, and `wrapLegacySse` presenting the same consumer interface (deprecated); 12-check stub-plane test at `test:hypervisor-app-events` |
 | W0.5 identity truth | ☑ 2026-08-05 | removed: adapter constant identity + `IDENTITY_REWRITES` (captured demo-identity HTML residue now deleted, not substituted), ToS/org-policy/service-account/runner-manager/runner-logs/subscription constants, runner dressing, env logs-token + mark-active lies, mock fallthrough; daemon-backed: GetAuthenticatedUser+GetAccount (whoami), GetOrganization (W0.6 `GET /v1/hypervisor/organization`), ListSCMIntegrations (scm-connectors), GetEnvironmentClass (environment-classes); typed-unavailable: GetOrganizationPolicies, GetTermsOfService, ListServiceAccounts, InsightsService, runner-managers/logs-tokens, org update + all unmatched RPCs 501; named-gap banners on 5 settings panes (85-settings-gaps.js) |
 | W0.6 backend enablers | ☑ 2026-08-05 | five routes live: `GET /v1/hypervisor/sessions/overview` (C-1: `subject_attachments` introduced on session records, the 3 named-field sites migrated) · `GET /v1/hypervisor/governance/approvals-inbox` (folds 4 decision planes + 2 named decision-shaped planes) · `GET /v1` (mechanically derived route-family index) · `GET /v1/hypervisor/scheduler/status` (liveness only; schedule posture stays on `/operations`) · `GET /v1/hypervisor/organization` (honest org-identity read) |
+| P0: SCM truthfulness defects (epic §1) | ☐ | five repair-or-disable defects, byte-verified — `internal-docs/implementation/scm-transition-chain-epic.md` §1; lands BEFORE any surface presents the Git workflow as governed |
 | work build (owns `/work/sessions`; Cut #2 is its W4 leg) | ☐ | surfaces/work.md §5 |
 | provenance build | ☐ | surfaces/provenance.md §5 |
 | environments build | ☐ | surfaces/environments.md §5 |
@@ -236,4 +249,8 @@ unchecked row, refreshes its brief at the bytes, and executes.
 | projects build | ☐ | surfaces/projects.md §5 |
 | applications build | ☐ | surfaces/applications.md §5 |
 | settings build | ☐ | surfaces/settings.md §5 |
+| SCM/Agentgres epic P1 contracts | ☐ | schemas/state vocabulary/threat model/admission + reconciliation contracts (epic §3 C1-C3/C5/C8/C12); interleaves with W1 per epic §4; contracts before wiring |
+| SCM/Agentgres epic P2 ingestion + owner wiring | ☐ | signed webhook ingestion + Agentgres projections; wire Projects/Console/Workspace/Automations/Work (epic §2); interleaves with W2/W3 per epic §4 |
+| SCM/Agentgres epic P3 proofs + parity + acceptance | ☐ | Governance/Provenance/Operations actions + proofs · CLI/TUI parity (C13) · a11y/security/observability/E2E acceptance; interleaves with W3/W4 per epic §4 |
 | Wave 4 shared cutover | ☐ | server.cjs mocks · fixture API lane · duplicate static copy · canon 5-vs-6 nit (settings.md pins the 5 locations) |
+| repo-wide UX disposition ledger — rule the UNDISPOSITIONED rows | ☐ | `internal-docs/implementation/repo-ux-disposition.md`; owner-scope pass over the estate surfaces the 2026-08-05 audit left undispositioned |


### PR DESCRIPTION
Absorbs the owner-delivered 2026-08-05 research audit into the bring-to-life run as docs-only planning: a cross-surface SCM/Agentgres transition-chain epic (`internal-docs/implementation/scm-transition-chain-epic.md`) whose §1 pins the five P0 truthfulness defects at byte-verified cites with per-defect repair-or-disable dispositions (cite drift corrected: `scm_publication_routes.rs:1773/:1798`, `ioi-agent-runs.mjs:450`, serve lane at `scripts/serve-product-ui.mjs:1400/:8682`, `orchestration_routes.rs:908-916`, `lifecycle_routes.rs:16948/:16984`), §2-§3 route all missing Git/Agentgres coverage into the nine EXISTING owners with a contract build-list, and §4-§5 interleave P0→P3 with the run's waves (P0 before any surface presents the Git workflow as governed; contracts before wiring; never a new top-level app); plus a repo-wide UX disposition ledger (`internal-docs/implementation/repo-ux-disposition.md` — sas.xyz demo-labeled per P0-5, unruled estate rows held UNDISPOSITIONED), the matching run-charter ledger rows and W0 client addenda, an Epics section in the surfaces index, and append-only epic pointers on the nine owner briefs (work.md explicitly notes the `HypervisorWorkRunIntegrationStatus` named-but-unmapped gap closes at epic P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)