### PR TITLE
foundry: reproducible training-program revisions — canon contract family, W3.0 contract wave, route-plane honesty fixes

### DIFF
--- a/crates/node/src/bin/hypervisor_daemon_routes/foundry_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/foundry_routes.rs
@@ -46,6 +46,31 @@ fn safe(seg: &str) -> String {
         "_",
     )
 }
+/// Content hash of a spec record with volatile timestamps excluded. Pins the
+/// MEANING a run plan was drafted against: a later spec edit flips the plan's
+/// computed `spec_drifted` readout instead of silently changing what the plan
+/// describes.
+fn spec_content_hash(spec: &Value) -> String {
+    use sha2::{Digest, Sha256};
+    let mut s = spec.clone();
+    if let Some(obj) = s.as_object_mut() {
+        obj.remove("created_at");
+        obj.remove("updated_at");
+    }
+    format!(
+        "sha256:{:x}",
+        Sha256::digest(serde_json::to_vec(&s).unwrap_or_default())
+    )
+}
+fn persist_failed(error: std::io::Error) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "ok": false, "error": {
+            "code": "foundry_persist_failed",
+            "message": format!("record was not durably persisted: {error}")
+        } })),
+    )
+}
 fn nanos() -> u128 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -340,7 +365,9 @@ pub(crate) async fn handle_foundry_spec_create(
         "created_at": now,
         "updated_at": now
     });
-    let _ = persist_record(&st.data_dir, SPEC_KIND, &id, &record);
+    if let Err(error) = persist_record(&st.data_dir, SPEC_KIND, &id, &record) {
+        return persist_failed(error);
+    }
     (
         StatusCode::CREATED,
         Json(json!({ "ok": true, "spec": record })),
@@ -414,7 +441,12 @@ pub(crate) async fn handle_foundry_spec_patch(
         }
     }
     s["updated_at"] = json!(iso_now());
-    let _ = persist_record(&st.data_dir, SPEC_KIND, &id, &s);
+    if let Err(error) = persist_record(&st.data_dir, SPEC_KIND, &id, &s) {
+        return Json(json!({ "ok": false, "error": {
+            "code": "foundry_persist_failed",
+            "message": format!("record was not durably persisted: {error}")
+        } }));
+    }
     Json(json!({ "ok": true, "spec": s }))
 }
 
@@ -520,6 +552,10 @@ pub(crate) async fn handle_foundry_run_plan_create(
         "object": "ioi.hypervisor.foundry_run_plan",
         "id": id,
         "spec_ref": spec_ref,
+        // Pins the spec CONTENT this plan was drafted against; a later spec
+        // edit surfaces as `spec_drifted` on reads instead of silently
+        // changing the plan's meaning.
+        "spec_content_hash": spec_content_hash(&spec),
         "name": body.get("name").and_then(|v| v.as_str()).unwrap_or("foundry-run-plan"),
         "description": body.get("description").and_then(|v| v.as_str()).unwrap_or(""),
         "status": "draft",
@@ -533,7 +569,9 @@ pub(crate) async fn handle_foundry_run_plan_create(
         "created_at": now,
         "updated_at": now
     });
-    let _ = persist_record(&st.data_dir, RUN_PLAN_KIND, &id, &record);
+    if let Err(error) = persist_record(&st.data_dir, RUN_PLAN_KIND, &id, &record) {
+        return persist_failed(error);
+    }
     (
         StatusCode::CREATED,
         Json(json!({ "ok": true, "run_plan": record })),
@@ -541,12 +579,38 @@ pub(crate) async fn handle_foundry_run_plan_create(
 }
 
 /// GET /v1/hypervisor/foundry/run-plans/:id — fetch one FoundryRunPlan.
+/// `spec_drifted` / `spec_missing` are COMPUTED read fields (never persisted):
+/// they compare the pinned `spec_content_hash` against the spec as it exists
+/// now, so a plan whose spec was edited or deleted after drafting reads as
+/// drifted instead of silently meaning something else.
 pub(crate) async fn handle_foundry_run_plan_get(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
 ) -> Json<Value> {
     match load(&st.data_dir, RUN_PLAN_KIND, &id) {
-        Some(p) => Json(json!({ "ok": true, "run_plan": p })),
+        Some(mut p) => {
+            if let Some(pinned) = p
+                .get("spec_content_hash")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+            {
+                let spec_ref = p
+                    .get("spec_ref")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                match load(&st.data_dir, SPEC_KIND, &spec_ref) {
+                    Some(spec) => {
+                        p["spec_drifted"] = json!(spec_content_hash(&spec) != pinned);
+                        p["spec_missing"] = json!(false);
+                    }
+                    None => {
+                        p["spec_missing"] = json!(true);
+                    }
+                }
+            }
+            Json(json!({ "ok": true, "run_plan": p }))
+        }
         None => Json(json!({ "ok": false, "reason": "foundry run plan not found" })),
     }
 }
@@ -644,6 +708,22 @@ mod foundry_tests {
         assert!(ids.contains("provider.y"));
         assert!(ids.contains("provider.z"));
         assert_eq!(ids.len(), 3);
+    }
+
+    #[test]
+    fn spec_content_hash_ignores_timestamps_and_tracks_content() {
+        let a = json!({
+            "id": "fspec_1", "kind": "model_eval", "inputs": {"objective": "x"},
+            "created_at": "2026-08-06T00:00:00Z", "updated_at": "2026-08-06T00:00:00Z"
+        });
+        // A patch that only bumps timestamps is NOT drift.
+        let mut b = a.clone();
+        b["updated_at"] = json!("2026-08-06T09:00:00Z");
+        assert_eq!(spec_content_hash(&a), spec_content_hash(&b));
+        // A content edit IS drift.
+        let mut c = a.clone();
+        c["inputs"] = json!({"objective": "y"});
+        assert_ne!(spec_content_hash(&a), spec_content_hash(&c));
     }
 
     #[test]

--- a/crates/node/src/bin/hypervisor_daemon_routes/operability_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/operability_routes.rs
@@ -546,7 +546,10 @@ pub(crate) async fn handle_v1_index() -> Json<Value> {
             row["retired"] = json!(true);
             row["note"] = json!("answers with the typed route-retirement refusal (410)");
         }
-        families.entry(family_of(&route.path)).or_default().push(row);
+        families
+            .entry(family_of(&route.path))
+            .or_default()
+            .push(row);
     }
     let total_routes = routes.len();
     let families_json: Vec<Value> = families

--- a/docs/architecture/components/hypervisor/foundry.md
+++ b/docs/architecture/components/hypervisor/foundry.md
@@ -776,6 +776,115 @@ provider has real compute, dataset, budget, and authority backing. Otherwise
 Foundry should expose them as blueprints, estimates, and readiness gaps, not
 fake execution.
 
+## Reproducible Training Program Revisions
+
+A training program is a phase graph, not one configuration file. Modern
+generalist programs compose native/multimodal pretraining, progressive context
+extension, SFT, domain-and-effort RL, on-policy teacher consolidation,
+quantization-aware posttraining, and draft-model tuning, and each phase changes
+its inputs, objectives, budgets, precision, and outputs. Foundry therefore
+treats the executable unit as an immutable, versioned
+`FoundryTrainingStackBlueprintRevision` spanning data, curriculum,
+optimization, execution topology, rollout state, environments, checkpoints,
+and deployment constraints. A `FoundryTrainingStackBlueprint` remains the
+mutable draft container; only an admitted revision is executable, and a
+revision resolves every parameter the run needs. A run that cannot be replayed
+from its revision plus admitted inputs is a defect, not a run.
+
+Revision doctrine:
+
+- **Data mixture and curriculum are executable configuration.** A phase binds
+  an exact `FoundryDataMixtureProfile` — mixture weights and stage token
+  budgets, tokenizer revision and token accounting, packing and length
+  distribution, filter/classifier versions, and synthetic-generation and
+  verifier configuration — not merely dataset references.
+- **Sequence format is part of the recipe.** Foundry preserves a logical
+  trajectory IR (messages, channels, typed tool calls, loss masks) and renders
+  backend-specific formats from it through the versioned serializer declared
+  in a `FoundrySequenceFormatProfile`. Changing the serializer version changes
+  the recipe.
+- **Rollout state is durable.** An RL attempt records prompt, policy version
+  and staleness, teacher matrix, reward/verifier versions, token budgets,
+  environment snapshot, cache identity, partial completion and resumption,
+  and generated-versus-applied/accepted token counts under its
+  `FoundryRolloutPolicy`.
+- **Environment state is training state.** A
+  `FoundryEnvironmentLifecycleProfile` versions the world image, tools, event
+  schedule, hidden-verifier separation, reset/snapshot/fork semantics,
+  isolation class, and recovery. An external environment platform is never an
+  authority boundary; authority remains wallet.network grants and daemon
+  admission.
+- **Deployment constraints may enter training.** Quantization-aware
+  posttraining and draft-model acceptance tuning bind their deployment
+  targets explicitly, and a portable higher-precision source checkpoint is
+  always retained.
+- **A checkpoint is complete or it is not a checkpoint.** The
+  `FoundryCheckpointContract` requires model, optimizer, scheduler,
+  router/scaler, RNG, and data-cursor state, the exact blueprint revision, a
+  topology-neutral layout or declared topology binding, restore-verification
+  evidence, and the last admitted step.
+- **Architecture-specific mechanisms are capability-gated experiments, not
+  defaults.** Novel attention/MoE/optimizer mechanisms enter as independently
+  ablated `FoundryExperimentOptimizationCycle` targets with their own gates;
+  no external program's architecture becomes a Foundry default recipe.
+
+Admission and settlement follow the estate rule that admission is the only
+write story. Agentgres settles blueprint revisions, phase boundaries,
+checkpoint records, trial decisions, gate results, and lineage. Every admitted
+revision or lifecycle transition commits its predecessor revision ref,
+expected head, content hash, exact input/policy/dataset/tokenizer/backend/
+environment revisions, from/to state, phase, reason, actor, authority grant or
+lease, output and checkpoint hashes, telemetry segment root, and receipt root.
+High-frequency per-step telemetry stays in the observability/artifact plane;
+Foundry periodically commits telemetry segment roots and summaries into
+Agentgres, preserving replayable hash-chain truth without turning every
+optimizer step into consensus traffic. Foundry builds and runs admitted
+experiments, the daemon governs execution, and Governance alone promotes
+(INV-13).
+
+### External Evidence Boundary
+
+Published model programs are systems-design and hypothesis sources, not
+baselines. A source-reported result — a fitted scaling-efficiency curve, a
+workload-specific throughput multiple, a kernel speedup — imports as a
+hypothesis with its measurement conditions attached: never as a predicted
+Foundry gain, and never as a reproducibility or throughput baseline when the
+source does not disclose enough to reconstruct the run (token counts and
+mixtures, curriculum allocation, optimizer schedules, hardware and topology,
+wall time, launch configuration). Higher raw throughput can worsen time to
+solution; time-to-quality remains the decisive measure for every adoption
+decision.
+
+### Throughput And Goodput Measurement Contract
+
+Foundry rejects an unqualified `tokens_per_second`. Every performance
+observation declares:
+
+```text
+phase        pretraining | sft | rollout_generation | policy_update |
+             evaluation | conversion
+numerator    raw | non_padding | loss_bearing | generated |
+             accepted_applied | verifier_admitted        (token class)
+denominator  steady_state | full_wall_clock, with explicit inclusion flags
+             for compilation, loading, evaluation, checkpointing, recovery
+scope        global | node | gpu | rank
+fingerprint  hardware/software/topology, precision, batch, and
+             sequence-length distribution
+```
+
+Foundry goodput is admitted non-padding loss-bearing tokens, or accepted
+rollout tokens, that contribute to a valid checkpoint or passed gate, divided
+by complete wall-clock time. Headline metrics: raw and effective tokens/s,
+tokens/s per GPU, tokens/s per dollar, MFU, and time-to-quality;
+padding/truncation waste; data, communication, pipeline, compilation,
+checkpoint, and recovery stalls; failure-lost work and verified restore time;
+MoE expert skew, drops/reroutes, and all-to-all bandwidth where MoE applies;
+RL rollout/train/verifier goodput, policy-staleness distribution,
+accepted-token ratio, verified trajectories per hour, and environment
+pause/resume time. Measurement precedes optimization: a trainer backend
+without a capability report and observation contract does not receive
+optimization work.
+
 ## Autonomous Experiment Optimizer
 
 Foundry may run an autonomous experiment optimizer as a subordinate execution
@@ -1756,8 +1865,191 @@ FoundryTrainingStackBlueprint:
   multimodal_contract_refs:
     - schema://... | ontology://...
   package_target_matrix_ref: optional artifact://... | policy://...
+  revision_refs:
+    - training_stack_revision://...
   status:
     draft | admitted | running | evaluated | packaged | rejected | archived
+
+FoundryTrainingStackBlueprintRevision:
+  training_stack_revision_ref: training_stack_revision://...
+  training_stack_ref: training_stack://...
+  revision_seq: integer
+  predecessor_revision_ref: training_stack_revision://... | null
+  content_hash: hash
+  hypothesis: string
+  phase_plan_refs:
+    - training_phase_plan://...
+  environment_lifecycle_profile_ref: optional environment_lifecycle://...
+  checkpoint_contract_ref: checkpoint_contract://...
+  performance_contract_ref: performance_contract://...
+  total_token_budget: optional integer
+  budget_policy_ref: policy://...
+  gate_refs:
+    - gate://...
+  expected_head: hash | null
+  receipt_root: hash
+  status:
+    proposed | admitted | superseded | rejected
+
+FoundryTrainingPhasePlan:
+  training_phase_plan_ref: training_phase_plan://...
+  phase_kind:
+    pretrain | context_extension | sft | preference_optimization |
+    rl | on_policy_distillation | quantization_aware_posttrain |
+    draft_tuning | conversion | evaluation
+  data_mixture_profile_ref: optional data_mixture://...
+  sequence_format_profile_ref: optional sequence_format://...
+  optimizer_numerics_profile_ref: optional optimizer_numerics://...
+  resolved_execution_plan_ref: optional resolved_execution://...
+  rollout_policy_ref: optional rollout_policy://...
+  distillation_plan_ref: optional distillation_plan://...
+  start_condition: object
+  stop_condition: object
+  token_budget: optional integer
+  gate_refs:
+    - gate://...
+  output_contract_refs:
+    - schema://... | artifact://...
+  status: draft | admitted | superseded
+
+FoundryDataMixtureProfile:
+  data_mixture_ref: data_mixture://...
+  dataset_snapshot_refs:
+    - dataset_snapshot://...
+  data_recipe_refs:
+    - data-recipe://.../revision/...
+  mixture_weights_by_stage: object
+  stage_token_budgets: object
+  tokenizer_revision_ref: artifact://... | schema://...
+  token_accounting_policy: raw | non_padding | loss_bearing
+  packing_policy: object
+  length_distribution_ref: optional artifact://...
+  filter_classifier_version_refs:
+    - artifact://...
+  synthetic_generation_config_ref: optional artifact://...
+  verifier_config_ref: optional artifact://...
+  dedupe_policy_ref: optional policy://...
+  content_hash: hash
+  status: draft | admitted | superseded
+
+FoundrySequenceFormatProfile:
+  sequence_format_ref: sequence_format://...
+  trajectory_ir_schema_ref: schema://...
+  serializer: string
+  serializer_version: string
+  rendered_format: string
+  channel_policy: object
+  option_scope: global | one_shot | dynamic
+  loss_mask_policy: object
+  truncation_policy: object
+  cache_placement_policy: optional object
+  content_hash: hash
+  status: draft | admitted | superseded
+
+FoundryOptimizerNumericsProfile:
+  optimizer_numerics_ref: optimizer_numerics://...
+  optimizer_by_parameter_class: object
+  schedule: object
+  precision_policy: object
+  clipping_and_scaling: object
+  stability_limits: object
+  seed_policy: object
+  content_hash: hash
+  status: draft | admitted | superseded
+
+FoundryResolvedExecutionPlan:
+  resolved_execution_ref: resolved_execution://...
+  trainer_backend_ref: trainer_backend://...
+  hardware_fingerprint: object
+  software_fingerprint: object
+  parallelism:
+    data_parallel: integer
+    tensor_parallel: integer
+    pipeline_parallel: integer
+    expert_parallel: integer
+    context_parallel: integer
+    virtual_pipeline: optional integer
+    sequence_parallel: optional boolean
+  batch_and_accumulation: object
+  activation_policy: object
+  overlap_plan: optional object
+  backend_capability_report_ref: artifact://...
+  content_hash: hash
+  status: draft | admitted | superseded
+
+FoundryRolloutPolicy:
+  rollout_policy_ref: rollout_policy://...
+  policy_model_ref: model://... | checkpoint://...
+  teacher_matrix_refs:
+    - model://... | model_route://...
+  reward_verifier_version_refs:
+    - worker://... | model://... | gate://...
+  token_budgets: object
+  effort_budget_policy_ref: optional policy://...
+  environment_snapshot_refs:
+    - environment_snapshot://...
+  cache_identity_policy: object
+  staleness_bounds: object
+  partial_completion_policy: object
+  token_record_policy:
+    generated | applied | accepted | verifier_admitted
+  content_hash: hash
+  status: draft | admitted | superseded
+
+FoundryDistillationPlan:
+  distillation_plan_ref: distillation_plan://...
+  teacher_session_refs:
+    - teacher_session://...
+  consolidation_mode: off_policy | on_policy | mixed
+  acceptance_metric_refs:
+    - metric://... | gate://...
+  effort_budget_policy_ref: optional policy://...
+  content_hash: hash
+  status: draft | admitted | superseded
+
+FoundryEnvironmentLifecycleProfile:
+  environment_lifecycle_ref: environment_lifecycle://...
+  world_image_ref: artifact://... | interactive_world://...
+  world_image_hash: hash
+  tool_manifest_refs:
+    - schema://... | artifact://...
+  event_schedule_ref: optional artifact://...
+  hidden_verifier_separation: enforced | not_applicable
+  reset_semantics: object
+  snapshot_fork_semantics: object
+  isolation_class: string
+  persistent_event_policy: optional object
+  recovery_policy: object
+  content_hash: hash
+  status: draft | admitted | superseded
+
+FoundryCheckpointContract:
+  checkpoint_contract_ref: checkpoint_contract://...
+  required_state:
+    - model | optimizer | scheduler | router_scaler | rng | data_cursor
+  blueprint_revision_ref: training_stack_revision://...
+  layout: topology_neutral | topology_bound
+  topology_binding_ref: optional resolved_execution://...
+  restore_verification_policy: object
+  last_admitted_step_required: true
+  retention_policy_ref: policy://...
+  status: draft | admitted | superseded
+
+FoundryPerformanceContract:
+  performance_contract_ref: performance_contract://...
+  token_definitions: object
+  measurement_windows: object
+  scopes:
+    - global | node | gpu | rank
+  required_fingerprints:
+    - hardware | software | topology | precision | batch |
+      sequence_length_distribution
+  goodput_definition_ref: schema://... | artifact://...
+  headline_metric_refs:
+    - metric://...
+  stall_taxonomy_ref: optional schema://...
+  time_to_quality_targets: optional object
+  status: draft | admitted | superseded
 
 FoundryTrainerBackendProfile:
   trainer_backend_ref: trainer_backend://...
@@ -1853,6 +2145,7 @@ FoundryTrainingPipelineRun:
   dataset_snapshot_refs:
     - dataset_snapshot://...
   training_config_ref: artifact://...
+  blueprint_revision_ref: optional training_stack_revision://...
   trial_refs:
     - trial://...
   eval_suite_refs:

--- a/internal-docs/implementation/surfaces/foundry.md
+++ b/internal-docs/implementation/surfaces/foundry.md
@@ -2,6 +2,10 @@
 
 Canonical route: `/foundry` · Owner: Foundry (owner application)
 Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected where noted
+Amended 2026-08-06: training-program revision audit — W3.0 contract wave inserted,
+route-plane defect register added (§6), functional-interface targets added to §4;
+canon counterpart is foundry.md "Reproducible Training Program Revisions" +
+the FoundryTrainingStackBlueprintRevision contract family.
 
 ## 1. Canon digest
 
@@ -84,6 +88,7 @@ Brief status: authored 2026-08-05 from bytes at 21ae389fe · v0 seed corrected w
 | Experiment optimization: FoundryExperimentOptimizationCycle (advisory) | foundry.md:1884,305-311 | `route-missing` — **W3** |
 | Deploy lineage: FoundryArtifactConversionRun/RegistryVersion/RouteBinding/PromotionBundle | foundry.md:1927,1344,1361,1973 | `route-missing` — **W3** |
 | Foundry-side eval assets: ExecutableEvalSuite/EvalWorld/EvalTrajectoryRun/TrajectoryScorecard | foundry.md:1398,1419,1438,1475 | `route-missing` — **W3** (judgment stays Evaluations) |
+| Training-program revision family: FoundryTrainingStackBlueprintRevision + TrainingPhasePlan + DataMixture/SequenceFormat/OptimizerNumerics profiles + ResolvedExecutionPlan + RolloutPolicy/DistillationPlan + EnvironmentLifecycleProfile + Checkpoint/Performance contracts | foundry.md "Reproducible Training Program Revisions" + contract block | `route-missing` — **W3.0** (contract registration precedes every mutation route) |
 
 No Foundry-family JSON Schema exists in `docs/architecture/_meta/schemas/`
 (158 files; zero model-route/foundry/model-mount entries) — the daemon schema
@@ -186,6 +191,15 @@ W3 family.
 | Govern · learning-boundary badge on every job/spec/promotion pane | InstitutionalLearningBoundaryProfile projection · route-missing (W3) | absent | disabled-named-gap now; when wired, projection-only — **never ambient permission**, never a toggle (core-clients-surfaces.md:2527-2528, :1096-1099) |
 | Govern · promotion bundle queue / route-binding candidates | foundry.md:1973 · route-missing | absent | disabled-named-gap; W3 (activation decisions stay Governance) |
 | Govern · weight-custody + worker-package admission timelines | POST-only planners :1080, :1099 | invisible | wired-read over admission records (new read projection is part of the W3 row) |
+| Train/Tune · blueprint revision diff viewer (revision N vs N-1: phases, profiles, budgets, gates) | FoundryTrainingStackBlueprintRevision + phase-plan/profile content hashes · W3.0 schemas | absent | disabled-named-gap now; wired-read after W3.0 (diff computed over admitted revisions, never drafts) |
+| Train/Tune · data-mixture/curriculum inspector (per-stage weights, token budgets, tokenizer accounting, filter versions) | FoundryDataMixtureProfile · W3.1 | absent | disabled-named-gap; wired-read after W3.1 |
+| Train/Tune · backend compatibility panel (blueprint revision × TrainerBackendProfile capability report) | FoundryResolvedExecutionPlan.backend_capability_report_ref · W3.2 | absent | disabled-named-gap; wired-read; incompatibility renders as named readiness gap, never silent downgrade |
+| Train/Tune · run DAG + controls (phase graph, stage state, pause/resume/stop) | FoundryTrainingPipelineRun.blueprint_revision_ref + phase plans · W3.2 | absent | controls wired-action-receipted via CapabilityLease; reads projection-only |
+| Train/Tune · live goodput/bottleneck view (qualified tokens/s, MFU, stalls, waste; every number carries phase/numerator/scope/fingerprint) | FoundryPerformanceContract observations · W3.4 | absent | wired-read; unqualified throughput numbers are a render defect |
+| Train/Tune · rollout-staleness queue (policy lag distribution, paused/resumable attempts, accepted-token ratio) | FoundryRolloutPolicy attempt records · W3.2 | absent | disabled-named-gap; wired-read after W3.2 |
+| Train/Tune · environment snapshot browser (world image hash, fork lineage, reset/recovery evidence) | FoundryEnvironmentLifecycleProfile + snapshots · W3.2 | absent | disabled-named-gap; wired-read after W3.2 |
+| Train/Tune · checkpoint restore evidence (required-state completeness, restore verification, last admitted step) | FoundryCheckpointContract · W3.3 | absent | wired-read; a checkpoint without restore verification renders as unverified, not as restorable |
+| Govern · gate/promotion lineage (revision → phases → checkpoints → gates → promotion bundle) | revision family + FoundryPromotionBundle · W3.3 | absent | wired-read; activation stays Governance (INV-13) |
 
 ## 5. Ordered PR list
 
@@ -208,21 +222,70 @@ W3 family.
    disabled-named-gap.
 6. **W2** — spec/run-plan mutation receipts: draft CRUD gains receipt refs
    (or is demoted to disabled-named-gap until it does).
-7. **W3 (backend-first, serialized on hypervisor-daemon.rs)** — dataset
-   family (`foundry/dataset-factory-runs`, snapshots, candidate-data,
-   holdout custody); then training family (pipeline runs, trials,
-   checkpoints, teacher sessions); then deploy-lineage family (conversion
-   runs, registry versions, promotion bundles — read/propose only); then
-   optimizer cycles (advisory); each lands routes + registry schema + UI in
-   the same wave.
-8. **W3** — learning-boundary projection route + badge wiring across every
+7. **W3.0 (contract-and-migration wave — precedes every mutation route and
+   every mutation UI)** — register the Foundry JSON Schema family in
+   `docs/architecture/_meta/schemas/` with generated Rust/TS contracts:
+   foundry-spec/run-plan v2 plus the training-program revision family
+   (BlueprintRevision, TrainingPhasePlan, DataMixtureProfile,
+   SequenceFormatProfile, OptimizerNumericsProfile, ResolvedExecutionPlan,
+   RolloutPolicy, DistillationPlan, EnvironmentLifecycleProfile,
+   CheckpointContract, PerformanceContract). Migrate the two local
+   schema-string constants onto registered shapes (v1 free-form `inputs` /
+   opaque `steps` stay readable under v1 names, never as v2 semantics —
+   adapter migration, not field mapping). Spec/run-plan writes move onto
+   Agentgres admission (expected-head CAS + receipts + revision) closing
+   defects D-3/D-4. Per family, before any route lands: state machine +
+   legal-transition table, authority path (CapabilityLease), named refusal
+   dimensions with negative fixtures, recovery semantics, telemetry
+   segment-root commitment points, and tests.
+8. **W3.1-W3.4 (backend-first, serialized on hypervisor-daemon.rs)** —
+   W3.1 dataset family (`foundry/dataset-factory-runs`, snapshots,
+   candidate-data, holdout custody, mixture profiles); W3.2 executor/
+   lifecycle family (pipeline runs bound to admitted blueprint revisions,
+   trials, teacher sessions, rollout-attempt records with staleness +
+   resumption, environment lifecycle/snapshots); W3.3 checkpoint/recovery
+   family (checkpoint contract enforcement, restore-verification evidence,
+   deploy-lineage: conversion runs, registry versions, promotion bundles —
+   read/propose only); W3.4 performance/telemetry family (qualified
+   throughput observations, goodput ledger, stall taxonomy, segment-root
+   commits) + optimizer cycles (advisory). Each wave lands routes +
+   registered schema + UI in the same PR set. Measurement (W3.4 read plane)
+   lands before any throughput-optimization work is accepted.
+9. **W3** — learning-boundary projection route + badge wiring across every
    Foundry job/promotion pane (projection-only).
-9. **W4** — event consumption for probe/receipt/run updates moves to
-   `/v1/event-streams` + `/v1/subscriptions`; legacy model-mount SSE
-   (`/v1/model-mount/server/events` :642) wrapped, not extended.
-10. **W4** — cutover: `/__ioi/foundry*`, `/__ioi/foundry/models`, and the
+10. **W4** — event consumption for probe/receipt/run updates moves to
+    `/v1/event-streams` + `/v1/subscriptions`; legacy model-mount SSE
+    (`/v1/model-mount/server/events` :642) wrapped, not extended.
+11. **W4** — cutover: `/__ioi/foundry*`, `/__ioi/foundry/models`, and the
     Agent Studio `#model-routes` tab retire with typed 410s; `models` row
     exits surface-registry; `/__apps/models`/`modelstudio`/`inference`
     captures remain dormant T4 evidence; reconcile the two
     `foundry_eval_training` profile_kind byte sites (connectors-tools
     contracts.md:162, doctrine.md:156) in whichever PR touches those files.
+
+## 6. Route-plane defect register (audited 2026-08-06)
+
+Byte-verified against `foundry_routes.rs` on master at 64b0607f4:
+
+- **D-1 persistence dishonesty — FIXED (this PR).** Spec create/patch and
+  run-plan create discarded `persist_record` errors (`let _ =`) while
+  returning success. Now a persist failure returns typed
+  `foundry_persist_failed` (500 on create, `ok:false` on patch) — INV-14.
+- **D-2 mutable meaning — FIXED (this PR).** Run plans referenced their spec
+  by mutable id only, so a later spec PATCH silently changed an existing
+  plan's meaning. Plans now pin `spec_content_hash` (timestamp-excluded
+  content hash) at creation; plan GET reports `spec_drifted`/`spec_missing`
+  as computed read fields (rows are views — drift is never persisted back).
+- **D-3 unregistered schemas — W3.0.** `ioi.hypervisor.foundry-spec.v1` /
+  `foundry-run-plan.v1` are local string constants; no
+  `_meta/schemas/` registration, no generated contracts.
+- **D-4 no admission — W3.0, gates all mutation UI.** Writes are direct
+  JSON-file persistence: not Agentgres-admitted, CAS-protected, receipted,
+  or revisioned. Per the Agentgres positioning constraints (#168, canon
+  #169), admission is the only write story — no surface may present these
+  drafts with mutation semantics beyond draft CRUD until W3.0 lands.
+- **D-5 authority named, unenforced — W2/W3.** `authority_policy_ref` is
+  declared-only; enforcement arrives with the CapabilityLease client wave.
+- **D-6 free-form payloads — W3.0.** Spec `inputs` and run-plan `steps` are
+  opaque JSON; v2 schemas type them (phase plans, profiles) and the v1
+  shapes survive read-only under v1 names.


### PR DESCRIPTION
## What

Executes the 2026-08-06 Foundry training-program audit (K3-informed). Three coordinated layers: canon contracts, implementation wave plan, and route-plane honesty fixes. Also carries the one-line rustfmt fix that has kept master CI red since W0.5 (separate commit).

## Canon — `docs/architecture/components/hypervisor/foundry.md`

- **Reproducible Training Program Revisions** (new section): training is a phase graph, not one configuration file. The executable unit is an immutable, versioned `FoundryTrainingStackBlueprintRevision`; the blueprint stays a mutable draft container. Doctrine bullets: mixture/curriculum are executable configuration; sequence format is part of the recipe (logical trajectory IR + versioned serializer); rollout state is durable (staleness, resumption, accepted-token records); environment state is training state (external env platforms are never authority boundaries); deployment constraints may enter training with a portable high-precision source checkpoint retained; a checkpoint is complete or it is not a checkpoint; architecture-specific mechanisms are capability-gated experiments, never defaults.
- **Admission**: Agentgres settles revisions, phase boundaries, checkpoints, trial decisions, gates, lineage — with commitment fields (predecessor ref, expected head, content hash, from/to state, actor, authority, receipt root). Per-step telemetry stays in the observability plane; segment roots commit periodically. Consistent with the #168/#169 positioning constraints and INV-13.
- **External Evidence Boundary**: source-reported results (fitted scaling curves, workload-specific multiples, kernel speedups) import as hypotheses with measurement conditions — never predicted gains, never reproducibility baselines when the source withholds run-reconstruction facts. Time-to-quality decides adoption.
- **Throughput And Goodput Measurement Contract**: unqualified `tokens_per_second` is rejected; every observation declares phase / numerator token class / denominator+inclusion flags / scope / fingerprints. Goodput = admitted non-padding loss-bearing (or accepted rollout) tokens contributing to a valid checkpoint or passed gate ÷ full wall clock. Measurement precedes optimization.
- **Contract block**: 11 new owner-qualified objects (BlueprintRevision, TrainingPhasePlan, DataMixture/SequenceFormat/OptimizerNumerics profiles, ResolvedExecutionPlan, RolloutPolicy, DistillationPlan, EnvironmentLifecycleProfile, Checkpoint/Performance contracts); blueprint gains `revision_refs`; pipeline runs gain `blueprint_revision_ref`. No `RecipeEnvelope`, no bare `Profile` (term-boundaries respected); `DataRecipe` referenced, not overloaded.

## Implementation brief — `internal-docs/implementation/surfaces/foundry.md`

- **W3.0 contract-and-migration wave** inserted ahead of every mutation route and mutation UI: schema registration in `_meta/schemas/` + generated contracts, Agentgres-admitted writes, per-family state machines, authority paths, named refusal dimensions with negative fixtures, recovery semantics, telemetry commitment points, tests. W3 proper split into W3.1-W3.4 (dataset → executor/lifecycle → checkpoint/recovery+deploy-lineage → performance/telemetry+optimizer).
- **Functional-interface targets** added to the schema→UI table: blueprint revision diff viewer, data-mixture/curriculum inspector, backend compatibility panel, run DAG + receipted controls, live goodput/bottleneck view (unqualified numbers are a render defect), rollout-staleness queue, environment snapshot browser, checkpoint restore evidence, gate/promotion lineage.
- **Defect register D-1..D-6** (byte-verified at 64b0607f4): D-1/D-2 fixed in this PR, D-3..D-6 scheduled with owning waves.

## Code — `foundry_routes.rs`

- **D-1 fixed**: the three `let _ = persist_record(...)` sites now refuse loudly with typed `foundry_persist_failed` instead of returning fabricated success (INV-14).
- **D-2 fixed**: run plans pin `spec_content_hash` (timestamp-excluded content hash) at creation; plan GET computes `spec_drifted`/`spec_missing` as read-only fields — rows are views, drift is never persisted.
- New unit test (hash ignores timestamps, tracks content). `cargo test -p ioi-node --bin hypervisor-daemon foundry`: **6/6 pass**; `cargo fmt --all -- --check`: clean.

## Explicitly deferred (not in this PR)

Schema registration (D-3), Agentgres admission for spec/plan writes (D-4), authority enforcement (D-5), typed v2 payloads (D-6) — all owned by W3.0 per the amended brief; landing them here would front-run the contract-first sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)