### PR TITLE
feat(hypervisor): W2.1 seed guards — tracked seed-provenance manifest, fail-closed CI gate, route-graph harvester (AUD-WS-002/003/005)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
           npm run check:owned-product-ui --workspace=@ioi/hypervisor-app
           npm run check:shell-parity --workspace=@ioi/hypervisor-app
           npm run check:ported-seed --workspace=@ioi/hypervisor-app
+          npm run check:seed-provenance --workspace=@ioi/hypervisor-app
           npm run check:source-neutral --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -12,6 +12,7 @@
     "serve:product-ui": "node scripts/serve-product-ui.mjs",
     "serve:reference": "node scripts/serve-product-ui.mjs",
     "check:ported-seed": "node scripts/verify-hypervisor-ported-seed-invariant.mjs",
+    "check:seed-provenance": "node scripts/verify-hypervisor-seed-provenance.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",
     "check:shell-parity": "node scripts/verify-hypervisor-shell-parity.mjs",

--- a/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
+++ b/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
@@ -86,7 +86,18 @@ if (!ownedRoute && !flag("--replay")) die(1, "--owned-route is required for capt
 
 const { chromium } = await import("playwright").catch(() => die(2, "playwright is not installed in this checkout"));
 
-const allowedOrigins = new Set([new URL(SERVE).origin, new URL(CAPTURE).origin]);
+// localhost and 127.0.0.1 are the same quarantine boundary — the historical
+// capture corpus embeds absolute localhost asset URLs, so both spellings of an
+// allowed origin are admitted; everything else stays outbound.
+const originVariants = (u) => {
+  const url = new URL(u);
+  const hosts = new Set([url.hostname]);
+  if (url.hostname === "127.0.0.1") hosts.add("localhost");
+  if (url.hostname === "localhost") hosts.add("127.0.0.1");
+  return [...hosts].map((h) => `${url.protocol}//${h}${url.port ? `:${url.port}` : ""}`);
+};
+const allowedOrigins = new Set([...originVariants(SERVE), ...originVariants(CAPTURE)]);
+const captureOrigins = new Set(originVariants(CAPTURE));
 const allowServeWrites = flag("--allow-serve-writes");
 const quarantine = {
   network_policy: "local-only",
@@ -120,7 +131,7 @@ function installQuarantine(context, blockedWrites) {
     }
     const method = req.method().toUpperCase();
     if (method !== "GET" && method !== "HEAD") {
-      if (url.origin === new URL(CAPTURE).origin) {
+      if (captureOrigins.has(url.origin)) {
         quarantine.violations.push({ kind: "corpus-mutation-attempt", url: req.url(), method });
         return route.abort("blockedbyclient");
       }

--- a/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
+++ b/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+// Full interaction/route-graph harvester and replay gate for Hypervisor seed UX
+// (AUD-WS-003, 2026-08-09 audit). A landing census is not a graph: this tool
+// enumerates every reachable route, tab, pane, modal, drawer, create/edit/detail
+// state, control, transition, back-stack edge and typed failure inside a seed's
+// allowlisted subtree, content-addresses the result, and replays it edge by edge.
+// complete_interaction_route_graph=true is required before a surface rehome begins
+// (enforced by verify-hypervisor-seed-provenance.mjs).
+//
+// Quarantine (AUD-WS-005) is enforced at launch, not promised: every request is
+// intercepted; any host outside the serve/capture origins is aborted and recorded
+// as a violation; any non-GET/HEAD to the capture origin (corpus mutation) is
+// aborted and recorded; writes to the serve origin are aborted and typed as
+// blocked-write-attempt edges unless --allow-serve-writes. A graph that records a
+// violation is inadmissible.
+//
+//   capture:  node scripts/capture-hypervisor-seed-route-graph.mjs \
+//               --surface work --slug jobs --owned-route /__ioi/missions \
+//               [--capture-route /workspace/job-tracker/] [--out seed-graphs/work/jobs.v1.json]
+//   replay:   node scripts/capture-hypervisor-seed-route-graph.mjs --replay --surface work [--slug jobs]
+//   recovery: node scripts/capture-hypervisor-seed-route-graph.mjs --surface systems --recover-from-history --out <path>
+//
+// Env: IOI_HYPERVISOR_SERVE_URL (default http://127.0.0.1:4173),
+//      IOI_HARVEST_CAPTURE_URL (default http://127.0.0.1:9225),
+//      IOI_SEED_SHOTS_DIR (default <repo>/.artifacts/seed-graph-shots).
+// Exit: 0 ok · 1 failure · 2 blocked (runtime unreachable).
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(appRoot, "..", "..");
+
+const argv = process.argv.slice(2);
+const flag = (name) => argv.includes(name);
+const opt = (name, dflt = null) => {
+  const i = argv.indexOf(name);
+  return i >= 0 && argv[i + 1] !== undefined ? argv[i + 1] : dflt;
+};
+
+const SERVE = process.env.IOI_HYPERVISOR_SERVE_URL ?? "http://127.0.0.1:4173";
+const CAPTURE = process.env.IOI_HARVEST_CAPTURE_URL ?? "http://127.0.0.1:9225";
+const SHOTS = process.env.IOI_SEED_SHOTS_DIR ?? path.join(repoRoot, ".artifacts", "seed-graph-shots");
+const SCHEMA = "ioi.hypervisor.seed-interaction-route-graph.v1";
+const MAX_NODES = Number(opt("--max-nodes", "400"));
+const MAX_CONTROLS_PER_NODE = Number(opt("--max-controls", "80"));
+
+const surface = opt("--surface");
+if (!surface) die(1, "--surface is required");
+const slug = opt("--slug", surface);
+const ownedRoute = opt("--owned-route");
+const captureRoute = opt("--capture-route");
+const outRel = opt("--out", `seed-graphs/${surface}/${slug}.v1.json`);
+const outPath = path.isAbsolute(outRel) ? outRel : path.join(appRoot, outRel);
+
+function die(code, msg) {
+  console.error(`seed-route-graph: ${msg}`);
+  process.exit(code);
+}
+
+// ------------------------------------------------------------- recovery record
+if (flag("--recover-from-history")) {
+  // Typed no-candidate record for a no-seed surface: documents the exhausted
+  // recovery, opens nothing. The audit pack holds the underlying reports.
+  const record = {
+    schema_version: "ioi.hypervisor.seed-recovery-record.v1",
+    surface,
+    mode: "recover-from-history",
+    outcome: "zero-candidates-promoted",
+    references: [
+      "internal-docs/audits/2026-08-09-hypervisor-live-ux-workstream-coverage/logs/no-valid-seed-provenance-recovery.md",
+      "internal-docs/audits/2026-08-09-hypervisor-live-ux-workstream-coverage/logs/palantir-missing-seed-candidate-recovery.md",
+    ],
+    consequence:
+      "blocked-no-valid-seed stands; only a typed greenfield-authorized-non-parity record opens work, and that work can never claim seed preservation or parity.",
+  };
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${JSON.stringify(record, null, 2)}\n`);
+  console.log(`seed-route-graph: recovery record written to ${outPath}`);
+  process.exit(0);
+}
+
+if (!ownedRoute && !flag("--replay")) die(1, "--owned-route is required for capture");
+
+const { chromium } = await import("playwright").catch(() => die(2, "playwright is not installed in this checkout"));
+
+const allowedOrigins = new Set([new URL(SERVE).origin, new URL(CAPTURE).origin]);
+const allowServeWrites = flag("--allow-serve-writes");
+const quarantine = {
+  network_policy: "local-only",
+  corpus_mutation: "denied",
+  html_injection: "denied",
+  spa_fallback: "denied",
+  allowed_origins: [...allowedOrigins],
+  violations: [],
+};
+
+const sha = (buf) => crypto.createHash("sha256").update(buf).digest("hex");
+const canonicalAddress = (g) =>
+  sha(JSON.stringify({ surface: g.surface, slug: g.slug, nodes: g.nodes, edges: g.edges }));
+
+async function reachable(url) {
+  try {
+    const res = await fetch(url, { method: "GET", redirect: "manual" });
+    return res.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+function installQuarantine(context, blockedWrites) {
+  return context.route("**/*", (route) => {
+    const req = route.request();
+    const url = new URL(req.url());
+    if (!allowedOrigins.has(url.origin)) {
+      quarantine.violations.push({ kind: "outbound-network", url: req.url(), method: req.method() });
+      return route.abort("blockedbyclient");
+    }
+    const method = req.method().toUpperCase();
+    if (method !== "GET" && method !== "HEAD") {
+      if (url.origin === new URL(CAPTURE).origin) {
+        quarantine.violations.push({ kind: "corpus-mutation-attempt", url: req.url(), method });
+        return route.abort("blockedbyclient");
+      }
+      if (!allowServeWrites) {
+        blockedWrites.push({ url: req.url(), method });
+        return route.abort("blockedbyclient");
+      }
+    }
+    return route.continue();
+  });
+}
+
+// Route allowlist: the seed's own subtree only. A link that leaves it is a typed
+// boundary edge, never a crawl expansion (SEED-UX-INVARIANT rule 3).
+const allowPrefixes = [ownedRoute, captureRoute].filter(Boolean).map((p) => p.replace(/\/$/u, ""));
+const inAllowlist = (pathname) =>
+  allowPrefixes.some((p) => pathname === p || pathname.startsWith(`${p}/`) || pathname.startsWith(`${p}?`));
+
+const CONTROL_SELECTOR = [
+  "a[href]", "button", "[role=button]", "[role=tab]", "[role=menuitem]",
+  "[role=treeitem]", "[role=option]", "summary", "select", "input[type=submit]",
+].join(", ");
+
+async function censusOf(page) {
+  return page.evaluate((sel) => {
+    const els = [...document.querySelectorAll(sel)].filter((el) => {
+      const r = el.getBoundingClientRect();
+      const style = getComputedStyle(el);
+      return r.width > 0 && r.height > 0 && style.visibility !== "hidden";
+    });
+    const label = (el) =>
+      (el.getAttribute("aria-label") || el.textContent || el.getAttribute("title") || "")
+        .trim().replace(/\s+/gu, " ").slice(0, 80);
+    return els.map((el, i) => ({
+      index: i,
+      tag: el.tagName.toLowerCase(),
+      role: el.getAttribute("role") || null,
+      href: el.getAttribute("href"),
+      disabled: el.hasAttribute("disabled") || el.getAttribute("aria-disabled") === "true",
+      label: label(el),
+    }));
+  }, CONTROL_SELECTOR);
+}
+
+async function stateSignature(page) {
+  return page.evaluate(() => {
+    const texts = [...document.querySelectorAll("h1,h2,h3,[role=dialog],[role=menu],[role=tabpanel]")]
+      .map((el) => `${el.tagName}:${(el.getAttribute("aria-label") || el.textContent || "").trim().slice(0, 60)}`);
+    const open = document.querySelectorAll("[role=dialog]:not([hidden]), [aria-expanded=true], dialog[open]").length;
+    return `${location.pathname}${location.search}#open=${open}|${texts.join("|")}`.slice(0, 800);
+  });
+}
+
+async function capture() {
+  const startUrl = new URL(ownedRoute, SERVE).toString();
+  if (!(await reachable(SERVE))) die(2, `BLOCKED: serve runtime unreachable at ${SERVE}`);
+  if (captureRoute && !(await reachable(CAPTURE))) die(2, `BLOCKED: capture runtime unreachable at ${CAPTURE}`);
+
+  const browser = await chromium.launch();
+  const nodes = [];
+  const edges = [];
+  const blockers = [];
+  const nodeIds = new Map(); // signature -> id
+  const shotsDir = path.join(SHOTS, surface, slug);
+  fs.mkdirSync(shotsDir, { recursive: true });
+
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const blockedWrites = [];
+  await installQuarantine(context, blockedWrites);
+  const page = await context.newPage();
+  const consoleErrors = [];
+  page.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text().slice(0, 200)); });
+  let pendingDownload = null;
+  page.on("download", (d) => { pendingDownload = d.suggestedFilename(); d.cancel().catch(() => {}); });
+
+  async function snapshotNode(kind, entryEdge) {
+    const signature = await stateSignature(page);
+    if (nodeIds.has(signature)) return { id: nodeIds.get(signature), fresh: false };
+    const id = `n${nodes.length}`;
+    nodeIds.set(signature, id);
+    const census = await censusOf(page);
+    const png = await page.screenshot({ fullPage: false });
+    const digest = sha(png);
+    fs.writeFileSync(path.join(shotsDir, `${id}-${digest.slice(0, 12)}.png`), png);
+    nodes.push({
+      id, kind, signature,
+      url: page.url().replace(SERVE, "").replace(CAPTURE, "") || "/",
+      title: await page.title(),
+      entry_edge: entryEdge,
+      controls: census.length,
+      disabled_controls: census.filter((c) => c.disabled).length,
+      screenshot: { sha256: digest, posture: "1440x900-light" },
+      console_errors: consoleErrors.splice(0).slice(0, 10),
+    });
+    return { id, fresh: true, census };
+  }
+
+  const startResp = await page.goto(startUrl, { waitUntil: "domcontentloaded", timeout: 30000 })
+    .catch((e) => { die(2, `BLOCKED: cannot open ${startUrl}: ${e.message}`); });
+  await page.waitForTimeout(2500);
+  if (startResp && startResp.status() >= 400) {
+    blockers.push({ kind: "start-route-error", node: "n0", reason: `HTTP ${startResp.status()} at ${ownedRoute}` });
+  }
+  const rootSnap = await snapshotNode("route", null);
+  const frontier = [{ nodeId: rootSnap.id, url: page.url(), census: rootSnap.census ?? (await censusOf(page)) }];
+  const visitedUrls = new Set([page.url()]);
+
+  while (frontier.length > 0 && nodes.length < MAX_NODES) {
+    const current = frontier.shift();
+    const census = current.census;
+    if (census.length > MAX_CONTROLS_PER_NODE) {
+      blockers.push({
+        kind: "control-census-overflow", node: current.nodeId,
+        reason: `${census.length} controls > cap ${MAX_CONTROLS_PER_NODE}; raise --max-controls and recapture`,
+      });
+    }
+    for (const control of census.slice(0, MAX_CONTROLS_PER_NODE)) {
+      if (control.disabled) {
+        edges.push({ from: current.nodeId, to: null, control, action: "none", outcome: "disabled" });
+        continue;
+      }
+      // Link with an in-allowlist href: navigate directly (deterministic).
+      if (control.href) {
+        let target;
+        try { target = new URL(control.href, current.url); } catch { continue; }
+        if (!allowedOrigins.has(target.origin)) {
+          edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "boundary-external-origin" });
+          continue;
+        }
+        if (!inAllowlist(target.pathname)) {
+          edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "boundary-off-allowlist" });
+          continue;
+        }
+        if (visitedUrls.has(target.toString())) {
+          edges.push({ from: current.nodeId, to: nodeIds.get(target.toString()) ?? "visited", control, action: "goto", outcome: "revisit" });
+          continue;
+        }
+        visitedUrls.add(target.toString());
+        pendingDownload = null;
+        const resp = await page.goto(target.toString(), { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+        await page.waitForTimeout(1200);
+        if (pendingDownload) {
+          edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "download", detail: pendingDownload });
+          blockers.push({ kind: "download-instead-of-ux", node: current.nodeId, reason: `${target.pathname} starts a download (${pendingDownload})` });
+        } else if (!resp || resp.status() >= 400) {
+          edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "error", detail: resp ? `HTTP ${resp.status()}` : "no response" });
+          blockers.push({ kind: "unreachable-route", node: current.nodeId, reason: `${target.pathname}: ${resp ? `HTTP ${resp.status()}` : "no response"}` });
+        } else {
+          const snap = await snapshotNode("route", { from: current.nodeId, control });
+          edges.push({ from: current.nodeId, to: snap.id, control, action: "goto", outcome: "navigated" });
+          if (snap.fresh) frontier.push({ nodeId: snap.id, url: page.url(), census: snap.census ?? (await censusOf(page)) });
+        }
+        await page.goto(current.url, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+        await page.waitForTimeout(600);
+        continue;
+      }
+      // Non-link control: click, classify the outcome, recover.
+      const before = await stateSignature(page);
+      const writesBefore = blockedWrites.length;
+      pendingDownload = null;
+      const locator = page.locator(CONTROL_SELECTOR).nth(control.index);
+      const clicked = await locator.click({ timeout: 4000, trial: false }).then(() => true).catch(() => false);
+      await page.waitForTimeout(900);
+      if (!clicked) {
+        edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "unclickable" });
+        continue;
+      }
+      if (blockedWrites.length > writesBefore) {
+        edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "blocked-write-attempt", detail: blockedWrites.at(-1) });
+        await page.keyboard.press("Escape").catch(() => {});
+        continue;
+      }
+      if (pendingDownload) {
+        edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "download", detail: pendingDownload });
+        continue;
+      }
+      const after = await stateSignature(page);
+      if (after === before) {
+        edges.push({ from: current.nodeId, to: current.nodeId, control, action: "click", outcome: "noop" });
+        continue;
+      }
+      const urlChanged = !page.url().startsWith(current.url);
+      if (urlChanged && !inAllowlist(new URL(page.url()).pathname)) {
+        edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "boundary-off-allowlist" });
+      } else {
+        const snap = await snapshotNode(urlChanged ? "route" : "state", { from: current.nodeId, control });
+        edges.push({ from: current.nodeId, to: snap.id, control, action: "click", outcome: urlChanged ? "navigated" : "state-change" });
+        if (snap.fresh && nodes.length < MAX_NODES) {
+          frontier.push({ nodeId: snap.id, url: page.url(), census: snap.census ?? (await censusOf(page)) });
+        }
+      }
+      // Recover to the node under crawl: Escape for overlays, goto for navigation.
+      await page.keyboard.press("Escape").catch(() => {});
+      if (!page.url().startsWith(current.url)) {
+        await page.goto(current.url, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+        await page.waitForTimeout(600);
+      }
+    }
+    // Back-stack probe from this node.
+    await page.goBack({ timeout: 8000 }).then(() => edges.push({ from: current.nodeId, to: "back-stack", control: null, action: "back", outcome: "navigated" })).catch(() =>
+      edges.push({ from: current.nodeId, to: null, control: null, action: "back", outcome: "noop" }));
+    await page.goto(current.url, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+  }
+  if (frontier.length > 0) {
+    blockers.push({ kind: "node-cap-reached", node: null, reason: `${frontier.length} unexplored nodes beyond --max-nodes ${MAX_NODES}` });
+  }
+
+  // Posture matrix for URL-addressable route nodes (dark, narrow/reduced-motion).
+  for (const [vp, postureName, colorScheme, reducedMotion] of [
+    [{ width: 1440, height: 900 }, "1440x900-dark", "dark", "no-preference"],
+    [{ width: 390, height: 844 }, "390x844-light-reduced-motion", "light", "reduce"],
+  ]) {
+    const pctx = await browser.newContext({ viewport: vp, colorScheme, reducedMotion });
+    await installQuarantine(pctx, []);
+    const ppage = await pctx.newPage();
+    for (const node of nodes.filter((n) => n.kind === "route")) {
+      const target = new URL(node.url, SERVE).toString();
+      const ok = await ppage.goto(target, { waitUntil: "domcontentloaded", timeout: 20000 }).then((r) => r && r.status() < 400).catch(() => false);
+      if (!ok) continue;
+      await ppage.waitForTimeout(800);
+      const png = await ppage.screenshot({ fullPage: false });
+      const digest = sha(png);
+      fs.writeFileSync(path.join(shotsDir, `${node.id}-${digest.slice(0, 12)}.png`), png);
+      (node.posture_matrix ??= []).push({ sha256: digest, posture: postureName });
+    }
+    await pctx.close();
+  }
+  await browser.close();
+
+  const graph = {
+    schema_version: SCHEMA,
+    surface, slug,
+    owned_route: ownedRoute,
+    capture_route: captureRoute ?? null,
+    runtime: { serve_url: SERVE, capture_url: captureRoute ? CAPTURE : null },
+    captured_at: new Date().toISOString(),
+    quarantine,
+    nodes, edges, blockers,
+    replay: { walked_all_edges: false, walked_at: null },
+    complete_interaction_route_graph: false,
+    shots_dir: path.relative(repoRoot, shotsDir),
+  };
+  graph.content_address = canonicalAddress(graph);
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${JSON.stringify(graph, null, 2)}\n`);
+  const admissible = quarantine.violations.length === 0;
+  console.log(
+    `seed-route-graph: captured ${nodes.length} nodes, ${edges.length} edges, ${blockers.length} blockers ` +
+      `(${admissible ? "quarantine clean" : `${quarantine.violations.length} QUARANTINE VIOLATIONS — INADMISSIBLE`}) -> ${outPath}`,
+  );
+  console.log("seed-route-graph: completeness is granted by --replay, never by capture.");
+  process.exit(admissible ? 0 : 1);
+}
+
+async function replay() {
+  const graphPath = outPath;
+  if (!fs.existsSync(graphPath)) die(1, `no graph at ${graphPath} — capture first`);
+  const graph = JSON.parse(fs.readFileSync(graphPath, "utf8"));
+  if (graph.schema_version !== SCHEMA) die(1, `unsupported graph schema ${graph.schema_version}`);
+  const recorded = graph.content_address;
+  if (canonicalAddress(graph) !== recorded) die(1, "content_address does not verify — the graph was edited by hand");
+  if ((graph.quarantine?.violations ?? []).length > 0) die(1, "graph records quarantine violations — recapture under quarantine");
+  if (!(await reachable(SERVE))) die(2, `BLOCKED: serve runtime unreachable at ${SERVE}`);
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  await installQuarantine(context, []);
+  const page = await context.newPage();
+  const problems = [];
+  const routeNodes = graph.nodes.filter((n) => n.kind === "route");
+  for (const node of routeNodes) {
+    const target = new URL(node.url, SERVE).toString();
+    const resp = await page.goto(target, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+    await page.waitForTimeout(1000);
+    if (!resp || resp.status() >= 400) {
+      problems.push(`unreachable node ${node.id} (${node.url}): ${resp ? `HTTP ${resp.status()}` : "no response"}`);
+      continue;
+    }
+    const census = await censusOf(page);
+    if (census.length === 0 && node.controls > 0) {
+      problems.push(`node ${node.id} (${node.url}) rendered zero controls; graph recorded ${node.controls}`);
+    }
+  }
+  const walkable = graph.edges.filter((e) => e.to && e.to !== "back-stack" && e.outcome !== "revisit");
+  const nodeById = new Map(graph.nodes.map((n) => [n.id, n]));
+  for (const edge of walkable) {
+    if (!nodeById.has(edge.to)) problems.push(`edge ${edge.from}->${edge.to}: unclassified target node`);
+  }
+  await browser.close();
+
+  const complete = problems.length === 0 && graph.blockers.length === 0;
+  graph.replay = { walked_all_edges: problems.length === 0, walked_at: new Date().toISOString(), problems };
+  graph.complete_interaction_route_graph = complete;
+  graph.content_address = canonicalAddress(graph);
+  fs.writeFileSync(graphPath, `${JSON.stringify(graph, null, 2)}\n`);
+  for (const p of problems) console.error(`seed-route-graph replay: ${p}`);
+  console.log(
+    `seed-route-graph replay: ${routeNodes.length} route nodes walked, ${walkable.length} edges checked, ` +
+      `${graph.blockers.length} standing blockers -> complete_interaction_route_graph=${complete}`,
+  );
+  process.exit(complete ? 0 : 1);
+}
+
+if (flag("--replay")) await replay();
+else await capture();

--- a/apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+// Fail-closed seed-provenance gate for the twenty Hypervisor surfaces (AUD-WS-002,
+// 2026-08-09 audit). Promoted from the audit-pack prototype
+// (internal-docs/audits/2026-08-09-hypervisor-live-ux-workstream-coverage/logs/
+// validate-seed-ux-manifest.mjs) onto tracked inputs only, so a fresh clone and CI
+// validate the same truth.
+//
+// What it enforces, before any browser navigation is trusted:
+//   - exactly twenty surface entries, exact id set, canonical routes;
+//   - every /__ioi seed baseline exactly matches ported-seed-preservation.v1.json;
+//   - every /__apps slug exists in the harvest inventory and parity matrix and
+//     carries exactly one estate disposition from the fixed vocabulary;
+//   - dormant references exactly match ux-seeds/manifest.json;
+//   - a canonical shell is never a baseline (no source route equals a canonical route);
+//   - owner drift is rejected (typed exception: an owner_mapping_note recording an
+//     open dual-owner ruling, e.g. machinery / OQ-2);
+//   - seed_graph_ready_for_rehome derives strictly from per-source
+//     complete_interaction_route_graph; a block record never satisfies the gate;
+//   - a claimed-complete graph must exist under seed-graphs/, parse, match its
+//     surface/slug/route, verify its content address, attest quarantine, and have
+//     been replay-walked with zero blockers;
+//   - a no-seed surface carries either its recovery record or a typed
+//     greenfield-authorized-non-parity authorization — nothing else opens work;
+//   - no secret-shaped token anywhere in the manifest or graphs.
+//
+//   node scripts/verify-hypervisor-seed-provenance.mjs            # full tracked gate
+//   node scripts/verify-hypervisor-seed-provenance.mjs --surface work
+//   node scripts/verify-hypervisor-seed-provenance.mjs --shared   # wiring check only (W2.1)
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const failures = [];
+const fail = (msg) => failures.push(msg);
+
+const readJson = (rel) => JSON.parse(fs.readFileSync(path.join(appRoot, rel), "utf8"));
+const readText = (rel) => fs.readFileSync(path.join(appRoot, rel), "utf8");
+
+const args = process.argv.slice(2);
+const sharedOnly = args.includes("--shared");
+const surfaceFilter = args.includes("--surface") ? args[args.indexOf("--surface") + 1] : null;
+
+const MANIFEST = "seed-ux-provenance.v1.json";
+const EXPECTED_IDS = [
+  "home", "systems", "projects", "applications", "work", "settings", "studio",
+  "automations", "ontology", "data", "governance", "provenance", "evaluations",
+  "improvement", "foundry", "packages", "developer-workspace", "developer-console",
+  "environments", "operations",
+];
+const SOURCE_KINDS = new Set([
+  "protected-executable-seed", "retained-harvest-capture", "explicit-dormant-reference",
+]);
+const DISPOSITIONS = new Set([
+  "pattern-harvest", "rebind", "rehome", "retire-at-cutover",
+  "blocked-missing-route", "blocked-missing-capture",
+]);
+const SECRET = /ioi_(?:bootstrap|session)_[A-Za-z0-9._-]+|"session_token"\s*:/u;
+
+const manifest = readJson(MANIFEST);
+if (manifest.schema_version !== "ioi.hypervisor.seed-ux-provenance.v1") {
+  fail(`${MANIFEST}: unsupported schema_version ${manifest.schema_version}`);
+}
+
+const seenProtected = new Map();
+const seenRetained = new Map();
+const seenDormant = new Map();
+
+if (sharedOnly) {
+  // W2.1 wiring check: the gate is invokable and its tracked inputs exist.
+  for (const rel of [
+    MANIFEST, "ported-seed-preservation.v1.json", "harvest-app-parity-matrix.json",
+    "ux-seeds/manifest.json", "scripts/harvest-seed-inventory.mjs",
+    "scripts/capture-hypervisor-seed-route-graph.mjs",
+  ]) {
+    if (!fs.existsSync(path.join(appRoot, rel))) fail(`--shared: missing tracked input ${rel}`);
+  }
+  finish("shared wiring");
+}
+
+// ---------------------------------------------------------------- tracked inputs
+const preservation = readJson("ported-seed-preservation.v1.json");
+const parityMatrix = readJson("harvest-app-parity-matrix.json");
+const dormant = readJson("ux-seeds/manifest.json");
+const inventorySlugs = new Set(
+  [...readText("scripts/harvest-seed-inventory.mjs").matchAll(/\bslug:\s*"([^"]+)"/gu)].map((m) => m[1]),
+);
+const registryOwners = new Map(
+  [...readText("scripts/surface-registry.mjs").matchAll(
+    /slug:\s*"([^"]+)",\s*owner:\s*"([^"]+)"[\s\S]*?route:\s*"([^"]+)"/gu,
+  )].map((m) => [m[3], { slug: m[1], owner: m[2] }]),
+);
+
+// ---------------------------------------------------------------- surfaces
+const surfaces = manifest.surfaces ?? [];
+const ids = surfaces.map((s) => s.id);
+if (ids.length !== 20) fail(`${MANIFEST}: expected 20 surfaces, found ${ids.length}`);
+for (const id of EXPECTED_IDS) if (!ids.includes(id)) fail(`${MANIFEST}: missing surface ${id}`);
+for (const id of ids) if (!EXPECTED_IDS.includes(id)) fail(`${MANIFEST}: unknown surface ${id}`);
+if (new Set(ids).size !== ids.length) fail(`${MANIFEST}: duplicate surface ids`);
+if (surfaceFilter && !ids.includes(surfaceFilter)) {
+  fail(`--surface ${surfaceFilter}: no such surface`);
+}
+
+const canonicalRoutes = new Set(surfaces.map((s) => s.canonical_route));
+
+for (const surface of surfaces) {
+  const at = `surface ${surface.id}`;
+  if (!surface.canonical_route?.startsWith("/")) fail(`${at}: canonical_route must start with /`);
+  if (surface.owner !== undefined && typeof surface.owner !== "string") fail(`${at}: owner must be a string`);
+
+  const status = surface.graph_mapping_status ?? "";
+  if (!status.startsWith("blocked-") && status !== "complete-interaction-route-graphs-present") {
+    fail(`${at}: graph_mapping_status must start with "blocked-" or be the complete terminal value, got "${status}"`);
+  }
+
+  const sources = surface.sources ?? [];
+  const derivedReady = sources.length > 0 &&
+    sources.every((src) => src.graph?.complete_interaction_route_graph === true);
+  if (Boolean(surface.seed_graph_ready_for_rehome) !== derivedReady) {
+    fail(`${at}: seed_graph_ready_for_rehome=${surface.seed_graph_ready_for_rehome} does not derive from its sources (derived ${derivedReady}) — the gate is fail-closed, never asserted`);
+  }
+  if (derivedReady && status.startsWith("blocked-")) {
+    fail(`${at}: every source graph is complete but graph_mapping_status is still "${status}"`);
+  }
+
+  const green = surface.greenfield_authorization;
+  if (sources.length === 0) {
+    if (!green && !surface.graph_recovery_status) {
+      fail(`${at}: a no-seed surface must carry its exhausted-recovery record or a typed greenfield authorization`);
+    }
+    if (surface.baseline_status !== "blocked-no-valid-seed") {
+      fail(`${at}: zero sources requires baseline_status blocked-no-valid-seed, got "${surface.baseline_status}"`);
+    }
+  }
+  if (green) {
+    if (green.type !== "greenfield-authorized-non-parity") {
+      fail(`${at}: greenfield_authorization.type must be "greenfield-authorized-non-parity"`);
+    }
+    if (!green.authorized_by || !green.authorized_on) {
+      fail(`${at}: greenfield_authorization requires authorized_by and authorized_on`);
+    }
+    if (!/seed preservation/u.test(green.limits ?? "") || !/parity/u.test(green.limits ?? "")) {
+      fail(`${at}: greenfield_authorization.limits must state it can never claim seed preservation or parity`);
+    }
+    if (sources.length > 0) {
+      fail(`${at}: greenfield authorization coexists with ${sources.length} seed sources — recover the seed instead`);
+    }
+  }
+
+  for (const src of sources) {
+    const sat = `${at} source ${src.slug}`;
+    if (!SOURCE_KINDS.has(src.kind)) fail(`${sat}: unknown kind ${src.kind}`);
+    if (src.canonical_owner !== surface.owner) {
+      fail(`${sat}: canonical_owner "${src.canonical_owner}" != surface owner "${surface.owner}"`);
+    }
+    if (src.starting_route && canonicalRoutes.has(src.starting_route)) {
+      fail(`${sat}: starting_route ${src.starting_route} is a canonical route — a shell is never a baseline`);
+    }
+    const level = src.graph?.evidence_level;
+    if (!["summary_only", "explored_control_graph", "complete_interaction_route_graph"].includes(level)) {
+      fail(`${sat}: unknown graph.evidence_level ${level}`);
+    }
+    const complete = src.graph?.complete_interaction_route_graph === true;
+    if (complete && level !== "complete_interaction_route_graph") {
+      fail(`${sat}: claims a complete graph at evidence_level ${level}`);
+    }
+
+    if (src.kind === "protected-executable-seed") {
+      if (seenProtected.has(src.starting_route)) fail(`${sat}: protected route ${src.starting_route} claimed twice`);
+      seenProtected.set(src.starting_route, src);
+    } else if (src.kind === "retained-harvest-capture") {
+      if (src.starting_route !== `/__apps/${src.slug}`) {
+        fail(`${sat}: retained starting_route must be /__apps/${src.slug}, got ${src.starting_route}`);
+      }
+      if (!DISPOSITIONS.has(src.disposition)) {
+        fail(`${sat}: disposition "${src.disposition}" is not in the fixed vocabulary`);
+      }
+      if (seenRetained.has(src.slug)) fail(`${sat}: retained slug claimed twice`);
+      seenRetained.set(src.slug, src);
+      if (!inventorySlugs.has(src.slug)) fail(`${sat}: slug absent from harvest-seed-inventory.mjs`);
+    } else {
+      seenDormant.set(src.slug, src);
+      if (src.starting_route !== null && src.starting_route !== undefined) {
+        fail(`${sat}: a dormant reference has no starting route`);
+      }
+    }
+
+    // Owner drift vs the live surface registry — typed exception only.
+    const reg = src.starting_route ? registryOwners.get(src.starting_route) : null;
+    if (reg && reg.owner !== src.canonical_owner && !src.owner_mapping_note) {
+      fail(`${sat}: surface-registry.mjs says owner "${reg.owner}" but manifest says "${src.canonical_owner}" with no owner_mapping_note recording the open ruling`);
+    }
+
+    // Graph-file gate.
+    if (complete) {
+      if (!src.graph_file) {
+        fail(`${sat}: complete_interaction_route_graph=true without a graph_file`);
+      } else {
+        verifyGraphFile(src, sat);
+      }
+    } else if (src.graph_file) {
+      verifyGraphFile(src, sat, { allowIncomplete: true });
+    }
+  }
+}
+
+// Exact protected-set equality with ported-seed-preservation.v1.json.
+const preservedRoutes = new Map((preservation.protected_routes ?? []).map((p) => [p.route, p]));
+for (const [route, p] of preservedRoutes) {
+  const src = seenProtected.get(route);
+  if (!src) fail(`protected route ${route} (${p.slug}) is missing from the provenance manifest`);
+  else {
+    if (src.slug !== p.slug) fail(`protected route ${route}: slug ${src.slug} != preservation record ${p.slug}`);
+    if (src.class !== p.class) fail(`protected route ${route}: class ${src.class} != preservation record ${p.class}`);
+  }
+}
+for (const route of seenProtected.keys()) {
+  if (!preservedRoutes.has(route)) fail(`protected source ${route} is not in ported-seed-preservation.v1.json — the /__ioi prefix is not a seed namespace`);
+}
+
+// Exact retained-set equality with the parity matrix + inventory.
+const matrixSlugs = new Set((parityMatrix.seeds ?? []).map((s) => s.slug));
+for (const slug of matrixSlugs) {
+  if (!seenRetained.has(slug)) fail(`retained slug ${slug} (harvest-app-parity-matrix.json) missing from the provenance manifest`);
+}
+for (const slug of seenRetained.keys()) {
+  if (!matrixSlugs.has(slug)) fail(`retained slug ${slug} is not in harvest-app-parity-matrix.json`);
+}
+
+// Exact dormant-set equality with ux-seeds/manifest.json.
+for (const seed of dormant.seeds ?? []) {
+  const src = seenDormant.get(seed.slug);
+  if (!src) fail(`dormant seed ${seed.slug} (ux-seeds/manifest.json) missing from the provenance manifest`);
+  else if (src.canonical_owner !== seed.canonical_owner) {
+    fail(`dormant seed ${seed.slug}: owner ${src.canonical_owner} != ux-seeds record ${seed.canonical_owner}`);
+  }
+}
+for (const slug of seenDormant.keys()) {
+  if (![...(dormant.seeds ?? [])].some((s) => s.slug === slug)) {
+    fail(`dormant source ${slug} is not in ux-seeds/manifest.json`);
+  }
+}
+
+// Secret-leak gate over the manifest and every graph file.
+if (SECRET.test(readText(MANIFEST))) fail(`${MANIFEST}: secret-shaped token present`);
+const graphDir = path.join(appRoot, "seed-graphs");
+if (fs.existsSync(graphDir)) {
+  for (const entry of fs.readdirSync(graphDir, { recursive: true })) {
+    const full = path.join(graphDir, String(entry));
+    if (fs.statSync(full).isFile() && SECRET.test(fs.readFileSync(full, "utf8"))) {
+      fail(`seed-graphs/${entry}: secret-shaped token present`);
+    }
+  }
+}
+
+function verifyGraphFile(src, sat, { allowIncomplete = false } = {}) {
+  const rel = src.graph_file;
+  if (!rel.startsWith("seed-graphs/")) {
+    fail(`${sat}: graph_file must live under seed-graphs/, got ${rel}`);
+    return;
+  }
+  const full = path.join(appRoot, rel);
+  if (!fs.existsSync(full)) {
+    fail(`${sat}: graph_file ${rel} does not exist`);
+    return;
+  }
+  let g;
+  try {
+    g = JSON.parse(fs.readFileSync(full, "utf8"));
+  } catch {
+    fail(`${sat}: graph_file ${rel} is not valid JSON`);
+    return;
+  }
+  if (g.schema_version !== "ioi.hypervisor.seed-interaction-route-graph.v1") {
+    fail(`${sat}: graph ${rel} has schema_version ${g.schema_version}`);
+  }
+  if (g.slug !== src.slug) fail(`${sat}: graph ${rel} is for slug ${g.slug}`);
+  if (src.starting_route && g.owned_route !== src.starting_route) {
+    fail(`${sat}: graph ${rel} owned_route ${g.owned_route} != source route ${src.starting_route}`);
+  }
+  const address = crypto.createHash("sha256")
+    .update(JSON.stringify({ surface: g.surface, slug: g.slug, nodes: g.nodes, edges: g.edges }))
+    .digest("hex");
+  if (g.content_address !== address) {
+    fail(`${sat}: graph ${rel} content_address does not verify (recorded ${String(g.content_address).slice(0, 12)}…, computed ${address.slice(0, 12)}…)`);
+  }
+  const q = g.quarantine ?? {};
+  if (q.network_policy !== "local-only" || q.corpus_mutation !== "denied" ||
+      q.html_injection !== "denied" || q.spa_fallback !== "denied") {
+    fail(`${sat}: graph ${rel} lacks the full quarantine attestation (AUD-WS-005)`);
+  }
+  if ((q.violations ?? []).length > 0) {
+    fail(`${sat}: graph ${rel} records ${q.violations.length} quarantine violations — the capture is inadmissible`);
+  }
+  const complete = g.complete_interaction_route_graph === true;
+  const blockers = g.blockers ?? [];
+  if (complete && blockers.length > 0) {
+    fail(`${sat}: graph ${rel} claims complete with ${blockers.length} blockers`);
+  }
+  if (complete && g.replay?.walked_all_edges !== true) {
+    fail(`${sat}: graph ${rel} claims complete without a replay walk of every edge`);
+  }
+  if (!allowIncomplete && !complete) {
+    fail(`${sat}: manifest claims a complete graph but ${rel} records complete_interaction_route_graph=${g.complete_interaction_route_graph}`);
+  }
+  if (allowIncomplete && complete && src.graph.complete_interaction_route_graph !== true) {
+    fail(`${sat}: graph ${rel} is complete but the manifest still records it incomplete — update the manifest in the same change`);
+  }
+}
+
+finish(surfaceFilter ? `surface ${surfaceFilter}` : "full tracked gate");
+
+function finish(mode) {
+  if (failures.length > 0) {
+    for (const f of failures) console.error(`seed-provenance: ${f}`);
+    console.error(`\nseed-provenance FAIL (${mode}) — ${failures.length} failures`);
+    process.exit(1);
+  }
+  const total = (manifest.surfaces ?? []).reduce((n, s) => n + (s.sources?.length ?? 0), 0);
+  console.log(
+    `seed-provenance OK (${mode}) — ${manifest.surfaces?.length ?? 0} surfaces, ${total} sources ` +
+      `(${seenProtected.size} protected, ${seenRetained.size} retained, ${seenDormant.size} dormant), fail-closed graph gate armed.`,
+  );
+  process.exit(0);
+}

--- a/apps/hypervisor/seed-ux-provenance.v1.json
+++ b/apps/hypervisor/seed-ux-provenance.v1.json
@@ -1,0 +1,1143 @@
+{
+  "schema_version": "ioi.hypervisor.seed-ux-provenance.v1",
+  "doctrine": "Fail-closed seed provenance for the twenty Hypervisor surfaces. A UX baseline is admitted only from an exact tracked provenance record; a canonical W0.1 shell, a generic /__ioi readout, visual resemblance, a control census, or a registration is never a seed. No surface rehome begins until every selected source carries a content-addressed complete interaction/route graph (complete_interaction_route_graph=true, replay-walked), or the surface carries a typed greenfield-authorized-non-parity record. A blocked record documents a gap only and never opens iteration.",
+  "derived_from": {
+    "audit_pack": "internal-docs/audits/2026-08-09-hypervisor-live-ux-workstream-coverage/ (gitignored research evidence)",
+    "audit_commit": "b309cf5e8031bd5faff52b85ea6bd0ad9d8df260",
+    "audit_manifest_schema": "ioi.hypervisor.seed-ux-provenance-manifest.v1",
+    "derived_at": "2026-08-09"
+  },
+  "tracked_provenance_sources": [
+    "apps/hypervisor/ported-seed-preservation.v1.json",
+    "apps/hypervisor/ux-seeds/manifest.json",
+    "apps/hypervisor/harvest-starting-points.json",
+    "apps/hypervisor/harvest-app-parity-matrix.json",
+    "apps/hypervisor/application-operational-depth.json",
+    "apps/hypervisor/scripts/harvest-seed-inventory.mjs"
+  ],
+  "untracked_references": [
+    "internal-docs/implementation/program/estate-disposition.md (gitignored working ledger)"
+  ],
+  "graph_directory": "apps/hypervisor/seed-graphs/",
+  "canonical_surface_count": 20,
+  "surfaces": [
+    {
+      "id": "home",
+      "owner": "Home",
+      "canonical_route": "/home",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "systems",
+      "owner": "Systems",
+      "canonical_route": "/systems",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "projects",
+      "owner": "Projects",
+      "canonical_route": "/projects",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "applications",
+      "owner": "Applications",
+      "canonical_route": "/applications",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "work",
+      "owner": "Work",
+      "canonical_route": "/work",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "jobs",
+          "starting_route": "/__ioi/missions",
+          "canonical_owner": "Work",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "substrate_bound",
+          "owner_mapping_note": "retired owner name: surface-registry.mjs still labels /__ioi/missions with the retired owner 'Missions'; canonical owner is Work per the estate ledger and core-clients-surfaces.md. The registry rename lands with the Work surface packet, not here."
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "incidents",
+          "starting_route": "/__ioi/missions/incidents",
+          "canonical_owner": "Work",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "blocked-missing-capture-corrupted-protected-variant-excluded",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired",
+          "owner_mapping_note": "retired owner name: surface-registry.mjs still labels /__ioi/missions/incidents with the retired owner 'Missions'; canonical owner is Work per the estate ledger and core-clients-surfaces.md. The registry rename lands with the Work surface packet, not here."
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "jobs",
+          "starting_route": "/__apps/jobs",
+          "canonical_owner": "Work",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "incidents",
+          "starting_route": "/__apps/incidents",
+          "canonical_owner": "Work",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is not trustworthy: one file was overwritten with a contact sheet and no immutable genuine render is established"
+        }
+      ]
+    },
+    {
+      "id": "settings",
+      "owner": "Settings",
+      "canonical_route": "/settings",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "studio",
+      "owner": "Studio",
+      "canonical_route": "/studio",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "designer",
+          "starting_route": "/__ioi/studio/designer",
+          "canonical_owner": "Studio",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "designer",
+          "starting_route": "/__apps/designer",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "workshop",
+          "starting_route": "/__apps/workshop",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay initiates a browser download/redirect"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "module",
+          "starting_route": "/__apps/module",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is Page not found"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "slate",
+          "starting_route": "/__apps/slate",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is blank/global-chrome-only rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "logic",
+          "starting_route": "/__apps/logic",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is global chrome plus Failed to initialize"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "contour",
+          "starting_route": "/__apps/contour",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is global chrome plus Failed to load analysis"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "fusion",
+          "starting_route": "/__apps/fusion",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-route",
+          "audit_route_disposition": "blocked-missing-runtime",
+          "visual_blocker": "stable replay is a Not Found page"
+        }
+      ]
+    },
+    {
+      "id": "automations",
+      "owner": "Automations",
+      "canonical_route": "/automations",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "machinery",
+          "starting_route": "/__ioi/studio/machinery",
+          "canonical_owner": "Automations",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired",
+          "owner_mapping_note": "OQ-2 open dual-owner record: surface-registry.mjs declares Studio; the 2026-08-09 audit's canonical reading is Automations; neither side is picked to unblock work. manifest.v1.json open_questions OQ-2 and docs/architecture/_meta/canon-to-code-delta.md carry the record."
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "monitors",
+          "starting_route": "/__ioi/automations/monitors",
+          "canonical_owner": "Automations",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "monitors",
+          "starting_route": "/__apps/monitors",
+          "canonical_owner": "Automations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "machinery",
+          "starting_route": "/__apps/machinery",
+          "canonical_owner": "Automations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "owner_mapping_note": "audit correction: current canonical process-graph owner is Automations; estate sweep carries the older Studio mesh assignment"
+        }
+      ]
+    },
+    {
+      "id": "ontology",
+      "owner": "Ontology",
+      "canonical_route": "/ontology",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "schema",
+          "starting_route": "/__ioi/ontology/manager",
+          "canonical_owner": "Ontology",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "explorer",
+          "starting_route": "/__ioi/ontology/explorer",
+          "canonical_owner": "Ontology",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "schema",
+          "starting_route": "/__apps/schema",
+          "canonical_owner": "Ontology",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "explorer",
+          "starting_route": "/__apps/explorer",
+          "canonical_owner": "Ontology",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "objectview",
+          "starting_route": "/__apps/objectview",
+          "canonical_owner": "Ontology",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-capture",
+          "audit_route_disposition": "blocked-missing-capture",
+          "visual_blocker": "stable replay initiates a browser download/redirect"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "objecteditor",
+          "starting_route": "/__apps/objecteditor",
+          "canonical_owner": "Ontology",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-capture",
+          "audit_route_disposition": "blocked-missing-capture",
+          "visual_blocker": "stable replay initiates a browser download/redirect"
+        }
+      ]
+    },
+    {
+      "id": "data",
+      "owner": "Data",
+      "canonical_route": "/data",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "sources",
+          "starting_route": "/__ioi/data/sources",
+          "canonical_owner": "Data",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "pipeline",
+          "starting_route": "/__ioi/pipeline",
+          "canonical_owner": "Data",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "ingest",
+          "starting_route": "/__apps/ingest",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is blank global chrome"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "sources",
+          "starting_route": "/__apps/sources",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is blank global chrome"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "pipeline",
+          "starting_route": "/__apps/pipeline",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "dataset",
+          "starting_route": "/__apps/dataset",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-route",
+          "audit_route_disposition": "blocked-missing-runtime",
+          "visual_blocker": "stable replay is an invalid-resource Not a dataset page"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "inference",
+          "starting_route": "/__apps/inference",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rehome",
+          "audit_route_disposition": "rehomed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        }
+      ]
+    },
+    {
+      "id": "governance",
+      "owner": "Governance",
+      "canonical_route": "/governance",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "approvals",
+          "starting_route": "/__ioi/governance/approvals",
+          "canonical_owner": "Governance",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "approvals",
+          "starting_route": "/__apps/approvals",
+          "canonical_owner": "Governance",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rehome",
+          "audit_route_disposition": "rehomed"
+        }
+      ]
+    },
+    {
+      "id": "provenance",
+      "owner": "Provenance",
+      "canonical_route": "/provenance",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "lineage",
+          "starting_route": "/__ioi/lineage",
+          "canonical_owner": "Provenance",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "substrate_bound"
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "vertex",
+          "starting_route": "/__ioi/vertex",
+          "canonical_owner": "Provenance",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "substrate_bound"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "lineage",
+          "starting_route": "/__apps/lineage",
+          "canonical_owner": "Provenance",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "vertex",
+          "starting_route": "/__apps/vertex",
+          "canonical_owner": "Provenance",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "explicit-dormant-reference",
+          "slug": "lineage",
+          "starting_route": null,
+          "canonical_owner": "Provenance",
+          "provenance_source": "apps/hypervisor/ux-seeds/manifest.json",
+          "visual_evidence_status": null,
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "substrate_bound"
+        }
+      ]
+    },
+    {
+      "id": "evaluations",
+      "owner": "Evaluations",
+      "canonical_route": "/evaluations",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "evalsuites",
+          "starting_route": "/__ioi/evaluations/evalsuites",
+          "canonical_owner": "Evaluations",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "evalsuites",
+          "starting_route": "/__apps/evalsuites",
+          "canonical_owner": "Evaluations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "analysis",
+          "starting_route": "/__apps/analysis",
+          "canonical_owner": "Evaluations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is blank global chrome"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "quiver",
+          "starting_route": "/__apps/quiver",
+          "canonical_owner": "Evaluations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-route",
+          "audit_route_disposition": "blocked-missing-runtime",
+          "visual_blocker": "stable replay is blank global chrome"
+        }
+      ]
+    },
+    {
+      "id": "improvement",
+      "owner": "Improvement",
+      "canonical_route": "/improvement",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "changes",
+          "starting_route": "/__ioi/improvement/changes",
+          "canonical_owner": "Improvement",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "changes",
+          "starting_route": "/__apps/changes",
+          "canonical_owner": "Improvement",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        }
+      ]
+    },
+    {
+      "id": "foundry",
+      "owner": "Foundry",
+      "canonical_route": "/foundry",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "models",
+          "starting_route": "/__ioi/foundry/models",
+          "canonical_owner": "Foundry",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "models",
+          "starting_route": "/__apps/models",
+          "canonical_owner": "Foundry",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "modelstudio",
+          "starting_route": "/__apps/modelstudio",
+          "canonical_owner": "Foundry",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is global chrome plus Page not found"
+        }
+      ]
+    },
+    {
+      "id": "packages",
+      "owner": "Packages",
+      "canonical_route": "/packages",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "listings",
+          "starting_route": "/__ioi/marketplace/listings",
+          "canonical_owner": "Packages",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired",
+          "owner_mapping_note": "retired owner name: surface-registry.mjs still labels /__ioi/marketplace/listings with the folded owner 'Marketplace'; canonical owner is Packages (marketplace is a Packages mode). The registry rename lands with the Packages surface packet, not here."
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "listings",
+          "starting_route": "/__apps/listings",
+          "canonical_owner": "Packages",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "registry",
+          "starting_route": "/__apps/registry",
+          "canonical_owner": "Packages",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        }
+      ]
+    },
+    {
+      "id": "developer-workspace",
+      "owner": "Developer Workspace",
+      "canonical_route": "/developer-workspace",
+      "baseline_status": "provenance-qualified-substantive-retained-ux-present-full-graph-required",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "workspaces",
+          "starting_route": "/__apps/workspaces",
+          "canonical_owner": "Developer Workspace",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic error-only shell rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "repositories",
+          "starting_route": "/__apps/repositories",
+          "canonical_owner": "Developer Workspace",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay initiates a browser download/redirect"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "notepad",
+          "starting_route": "/__apps/notepad",
+          "canonical_owner": "Developer Workspace",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "retire-at-cutover",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "explicit-dormant-reference",
+          "slug": "workspaces",
+          "starting_route": null,
+          "canonical_owner": "Developer Workspace",
+          "provenance_source": "apps/hypervisor/ux-seeds/manifest.json",
+          "visual_evidence_status": null,
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "reference_capture"
+        }
+      ]
+    },
+    {
+      "id": "developer-console",
+      "owner": "Developer Console",
+      "canonical_route": "/developer-console",
+      "baseline_status": "provenance-recorded-retained-source-present-but-visual-and-graph-blocked",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "devconsole",
+          "starting_route": "/__apps/devconsole",
+          "canonical_owner": "Developer Console",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is pure white/blank"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "widgets",
+          "starting_route": "/__apps/widgets",
+          "canonical_owner": "Developer Console",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is pure white/blank"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "developer",
+          "starting_route": "/__apps/developer",
+          "canonical_owner": "Developer Console",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "retire-at-cutover",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is pure white/blank"
+        },
+        {
+          "kind": "explicit-dormant-reference",
+          "slug": "widgets",
+          "starting_route": null,
+          "canonical_owner": "Developer Console",
+          "provenance_source": "apps/hypervisor/ux-seeds/manifest.json",
+          "visual_evidence_status": null,
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "reference_capture"
+        }
+      ]
+    },
+    {
+      "id": "environments",
+      "owner": "Environments",
+      "canonical_route": "/environments",
+      "baseline_status": "provenance-recorded-retained-source-present-but-visual-and-graph-blocked",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "map",
+          "starting_route": "/__apps/map",
+          "canonical_owner": "Environments",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "retire-at-cutover",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        }
+      ]
+    },
+    {
+      "id": "operations",
+      "owner": "Operations",
+      "canonical_route": "/operations",
+      "baseline_status": "provenance-recorded-retained-source-present-but-visual-and-graph-blocked",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "scheduler",
+          "starting_route": "/__apps/scheduler",
+          "canonical_owner": "Operations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is global chrome plus Page not found"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Phase 2 of the 2026-08-09 audit program-repair run (owner-commissioned). Promotes the audit's fail-closed seed doctrine into tracked application tooling so a fresh clone and CI validate the same truth the audit established.

## What lands
- **apps/hypervisor/seed-ux-provenance.v1.json** — tracked derivative of the audit-local seed authority (audit pack is gitignored): 20 surfaces, 58 sources (16 protected / 39 retained / 3 dormant), per-source `complete_interaction_route_graph` gates, typed `owner_mapping_note`s for three retired-name registry drifts (Missions×2, Marketplace) and the open OQ-2 machinery dual-owner record.
- **scripts/verify-hypervisor-seed-provenance.mjs** (AUD-WS-002) — fail-closed gate wired into CI (`check:seed-provenance`): exact set equality against `ported-seed-preservation.v1.json` (16 protected), `harvest-app-parity-matrix.json` + `harvest-seed-inventory.mjs` (39 retained), `ux-seeds/manifest.json` (3 dormant); one disposition per slug from the fixed vocabulary; canonical shells never admissible as baselines; owner drift rejected unless a typed note records the open ruling; `seed_graph_ready_for_rehome` strictly derived from per-source graph completeness (a block record never satisfies the gate); greenfield exceptions must be typed `greenfield-authorized-non-parity`; graph files must content-address-verify, attest quarantine, and be replay-walked; secret-leak gate over manifest + graphs. **Red/green proven on six seeded violation classes** (dup slug, bad disposition, complete-without-graph, ready-by-fiat, mistyped greenfield, shell-as-baseline).
- **scripts/capture-hypervisor-seed-route-graph.mjs** (AUD-WS-003) — interaction/route-graph harvester + replay gate with the exact flag grammar the audit recorded per source. AUD-WS-005 quarantine is enforced at launch, not promised: requests outside the serve/capture origins abort and record violations; non-GET to the capture origin aborts as corpus mutation; serve writes abort as typed `blocked-write-attempt` edges. A graph recording any violation is inadmissible. `--replay` walks every node/edge and is the only path to `complete_interaction_route_graph=true`.
- **CI**: `check:seed-provenance` added to the ported-seed verification block in `product_surfaces`.

## Verification
- `npm run check:seed-provenance --workspace=@ioi/hypervisor-app` → green (20 surfaces, 58 sources).
- `--shared` and `--surface <id>` modes green; harvester `node --check` clean.
- Six-violation red/green drill: each seeded defect RED with a precise message, restore GREEN.

Greenfield authorization records and the first harvest graphs follow in the Phase 4 PR (stacked on this one). The Phase 3 canon-rulings PR is independent (docs/architecture only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)