### PR TITLE
canon: Agentgres positioning hierarchy — category claim leads, bridge follows, never the identity

### DIFF
--- a/docs/architecture/components/agentgres/doctrine.md
+++ b/docs/architecture/components/agentgres/doctrine.md
@@ -80,6 +80,11 @@ Agent execution branch doctrine:
 
 > **Git versions code. Agentgres versions autonomous work.**
 
+This sentence is also the canonical positioning headline: per
+[`postgres-bridge-and-readiness-contract.md`](./postgres-bridge-and-readiness-contract.md),
+every surface that positions Agentgres leads with this category claim, and the
+Postgres bridge follows as the adoption feature, never the identity.
+
 Agentgres must treat serious agent work as branchable, replayable execution
 state, not only as an event log after the run finishes. A branch may include
 source diffs, but it is broader than Git: it binds the workspace snapshot,

--- a/docs/architecture/components/agentgres/postgres-bridge-and-readiness-contract.md
+++ b/docs/architecture/components/agentgres/postgres-bridge-and-readiness-contract.md
@@ -1,8 +1,8 @@
 # Agentgres Postgres Bridge and Readiness Contract
 
 Status: canonical architecture authority.
-Canonical owner: this file for Agentgres Postgres bridge posture, database-readiness guarantees, consistency names, durability expectations, schema/migration lifecycle, replication profile, recovery profile, and operator surface.
-Supersedes: loose "Postgres replacement" language when compatibility or database guarantees are discussed.
+Canonical owner: this file for Agentgres positioning hierarchy, Postgres bridge posture, database-readiness guarantees, consistency names, durability expectations, schema/migration lifecycle, replication profile, recovery profile, and operator surface.
+Supersedes: loose "Postgres replacement" language when compatibility or database guarantees are discussed, and any Postgres-led positioning ("evolution of Postgres", "Postgres, but better") wherever Agentgres is positioned.
 Superseded by: none.
 Last alignment pass: 2026-05-14.
 Doctrine status: canonical
@@ -22,6 +22,30 @@ Public positioning:
 Builder-facing positioning:
 
 > **Agentgres is a Postgres-compatible operational substrate for worker-produced state.**
+
+Positioning hierarchy:
+
+> **The category claim leads. The bridge follows. The bridge is never the
+> identity.**
+
+Every surface that positions Agentgres — canonical docs, product stories,
+launch and demo surfaces, external copy — leads with the agent execution
+branch doctrine owned by [`doctrine.md`](./doctrine.md): **Git versions code.
+Agentgres versions autonomous work.** The category is branchable, replayable,
+receipted autonomous work under admitted authority; no incumbent competes on
+that axis. The Postgres bridge is the adoption feature stated after the
+category claim, with its contract stated the same way every time: reads are
+Postgres-shaped projections of settled state; writes cross the admission
+boundary. Positioning that leads
+with Postgres — "an evolution of Postgres", "a Postgres replacement",
+"Postgres, but better" — is non-canonical and superseded by this ruling, for
+the same reason the naked-replacement language below is: it invites evaluation
+on the incumbent's axis (SQL completeness, OLTP throughput, extension
+ecosystem) and hides the category Agentgres creates.
+
+While this file's bridge posture remains planned, positioning surfaces state
+the bridge as roadmap, not as a present capability; demonstrations carry
+receipts, replay, and execution branches, not SQL.
 
 Avoid naked "Agentgres is a Postgres replacement" language in canonical docs.
 The stronger claim is narrower and more defensible: Agentgres replaces


### PR DESCRIPTION
## What

Canonizes the 2026-08-05 owner ruling in the `docs/architecture` authority files. PR #168 bound this ruling onto the SCM transition-chain epic as program constraints; this PR is the canon half — without it, the epic cites an emphasis rule canon does not state.

## Changes

**`postgres-bridge-and-readiness-contract.md`** (positioning owner)
- New **Positioning hierarchy** ruling after the public/builder positioning quotes: every surface that positions Agentgres leads with the agent-execution-branch doctrine ("Git versions code. Agentgres versions autonomous work"); the Postgres bridge is the adoption feature stated after it, its contract always stated as *reads are Postgres-shaped projections of settled state; writes cross the admission boundary*. Postgres-led positioning ("evolution of Postgres", "Postgres replacement", "Postgres, but better") is non-canonical.
- No-bridge-front-running rule: while the bridge posture remains `planned`, positioning surfaces state it as roadmap; demonstrations carry receipts, replay, and execution branches, not SQL.
- Front-matter: owner scope gains "positioning hierarchy"; Supersedes widened to Postgres-led positioning.
- The epic's pin-cites into this file (`:9`, `:18-26`) are unmoved by the insertions.

**`doctrine.md`**
- One cross-reference paragraph at the agent execution branch doctrine naming it the canonical positioning headline, pointing at the owner file.

## Alignment

- Consistent with epic constraints 2 and 3 from #168 (front-running, headline); constraint 1 (admission-only writes) already lives in canon at `doctrine.md` ("Rows are views. Settled state is truth") and needs no new statement.
- Estate sweep found no Postgres-led positioning to reconcile: ADR 0003 and the archived v2 reference already reject replacement language.
- Docs-only; not on the M5 branch; independent of the W0 merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)