### PR TITLE
docs(X-1): ODK extension-application program doc — the user-tailored application lane

### DIFF
--- a/docs/architecture/foundations/domain-ontologies-and-data-recipes.md
+++ b/docs/architecture/foundations/domain-ontologies-and-data-recipes.md
@@ -417,6 +417,9 @@ daemon; authority remains with local/domain governance and portable authority
 providers; operational truth remains with each Agentgres domain.
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 08c6d96f9 (canon(X-0b): the composable application journey — one stage ladder, one owner per stage)
 ## The Composable Application Journey
 
 This layer's builder promise — that a user can turn a described domain into a
@@ -476,8 +479,11 @@ revocation remove launch eligibility at once; they do not wait for a rebuild of
 the catalog. A recalled release must stop appearing as a launchable row even
 though its historical receipts remain immutable evidence that it once ran.
 
+<<<<<<< HEAD
 =======
 >>>>>>> cb60e0008 (canon(X-0a): DomainApp envelope family — objects, governed mount ladder, filed deltas)
+=======
+>>>>>>> 08c6d96f9 (canon(X-0b): the composable application journey — one stage ladder, one owner per stage)
 ## Domain Apps And The Governed Mount Ladder
 
 A **Domain App** is the app-shaped consumer of this layer: one


### PR DESCRIPTION
Packet **X-1** of the seed-mesh + ODK wiring run. Stacked on #174 → #173 → #172 → #171.

Writes `internal-docs/implementation/odk-extension-apps.md` — the umbrella every per-surface brief's `## N+2. ODK descriptor and extension lane` section points into.

## Headline finding

**Both ends of the journey are built. The middle is not.**

Byte-verified at `44787da9e`:

| | State |
|---|---|
| Authoring (stages 1–4) | **real object plane** — 56 ODK route registrations across twelve families |
| Mount / serve (stage 10) | **fully implemented** governed ladder — approval gating, live re-validation, receipts, kill-switch enforcement |
| Package → admit → install → register → expose → System-bind (stages 5–9) | **almost nothing** |

- **No `/v1/hypervisor/packages/*` route family exists at all** — zero registrations.
- **Zero `extension_application` registrations** — all 15 surface records are first-party (13 owner + 2 substrate) and `include_str!` static, not durable storage.
- **`system_interface_bindings: []`** — empty array, no route.

This explains a fact that otherwise looks like laziness: the implemented `DomainApp.status` is pinned to `"draft"` and never advances (`domain_apps_routes.rs:344`). **There is nothing for it to advance to.** The field is honest about the estate.

**Build consequence:** the extension lane is gated on the **Packages registry family (W3)**, not on more ODK work. Any plan that adds authoring capability first moves the estate *further* from a walkable journey.

## Also recorded

- **The mount ladder as implemented** (`domain_apps_routes.rs`, 1,217 lines), rung by rung with byte cites — the part of the lane most at risk of being rebuilt by someone who does not know it exists. Three properties to preserve verbatim on rehome: serving **re-validates rather than inherits**; enforcement is **not a private path** (kill uses the same receipt writer); the plane **refuses to overclaim**.
- **The invariant-11 conformance bar** as a checklist, against a descriptor record that carries **none** of its eight required bindings. The consequence stated precisely: no stored descriptor can be checked against invariant 11 today — not because checking is unimplemented, but because the fields it would read do not exist. The eleven-member pattern vocabulary, by contrast, *is* complete and enforced.
- **The two-ledger contract** each brief's `## N+2` section fills in, with the legitimate exemption reasons and the expected stage owners — so a brief claiming a stage it does not own is a detectable defect.
- **Slate / Logic / Contour / Fusion** as `pattern-harvest` evidence only. `slate` is `blocked_missing_capture`, so claims about its behavior are unsupportable; only its recorded grammar and tier are citable. `Domain Apps` is a retired owner — these rehome under Studio, never as a peer app.
- **A seven-item build-list** ordered by dependency, distinguishing the four items that predate this run (the real critical path) from the three canon-ahead-of-code deltas it filed.

§8 states plainly what the doc is not — including that **no extension application has ever been registered, admitted, installed, exposed, or System-bound in this estate**, and anything implying otherwise is describing fixtures.

## Scope

Docs only. Index updated with the pointer; ledger row X-1 carries the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)