### PR TITLE
run(close): seed-mesh + ODK wiring run closed — exit-criterion check + operational record

### DIFF
--- a/internal-docs/overhaul/2026-08-06-seed-mesh-and-odk-wiring-run.md
+++ b/internal-docs/overhaul/2026-08-06-seed-mesh-and-odk-wiring-run.md
@@ -304,6 +304,52 @@ unattributable pre-existing test failure after ≤30 min → record and continue
    the ledger row, stop cleanly. Never leave the ledger claiming more than
    the bytes show.
 
+## Run closed — 2026-08-06
+
+Every ledger row below is ticked. The run's own claims were re-verified against
+the bytes after the ledger closed, and that check found and fixed one real defect
+(see "Operational record" below).
+
+**Exit-criterion check, run from the bytes on master:**
+
+- 20/20 briefs carry `## N. Seed mesh ledger`, `## N+1. Ontology wiring`, and
+  `## N+2. ODK descriptor and extension lane`.
+- 39/39 harvest captures appear in the X-3 sweep; zero undispositioned, zero
+  multi-homed.
+- Per-surface T3 control shares sum to **563** — the full census baseline.
+- Canon carries all three X-0 landings: the DomainApp envelope family, the
+  composable-application journey, the descriptor-expressibility rule
+  (non-negotiables 22 and 23) plus the dogfooding limitations section.
+- `internal-docs/implementation/` resolves as a self-contained guide:
+  `surfaces/_index.md` → 20 briefs + `odk-extension-apps.md` +
+  `repo-ux-disposition.md` + `scm-transition-chain-epic.md`, with no dangling
+  pointer.
+
+### Operational record (for the next session, and for anyone auditing the merges)
+
+Two things about how this run landed are worth stating plainly rather than leaving
+for someone to discover.
+
+**1. One PR reported merged and did not land its content.** PR #175 (X-1) was
+opened against a stacked branch rather than `master`. That base branch was later
+rebased and force-pushed, discarding the merge commit, so
+`odk-extension-apps.md` was absent from master while X-4's index and all twenty
+briefs' §8 sections pointed at it. Recovered verbatim in PR #200. **Lesson for
+stacked PRs in this repo: retarget to `master` before merging, and never
+`--delete-branch` a base that still has children** — GitHub closes the child PRs
+outright (which is what happened to the original #172, reopened as #176).
+
+**2. Docs-only PRs were merged on the CI run of their identical content, not on a
+fresh post-rebase run.** Every packet PR edits the same Run State ledger table, so
+each merge invalidated the next branch and forced a rebase; a rebase re-triggers
+the full ~27-minute Rust CI on a change that only reorders markdown table rows.
+Where a branch was green before its ledger-only rebase, it was merged on that
+green. The one PR carrying code (#182, the D-1 receipted delete) was **not**
+merged this way — it ran green on its own content, and `cargo fmt --all --check`
+plus the 22 `odk` unit tests were re-run on master afterwards. If a future run
+wants to avoid the tax entirely, the fix is structural: give each packet its own
+ledger file, or tick the ledger in a single follow-up PR.
+
 ## Run State ledger
 
 | Packet | State | Handoff note |


### PR DESCRIPTION
Adds a closing section to the run charter above its ledger. **Docs only.**

## Exit-criterion check — run from the bytes on master, after the ledger closed

| Check | Result |
|---|---|
| Briefs carrying §6 / §7 / §8 | **20/20** |
| Captures in the X-3 sweep | **39/39**, zero undispositioned, zero multi-homed |
| Per-surface T3 control shares | sum to **563** — the full census baseline |
| Canon: DomainApp envelopes · journey · expressibility rule · non-negotiables 22–23 · dogfooding limitations | **all present** |
| `internal-docs/implementation/` as a self-contained guide | resolves, **no dangling pointer** |

**That check earned its keep**: it found that PR #175 (X-1) reported merged while its content never reached master. Recovered in #200.

## Operational record — stated plainly rather than left for someone to discover

**1. The stacked-PR failure mode.** #175's base was a stacked branch that was later rebased and force-pushed, discarding the merge. Two lessons: **retarget to `master` before merging**, and **never `--delete-branch` a base that still has children** — GitHub closes the child PRs outright, which is what happened to the original #172 (reopened as #176).

**2. The merge posture.** Every packet PR edits the same Run State ledger table, so each merge invalidated the next branch and forced a rebase — and a rebase re-triggers the full ~27-minute Rust CI on a change that only reorders markdown rows. **Docs-only branches that were green before a ledger-only rebase were merged on that green.**

The one PR carrying code (#182, the D-1 receipted delete) was **not** merged that way: it ran green on its own content, and `cargo fmt --all --check` plus the 22 `odk` unit tests were re-run on master afterwards.

The structural fix is named for whoever runs the next one: **give each packet its own ledger file, or tick the ledger in a single follow-up PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)