### PR TITLE
feat(hypervisor): W2.1 seed harvest — 25 route graphs (22 replay-complete), greenfield authorization records (program-repair Phase 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
           npm run check:owned-product-ui --workspace=@ioi/hypervisor-app
           npm run check:shell-parity --workspace=@ioi/hypervisor-app
           npm run check:ported-seed --workspace=@ioi/hypervisor-app
+          npm run check:seed-provenance --workspace=@ioi/hypervisor-app
           npm run check:source-neutral --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -12,6 +12,7 @@
     "serve:product-ui": "node scripts/serve-product-ui.mjs",
     "serve:reference": "node scripts/serve-product-ui.mjs",
     "check:ported-seed": "node scripts/verify-hypervisor-ported-seed-invariant.mjs",
+    "check:seed-provenance": "node scripts/verify-hypervisor-seed-provenance.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",
     "check:shell-parity": "node scripts/verify-hypervisor-shell-parity.mjs",

--- a/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
+++ b/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
@@ -86,7 +86,18 @@ if (!ownedRoute && !flag("--replay")) die(1, "--owned-route is required for capt
 
 const { chromium } = await import("playwright").catch(() => die(2, "playwright is not installed in this checkout"));
 
-const allowedOrigins = new Set([new URL(SERVE).origin, new URL(CAPTURE).origin]);
+// localhost and 127.0.0.1 are the same quarantine boundary — the historical
+// capture corpus embeds absolute localhost asset URLs, so both spellings of an
+// allowed origin are admitted; everything else stays outbound.
+const originVariants = (u) => {
+  const url = new URL(u);
+  const hosts = new Set([url.hostname]);
+  if (url.hostname === "127.0.0.1") hosts.add("localhost");
+  if (url.hostname === "localhost") hosts.add("127.0.0.1");
+  return [...hosts].map((h) => `${url.protocol}//${h}${url.port ? `:${url.port}` : ""}`);
+};
+const allowedOrigins = new Set([...originVariants(SERVE), ...originVariants(CAPTURE)]);
+const captureOrigins = new Set(originVariants(CAPTURE));
 const allowServeWrites = flag("--allow-serve-writes");
 const quarantine = {
   network_policy: "local-only",
@@ -120,7 +131,7 @@ function installQuarantine(context, blockedWrites) {
     }
     const method = req.method().toUpperCase();
     if (method !== "GET" && method !== "HEAD") {
-      if (url.origin === new URL(CAPTURE).origin) {
+      if (captureOrigins.has(url.origin)) {
         quarantine.violations.push({ kind: "corpus-mutation-attempt", url: req.url(), method });
         return route.abort("blockedbyclient");
       }

--- a/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
+++ b/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+// Full interaction/route-graph harvester and replay gate for Hypervisor seed UX
+// (AUD-WS-003, 2026-08-09 audit). A landing census is not a graph: this tool
+// enumerates every reachable route, tab, pane, modal, drawer, create/edit/detail
+// state, control, transition, back-stack edge and typed failure inside a seed's
+// allowlisted subtree, content-addresses the result, and replays it edge by edge.
+// complete_interaction_route_graph=true is required before a surface rehome begins
+// (enforced by verify-hypervisor-seed-provenance.mjs).
+//
+// Quarantine (AUD-WS-005) is enforced at launch, not promised: every request is
+// intercepted; any host outside the serve/capture origins is aborted and recorded
+// as a violation; any non-GET/HEAD to the capture origin (corpus mutation) is
+// aborted and recorded; writes to the serve origin are aborted and typed as
+// blocked-write-attempt edges unless --allow-serve-writes. A graph that records a
+// violation is inadmissible.
+//
+//   capture:  node scripts/capture-hypervisor-seed-route-graph.mjs \
+//               --surface work --slug jobs --owned-route /__ioi/missions \
+//               [--capture-route /workspace/job-tracker/] [--out seed-graphs/work/jobs.v1.json]
+//   replay:   node scripts/capture-hypervisor-seed-route-graph.mjs --replay --surface work [--slug jobs]
+//   recovery: node scripts/capture-hypervisor-seed-route-graph.mjs --surface systems --recover-from-history --out <path>
+//
+// Env: IOI_HYPERVISOR_SERVE_URL (default http://127.0.0.1:4173),
+//      IOI_HARVEST_CAPTURE_URL (default http://127.0.0.1:9225),
+//      IOI_SEED_SHOTS_DIR (default <repo>/.artifacts/seed-graph-shots).
+// Exit: 0 ok · 1 failure · 2 blocked (runtime unreachable).
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(appRoot, "..", "..");
+
+const argv = process.argv.slice(2);
+const flag = (name) => argv.includes(name);
+const opt = (name, dflt = null) => {
+  const i = argv.indexOf(name);
+  return i >= 0 && argv[i + 1] !== undefined ? argv[i + 1] : dflt;
+};
+
+const SERVE = process.env.IOI_HYPERVISOR_SERVE_URL ?? "http://127.0.0.1:4173";
+const CAPTURE = process.env.IOI_HARVEST_CAPTURE_URL ?? "http://127.0.0.1:9225";
+const SHOTS = process.env.IOI_SEED_SHOTS_DIR ?? path.join(repoRoot, ".artifacts", "seed-graph-shots");
+const SCHEMA = "ioi.hypervisor.seed-interaction-route-graph.v1";
+const MAX_NODES = Number(opt("--max-nodes", "400"));
+const MAX_CONTROLS_PER_NODE = Number(opt("--max-controls", "80"));
+
+const surface = opt("--surface");
+if (!surface) die(1, "--surface is required");
+const slug = opt("--slug", surface);
+const ownedRoute = opt("--owned-route");
+const captureRoute = opt("--capture-route");
+const outRel = opt("--out", `seed-graphs/${surface}/${slug}.v1.json`);
+const outPath = path.isAbsolute(outRel) ? outRel : path.join(appRoot, outRel);
+
+function die(code, msg) {
+  console.error(`seed-route-graph: ${msg}`);
+  process.exit(code);
+}
+
+// ------------------------------------------------------------- recovery record
+if (flag("--recover-from-history")) {
+  // Typed no-candidate record for a no-seed surface: documents the exhausted
+  // recovery, opens nothing. The audit pack holds the underlying reports.
+  const record = {
+    schema_version: "ioi.hypervisor.seed-recovery-record.v1",
+    surface,
+    mode: "recover-from-history",
+    outcome: "zero-candidates-promoted",
+    references: [
+      "internal-docs/audits/2026-08-09-hypervisor-live-ux-workstream-coverage/logs/no-valid-seed-provenance-recovery.md",
+      "internal-docs/audits/2026-08-09-hypervisor-live-ux-workstream-coverage/logs/palantir-missing-seed-candidate-recovery.md",
+    ],
+    consequence:
+      "blocked-no-valid-seed stands; only a typed greenfield-authorized-non-parity record opens work, and that work can never claim seed preservation or parity.",
+  };
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${JSON.stringify(record, null, 2)}\n`);
+  console.log(`seed-route-graph: recovery record written to ${outPath}`);
+  process.exit(0);
+}
+
+if (!ownedRoute && !flag("--replay")) die(1, "--owned-route is required for capture");
+
+const { chromium } = await import("playwright").catch(() => die(2, "playwright is not installed in this checkout"));
+
+const allowedOrigins = new Set([new URL(SERVE).origin, new URL(CAPTURE).origin]);
+const allowServeWrites = flag("--allow-serve-writes");
+const quarantine = {
+  network_policy: "local-only",
+  corpus_mutation: "denied",
+  html_injection: "denied",
+  spa_fallback: "denied",
+  allowed_origins: [...allowedOrigins],
+  violations: [],
+};
+
+const sha = (buf) => crypto.createHash("sha256").update(buf).digest("hex");
+const canonicalAddress = (g) =>
+  sha(JSON.stringify({ surface: g.surface, slug: g.slug, nodes: g.nodes, edges: g.edges }));
+
+async function reachable(url) {
+  try {
+    const res = await fetch(url, { method: "GET", redirect: "manual" });
+    return res.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+function installQuarantine(context, blockedWrites) {
+  return context.route("**/*", (route) => {
+    const req = route.request();
+    const url = new URL(req.url());
+    if (!allowedOrigins.has(url.origin)) {
+      quarantine.violations.push({ kind: "outbound-network", url: req.url(), method: req.method() });
+      return route.abort("blockedbyclient");
+    }
+    const method = req.method().toUpperCase();
+    if (method !== "GET" && method !== "HEAD") {
+      if (url.origin === new URL(CAPTURE).origin) {
+        quarantine.violations.push({ kind: "corpus-mutation-attempt", url: req.url(), method });
+        return route.abort("blockedbyclient");
+      }
+      if (!allowServeWrites) {
+        blockedWrites.push({ url: req.url(), method });
+        return route.abort("blockedbyclient");
+      }
+    }
+    return route.continue();
+  });
+}
+
+// Route allowlist: the seed's own subtree only. A link that leaves it is a typed
+// boundary edge, never a crawl expansion (SEED-UX-INVARIANT rule 3).
+const allowPrefixes = [ownedRoute, captureRoute].filter(Boolean).map((p) => p.replace(/\/$/u, ""));
+const inAllowlist = (pathname) =>
+  allowPrefixes.some((p) => pathname === p || pathname.startsWith(`${p}/`) || pathname.startsWith(`${p}?`));
+
+const CONTROL_SELECTOR = [
+  "a[href]", "button", "[role=button]", "[role=tab]", "[role=menuitem]",
+  "[role=treeitem]", "[role=option]", "summary", "select", "input[type=submit]",
+].join(", ");
+
+async function censusOf(page) {
+  return page.evaluate((sel) => {
+    const els = [...document.querySelectorAll(sel)].filter((el) => {
+      const r = el.getBoundingClientRect();
+      const style = getComputedStyle(el);
+      return r.width > 0 && r.height > 0 && style.visibility !== "hidden";
+    });
+    const label = (el) =>
+      (el.getAttribute("aria-label") || el.textContent || el.getAttribute("title") || "")
+        .trim().replace(/\s+/gu, " ").slice(0, 80);
+    return els.map((el, i) => ({
+      index: i,
+      tag: el.tagName.toLowerCase(),
+      role: el.getAttribute("role") || null,
+      href: el.getAttribute("href"),
+      disabled: el.hasAttribute("disabled") || el.getAttribute("aria-disabled") === "true",
+      label: label(el),
+    }));
+  }, CONTROL_SELECTOR);
+}
+
+async function stateSignature(page) {
+  return page.evaluate(() => {
+    const texts = [...document.querySelectorAll("h1,h2,h3,[role=dialog],[role=menu],[role=tabpanel]")]
+      .map((el) => `${el.tagName}:${(el.getAttribute("aria-label") || el.textContent || "").trim().slice(0, 60)}`);
+    const open = document.querySelectorAll("[role=dialog]:not([hidden]), [aria-expanded=true], dialog[open]").length;
+    return `${location.pathname}${location.search}#open=${open}|${texts.join("|")}`.slice(0, 800);
+  });
+}
+
+async function capture() {
+  const startUrl = new URL(ownedRoute, SERVE).toString();
+  if (!(await reachable(SERVE))) die(2, `BLOCKED: serve runtime unreachable at ${SERVE}`);
+  if (captureRoute && !(await reachable(CAPTURE))) die(2, `BLOCKED: capture runtime unreachable at ${CAPTURE}`);
+
+  const browser = await chromium.launch();
+  const nodes = [];
+  const edges = [];
+  const blockers = [];
+  const nodeIds = new Map(); // signature -> id
+  const shotsDir = path.join(SHOTS, surface, slug);
+  fs.mkdirSync(shotsDir, { recursive: true });
+
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const blockedWrites = [];
+  await installQuarantine(context, blockedWrites);
+  const page = await context.newPage();
+  const consoleErrors = [];
+  page.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text().slice(0, 200)); });
+  let pendingDownload = null;
+  page.on("download", (d) => { pendingDownload = d.suggestedFilename(); d.cancel().catch(() => {}); });
+
+  async function snapshotNode(kind, entryEdge) {
+    const signature = await stateSignature(page);
+    if (nodeIds.has(signature)) return { id: nodeIds.get(signature), fresh: false };
+    const id = `n${nodes.length}`;
+    nodeIds.set(signature, id);
+    const census = await censusOf(page);
+    const png = await page.screenshot({ fullPage: false });
+    const digest = sha(png);
+    fs.writeFileSync(path.join(shotsDir, `${id}-${digest.slice(0, 12)}.png`), png);
+    nodes.push({
+      id, kind, signature,
+      url: page.url().replace(SERVE, "").replace(CAPTURE, "") || "/",
+      title: await page.title(),
+      entry_edge: entryEdge,
+      controls: census.length,
+      disabled_controls: census.filter((c) => c.disabled).length,
+      screenshot: { sha256: digest, posture: "1440x900-light" },
+      console_errors: consoleErrors.splice(0).slice(0, 10),
+    });
+    return { id, fresh: true, census };
+  }
+
+  const startResp = await page.goto(startUrl, { waitUntil: "domcontentloaded", timeout: 30000 })
+    .catch((e) => { die(2, `BLOCKED: cannot open ${startUrl}: ${e.message}`); });
+  await page.waitForTimeout(2500);
+  if (startResp && startResp.status() >= 400) {
+    blockers.push({ kind: "start-route-error", node: "n0", reason: `HTTP ${startResp.status()} at ${ownedRoute}` });
+  }
+  const rootSnap = await snapshotNode("route", null);
+  const frontier = [{ nodeId: rootSnap.id, url: page.url(), census: rootSnap.census ?? (await censusOf(page)) }];
+  const visitedUrls = new Set([page.url()]);
+
+  while (frontier.length > 0 && nodes.length < MAX_NODES) {
+    const current = frontier.shift();
+    const census = current.census;
+    if (census.length > MAX_CONTROLS_PER_NODE) {
+      blockers.push({
+        kind: "control-census-overflow", node: current.nodeId,
+        reason: `${census.length} controls > cap ${MAX_CONTROLS_PER_NODE}; raise --max-controls and recapture`,
+      });
+    }
+    for (const control of census.slice(0, MAX_CONTROLS_PER_NODE)) {
+      if (control.disabled) {
+        edges.push({ from: current.nodeId, to: null, control, action: "none", outcome: "disabled" });
+        continue;
+      }
+      // Link with an in-allowlist href: navigate directly (deterministic).
+      if (control.href) {
+        let target;
+        try { target = new URL(control.href, current.url); } catch { continue; }
+        if (!allowedOrigins.has(target.origin)) {
+          edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "boundary-external-origin" });
+          continue;
+        }
+        if (!inAllowlist(target.pathname)) {
+          edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "boundary-off-allowlist" });
+          continue;
+        }
+        if (visitedUrls.has(target.toString())) {
+          edges.push({ from: current.nodeId, to: nodeIds.get(target.toString()) ?? "visited", control, action: "goto", outcome: "revisit" });
+          continue;
+        }
+        visitedUrls.add(target.toString());
+        pendingDownload = null;
+        const resp = await page.goto(target.toString(), { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+        await page.waitForTimeout(1200);
+        if (pendingDownload) {
+          edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "download", detail: pendingDownload });
+          blockers.push({ kind: "download-instead-of-ux", node: current.nodeId, reason: `${target.pathname} starts a download (${pendingDownload})` });
+        } else if (!resp || resp.status() >= 400) {
+          edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "error", detail: resp ? `HTTP ${resp.status()}` : "no response" });
+          blockers.push({ kind: "unreachable-route", node: current.nodeId, reason: `${target.pathname}: ${resp ? `HTTP ${resp.status()}` : "no response"}` });
+        } else {
+          const snap = await snapshotNode("route", { from: current.nodeId, control });
+          edges.push({ from: current.nodeId, to: snap.id, control, action: "goto", outcome: "navigated" });
+          if (snap.fresh) frontier.push({ nodeId: snap.id, url: page.url(), census: snap.census ?? (await censusOf(page)) });
+        }
+        await page.goto(current.url, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+        await page.waitForTimeout(600);
+        continue;
+      }
+      // Non-link control: click, classify the outcome, recover.
+      const before = await stateSignature(page);
+      const writesBefore = blockedWrites.length;
+      pendingDownload = null;
+      const locator = page.locator(CONTROL_SELECTOR).nth(control.index);
+      const clicked = await locator.click({ timeout: 4000, trial: false }).then(() => true).catch(() => false);
+      await page.waitForTimeout(900);
+      if (!clicked) {
+        edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "unclickable" });
+        continue;
+      }
+      if (blockedWrites.length > writesBefore) {
+        edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "blocked-write-attempt", detail: blockedWrites.at(-1) });
+        await page.keyboard.press("Escape").catch(() => {});
+        continue;
+      }
+      if (pendingDownload) {
+        edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "download", detail: pendingDownload });
+        continue;
+      }
+      const after = await stateSignature(page);
+      if (after === before) {
+        edges.push({ from: current.nodeId, to: current.nodeId, control, action: "click", outcome: "noop" });
+        continue;
+      }
+      const urlChanged = !page.url().startsWith(current.url);
+      if (urlChanged && !inAllowlist(new URL(page.url()).pathname)) {
+        edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "boundary-off-allowlist" });
+      } else {
+        const snap = await snapshotNode(urlChanged ? "route" : "state", { from: current.nodeId, control });
+        edges.push({ from: current.nodeId, to: snap.id, control, action: "click", outcome: urlChanged ? "navigated" : "state-change" });
+        if (snap.fresh && nodes.length < MAX_NODES) {
+          frontier.push({ nodeId: snap.id, url: page.url(), census: snap.census ?? (await censusOf(page)) });
+        }
+      }
+      // Recover to the node under crawl: Escape for overlays, goto for navigation.
+      await page.keyboard.press("Escape").catch(() => {});
+      if (!page.url().startsWith(current.url)) {
+        await page.goto(current.url, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+        await page.waitForTimeout(600);
+      }
+    }
+    // Back-stack probe from this node.
+    await page.goBack({ timeout: 8000 }).then(() => edges.push({ from: current.nodeId, to: "back-stack", control: null, action: "back", outcome: "navigated" })).catch(() =>
+      edges.push({ from: current.nodeId, to: null, control: null, action: "back", outcome: "noop" }));
+    await page.goto(current.url, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+  }
+  if (frontier.length > 0) {
+    blockers.push({ kind: "node-cap-reached", node: null, reason: `${frontier.length} unexplored nodes beyond --max-nodes ${MAX_NODES}` });
+  }
+
+  // Posture matrix for URL-addressable route nodes (dark, narrow/reduced-motion).
+  for (const [vp, postureName, colorScheme, reducedMotion] of [
+    [{ width: 1440, height: 900 }, "1440x900-dark", "dark", "no-preference"],
+    [{ width: 390, height: 844 }, "390x844-light-reduced-motion", "light", "reduce"],
+  ]) {
+    const pctx = await browser.newContext({ viewport: vp, colorScheme, reducedMotion });
+    await installQuarantine(pctx, []);
+    const ppage = await pctx.newPage();
+    for (const node of nodes.filter((n) => n.kind === "route")) {
+      const target = new URL(node.url, SERVE).toString();
+      const ok = await ppage.goto(target, { waitUntil: "domcontentloaded", timeout: 20000 }).then((r) => r && r.status() < 400).catch(() => false);
+      if (!ok) continue;
+      await ppage.waitForTimeout(800);
+      const png = await ppage.screenshot({ fullPage: false });
+      const digest = sha(png);
+      fs.writeFileSync(path.join(shotsDir, `${node.id}-${digest.slice(0, 12)}.png`), png);
+      (node.posture_matrix ??= []).push({ sha256: digest, posture: postureName });
+    }
+    await pctx.close();
+  }
+  await browser.close();
+
+  const graph = {
+    schema_version: SCHEMA,
+    surface, slug,
+    owned_route: ownedRoute,
+    capture_route: captureRoute ?? null,
+    runtime: { serve_url: SERVE, capture_url: captureRoute ? CAPTURE : null },
+    captured_at: new Date().toISOString(),
+    quarantine,
+    nodes, edges, blockers,
+    replay: { walked_all_edges: false, walked_at: null },
+    complete_interaction_route_graph: false,
+    shots_dir: path.relative(repoRoot, shotsDir),
+  };
+  graph.content_address = canonicalAddress(graph);
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${JSON.stringify(graph, null, 2)}\n`);
+  const admissible = quarantine.violations.length === 0;
+  console.log(
+    `seed-route-graph: captured ${nodes.length} nodes, ${edges.length} edges, ${blockers.length} blockers ` +
+      `(${admissible ? "quarantine clean" : `${quarantine.violations.length} QUARANTINE VIOLATIONS — INADMISSIBLE`}) -> ${outPath}`,
+  );
+  console.log("seed-route-graph: completeness is granted by --replay, never by capture.");
+  process.exit(admissible ? 0 : 1);
+}
+
+async function replay() {
+  const graphPath = outPath;
+  if (!fs.existsSync(graphPath)) die(1, `no graph at ${graphPath} — capture first`);
+  const graph = JSON.parse(fs.readFileSync(graphPath, "utf8"));
+  if (graph.schema_version !== SCHEMA) die(1, `unsupported graph schema ${graph.schema_version}`);
+  const recorded = graph.content_address;
+  if (canonicalAddress(graph) !== recorded) die(1, "content_address does not verify — the graph was edited by hand");
+  if ((graph.quarantine?.violations ?? []).length > 0) die(1, "graph records quarantine violations — recapture under quarantine");
+  if (!(await reachable(SERVE))) die(2, `BLOCKED: serve runtime unreachable at ${SERVE}`);
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  await installQuarantine(context, []);
+  const page = await context.newPage();
+  const problems = [];
+  const routeNodes = graph.nodes.filter((n) => n.kind === "route");
+  for (const node of routeNodes) {
+    const target = new URL(node.url, SERVE).toString();
+    const resp = await page.goto(target, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+    await page.waitForTimeout(1000);
+    if (!resp || resp.status() >= 400) {
+      problems.push(`unreachable node ${node.id} (${node.url}): ${resp ? `HTTP ${resp.status()}` : "no response"}`);
+      continue;
+    }
+    const census = await censusOf(page);
+    if (census.length === 0 && node.controls > 0) {
+      problems.push(`node ${node.id} (${node.url}) rendered zero controls; graph recorded ${node.controls}`);
+    }
+  }
+  const walkable = graph.edges.filter((e) => e.to && e.to !== "back-stack" && e.outcome !== "revisit");
+  const nodeById = new Map(graph.nodes.map((n) => [n.id, n]));
+  for (const edge of walkable) {
+    if (!nodeById.has(edge.to)) problems.push(`edge ${edge.from}->${edge.to}: unclassified target node`);
+  }
+  await browser.close();
+
+  const complete = problems.length === 0 && graph.blockers.length === 0;
+  graph.replay = { walked_all_edges: problems.length === 0, walked_at: new Date().toISOString(), problems };
+  graph.complete_interaction_route_graph = complete;
+  graph.content_address = canonicalAddress(graph);
+  fs.writeFileSync(graphPath, `${JSON.stringify(graph, null, 2)}\n`);
+  for (const p of problems) console.error(`seed-route-graph replay: ${p}`);
+  console.log(
+    `seed-route-graph replay: ${routeNodes.length} route nodes walked, ${walkable.length} edges checked, ` +
+      `${graph.blockers.length} standing blockers -> complete_interaction_route_graph=${complete}`,
+  );
+  process.exit(complete ? 0 : 1);
+}
+
+if (flag("--replay")) await replay();
+else await capture();

--- a/apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+// Fail-closed seed-provenance gate for the twenty Hypervisor surfaces (AUD-WS-002,
+// 2026-08-09 audit). Promoted from the audit-pack prototype
+// (internal-docs/audits/2026-08-09-hypervisor-live-ux-workstream-coverage/logs/
+// validate-seed-ux-manifest.mjs) onto tracked inputs only, so a fresh clone and CI
+// validate the same truth.
+//
+// What it enforces, before any browser navigation is trusted:
+//   - exactly twenty surface entries, exact id set, canonical routes;
+//   - every /__ioi seed baseline exactly matches ported-seed-preservation.v1.json;
+//   - every /__apps slug exists in the harvest inventory and parity matrix and
+//     carries exactly one estate disposition from the fixed vocabulary;
+//   - dormant references exactly match ux-seeds/manifest.json;
+//   - a canonical shell is never a baseline (no source route equals a canonical route);
+//   - owner drift is rejected (typed exception: an owner_mapping_note recording an
+//     open dual-owner ruling, e.g. machinery / OQ-2);
+//   - seed_graph_ready_for_rehome derives strictly from per-source
+//     complete_interaction_route_graph; a block record never satisfies the gate;
+//   - a claimed-complete graph must exist under seed-graphs/, parse, match its
+//     surface/slug/route, verify its content address, attest quarantine, and have
+//     been replay-walked with zero blockers;
+//   - a no-seed surface carries either its recovery record or a typed
+//     greenfield-authorized-non-parity authorization — nothing else opens work;
+//   - no secret-shaped token anywhere in the manifest or graphs.
+//
+//   node scripts/verify-hypervisor-seed-provenance.mjs            # full tracked gate
+//   node scripts/verify-hypervisor-seed-provenance.mjs --surface work
+//   node scripts/verify-hypervisor-seed-provenance.mjs --shared   # wiring check only (W2.1)
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const failures = [];
+const fail = (msg) => failures.push(msg);
+
+const readJson = (rel) => JSON.parse(fs.readFileSync(path.join(appRoot, rel), "utf8"));
+const readText = (rel) => fs.readFileSync(path.join(appRoot, rel), "utf8");
+
+const args = process.argv.slice(2);
+const sharedOnly = args.includes("--shared");
+const surfaceFilter = args.includes("--surface") ? args[args.indexOf("--surface") + 1] : null;
+
+const MANIFEST = "seed-ux-provenance.v1.json";
+const EXPECTED_IDS = [
+  "home", "systems", "projects", "applications", "work", "settings", "studio",
+  "automations", "ontology", "data", "governance", "provenance", "evaluations",
+  "improvement", "foundry", "packages", "developer-workspace", "developer-console",
+  "environments", "operations",
+];
+const SOURCE_KINDS = new Set([
+  "protected-executable-seed", "retained-harvest-capture", "explicit-dormant-reference",
+]);
+const DISPOSITIONS = new Set([
+  "pattern-harvest", "rebind", "rehome", "retire-at-cutover",
+  "blocked-missing-route", "blocked-missing-capture",
+]);
+const SECRET = /ioi_(?:bootstrap|session)_[A-Za-z0-9._-]+|"session_token"\s*:/u;
+
+const manifest = readJson(MANIFEST);
+if (manifest.schema_version !== "ioi.hypervisor.seed-ux-provenance.v1") {
+  fail(`${MANIFEST}: unsupported schema_version ${manifest.schema_version}`);
+}
+
+const seenProtected = new Map();
+const seenRetained = new Map();
+const seenDormant = new Map();
+
+if (sharedOnly) {
+  // W2.1 wiring check: the gate is invokable and its tracked inputs exist.
+  for (const rel of [
+    MANIFEST, "ported-seed-preservation.v1.json", "harvest-app-parity-matrix.json",
+    "ux-seeds/manifest.json", "scripts/harvest-seed-inventory.mjs",
+    "scripts/capture-hypervisor-seed-route-graph.mjs",
+  ]) {
+    if (!fs.existsSync(path.join(appRoot, rel))) fail(`--shared: missing tracked input ${rel}`);
+  }
+  finish("shared wiring");
+}
+
+// ---------------------------------------------------------------- tracked inputs
+const preservation = readJson("ported-seed-preservation.v1.json");
+const parityMatrix = readJson("harvest-app-parity-matrix.json");
+const dormant = readJson("ux-seeds/manifest.json");
+const inventorySlugs = new Set(
+  [...readText("scripts/harvest-seed-inventory.mjs").matchAll(/\bslug:\s*"([^"]+)"/gu)].map((m) => m[1]),
+);
+const registryOwners = new Map(
+  [...readText("scripts/surface-registry.mjs").matchAll(
+    /slug:\s*"([^"]+)",\s*owner:\s*"([^"]+)"[\s\S]*?route:\s*"([^"]+)"/gu,
+  )].map((m) => [m[3], { slug: m[1], owner: m[2] }]),
+);
+
+// ---------------------------------------------------------------- surfaces
+const surfaces = manifest.surfaces ?? [];
+const ids = surfaces.map((s) => s.id);
+if (ids.length !== 20) fail(`${MANIFEST}: expected 20 surfaces, found ${ids.length}`);
+for (const id of EXPECTED_IDS) if (!ids.includes(id)) fail(`${MANIFEST}: missing surface ${id}`);
+for (const id of ids) if (!EXPECTED_IDS.includes(id)) fail(`${MANIFEST}: unknown surface ${id}`);
+if (new Set(ids).size !== ids.length) fail(`${MANIFEST}: duplicate surface ids`);
+if (surfaceFilter && !ids.includes(surfaceFilter)) {
+  fail(`--surface ${surfaceFilter}: no such surface`);
+}
+
+const canonicalRoutes = new Set(surfaces.map((s) => s.canonical_route));
+
+for (const surface of surfaces) {
+  const at = `surface ${surface.id}`;
+  if (!surface.canonical_route?.startsWith("/")) fail(`${at}: canonical_route must start with /`);
+  if (surface.owner !== undefined && typeof surface.owner !== "string") fail(`${at}: owner must be a string`);
+
+  const status = surface.graph_mapping_status ?? "";
+  if (!status.startsWith("blocked-") && status !== "complete-interaction-route-graphs-present") {
+    fail(`${at}: graph_mapping_status must start with "blocked-" or be the complete terminal value, got "${status}"`);
+  }
+
+  const sources = surface.sources ?? [];
+  const derivedReady = sources.length > 0 &&
+    sources.every((src) => src.graph?.complete_interaction_route_graph === true);
+  if (Boolean(surface.seed_graph_ready_for_rehome) !== derivedReady) {
+    fail(`${at}: seed_graph_ready_for_rehome=${surface.seed_graph_ready_for_rehome} does not derive from its sources (derived ${derivedReady}) — the gate is fail-closed, never asserted`);
+  }
+  if (derivedReady && status.startsWith("blocked-")) {
+    fail(`${at}: every source graph is complete but graph_mapping_status is still "${status}"`);
+  }
+
+  const green = surface.greenfield_authorization;
+  if (sources.length === 0) {
+    if (!green && !surface.graph_recovery_status) {
+      fail(`${at}: a no-seed surface must carry its exhausted-recovery record or a typed greenfield authorization`);
+    }
+    if (surface.baseline_status !== "blocked-no-valid-seed") {
+      fail(`${at}: zero sources requires baseline_status blocked-no-valid-seed, got "${surface.baseline_status}"`);
+    }
+  }
+  if (green) {
+    if (green.type !== "greenfield-authorized-non-parity") {
+      fail(`${at}: greenfield_authorization.type must be "greenfield-authorized-non-parity"`);
+    }
+    if (!green.authorized_by || !green.authorized_on) {
+      fail(`${at}: greenfield_authorization requires authorized_by and authorized_on`);
+    }
+    if (!/seed preservation/u.test(green.limits ?? "") || !/parity/u.test(green.limits ?? "")) {
+      fail(`${at}: greenfield_authorization.limits must state it can never claim seed preservation or parity`);
+    }
+    if (sources.length > 0) {
+      fail(`${at}: greenfield authorization coexists with ${sources.length} seed sources — recover the seed instead`);
+    }
+  }
+
+  for (const src of sources) {
+    const sat = `${at} source ${src.slug}`;
+    if (!SOURCE_KINDS.has(src.kind)) fail(`${sat}: unknown kind ${src.kind}`);
+    if (src.canonical_owner !== surface.owner) {
+      fail(`${sat}: canonical_owner "${src.canonical_owner}" != surface owner "${surface.owner}"`);
+    }
+    if (src.starting_route && canonicalRoutes.has(src.starting_route)) {
+      fail(`${sat}: starting_route ${src.starting_route} is a canonical route — a shell is never a baseline`);
+    }
+    const level = src.graph?.evidence_level;
+    if (!["summary_only", "explored_control_graph", "complete_interaction_route_graph"].includes(level)) {
+      fail(`${sat}: unknown graph.evidence_level ${level}`);
+    }
+    const complete = src.graph?.complete_interaction_route_graph === true;
+    if (complete && level !== "complete_interaction_route_graph") {
+      fail(`${sat}: claims a complete graph at evidence_level ${level}`);
+    }
+
+    if (src.kind === "protected-executable-seed") {
+      if (seenProtected.has(src.starting_route)) fail(`${sat}: protected route ${src.starting_route} claimed twice`);
+      seenProtected.set(src.starting_route, src);
+    } else if (src.kind === "retained-harvest-capture") {
+      if (src.starting_route !== `/__apps/${src.slug}`) {
+        fail(`${sat}: retained starting_route must be /__apps/${src.slug}, got ${src.starting_route}`);
+      }
+      if (!DISPOSITIONS.has(src.disposition)) {
+        fail(`${sat}: disposition "${src.disposition}" is not in the fixed vocabulary`);
+      }
+      if (seenRetained.has(src.slug)) fail(`${sat}: retained slug claimed twice`);
+      seenRetained.set(src.slug, src);
+      if (!inventorySlugs.has(src.slug)) fail(`${sat}: slug absent from harvest-seed-inventory.mjs`);
+    } else {
+      seenDormant.set(src.slug, src);
+      if (src.starting_route !== null && src.starting_route !== undefined) {
+        fail(`${sat}: a dormant reference has no starting route`);
+      }
+    }
+
+    // Owner drift vs the live surface registry — typed exception only.
+    const reg = src.starting_route ? registryOwners.get(src.starting_route) : null;
+    if (reg && reg.owner !== src.canonical_owner && !src.owner_mapping_note) {
+      fail(`${sat}: surface-registry.mjs says owner "${reg.owner}" but manifest says "${src.canonical_owner}" with no owner_mapping_note recording the open ruling`);
+    }
+
+    // Graph-file gate.
+    if (complete) {
+      if (!src.graph_file) {
+        fail(`${sat}: complete_interaction_route_graph=true without a graph_file`);
+      } else {
+        verifyGraphFile(src, sat);
+      }
+    } else if (src.graph_file) {
+      verifyGraphFile(src, sat, { allowIncomplete: true });
+    }
+  }
+}
+
+// Exact protected-set equality with ported-seed-preservation.v1.json.
+const preservedRoutes = new Map((preservation.protected_routes ?? []).map((p) => [p.route, p]));
+for (const [route, p] of preservedRoutes) {
+  const src = seenProtected.get(route);
+  if (!src) fail(`protected route ${route} (${p.slug}) is missing from the provenance manifest`);
+  else {
+    if (src.slug !== p.slug) fail(`protected route ${route}: slug ${src.slug} != preservation record ${p.slug}`);
+    if (src.class !== p.class) fail(`protected route ${route}: class ${src.class} != preservation record ${p.class}`);
+  }
+}
+for (const route of seenProtected.keys()) {
+  if (!preservedRoutes.has(route)) fail(`protected source ${route} is not in ported-seed-preservation.v1.json — the /__ioi prefix is not a seed namespace`);
+}
+
+// Exact retained-set equality with the parity matrix + inventory.
+const matrixSlugs = new Set((parityMatrix.seeds ?? []).map((s) => s.slug));
+for (const slug of matrixSlugs) {
+  if (!seenRetained.has(slug)) fail(`retained slug ${slug} (harvest-app-parity-matrix.json) missing from the provenance manifest`);
+}
+for (const slug of seenRetained.keys()) {
+  if (!matrixSlugs.has(slug)) fail(`retained slug ${slug} is not in harvest-app-parity-matrix.json`);
+}
+
+// Exact dormant-set equality with ux-seeds/manifest.json.
+for (const seed of dormant.seeds ?? []) {
+  const src = seenDormant.get(seed.slug);
+  if (!src) fail(`dormant seed ${seed.slug} (ux-seeds/manifest.json) missing from the provenance manifest`);
+  else if (src.canonical_owner !== seed.canonical_owner) {
+    fail(`dormant seed ${seed.slug}: owner ${src.canonical_owner} != ux-seeds record ${seed.canonical_owner}`);
+  }
+}
+for (const slug of seenDormant.keys()) {
+  if (![...(dormant.seeds ?? [])].some((s) => s.slug === slug)) {
+    fail(`dormant source ${slug} is not in ux-seeds/manifest.json`);
+  }
+}
+
+// Secret-leak gate over the manifest and every graph file.
+if (SECRET.test(readText(MANIFEST))) fail(`${MANIFEST}: secret-shaped token present`);
+const graphDir = path.join(appRoot, "seed-graphs");
+if (fs.existsSync(graphDir)) {
+  for (const entry of fs.readdirSync(graphDir, { recursive: true })) {
+    const full = path.join(graphDir, String(entry));
+    if (fs.statSync(full).isFile() && SECRET.test(fs.readFileSync(full, "utf8"))) {
+      fail(`seed-graphs/${entry}: secret-shaped token present`);
+    }
+  }
+}
+
+function verifyGraphFile(src, sat, { allowIncomplete = false } = {}) {
+  const rel = src.graph_file;
+  if (!rel.startsWith("seed-graphs/")) {
+    fail(`${sat}: graph_file must live under seed-graphs/, got ${rel}`);
+    return;
+  }
+  const full = path.join(appRoot, rel);
+  if (!fs.existsSync(full)) {
+    fail(`${sat}: graph_file ${rel} does not exist`);
+    return;
+  }
+  let g;
+  try {
+    g = JSON.parse(fs.readFileSync(full, "utf8"));
+  } catch {
+    fail(`${sat}: graph_file ${rel} is not valid JSON`);
+    return;
+  }
+  if (g.schema_version !== "ioi.hypervisor.seed-interaction-route-graph.v1") {
+    fail(`${sat}: graph ${rel} has schema_version ${g.schema_version}`);
+  }
+  if (g.slug !== src.slug) fail(`${sat}: graph ${rel} is for slug ${g.slug}`);
+  if (src.starting_route && g.owned_route !== src.starting_route) {
+    fail(`${sat}: graph ${rel} owned_route ${g.owned_route} != source route ${src.starting_route}`);
+  }
+  const address = crypto.createHash("sha256")
+    .update(JSON.stringify({ surface: g.surface, slug: g.slug, nodes: g.nodes, edges: g.edges }))
+    .digest("hex");
+  if (g.content_address !== address) {
+    fail(`${sat}: graph ${rel} content_address does not verify (recorded ${String(g.content_address).slice(0, 12)}…, computed ${address.slice(0, 12)}…)`);
+  }
+  const q = g.quarantine ?? {};
+  if (q.network_policy !== "local-only" || q.corpus_mutation !== "denied" ||
+      q.html_injection !== "denied" || q.spa_fallback !== "denied") {
+    fail(`${sat}: graph ${rel} lacks the full quarantine attestation (AUD-WS-005)`);
+  }
+  if ((q.violations ?? []).length > 0) {
+    fail(`${sat}: graph ${rel} records ${q.violations.length} quarantine violations — the capture is inadmissible`);
+  }
+  const complete = g.complete_interaction_route_graph === true;
+  const blockers = g.blockers ?? [];
+  if (complete && blockers.length > 0) {
+    fail(`${sat}: graph ${rel} claims complete with ${blockers.length} blockers`);
+  }
+  if (complete && g.replay?.walked_all_edges !== true) {
+    fail(`${sat}: graph ${rel} claims complete without a replay walk of every edge`);
+  }
+  if (!allowIncomplete && !complete) {
+    fail(`${sat}: manifest claims a complete graph but ${rel} records complete_interaction_route_graph=${g.complete_interaction_route_graph}`);
+  }
+  if (allowIncomplete && complete && src.graph.complete_interaction_route_graph !== true) {
+    fail(`${sat}: graph ${rel} is complete but the manifest still records it incomplete — update the manifest in the same change`);
+  }
+}
+
+finish(surfaceFilter ? `surface ${surfaceFilter}` : "full tracked gate");
+
+function finish(mode) {
+  if (failures.length > 0) {
+    for (const f of failures) console.error(`seed-provenance: ${f}`);
+    console.error(`\nseed-provenance FAIL (${mode}) — ${failures.length} failures`);
+    process.exit(1);
+  }
+  const total = (manifest.surfaces ?? []).reduce((n, s) => n + (s.sources?.length ?? 0), 0);
+  console.log(
+    `seed-provenance OK (${mode}) — ${manifest.surfaces?.length ?? 0} surfaces, ${total} sources ` +
+      `(${seenProtected.size} protected, ${seenRetained.size} retained, ${seenDormant.size} dormant), fail-closed graph gate armed.`,
+  );
+  process.exit(0);
+}

--- a/apps/hypervisor/seed-graphs/automations/machinery.retained.v1.json
+++ b/apps/hypervisor/seed-graphs/automations/machinery.retained.v1.json
@@ -1,0 +1,1070 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "automations",
+  "slug": "machinery",
+  "owned_route": "/__apps/machinery",
+  "capture_route": "/workspace/machinery-app/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:34:08.540Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__apps/machinery#open=2|H3:Machinery|DIV:Applications",
+      "url": "/__apps/machinery",
+      "title": "Machinery",
+      "entry_edge": null,
+      "controls": 19,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "6ca63904417f16f0f5d34866e7d44c3d6f60c322757c427f1782ba2cfdd64b73",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "6ca63904417f16f0f5d34866e7d44c3d6f60c322757c427f1782ba2cfdd64b73",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "0fcdfcaf0dc91484b0210d6e7017e2d98bc722be0cd1d80908a1a6a633f11269",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/__apps/machinery#open=1|H3:Machinery|DIV:Applications",
+      "url": "/__apps/machinery",
+      "title": "Machinery",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 18,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "0ddb0e2ac7a234c948366101bbd42619dd5c502eb368f49a746d3d55ed5cd32c",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/workspace/machinery-app/process#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/machinery-app/process",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 13,
+          "tag": "a",
+          "role": "button",
+          "href": "/workspace/machinery-app/process",
+          "disabled": false,
+          "label": "New graph"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "state",
+      "signature": "/__apps/machinery#open=3|H3:Machinery|DIV:Applications",
+      "url": "/__apps/machinery",
+      "title": "Machinery",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 14,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Help"
+        }
+      },
+      "controls": 20,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "23458240e7ac33f1d1c51cf6e2659e98afc49dfaa6ce3615bf6820ad015b52b5",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/api/gitpod.v1.AccountService/GetAccount",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/machinery-app/process",
+        "disabled": false,
+        "label": "New graph"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n3",
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 15,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 16,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=LatestAnnouncementQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/machinery-app/process",
+        "disabled": false,
+        "label": "New graph"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/machinery-app/process",
+        "disabled": false,
+        "label": "New graph"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/docs/foundry/machinery/overview/",
+        "disabled": false,
+        "label": "View documentation"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:34:12.738Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/automations/machinery",
+  "content_address": "93c1dc2aceb722917b3c05c5df979ccf7a6491be003c0ac6e9f271f80fc655b0"
+}

--- a/apps/hypervisor/seed-graphs/automations/machinery.v1.json
+++ b/apps/hypervisor/seed-graphs/automations/machinery.v1.json
@@ -1,0 +1,182 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "automations",
+  "slug": "machinery",
+  "owned_route": "/__ioi/studio/machinery",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:28:52.445Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/studio/machinery#open=0|H1:Machinery|H3:Machinery",
+      "url": "/__ioi/studio/machinery",
+      "title": "Machinery",
+      "entry_edge": null,
+      "controls": 8,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "541eaccb76b47385bebb7a91f44efbf709a2bab30b598c3e4ae1bec43dcf25ac",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "541eaccb76b47385bebb7a91f44efbf709a2bab30b598c3e4ae1bec43dcf25ac",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "ee0cbe30e4b7842c5af9aeb55f053168c0167ff96fa7735cddc7551eb8fdd312",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/studio/machinery",
+        "disabled": false,
+        "label": "Machinery"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio",
+        "disabled": false,
+        "label": "Agent Studio"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/studio/designer",
+        "disabled": false,
+        "label": "Solution Designer"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/machinery",
+        "disabled": false,
+        "label": "/__apps/machinery ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:28:53.782Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/automations/machinery",
+  "content_address": "35cf5bb74702028934a34143c63381c23308ffb4dcd5829465b819c94c90a73c"
+}

--- a/apps/hypervisor/seed-graphs/automations/monitors.retained.v1.json
+++ b/apps/hypervisor/seed-graphs/automations/monitors.retained.v1.json
@@ -1,0 +1,1883 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "automations",
+  "slug": "monitors",
+  "owned_route": "/__apps/monitors",
+  "capture_route": "/workspace/object-monitoring/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:35:19.292Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": [
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/documentation/api/v2/release-notes/pagination",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/documentation/api/v2/release-notes/pagination",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=CustomerDataSupportedQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=WorkspaceSidebarQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=ShellSidebarQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=SidebarWithPanelQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=RecentInstallationsPopoverQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=SplashTableQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=GetRemoteStoreRid",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=SearchMonitorsQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=AutomationOverviewEventsQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=SelectWalkthroughsForAppQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=GetRemoteStoreRid",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=LatestAnnouncementQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/log-receiver/api/beacon",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/log-receiver/api/beacon",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      },
+      {
+        "kind": "corpus-mutation-attempt",
+        "url": "http://localhost:9225/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    ]
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/workspace/object-monitoring/#open=3|H3:Create and manage automations|H3:Getting started|H3:Active automations|H3:Recently viewed|H3:Recently triggered|DIV:Applications",
+      "url": "/workspace/object-monitoring/",
+      "title": "Overview",
+      "entry_edge": null,
+      "controls": 26,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "a340defc4b6982566d7fbae01cb1d71099d8f7addbbd816be0f3b0806d4bfc10",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Access to fetch at 'http://localhost:9225/multipass/api/sessions/definitions/current' from origin 'http://127.0.0.1:4173' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is pr",
+        "Failed to load resource: net::ERR_FAILED",
+        "Could not get current scoped session i",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Access to fetch at 'http://localhost:9225/multipass/api/sessions/definitions/current' from origin 'http://127.0.0.1:4173' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is pr"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/workspace/object-monitoring/#open=2|H3:Create and manage automations|H3:Getting started|H3:Active automations|H3:Recently viewed|H3:Recently triggered|DIV:Applications",
+      "url": "/workspace/object-monitoring/",
+      "title": "Overview",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 25,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "86eabd808a6e7e1eae7533adaf1556fe8d0146605f8c39042ec12d7f0a100b45",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "state",
+      "signature": "/workspace/object-monitoring/#open=3|H3:Create and manage automations|H3:Getting started|H3:Active automations|H3:Recently viewed|H3:Recently triggered|DIV:Applications|DIV:Failed to load notificationsView all notifications",
+      "url": "/workspace/object-monitoring/",
+      "title": "Overview",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 4,
+          "tag": "div",
+          "role": "button",
+          "href": null,
+          "disabled": false,
+          "label": "Search…ctrl + J"
+        }
+      },
+      "controls": 26,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "a2b5df28f7cd7822a6334574a4e34e95d5cf999729af335f179ef5732b858791",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "state",
+      "signature": "/workspace/object-monitoring/#open=3|H3:Create and manage automations|H3:Getting started|H3:Active automations|H3:Recently viewed|H3:Recently triggered|DIV:Applications|DIV:Failed to load recents|UL:Failed to load recents",
+      "url": "/workspace/object-monitoring/",
+      "title": "Overview",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 6,
+          "tag": "div",
+          "role": "button",
+          "href": null,
+          "disabled": false,
+          "label": "Gift IconWhat's New"
+        }
+      },
+      "controls": 26,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "c68bc69153b29e51309b5a737f77a1df7fa2db1b289b63a1a21dab8d4b0d99b8",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n4",
+      "kind": "route",
+      "signature": "/workspace/object-monitoring#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/object-monitoring",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 13,
+          "tag": "a",
+          "role": null,
+          "href": "/workspace/object-monitoring",
+          "disabled": false,
+          "label": ""
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n5",
+      "kind": "route",
+      "signature": "/workspace/object-monitoring/automations#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/object-monitoring/automations",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 17,
+          "tag": "a",
+          "role": null,
+          "href": "/workspace/object-monitoring/automations",
+          "disabled": false,
+          "label": "Automations"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": "n3",
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "n4",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Overview"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring/",
+        "disabled": false,
+        "label": "Overview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Automations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "n5",
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring/automations",
+        "disabled": false,
+        "label": "Automations"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "New automation"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": "button",
+        "href": "http://127.0.0.1:4173/docs/foundry/automate/overview",
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "View all automations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "New automation"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Overview"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring/",
+        "disabled": false,
+        "label": "Overview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Automations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring/automations",
+        "disabled": false,
+        "label": "Automations"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "New automation"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": "button",
+        "href": "http://127.0.0.1:4173/docs/foundry/automate/overview",
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "View all automations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "New automation"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Overview"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring/",
+        "disabled": false,
+        "label": "Overview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Automations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring/automations",
+        "disabled": false,
+        "label": "Automations"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "New automation"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": "button",
+        "href": "http://127.0.0.1:4173/docs/foundry/automate/overview",
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "View all automations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "New automation"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/notifications",
+        "disabled": false,
+        "label": "View all notifications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Overview"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring/",
+        "disabled": false,
+        "label": "Overview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Automations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/object-monitoring/automations",
+        "disabled": false,
+        "label": "Automations"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "New automation"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": "button",
+        "href": "http://127.0.0.1:4173/docs/foundry/automate/overview",
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "View all automations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "New automation"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open docs"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Failed to load recents"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": "n5",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": false,
+    "walked_at": null
+  },
+  "complete_interaction_route_graph": false,
+  "shots_dir": ".artifacts/seed-graph-shots/automations/monitors",
+  "content_address": "955b1e5b5563a64ee3f24a74f2de3472873058f310f47074e09a84d366b681f4"
+}

--- a/apps/hypervisor/seed-graphs/automations/monitors.v1.json
+++ b/apps/hypervisor/seed-graphs/automations/monitors.v1.json
@@ -1,0 +1,238 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "automations",
+  "slug": "monitors",
+  "owned_route": "/__ioi/automations/monitors",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:28:58.419Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/automations/monitors#open=0|H1:Automate|H3:Create and manage automations|H2:Getting started|H2:Active automations0|H2:Recently viewed|H2:Recently triggered",
+      "url": "/__ioi/automations/monitors",
+      "title": "Automate",
+      "entry_edge": null,
+      "controls": 12,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "726e5de08d3c1d3738718892b7a2f0662546653f9cbcef64fc3102fda341f313",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "726e5de08d3c1d3738718892b7a2f0662546653f9cbcef64fc3102fda341f313",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "cf8a452e0e5aebd094a3859813a478a4ceaf0eeb3c15b731ea2f249d13da7a96",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/automations/monitors",
+        "disabled": false,
+        "label": "Automate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/automations",
+        "disabled": false,
+        "label": "Automations"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/automations",
+        "disabled": false,
+        "label": "View all automations"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/automations",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/automations",
+        "disabled": false,
+        "label": "Automations substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/automations",
+        "disabled": false,
+        "label": "Automations substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/object-monitoring/",
+        "disabled": false,
+        "label": "Automate capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/monitors",
+        "disabled": false,
+        "label": "/__apps/monitors proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:28:59.781Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/automations/monitors",
+  "content_address": "2ecf92c7b67e76a13b6932e4c71328f4b917794d18faff11f8015230822ba20f"
+}

--- a/apps/hypervisor/seed-graphs/data/pipeline.retained.v1.json
+++ b/apps/hypervisor/seed-graphs/data/pipeline.retained.v1.json
@@ -1,0 +1,2123 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "data",
+  "slug": "pipeline",
+  "owned_route": "/__apps/pipeline",
+  "capture_route": "/workspace/builder/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:42:40.569Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__apps/pipeline#open=2|DIV:Applications",
+      "url": "/__apps/pipeline",
+      "title": "Pipeline Builder",
+      "entry_edge": null,
+      "controls": 18,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c68f1c489214de8306b84aebea3edafc32b6c4618ccecdb71f82ce85cab27317",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "r",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "40ec228e5af425926e9b5f34f8d7aba5ed87b52dae2451374031c83fdb60a4f4",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "4c292e147e2e7a4cc117e56f8be6b69dd3be2d511c4ddd900a6481b733155ce1",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/__apps/pipeline#open=1|DIV:Applications",
+      "url": "/__apps/pipeline",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 17,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "0198e37de9b1d11bc94b6204c6581c4202225356fbd7983e9856b3379d8e6080",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "state",
+      "signature": "/__apps/pipeline#open=2|DIV:Applications|UL:",
+      "url": "/__apps/pipeline",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 10,
+          "tag": "div",
+          "role": "button",
+          "href": null,
+          "disabled": false,
+          "label": "Applications"
+        }
+      },
+      "controls": 20,
+      "disabled_controls": 3,
+      "screenshot": {
+        "sha256": "9b5244bddf646e1c40128a293541dcb463395578062be2eb1823b627c61a3f06",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "r",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "route",
+      "signature": "/workspace/builder/#open=2|DIV:Applications",
+      "url": "/workspace/builder/",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 12,
+          "tag": "div",
+          "role": "button",
+          "href": null,
+          "disabled": false,
+          "label": "Account"
+        }
+      },
+      "controls": 17,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c1314c0eb7da4167bbbcb5925eec84d05334ddc278f1e8e810ce26f5e06b3233",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n4",
+      "kind": "route",
+      "signature": "/workspace/builder#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/builder",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 13,
+          "tag": "a",
+          "role": null,
+          "href": "/workspace/builder",
+          "disabled": false,
+          "label": "Pipeline Builder Home"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "r",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n5",
+      "kind": "state",
+      "signature": "/__apps/pipeline#open=4|DIV:Applications|UL:Loading projectsLoading projectsLoading projects",
+      "url": "/__apps/pipeline",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 14,
+          "tag": "a",
+          "role": "button",
+          "href": null,
+          "disabled": false,
+          "label": "Recents"
+        }
+      },
+      "controls": 20,
+      "disabled_controls": 3,
+      "screenshot": {
+        "sha256": "a22e12928b521c560842901e6375326fff7375b20434b1bee1717fa6733931b6",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "r",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n6",
+      "kind": "route",
+      "signature": "/workspace/builder/create-pipeline#open=2|DIV:Applications",
+      "url": "/workspace/builder/create-pipeline",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 16,
+          "tag": "a",
+          "role": "button",
+          "href": null,
+          "disabled": false,
+          "label": "Created by…"
+        }
+      },
+      "controls": 19,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "275875dca8217424364aa15c85eaf94838cee8b4421315f341372c4e426935d3",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "%c ERROR %c foundry.objects.async-select.SelectComponentMechanism %cFailed to fetch options for the given query. padding: 2px 0px; background: #E47A2E; color: #f5f8fa; border-radius: 10px; font-weight"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n7",
+      "kind": "route",
+      "signature": "/workspace/builder/create-pipeline#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/builder/create-pipeline",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 17,
+          "tag": "a",
+          "role": "button",
+          "href": "/workspace/builder/create-pipeline",
+          "disabled": false,
+          "label": "New pipeline"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "r",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n8",
+      "kind": "route",
+      "signature": "/workspace/builder/#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/builder/",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 17,
+          "tag": "a",
+          "role": "button",
+          "href": "/workspace/builder/",
+          "disabled": false,
+          "label": "Back"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "r",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=AccountEntryPopoverContentQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": "n3",
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n4",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/builder",
+        "disabled": false,
+        "label": "Pipeline Builder Home"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n5",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Project"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql/batch",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": "n6",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by…"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n7",
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/builder/create-pipeline",
+        "disabled": false,
+        "label": "New pipeline"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=UseTitleSearchQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/builder",
+        "disabled": false,
+        "label": "Pipeline Builder Home"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Project"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by…"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/builder/create-pipeline",
+        "disabled": false,
+        "label": "New pipeline"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/builder",
+        "disabled": false,
+        "label": "Pipeline Builder Home"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Project"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by…"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/builder/create-pipeline",
+        "disabled": false,
+        "label": "New pipeline"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": ""
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": ""
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": ""
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql/batch",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/builder",
+        "disabled": false,
+        "label": "Pipeline Builder Home"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Project"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by…"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/builder/create-pipeline",
+        "disabled": false,
+        "label": "New pipeline"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/builder",
+        "disabled": false,
+        "label": "Pipeline Builder Home"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Project"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by…"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/builder/create-pipeline",
+        "disabled": false,
+        "label": "New pipeline"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Loading projects"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Loading projects"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Loading projects"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select location"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Create project"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Compare types"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/docs/foundry/building-pipelines/create-faster-pipeline-pb/",
+        "disabled": false,
+        "label": "Learn More"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/docs/foundry/building-pipelines/create-external-pipeline-pb/",
+        "disabled": false,
+        "label": "Learn More"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "n8",
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/builder/",
+        "disabled": false,
+        "label": "Back"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Create pipeline"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "error",
+      "detail": "no response"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [
+    {
+      "kind": "unreachable-route",
+      "node": "n7",
+      "reason": "/workspace/builder/create-pipeline: no response"
+    }
+  ],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:42:56.045Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": false,
+  "shots_dir": ".artifacts/seed-graph-shots/data/pipeline",
+  "content_address": "1805550b845ee2a956e1abe947a55fd3f3c239189cb356c7dd5759b4d8740793"
+}

--- a/apps/hypervisor/seed-graphs/data/pipeline.v1.json
+++ b/apps/hypervisor/seed-graphs/data/pipeline.v1.json
@@ -1,0 +1,12730 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "data",
+  "slug": "pipeline",
+  "owned_route": "/__ioi/pipeline",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:41:07.742Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/pipeline#open=2|",
+      "url": "/__ioi/pipeline",
+      "title": "Pipeline Builder",
+      "entry_edge": null,
+      "controls": 60,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "0f59490bd5b3e7d2e79e4dfb24713818fae7554f2b6bfb94c84f687b1c5e265b",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "0f59490bd5b3e7d2e79e4dfb24713818fae7554f2b6bfb94c84f687b1c5e265b",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a64210bd760d57529af8619b6e7ba8346b8a96af357600e047b7d21bc508728e",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 5,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+          "disabled": false,
+          "label": "Preview"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "3c965257aa0fb2387554233366a5343c79b110865986372097094f5560bcbb24",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "3c965257aa0fb2387554233366a5343c79b110865986372097094f5560bcbb24",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "04e8989c75f2ed1145a0f97813d540a0e935c8b9c35dfc98480849a6da40b595",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 28,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+          "disabled": false,
+          "label": "Search pipeline — the right panel becomes the real record search"
+        }
+      },
+      "controls": 58,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "c3ef9b9bde08142ce23c1d843e9def1bc694cd648ef831ef7b75d0c613d2bbb7",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "c3ef9b9bde08142ce23c1d843e9def1bc694cd648ef831ef7b75d0c613d2bbb7",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "80c56be988f0a72d77a932f8b1c7ecaf8521b82ec4d6010a55053ba3be2cf48f",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?legend=0#open=1|",
+      "url": "/__ioi/pipeline?legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 55,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "20f765b1f71914f1be7f7dfe0b4c473d7b452e310cfbc03612d7c22f8abbe1ef",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n4",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 40,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "probe-reencode"
+        }
+      },
+      "controls": 60,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "0f59490bd5b3e7d2e79e4dfb24713818fae7554f2b6bfb94c84f687b1c5e265b",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "0f59490bd5b3e7d2e79e4dfb24713818fae7554f2b6bfb94c84f687b1c5e265b",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a64210bd760d57529af8619b6e7ba8346b8a96af357600e047b7d21bc508728e",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n5",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7#open=2|",
+      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 41,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "Datasource"
+        }
+      },
+      "controls": 74,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "bf48622bcd242d22377d53d803b2bed5de7646b2e39e16bcd61ea0673bcd1bc0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "bf48622bcd242d22377d53d803b2bed5de7646b2e39e16bcd61ea0673bcd1bc0",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "6b4c77944af56832698480c4678b00eaf4d309c6d376bbeaeecda81b42a96f61",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n6",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7#open=2|",
+      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 42,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "Object mapping"
+        }
+      },
+      "controls": 74,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "d90828302d6e7a8c6987424387c672fb23e44ff5205ac83dd64e8d91c126d4ce",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "d90828302d6e7a8c6987424387c672fb23e44ff5205ac83dd64e8d91c126d4ce",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "b10a19959f4889fd82ce17a28f1244e65a55a2dfab44e7570c965b2ccc79ddad",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n7",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7#open=2|",
+      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 43,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "Policy gate"
+        }
+      },
+      "controls": 74,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "e9492b9d4805e12a7c344f7eea815747c93bd74910940309bba02eb0a112efa1",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "e9492b9d4805e12a7c344f7eea815747c93bd74910940309bba02eb0a112efa1",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "008e67eb8580adacc362aae36c896b86f4069cbe05eaf91f42a0fc55f132250c",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n8",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7#open=2|",
+      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 44,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "Transform plan"
+        }
+      },
+      "controls": 74,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "d2fb4a001340cdaccaa262fd2d58d59ba745befd518a65a8046f178131c94786",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "d2fb4a001340cdaccaa262fd2d58d59ba745befd518a65a8046f178131c94786",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "cfffb44e7e9ad611357059fd063384b84bd9da6efbd95843f1308c505c058411",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n9",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7#open=2|",
+      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 45,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "Read projection"
+        }
+      },
+      "controls": 74,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "6b6cd598a5350a3ff715a948ca5f7e3f3e9c52d72376172f3ce6ed738136f537",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "6b6cd598a5350a3ff715a948ca5f7e3f3e9c52d72376172f3ce6ed738136f537",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a95a386f189dff8783e7e900b078527e1ba5eba8ef3214aea9c929f4a8325220",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n10",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7#open=2|",
+      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 46,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "Lease + session"
+        }
+      },
+      "controls": 74,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "d3e78102c5139602fac8200c04644540e23f92619084ee51418ea8ce3f01b9ae",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "d3e78102c5139602fac8200c04644540e23f92619084ee51418ea8ce3f01b9ae",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "c79aed01e54b4cc5267f378e40e30054ea4b7b688ee965f6c6c415b95feb711e",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n11",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 47,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "Materialized objects"
+        }
+      },
+      "controls": 74,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "ce98919f63165943823adb64a5b3b2f6aa9d16af8b3a4f2672d044bac400209f",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "ce98919f63165943823adb64a5b3b2f6aa9d16af8b3a4f2672d044bac400209f",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "e508b921602e8d2d049207523ee3035d2f42dc7339dcc2d722c68ac8e6e4772c",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n12",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 49,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 58,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "7e791fdb527f71c0ee00232ddb021e33205d93b776a1d9b859f27a617c66778d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "7e791fdb527f71c0ee00232ddb021e33205d93b776a1d9b859f27a617c66778d",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a941e38f7d7bcba816c8b0093ae0bea408a7463f35cb827ede6b1c6cc477d565",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n13",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 50,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
+          "disabled": false,
+          "label": "Pipeline warnings"
+        }
+      },
+      "controls": 64,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "bd73fba1c2e99f83a57e244320268b06a98f7c5395303e5d4a6c1b3965912493",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "bd73fba1c2e99f83a57e244320268b06a98f7c5395303e5d4a6c1b3965912493",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "8ce465fccd9f866187689c41551f100c2a024e0e6d54385e28f4eb060d73a5a5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n14",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 59,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
+          "disabled": false,
+          "label": "Pipeline file tree — the real ladder-record tree"
+        }
+      },
+      "controls": 58,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "1211ad5150f02936db6e4c222341fdd25e2c0eb1e3ec6b77f42fec43d496cddb",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "1211ad5150f02936db6e4c222341fdd25e2c0eb1e3ec6b77f42fec43d496cddb",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "59b556b42deac5bc9ea5a85bff6f0eea4e97693584665963b3897417bfc6e306",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n15",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 28,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview",
+          "disabled": false,
+          "label": "Search pipeline — the right panel becomes the real record search"
+        }
+      },
+      "controls": 66,
+      "disabled_controls": 30,
+      "screenshot": {
+        "sha256": "1bf82062b3dfdc6310162dc4e9a0aaa92a0e0dca8348a2bd97a1d7ae85667f66",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "1bf82062b3dfdc6310162dc4e9a0aaa92a0e0dca8348a2bd97a1d7ae85667f66",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "8710d0d8f2e5629921af4722d1cff3c018effa77199434d3d7a89ff4dec894c5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n16",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&legend=0#open=1|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&legend=0#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 63,
+      "disabled_controls": 30,
+      "screenshot": {
+        "sha256": "6e8c9c0941749a3ed3d2066bb36b262ec1c85ba48743eb632ed7df713374a2d9",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "daca982fe96f4a2c415785fe1577ed232571ddcb3da5a263016c1af833534ee9",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "04e8989c75f2ed1145a0f97813d540a0e935c8b9c35dfc98480849a6da40b595",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n17",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=input#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=input#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 67,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "5c478f387b5bfe995f3f4ca4943a3426e3ff70def2faab0ff6ce0f3c281d52d6",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "5c478f387b5bfe995f3f4ca4943a3426e3ff70def2faab0ff6ce0f3c281d52d6",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "04e8989c75f2ed1145a0f97813d540a0e935c8b9c35dfc98480849a6da40b595",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n18",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=clean#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=clean#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 66,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "77a4fcbd13f8e14f8df63cb1fca15b8308bbb8a94d24443cf79c22f9b534f497",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "77a4fcbd13f8e14f8df63cb1fca15b8308bbb8a94d24443cf79c22f9b534f497",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "04e8989c75f2ed1145a0f97813d540a0e935c8b9c35dfc98480849a6da40b595",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n19",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=calc#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=calc#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 65,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "7a5b8d93a8ddbe917a65f43454d72cad90898f1a1cb9194dc6b517c3f6ebc706",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "7a5b8d93a8ddbe917a65f43454d72cad90898f1a1cb9194dc6b517c3f6ebc706",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "4fda88767bd67dfd7baef455ee6fc33112737902eed1deb365ec1d9a127facc0",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n20",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=output#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=output#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 67,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "c8a2ddf0d45d90ed584ac0395493252cb26a0bd745ba55ce115710bd65824e01",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "e1dd3585e2a761e36e64fd104e4e122801b23be6f8ee0ebdaf297bfaaa0d63f4",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "b15ffc3d7bdb088c9c93605bcf9f06d31905d724e525807b91d5b04a3343d7ef",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n21",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
+      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 41,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview",
+          "disabled": false,
+          "label": "Datasource"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "6abcb20c040f503ab1dcb3b618de4441ea0e32564547b2647e4571297953e71e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "6abcb20c040f503ab1dcb3b618de4441ea0e32564547b2647e4571297953e71e",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "8418ed733f449eba7b629ba8f0c7fe0cc28a39e977455eae9bfd772bed1cd60a",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n22",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
+      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 42,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview",
+          "disabled": false,
+          "label": "Object mapping"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "4f6f670e065803dbb4f2889629797fdb73c056f81c35d9d10a3c72b8408b6f4d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "4f6f670e065803dbb4f2889629797fdb73c056f81c35d9d10a3c72b8408b6f4d",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9e1c7c54762551f8b406101b9cb12f1f50eb1791610f80c519beca76d56c61b4",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n23",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
+      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 43,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview",
+          "disabled": false,
+          "label": "Policy gate"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "176c8201bada21ad1416351bb91035b47a726210739c7d1c7a3edc62661bb4c6",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "176c8201bada21ad1416351bb91035b47a726210739c7d1c7a3edc62661bb4c6",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "339e887432907d923a779f4c374b0c9c32fe8e991c5cb6cba09bedc31ae2310f",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n24",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
+      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 44,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview",
+          "disabled": false,
+          "label": "Transform plan"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "06cf13aab2a762786b40e54a33e88463d767bce1705b436a38514e788c442345",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "06cf13aab2a762786b40e54a33e88463d767bce1705b436a38514e788c442345",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "3fa049f63f42872ad9f9a80ffedf915bfdd0b85bb59027dca6695ac6abb7800f",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n25",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
+      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 45,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview",
+          "disabled": false,
+          "label": "Read projection"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "1e5de1aa327bb35d9c46bb9de0944e6bb4f53f5a5116f357eef9b8dc284d4e2f",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "1e5de1aa327bb35d9c46bb9de0944e6bb4f53f5a5116f357eef9b8dc284d4e2f",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "ab014727dd579bc420bd4c6f4329749984686539f85f0a503e4d1464a8e18e20",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n26",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
+      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 46,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview",
+          "disabled": false,
+          "label": "Lease + session"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "b9d1cbf01865123ebebbf225a93128a68b86bc6b9cc4fb309ec8d3081d157cb1",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "b9d1cbf01865123ebebbf225a93128a68b86bc6b9cc4fb309ec8d3081d157cb1",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "3bb5f799ff6c18e700ec6d0b4d33d26a80bd9b4b25f93c4848818a830cf52095",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n27",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 59,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "7990b0181a42e3886bb047006ac59e880180450c1dfd28db5f05cf6baa7168e0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "7990b0181a42e3886bb047006ac59e880180450c1dfd28db5f05cf6baa7168e0",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "7c2d6cdbf3ed96132bbe2445542e317cabba1b12bb534882f0a2274d904aee63",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n28",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&legend=0#open=1|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 53,
+      "disabled_controls": 20,
+      "screenshot": {
+        "sha256": "af57bcc9a4ede4f1b5656c4591b7dc8f89925c60605d85ae34bcd1d7b024c4e1",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n29",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
+      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 41,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search",
+          "disabled": false,
+          "label": "Datasource"
+        }
+      },
+      "controls": 72,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "edce2db1a012a967a82d8a7da8439bb4365d27532c74dc76b70911b081a77148",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "edce2db1a012a967a82d8a7da8439bb4365d27532c74dc76b70911b081a77148",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "1d33aecb81e0395a82e613f6f98f6884c5f40a49bbb9caae310f700d7cdcc411",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n30",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
+      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 42,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search",
+          "disabled": false,
+          "label": "Object mapping"
+        }
+      },
+      "controls": 72,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "da74b5d62ea3ba5b199da41a85c9a3685c50f4af4bbba8b30263536c0ff5af9c",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "da74b5d62ea3ba5b199da41a85c9a3685c50f4af4bbba8b30263536c0ff5af9c",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "acf18a3a36dbef1c9c78329a481f6f25aa2bd59502d56ee27512b8fb9da40fb8",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n31",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
+      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 43,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search",
+          "disabled": false,
+          "label": "Policy gate"
+        }
+      },
+      "controls": 72,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "992f7248fa8c719c83810456a04c9a33bf0d1ee49c891de76fa83ab8b776f0b2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "992f7248fa8c719c83810456a04c9a33bf0d1ee49c891de76fa83ab8b776f0b2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "ab39f8c07f9f09fa1b79fcbdd186b02af77a421032016695b2c3c158ab13a345",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n32",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
+      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 44,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search",
+          "disabled": false,
+          "label": "Transform plan"
+        }
+      },
+      "controls": 72,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "7782cce648735ef4217d2529f13b71e0b22bff518e9ea97fa3f9ddbb78f17960",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "7782cce648735ef4217d2529f13b71e0b22bff518e9ea97fa3f9ddbb78f17960",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "d60d3f161c3d637c6176f50ec117eb441cf92294f74f18603bfa8707c2a81bde",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n33",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
+      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 45,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search",
+          "disabled": false,
+          "label": "Read projection"
+        }
+      },
+      "controls": 72,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "d09614412c970d31b3886bdaaf74fc36e3ec3391f1f589df62f2b739c935bed2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "d09614412c970d31b3886bdaaf74fc36e3ec3391f1f589df62f2b739c935bed2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "931331a87881b923d79f8c3646f105e9deae64c959a1141b07a11e0dac5f698f",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n34",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
+      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 46,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search",
+          "disabled": false,
+          "label": "Lease + session"
+        }
+      },
+      "controls": 72,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "15d61c19c0aee46679ad1e18568a2c2c91702592ad549896078738a0454647d6",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "15d61c19c0aee46679ad1e18568a2c2c91702592ad549896078738a0454647d6",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "2e6f392f785523cea6a42fb623f7d712bf9903c2a0ae02027ea0b2f8c6af825f",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n35",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 47,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search",
+          "disabled": false,
+          "label": "Materialized objects"
+        }
+      },
+      "controls": 72,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "8211743c48fb31427e5af7db7954cdda6b1c47158d95a91522ac8836dfaf0126",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "8211743c48fb31427e5af7db7954cdda6b1c47158d95a91522ac8836dfaf0126",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "e170af0297929f86c8573a8d140caea6e7bacddbab1863bcca27af28ec26f177",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n36",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=suggestions#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 49,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 56,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "d99750b00f7eb2aa8b41081ebc74847c30bf2ede376e6a82634806b1d7ed841d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "d99750b00f7eb2aa8b41081ebc74847c30bf2ede376e6a82634806b1d7ed841d",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "4b40096e86a9ed2517896f36c190e59e3046f477a55a16ab8672413b7aa8dec4",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n37",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=warnings#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=warnings",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 50,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=warnings",
+          "disabled": false,
+          "label": "Pipeline warnings"
+        }
+      },
+      "controls": 62,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "24bde16fd8e580b95de31e55aa41bd4e810ee9afa7c7d2454849c210cbaffc48",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "24bde16fd8e580b95de31e55aa41bd4e810ee9afa7c7d2454849c210cbaffc48",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "7597b1b370db73307d84bd2ed7f0b576f6ce3fdbd6cdf68b99e8053d3a0a8bb5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n38",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?legend=0&node=lease&ontology=ont_18ca2757d28a20f7#open=1|",
+      "url": "/__ioi/pipeline?legend=0&node=lease&ontology=ont_18ca2757d28a20f7",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n3",
+        "control": {
+          "index": 46,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle bottom bar"
+        }
+      },
+      "controls": 69,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "a2725446b86ef3098234729ffa5b7149a08e1db7fd3f65f7dd58dd8e822bf7cb",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n39",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n4",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 59,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "8ea283134416f881fac7b21c6f305814541a81d5e5bc122efd9c97571de98cd9",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n40",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n4",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 57,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "a11f57d93b7a861b3eb2c61b428a1b29263af727f55b5a9e3f06033af293424e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n41",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n4",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 54,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "97ace4be5a3f56e2f8f62c9d959935175d44f5f5bdb9c89a2036aa2923244b30",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n42",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n4",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 53,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "9ea1814d95817949d3ef0fa8c167abbdcaaf660833015cd60ab5379b8672335f",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n43",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
+      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 55,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "20f765b1f71914f1be7f7dfe0b4c473d7b452e310cfbc03612d7c22f8abbe1ef",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "8a4b6b82fe2342910f7af13e72b0832a243db2472b44fab7602afa8a9b1e4930",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "1438ce792c930536c234940d53d0a7743b33a90f8391ef104c136b39115621d1",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n44",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
+      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 73,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "d4791db7a08071b41592221c8ab3a99a1a20c1f1c9af1f7aa7dd30aab8a2e8d8",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n45",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
+      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 71,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "59ad89ca2460c1cd7bf5cf72ae0e615e755016638554a3dd24b745d5267246d3",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n46",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
+      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "86ea5cc5a7943052591d86aa48191f46ce5ffe362db5f53a73973c3a7e91ddb3",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n47",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
+      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 67,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "f434d31027a9f34f15b79444797a6ae120d83bcb996e52a9cbbc035681261111",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n48",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
+      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 59,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "1a7de17f0d4aa65dd2c8e90acf29bc59957be7ba38508fbae81f5e97c1f37a73",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "1a7de17f0d4aa65dd2c8e90acf29bc59957be7ba38508fbae81f5e97c1f37a73",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a04aaf19dc9707de0ffb1a0cd5e96608f8582edc21837a43449eedfab314734b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n49",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
+      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 69,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "51e38c77d02fcbf337acdb1f1a2fa6fb08f996e340106c43eff20e3f5a637894",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "1e69f59a91672873c6cfed8e16d17a9abf7cc8e695e76019b50ca046e16eab2c",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "89206977091b0b60cbbcdbd948775d7643f3bce1dc9d71c18abfb4ae86a9d498",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n50",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
+      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 73,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "2b17e782aa0cc0b772a1753ab752c979720222a1a395e91ca6f8268bf7eda488",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n51",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
+      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 71,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "eb67f9277f45be0b605be5f332264e312077427e1b68e176ed45c21e5b87b581",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n52",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
+      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "dd2edf2d59af64b4bae86367d261516c27c24db18c885d0468c5d78090c94117",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n53",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
+      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 67,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "0571bb3972ea4d47f5edfcf289ae5e49314ec4f3535bb4be25f1c5b74acd264d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n54",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
+      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 59,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "cc7e9f92421d656d13ec9fba8445aa176561f5949032493ece188a81bee602f1",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "cc7e9f92421d656d13ec9fba8445aa176561f5949032493ece188a81bee602f1",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "bd6e5385163cbcf2a3ab84eb39a892ad6b40699405144d080b8c894a167c8bfe",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n55",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
+      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n7",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 69,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "e8edf38d555bbcbced2c9594e8426fbf442990c708b93c95b5dc8332cafb0d19",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "3bcaeea5a0c7537e4e773f3d26a3d35f46c55369adc4bcf299ad87b053ac2817",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "10982cec16da1194b2e91a0530b2cc4ea70630b9c1d746b3b82255afbaae8e51",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n56",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
+      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n7",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 73,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "aa790712b9430844e1794824fb9b8f6400cb75a99f15dd3cf3eb229dbcc2f62e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n57",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
+      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n7",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 71,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "d209edab011b7966bf8ebec5737f3bc61bd0e8f7f5bf4297f264e21c9739151c",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n58",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
+      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n7",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "c6c59a3c9ccda38b1eaaeb841be0c6fa00ffdecdf89c99f6a37bf27ec64fd6f2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n59",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
+      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n7",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 67,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "d3a1b2bfcbc8f9b2844247c2ed00e7f1f71741cecc3ebb47b62112ac621719a0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n60",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
+      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n7",
+        "control": {
+          "index": 59,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "20a461b75fb447dc043fc51257cb041c45ee4697e6d067fb2a596d1e1f2b9fe9",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "20a461b75fb447dc043fc51257cb041c45ee4697e6d067fb2a596d1e1f2b9fe9",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "d1ddef4f2c1a8c2aff14e5f50b02ee958cbb3c8ee28f1eebd8e24af0fac66880",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n61",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
+      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 69,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "fa9068f2ed47a5ca8673262172ed2aa9ae6c0b58a6ab10ea454df6efafd7a6cd",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "5498cf68ce37b87c8df9f0cc88a1530196594ddd2edc2e59c204cc3feffd8bb7",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "8b62fd7771f73ca28b6f09c046a9e40fbb3b9d5c72df6cd7f43f61b41a85eb2e",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n62",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
+      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 73,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "d30b4376d3ae983f1ac9c362b236e559844e1087e75972010718f0f45b66bf40",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n63",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
+      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 71,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "a0568cdac858efc51fab940707d2aabac9b3fb7a92b81997326c33ef5d3610e4",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n64",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
+      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "3ca99d90923ad7c4130dbe43e814c0dee5cbdbcdf60f2269dae13543db1fe0aa",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n65",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
+      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 67,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "df1ed29c7022a857933c957aeb80cd9666fdaa26e1e223463b9c9882bf1e70a0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n66",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
+      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 59,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "8b92473be56aae39bd0f803f2fb1abca4c2a288f4db597505b9998de65aad923",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "8b92473be56aae39bd0f803f2fb1abca4c2a288f4db597505b9998de65aad923",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "535b371168a36a28d5fe15cffefd51cc3d8841720556ed6eb51446a336dab36a",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n67",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
+      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 69,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "1b1d9ac2105beb21e0f2f2a0bc9c5f687d9ee2d38205a5da8a1c96cc33238779",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "89b8f3df9077cc1c7c019e4b5ab0faa742bbf720dbbb778532c64855a59fb98e",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "8450e8ee3b05061388a2d85eaacc28bc88031c9f3ab294c38651175329872f6c",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n68",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
+      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 73,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "36d565f87a16bdff29fa4bccf8460995fc048b7eb379a6ebcfc3b93d45a6437f",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n69",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
+      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 71,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "cebbcbb800e40fca8abd394f12e70b2ad1b7a8564487ba2c9c3298b606ad040e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n70",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
+      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "2e4eff55feb1fb1b30e93cb5f1b73797aa6420feab7a03f67d082a0ddf9bbf3f",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n71",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
+      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 67,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "673d9a7b7d8d30e72100a4ec602f63325e166206a9d266e70679eb568bd7c3a0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n72",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
+      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 59,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "c791964e5376a490a5af70846325e7dd9304704eae002fab1ad8dc9bf4036538",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "c791964e5376a490a5af70846325e7dd9304704eae002fab1ad8dc9bf4036538",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "c13db80cc17482f4a9b063ef63a48c6e2ea86cf2ca3ddbf4057f7d58a8bd01ec",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n73",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
+      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 69,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "4f82913002fc21d9fbc92b44792ac2c55f532d81e69d9cfc15dec74fb6d81b72",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "6a0549c3bad8a00785ce2ecef9c01ca9fd945c5b0a0d36931efdd1df8493522d",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "b0361a3be1d589a14e54418a947c1b93907b1fea9f76a7e7a20cb135b5413eb2",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n74",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
+      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 73,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "740edf255e2ae7ff30a0e1cd7ac14eb2cae89d3339948c8ba3adc1aed14cdad3",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n75",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
+      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 71,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "49c8c10e3cd98696c3f53e42627b977bdf6138f9f083c20895383cf0194ddf2b",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n76",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
+      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "0fdbbed4e8deeef7754aaf018ca21788576327fccce3c56a73d0489aaed2ad76",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n77",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
+      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 67,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "0101d150fe4833ae7b832acb6c988b0add51a450cd6391153805b1c6ec58be33",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n78",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
+      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 59,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "a2cc9a7afbe18824d71d78b36ae70df4b7e0c68bd1be80af8b5e5bb00b9343f6",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "a2cc9a7afbe18824d71d78b36ae70df4b7e0c68bd1be80af8b5e5bb00b9343f6",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "d569a147122f2aa227c00ffd9856eb47cde86c507c38e7fad2109c843319f17c",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n79",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
+      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n11",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 69,
+      "disabled_controls": 31,
+      "screenshot": {
+        "sha256": "267a7107be56d4888fedf0427901c542325f83758348af4084f09846624a84ff",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "a2725446b86ef3098234729ffa5b7149a08e1db7fd3f65f7dd58dd8e822bf7cb",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "477287e6bfa59554d0a64f0ce355681d31563d3c7620ed4c449266ff03b69453",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n80",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n11",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 73,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "c0d056c760aa73ae8598013e6d224aca8fc915e004d161df1d6b8f5573ecfdab",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n81",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n11",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 71,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "371c074ff5ee130805ec402f73d1b769b7bf6744c35521b6dfa1e7a36459796e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n82",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n11",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 68,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "3ecaf9ab98155e4f816e432d670dfc6533f30a4962f5719609f66734026363b4",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n83",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
+      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n11",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 67,
+      "disabled_controls": 32,
+      "screenshot": {
+        "sha256": "bc04e93222403b96a5599a994c4e1f1050786ca8b1e48a222fa884d35ab8e110",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n3",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n4",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n5",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n6",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n7",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n8",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n9",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n10",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n11",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n12",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n13",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n14",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "n15",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "n16",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n17",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n18",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n19",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n20",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "n21",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n22",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n23",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n24",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n25",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n26",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Snapshot"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Transform"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Split"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Join"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Union"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Use LLM"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Generate"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Explain"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "n27",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": "n15",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n2",
+      "to": "n28",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "n29",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n30",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n31",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n32",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n33",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n34",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n35",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "n36",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n37",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 55,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 56,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "n3",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "n3",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n3",
+      "to": "n3",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n3",
+      "to": "n3",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n3",
+      "to": "n28",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 38,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "n38",
+      "control": {
+        "index": 46,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 52,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 53,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 54,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": "n0",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": "n39",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n4",
+      "to": "n40",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n4",
+      "to": "n41",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n4",
+      "to": "n42",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "n5",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": "n5",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n5",
+      "to": "n5",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n5",
+      "to": "n5",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n5",
+      "to": "n43",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": "n44",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n5",
+      "to": "n45",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n5",
+      "to": "n46",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n5",
+      "to": "n47",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": "n5",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Snapshot"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Transform"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Split"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Join"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Union"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Use LLM"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Generate"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Explain"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "n48",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": "n49",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": "n50",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n6",
+      "to": "n51",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n6",
+      "to": "n52",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n6",
+      "to": "n53",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Snapshot"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Transform"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Split"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Join"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Union"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Use LLM"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Generate"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Explain"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "n54",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": "n55",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": "n56",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n7",
+      "to": "n57",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n7",
+      "to": "n58",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n7",
+      "to": "n59",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Snapshot"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Transform"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Split"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Join"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Union"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Use LLM"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Generate"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Explain"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "n60",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": "n61",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n8",
+      "to": "n62",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n8",
+      "to": "n63",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n8",
+      "to": "n64",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n8",
+      "to": "n65",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Snapshot"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Transform"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Split"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Join"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Union"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Use LLM"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Generate"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Explain"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "n66",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n8",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": "n67",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n9",
+      "to": "n68",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n9",
+      "to": "n69",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n9",
+      "to": "n70",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n9",
+      "to": "n71",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Snapshot"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Transform"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Split"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Join"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Union"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Use LLM"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Generate"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Explain"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "n72",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n9",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": "n10",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": "n10",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n10",
+      "to": "n10",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n10",
+      "to": "n10",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n10",
+      "to": "n73",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n10",
+      "to": "n74",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n10",
+      "to": "n75",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n10",
+      "to": "n76",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n10",
+      "to": "n77",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": "n10",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Snapshot"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Transform"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Split"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Join"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Union"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Use LLM"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Generate"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Explain"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "n78",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n10",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": "n11",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": "n11",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n11",
+      "to": "n11",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n11",
+      "to": "n11",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n11",
+      "to": "n79",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n11",
+      "to": "n80",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n11",
+      "to": "n81",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n11",
+      "to": "n82",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n11",
+      "to": "n83",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": "n11",
+      "control": {
+        "index": 39,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Pipeline: probe-reencode ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Datasource"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Object mapping"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Policy gate"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Transform plan"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Read projection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lease + session"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Materialized objects"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Snapshot"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Transform"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Split"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Join"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Union"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Use LLM"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Generate"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Explain"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 57,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 58,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 59,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [
+    {
+      "kind": "control-census-overflow",
+      "node": "n1",
+      "reason": "68 controls > cap 60; raise --max-controls and recapture"
+    },
+    {
+      "kind": "control-census-overflow",
+      "node": "n5",
+      "reason": "74 controls > cap 60; raise --max-controls and recapture"
+    },
+    {
+      "kind": "control-census-overflow",
+      "node": "n6",
+      "reason": "74 controls > cap 60; raise --max-controls and recapture"
+    },
+    {
+      "kind": "control-census-overflow",
+      "node": "n7",
+      "reason": "74 controls > cap 60; raise --max-controls and recapture"
+    },
+    {
+      "kind": "control-census-overflow",
+      "node": "n8",
+      "reason": "74 controls > cap 60; raise --max-controls and recapture"
+    },
+    {
+      "kind": "control-census-overflow",
+      "node": "n9",
+      "reason": "74 controls > cap 60; raise --max-controls and recapture"
+    },
+    {
+      "kind": "control-census-overflow",
+      "node": "n10",
+      "reason": "74 controls > cap 60; raise --max-controls and recapture"
+    },
+    {
+      "kind": "control-census-overflow",
+      "node": "n11",
+      "reason": "74 controls > cap 60; raise --max-controls and recapture"
+    },
+    {
+      "kind": "node-cap-reached",
+      "node": null,
+      "reason": "67 unexplored nodes beyond --max-nodes 80"
+    }
+  ],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:41:59.197Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": false,
+  "shots_dir": ".artifacts/seed-graph-shots/data/pipeline",
+  "content_address": "9bdb65ed98eda3b92d9da52292611c6850dd2fed5668044921b5edf14a9140b0"
+}

--- a/apps/hypervisor/seed-graphs/data/sources.v1.json
+++ b/apps/hypervisor/seed-graphs/data/sources.v1.json
@@ -1,0 +1,627 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "data",
+  "slug": "sources",
+  "owned_route": "/__ioi/data/sources",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:10:16.935Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://127.0.0.1:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/data/sources#open=0|H1:Data Connection|H3:Data Connection|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
+      "url": "/__ioi/data/sources",
+      "title": "Data Connection",
+      "entry_edge": null,
+      "controls": 16,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "2f9e9890fc89f264f5c61fc2ad5a2b5166693a5e0d53f518214fb3cf3030fac0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "2f9e9890fc89f264f5c61fc2ad5a2b5166693a5e0d53f518214fb3cf3030fac0",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "c3d4d6ee9260f01b780e0cd1fc388431ff673035d2fe8f30e26492a12a372c47",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/data/sources?declare=1#open=0|H1:Data Connection|H3:Data Connection|H2:Declare a new data source a validated, receipted registry re|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
+      "url": "/__ioi/data/sources?declare=1",
+      "title": "Data Connection",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 6,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/data/sources?declare=1",
+          "disabled": false,
+          "label": "New source"
+        }
+      },
+      "controls": 20,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "dc9526742d9e5042bbfebc9938b4240da7d365559c31795fed369b20ccce63a7",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "dc9526742d9e5042bbfebc9938b4240da7d365559c31795fed369b20ccce63a7",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "2782eb29afaa7b8ea9dccfc2198d3a2d18c489d8115bdbafceada387fea57ca5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources",
+        "disabled": false,
+        "label": "Data Connection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources",
+        "disabled": false,
+        "label": "Sources"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources?declare=1",
+        "disabled": false,
+        "label": "New source"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources?declare=1",
+        "disabled": false,
+        "label": "Connect to external system — DECLARES a validated, receipted source record (POST"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "#sources-catalog",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "error",
+      "detail": "no response"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources?declare=1",
+        "disabled": false,
+        "label": "New source"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Data ladder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "ODK ladder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Data ladder (Pipeline Builder)"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "ODK builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/data-ingestion-app/",
+        "disabled": false,
+        "label": "Data Connection capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-external-origin"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/sources",
+        "disabled": false,
+        "label": "/__apps/sources proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources",
+        "disabled": false,
+        "label": "Data Connection"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources",
+        "disabled": false,
+        "label": "Sources"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources?declare=1",
+        "disabled": false,
+        "label": "New source"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 7,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "postgres — endpoint requiredmysql — endpoint requiredrest_api — endpoint require"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 8,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "no_credentials_requiredwallet_credential_leaseprovider_vault_tokencustomer_bound"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 9,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Declare source"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources",
+        "disabled": false,
+        "label": "Close"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources?declare=1",
+        "disabled": false,
+        "label": "Connect to external system — DECLARES a validated, receipted source record (POST"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "#sources-catalog",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "error",
+      "detail": "no response"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/data/sources?declare=1",
+        "disabled": false,
+        "label": "New source"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Data ladder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "ODK ladder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Data ladder (Pipeline Builder)"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "ODK builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/data-ingestion-app/",
+        "disabled": false,
+        "label": "Data Connection capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-external-origin"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/sources",
+        "disabled": false,
+        "label": "/__apps/sources proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [
+    {
+      "kind": "unreachable-route",
+      "node": "n0",
+      "reason": "/__ioi/data/sources: no response"
+    },
+    {
+      "kind": "unreachable-route",
+      "node": "n1",
+      "reason": "/__ioi/data/sources: no response"
+    }
+  ],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:10:19.433Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": false,
+  "shots_dir": ".artifacts/seed-graph-shots/data/sources",
+  "content_address": "f57710997daeff9fec3583955763a45b89f90bd7f77ed1f6fa4f1fa5e0aef2c6"
+}

--- a/apps/hypervisor/seed-graphs/developer-workspace/notepad.v1.json
+++ b/apps/hypervisor/seed-graphs/developer-workspace/notepad.v1.json
@@ -1,0 +1,2017 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "developer-workspace",
+  "slug": "notepad",
+  "owned_route": "/__apps/notepad",
+  "capture_route": "/workspace/notepad/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:26:14.114Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://127.0.0.1:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__apps/notepad#open=2|H3:Notepad|DIV:Applications",
+      "url": "/__apps/notepad",
+      "title": "Notepad Home",
+      "entry_edge": null,
+      "controls": 27,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "793e0a04a4d5e3cd25459f61366528610b250cc652fcd6d7caa676b71f549d7d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "793e0a04a4d5e3cd25459f61366528610b250cc652fcd6d7caa676b71f549d7d",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "295fc75aaa079f432c393028d10144cd3131da306e38ad454c90eec6cdeb5398",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/__apps/notepad#open=1|H3:Notepad|DIV:Applications",
+      "url": "/__apps/notepad",
+      "title": "Notepad Home",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 26,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "dd7163de01793b876acefaf0a507eef416466b90a9f7a45db38e0baf0a97d656",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/workspace/notepad/create#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/notepad/create",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 13,
+          "tag": "a",
+          "role": "button",
+          "href": "/workspace/notepad/create",
+          "disabled": false,
+          "label": "New document"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "state",
+      "signature": "/__apps/notepad#open=3|H3:Notepad|DIV:Applications|UL:New from templateNew document template",
+      "url": "/__apps/notepad",
+      "title": "Notepad Home",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 14,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Show more options"
+        }
+      },
+      "controls": 29,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "ef9988f4cc169d41fcfc7645f0e0b372da2570176bc235694a91f54060c641ce",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n4",
+      "kind": "state",
+      "signature": "/__apps/notepad#open=3|H3:Notepad|DIV:Applications",
+      "url": "/__apps/notepad",
+      "title": "Notepad Home",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 15,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Help"
+        }
+      },
+      "controls": 28,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "f800230e09b78e4408cc1880e333d8b74bbe57359e874ba132f82d1f63b99db6",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n5",
+      "kind": "route",
+      "signature": "/workspace/notepad/create-new-from-template#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/notepad/create-new-from-template",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 17,
+          "tag": "a",
+          "role": null,
+          "href": "/workspace/notepad/create-new-from-template",
+          "disabled": false,
+          "label": "New from templateCreate a document from a template to efficiently populate it wi"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n6",
+      "kind": "route",
+      "signature": "/workspace/notepad/create-template#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/notepad/create-template",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 18,
+          "tag": "a",
+          "role": null,
+          "href": "/workspace/notepad/create-template",
+          "disabled": false,
+          "label": "Document templateCreate a blueprint that allows users to generate a new document"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/notepad/create",
+        "disabled": false,
+        "label": "New document"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n3",
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show more options"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": "n4",
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create",
+        "disabled": false,
+        "label": "Blank documentCreate an object-aware collaborative rich-text document with widge"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n5",
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create-new-from-template",
+        "disabled": false,
+        "label": "New from templateCreate a document from a template to efficiently populate it wi"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n6",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create-template",
+        "disabled": false,
+        "label": "Document templateCreate a blueprint that allows users to generate a new document"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 19,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 20,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 21,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by me"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by me"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=LatestAnnouncementQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 24,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 25,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 26,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/api/gitpod.v1.AccountService/GetAccount",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/notepad/create",
+        "disabled": false,
+        "label": "New document"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show more options"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create",
+        "disabled": false,
+        "label": "Blank documentCreate an object-aware collaborative rich-text document with widge"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create-new-from-template",
+        "disabled": false,
+        "label": "New from templateCreate a document from a template to efficiently populate it wi"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create-template",
+        "disabled": false,
+        "label": "Document templateCreate a blueprint that allows users to generate a new document"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by me"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by me"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/notepad/create",
+        "disabled": false,
+        "label": "New document"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show more options"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create",
+        "disabled": false,
+        "label": "Blank documentCreate an object-aware collaborative rich-text document with widge"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create-new-from-template",
+        "disabled": false,
+        "label": "New from templateCreate a document from a template to efficiently populate it wi"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create-template",
+        "disabled": false,
+        "label": "Document templateCreate a blueprint that allows users to generate a new document"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by me"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by me"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 27,
+        "tag": "a",
+        "role": "menuitem",
+        "href": "/workspace/notepad/create-new-from-template",
+        "disabled": false,
+        "label": "New from template"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": "menuitem",
+        "href": "/workspace/notepad/create-template",
+        "disabled": false,
+        "label": "New document template"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n4",
+      "to": "n1",
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": "/workspace/notepad/create",
+        "disabled": false,
+        "label": "New document"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show more options"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create",
+        "disabled": false,
+        "label": "Blank documentCreate an object-aware collaborative rich-text document with widge"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create-new-from-template",
+        "disabled": false,
+        "label": "New from templateCreate a document from a template to efficiently populate it wi"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/notepad/create-template",
+        "disabled": false,
+        "label": "Document templateCreate a blueprint that allows users to generate a new document"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recents"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by me"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Created by me"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Favorites"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "a",
+        "role": null,
+        "href": "/docs/foundry/notepad/overview/",
+        "disabled": false,
+        "label": "View documentation"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": "n5",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:26:22.581Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/developer-workspace/notepad",
+  "content_address": "dd17739c230bca26453f6844efc941fb8cc7cdd4ec30bb2dc555e184f1ae4830"
+}

--- a/apps/hypervisor/seed-graphs/evaluations/evalsuites.v1.json
+++ b/apps/hypervisor/seed-graphs/evaluations/evalsuites.v1.json
@@ -1,0 +1,208 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "evaluations",
+  "slug": "evalsuites",
+  "owned_route": "/__ioi/evaluations/evalsuites",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:18:13.566Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://127.0.0.1:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/evaluations/evalsuites#open=0|H1:AIP Evals|H3:AIP Evals|H2:Suite library truth 0 the real eval-suite plane — every reco|H3:By health (declared-completeness)|H3:By status|H3:Declared suites (0, full records)",
+      "url": "/__ioi/evaluations/evalsuites",
+      "title": "AIP Evals",
+      "entry_edge": null,
+      "controls": 10,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "bcdb52f0605bf44722531ad6095a6db94f8981bde56e63ccbcc31800e4f76c16",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "bcdb52f0605bf44722531ad6095a6db94f8981bde56e63ccbcc31800e4f76c16",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "6e86d96dd384b07032f140c209cf4b42132fe6f8a10ed0ec1fcf4053accdc81b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/evaluations/evalsuites",
+        "disabled": false,
+        "label": "AIP Evals"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/evaluations",
+        "disabled": false,
+        "label": "Evaluations substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/evaluations",
+        "disabled": false,
+        "label": "Evaluations owner surface →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/feedback",
+        "disabled": false,
+        "label": "Feedback & Annotations"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/evals/",
+        "disabled": false,
+        "label": "AIP Evals capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-external-origin"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/evalsuites",
+        "disabled": false,
+        "label": "/__apps/evalsuites proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:18:14.944Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/evaluations/evalsuites",
+  "content_address": "5e2c624a789ef56af2b4dc7ad2b598689cc3ea3554f86b6ecab6580d4630e508"
+}

--- a/apps/hypervisor/seed-graphs/foundry/models.v1.json
+++ b/apps/hypervisor/seed-graphs/foundry/models.v1.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "foundry",
+  "slug": "models",
+  "owned_route": "/__ioi/foundry/models",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:20:37.599Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://127.0.0.1:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/foundry/models#open=0|H1:Model Catalog|H2:IOI-provided models|H3:Additional models",
+      "url": "/__ioi/foundry/models",
+      "title": "Model Catalog",
+      "entry_edge": null,
+      "controls": 11,
+      "disabled_controls": 4,
+      "screenshot": {
+        "sha256": "1bc29f2fed02b31f50b8e93c44ac9f3af3b27b9e3c04ecf749caf710cca4009b",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "1bc29f2fed02b31f50b8e93c44ac9f3af3b27b9e3c04ecf749caf710cca4009b",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "1a634feab810c14a3136427ca08c1a58b2229b535af36e180777d3b4f4496abe",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/foundry/models",
+        "disabled": false,
+        "label": "Model Catalog"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Compare models"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Clear"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Clear"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Clear"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#model-routes",
+        "disabled": false,
+        "label": "Agent Studio →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/foundry",
+        "disabled": false,
+        "label": "Foundry →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/models",
+        "disabled": false,
+        "label": "Model Catalog capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:20:39.315Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/foundry/models",
+  "content_address": "ddb16292d855c9456243c2fb185da6ac9ff37514943bd2da81c5447811abeb56"
+}

--- a/apps/hypervisor/seed-graphs/governance/approvals.retained.v1.json
+++ b/apps/hypervisor/seed-graphs/governance/approvals.retained.v1.json
@@ -1,0 +1,1224 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "governance",
+  "slug": "approvals",
+  "owned_route": "/__apps/approvals",
+  "capture_route": "/workspace/approvals-app/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:42:10.821Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__apps/approvals#open=2|DIV:Applications",
+      "url": "/__apps/approvals",
+      "title": "Approvals inbox",
+      "entry_edge": null,
+      "controls": 21,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "9eccac201c76e390dd15085d17b414f784997cf1776757cb8dd414e901c13dbb",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "9eccac201c76e390dd15085d17b414f784997cf1776757cb8dd414e901c13dbb",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "643538bea4d2b22ba2b7baec17c80c1979894e47178122ec710fc53740108b6f",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/__apps/approvals#open=1|DIV:Applications",
+      "url": "/__apps/approvals",
+      "title": "Approvals inbox",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 20,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "385295cc4bb4bf263e6882461b0f2132170d6b2943cd61fe31b635546ca8b06c",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/workspace/approvals-app#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/approvals-app",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 13,
+          "tag": "a",
+          "role": null,
+          "href": "/workspace/approvals-app",
+          "disabled": false,
+          "label": "Approvals Home"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "state",
+      "signature": "/__apps/approvals#open=2|DIV:Applications|UL:OpenApprovedChanges requestedAction requiredPending approval",
+      "url": "/__apps/approvals",
+      "title": "Approvals inbox",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 15,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Access requests"
+        }
+      },
+      "controls": 27,
+      "disabled_controls": 9,
+      "screenshot": {
+        "sha256": "8c18365fd6f2c80d6ec960aea54dda1b7ac86be83c6ae85cee20b088bb7f2713",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/api/gitpod.v1.AccountService/GetAccount",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/approvals-app",
+        "disabled": false,
+        "label": "Approvals Home"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Clear"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/approvals/api/search/task-requests",
+        "method": "PUT"
+      }
+    },
+    {
+      "from": "n0",
+      "to": "n3",
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Access requests"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Approved +3"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select user"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=LatestAnnouncementQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select user or group"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select group"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Sort: Recently created"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/approvals-app",
+        "disabled": false,
+        "label": "Approvals Home"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Clear"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Access requests"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Approved +3"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select user"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select user or group"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select group"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Sort: Recently created"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/approvals-app",
+        "disabled": false,
+        "label": "Approvals Home"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Type"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Approved +3"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select user"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Sort: Recently created"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Open"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Approved"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Changes requested"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Action required"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Pending approval"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Draft"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Closed"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Rejected and closed"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "a",
+        "role": "menuitem",
+        "href": null,
+        "disabled": true,
+        "label": "Completed"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:42:15.257Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/governance/approvals",
+  "content_address": "a6cdb8e5522a0e98dc7b30abf546b337941b8cd750f0a8d719755aa89f1f5797"
+}

--- a/apps/hypervisor/seed-graphs/governance/approvals.v1.json
+++ b/apps/hypervisor/seed-graphs/governance/approvals.v1.json
@@ -1,0 +1,910 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "governance",
+  "slug": "approvals",
+  "owned_route": "/__ioi/governance/approvals",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:38:45.607Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/governance/approvals#open=0|H2:Your inbox (0)",
+      "url": "/__ioi/governance/approvals",
+      "title": "Approvals inbox",
+      "entry_edge": null,
+      "controls": 18,
+      "disabled_controls": 5,
+      "screenshot": {
+        "sha256": "4490c84bfd4224e2018a1533c160f614ebc86e8f0ed0901db3b10c3e0ca6a4be",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "4490c84bfd4224e2018a1533c160f614ebc86e8f0ed0901db3b10c3e0ca6a4be",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "c27f33d8fd53218b9ed23d0ca899ef4ae947cd1559da8229644403d81ceb3662",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/governance/approvals?status=pending#open=0|H2:Your inbox (0)",
+      "url": "/__ioi/governance/approvals?status=pending",
+      "title": "Approvals inbox",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 6,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/governance/approvals?status=pending",
+          "disabled": false,
+          "label": "Your inbox0"
+        }
+      },
+      "controls": 18,
+      "disabled_controls": 5,
+      "screenshot": {
+        "sha256": "4490c84bfd4224e2018a1533c160f614ebc86e8f0ed0901db3b10c3e0ca6a4be",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "4490c84bfd4224e2018a1533c160f614ebc86e8f0ed0901db3b10c3e0ca6a4be",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "c27f33d8fd53218b9ed23d0ca899ef4ae947cd1559da8229644403d81ceb3662",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/__ioi/governance/approvals?status=all#open=0|H2:All requests (0)",
+      "url": "/__ioi/governance/approvals?status=all",
+      "title": "Approvals inbox",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 7,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/governance/approvals?status=all",
+          "disabled": false,
+          "label": "All requests0"
+        }
+      },
+      "controls": 18,
+      "disabled_controls": 5,
+      "screenshot": {
+        "sha256": "4268ee24e4d24e9f6f52570ec89f1462fec58f75de1f0eb85f105c2ae00dfd32",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "4268ee24e4d24e9f6f52570ec89f1462fec58f75de1f0eb85f105c2ae00dfd32",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5a31aa6f11c3e72c2ae0e58970057d1ef995421b5b28d15a15b70f77ca4540fc",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals",
+        "disabled": false,
+        "label": "Approvals"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance?tab=approvals",
+        "disabled": false,
+        "label": "⇱"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals?status=pending",
+        "disabled": false,
+        "label": "Your inbox0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals?status=all",
+        "disabled": false,
+        "label": "All requests0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals",
+        "disabled": false,
+        "label": "Clear"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Access requests"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 10,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "All requestsPending approvalApprovedRejectedRevoked"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select user"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select project"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select user or group"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select group"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/governance/approvals",
+        "disabled": false,
+        "label": "governance approval request 0 →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/sessions",
+        "disabled": false,
+        "label": "thread approval 0 →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/marketplace",
+        "disabled": false,
+        "label": "marketplace admission review 0 →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals",
+        "disabled": false,
+        "label": "Approvals"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance?tab=approvals",
+        "disabled": false,
+        "label": "⇱"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals?status=pending",
+        "disabled": false,
+        "label": "Your inbox0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals?status=all",
+        "disabled": false,
+        "label": "All requests0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals",
+        "disabled": false,
+        "label": "Clear"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Access requests"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 10,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "All requestsPending approvalApprovedRejectedRevoked"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select user"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select project"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select user or group"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select group"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/governance/approvals",
+        "disabled": false,
+        "label": "governance approval request 0 →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/sessions",
+        "disabled": false,
+        "label": "thread approval 0 →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/marketplace",
+        "disabled": false,
+        "label": "marketplace admission review 0 →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals",
+        "disabled": false,
+        "label": "Approvals"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance?tab=approvals",
+        "disabled": false,
+        "label": "⇱"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals?status=pending",
+        "disabled": false,
+        "label": "Your inbox0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals?status=all",
+        "disabled": false,
+        "label": "All requests0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/governance/approvals",
+        "disabled": false,
+        "label": "Clear"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Access requests"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 10,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "All requestsPending approvalApprovedRejectedRevoked"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select user"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select project"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select user or group"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Select group"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/governance/approvals",
+        "disabled": false,
+        "label": "governance approval request 0 →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/sessions",
+        "disabled": false,
+        "label": "thread approval 0 →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/marketplace",
+        "disabled": false,
+        "label": "marketplace admission review 0 →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:38:48.978Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/governance/approvals",
+  "content_address": "0b954f903a038f33fb19f08ab9a4827093a8ec3c7e4c7c8a00ad53525e524aa1"
+}

--- a/apps/hypervisor/seed-graphs/improvement/changes.retained.v1.json
+++ b/apps/hypervisor/seed-graphs/improvement/changes.retained.v1.json
@@ -1,0 +1,500 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "improvement",
+  "slug": "changes",
+  "owned_route": "/__apps/changes",
+  "capture_route": "/workspace/upgrade-assistant/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:45:05.865Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/workspace/upgrade-assistant/#open=2|DIV:Applications",
+      "url": "/workspace/upgrade-assistant/",
+      "title": "Upgrade Assistant",
+      "entry_edge": null,
+      "controls": 14,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "1664887b9213d60460bddc572ecd8e05667cec34db59e7822172847d4f55817c",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/workspace/upgrade-assistant/#open=1|DIV:Applications",
+      "url": "/workspace/upgrade-assistant/",
+      "title": "Upgrade Assistant",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 13,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "8fe60e3fabb6331cd588decd44fba135692f837b86d0045907b8b23219780a5a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show error"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show error"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:45:09.864Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/improvement/changes",
+  "content_address": "0b5acfd4457d71ed9397f95bd976030715e0a3d857f6f2e3bd07bd55def6f983"
+}

--- a/apps/hypervisor/seed-graphs/improvement/changes.v1.json
+++ b/apps/hypervisor/seed-graphs/improvement/changes.v1.json
@@ -1,0 +1,1596 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "improvement",
+  "slug": "changes",
+  "owned_route": "/__ioi/improvement/changes",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:43:22.328Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/improvement/changes#open=0|H1:Upgrade Assistant",
+      "url": "/__ioi/improvement/changes",
+      "title": "Upgrade Assistant",
+      "entry_edge": null,
+      "controls": 13,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "73af5225fd24927a82de4a6d71fed55fb24b0eff8a8d40699652599fbc06477d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "73af5225fd24927a82de4a6d71fed55fb24b0eff8a8d40699652599fbc06477d",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "bb03d9f92b19ea784cc6e75e616de2104c4b53672558a3f9688425f358286bd5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/improvement/changes?lane=active#open=0|H1:Upgrade Assistant",
+      "url": "/__ioi/improvement/changes?lane=active",
+      "title": "Upgrade Assistant",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 5,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/improvement/changes?lane=active",
+          "disabled": false,
+          "label": "Active"
+        }
+      },
+      "controls": 13,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "73af5225fd24927a82de4a6d71fed55fb24b0eff8a8d40699652599fbc06477d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "73af5225fd24927a82de4a6d71fed55fb24b0eff8a8d40699652599fbc06477d",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "bb03d9f92b19ea784cc6e75e616de2104c4b53672558a3f9688425f358286bd5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/__ioi/improvement/changes?lane=pastdue#open=0|H1:Upgrade Assistant",
+      "url": "/__ioi/improvement/changes?lane=pastdue",
+      "title": "Upgrade Assistant",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 6,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/improvement/changes?lane=pastdue",
+          "disabled": false,
+          "label": "Past due"
+        }
+      },
+      "controls": 13,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "255feae1cd8a8e43e7cc296bb925e1e40ce7ec692dfb47df1f83243ce89afd83",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "255feae1cd8a8e43e7cc296bb925e1e40ce7ec692dfb47df1f83243ce89afd83",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "cf4697a6dbfacedf87909e296877ed70a3cfa275551858744f794e8172f5640e",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "route",
+      "signature": "/__ioi/improvement/changes?lane=archived#open=0|H1:Upgrade Assistant",
+      "url": "/__ioi/improvement/changes?lane=archived",
+      "title": "Upgrade Assistant",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 7,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/improvement/changes?lane=archived",
+          "disabled": false,
+          "label": "Archived"
+        }
+      },
+      "controls": 13,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "5b6b39a4c60a5db21eec7699a6b4a79849b0a639c36e82b757e7814434a451b3",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "5b6b39a4c60a5db21eec7699a6b4a79849b0a639c36e82b757e7814434a451b3",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "69fd01f65a7775b4096abadda7911113f1e3b3b8052e648e47b7b9b810c31cd9",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n4",
+      "kind": "route",
+      "signature": "/__ioi/improvement/changes?lane=active&filter=all#open=0|H1:Upgrade Assistant",
+      "url": "/__ioi/improvement/changes?lane=active&filter=all",
+      "title": "Upgrade Assistant",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 8,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/improvement/changes?lane=active&filter=all",
+          "disabled": false,
+          "label": "All upgrades0"
+        }
+      },
+      "controls": 13,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "0345c53eeee4f3159dc559fe9d48076e31e603979e3423ff2fe07d31475c21bf",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "0345c53eeee4f3159dc559fe9d48076e31e603979e3423ff2fe07d31475c21bf",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9c356502515111da680dfbe3d865e3ad76f28227a65e5d059ed1a0e19c7ffa9a",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n5",
+      "kind": "route",
+      "signature": "/__ioi/improvement/changes?lane=pastdue&filter=all#open=0|H1:Upgrade Assistant",
+      "url": "/__ioi/improvement/changes?lane=pastdue&filter=all",
+      "title": "Upgrade Assistant",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 8,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/improvement/changes?lane=pastdue&filter=all",
+          "disabled": false,
+          "label": "All upgrades0"
+        }
+      },
+      "controls": 13,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "492d0774bc03b009877477119759171507f65456cf99ac466f7a0b7eaa86b663",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "492d0774bc03b009877477119759171507f65456cf99ac466f7a0b7eaa86b663",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "1b6f41e7843dc8a929d7b4abc806d04d4df2168320c99dafba3f3e24701bfb86",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n6",
+      "kind": "route",
+      "signature": "/__ioi/improvement/changes?lane=archived&filter=all#open=0|H1:Upgrade Assistant",
+      "url": "/__ioi/improvement/changes?lane=archived&filter=all",
+      "title": "Upgrade Assistant",
+      "entry_edge": {
+        "from": "n3",
+        "control": {
+          "index": 8,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/improvement/changes?lane=archived&filter=all",
+          "disabled": false,
+          "label": "All upgrades0"
+        }
+      },
+      "controls": 13,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "8d92f3af88037f58c1b033bc7e180486b6b8cb18dd92aa7d0a9ca3fe561bc249",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "8d92f3af88037f58c1b033bc7e180486b6b8cb18dd92aa7d0a9ca3fe561bc249",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "7a77458171f2b993a7b6983089d9f3d8537df0ea922ad7876d82408ef18f1804",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes",
+        "disabled": false,
+        "label": "Upgrade Assistant"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active",
+        "disabled": false,
+        "label": "Active"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue",
+        "disabled": false,
+        "label": "Past due"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n3",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived",
+        "disabled": false,
+        "label": "Archived"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n4",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active&filter=all",
+        "disabled": false,
+        "label": "All upgrades0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active",
+        "disabled": false,
+        "label": "Upgrades requiring my action0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "owner surface (Agent Studio) →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/upgrade-assistant/",
+        "disabled": false,
+        "label": "Upgrade Assistant capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/changes",
+        "disabled": false,
+        "label": "/__apps/changes proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes",
+        "disabled": false,
+        "label": "Upgrade Assistant"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active",
+        "disabled": false,
+        "label": "Active"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue",
+        "disabled": false,
+        "label": "Past due"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived",
+        "disabled": false,
+        "label": "Archived"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active&filter=all",
+        "disabled": false,
+        "label": "All upgrades0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active",
+        "disabled": false,
+        "label": "Upgrades requiring my action0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "owner surface (Agent Studio) →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/upgrade-assistant/",
+        "disabled": false,
+        "label": "Upgrade Assistant capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/changes",
+        "disabled": false,
+        "label": "/__apps/changes proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes",
+        "disabled": false,
+        "label": "Upgrade Assistant"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active",
+        "disabled": false,
+        "label": "Active"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue",
+        "disabled": false,
+        "label": "Past due"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived",
+        "disabled": false,
+        "label": "Archived"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "n5",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue&filter=all",
+        "disabled": false,
+        "label": "All upgrades0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue",
+        "disabled": false,
+        "label": "Upgrades requiring my action0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "owner surface (Agent Studio) →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/upgrade-assistant/",
+        "disabled": false,
+        "label": "Upgrade Assistant capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/changes",
+        "disabled": false,
+        "label": "/__apps/changes proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes",
+        "disabled": false,
+        "label": "Upgrade Assistant"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active",
+        "disabled": false,
+        "label": "Active"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue",
+        "disabled": false,
+        "label": "Past due"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived",
+        "disabled": false,
+        "label": "Archived"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "n6",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived&filter=all",
+        "disabled": false,
+        "label": "All upgrades0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived",
+        "disabled": false,
+        "label": "Upgrades requiring my action0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "owner surface (Agent Studio) →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/upgrade-assistant/",
+        "disabled": false,
+        "label": "Upgrade Assistant capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/changes",
+        "disabled": false,
+        "label": "/__apps/changes proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes",
+        "disabled": false,
+        "label": "Upgrade Assistant"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active&filter=all",
+        "disabled": false,
+        "label": "Active"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue&filter=all",
+        "disabled": false,
+        "label": "Past due"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived&filter=all",
+        "disabled": false,
+        "label": "Archived"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active&filter=all",
+        "disabled": false,
+        "label": "All upgrades0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active",
+        "disabled": false,
+        "label": "Upgrades requiring my action0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "owner surface (Agent Studio) →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/upgrade-assistant/",
+        "disabled": false,
+        "label": "Upgrade Assistant capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/changes",
+        "disabled": false,
+        "label": "/__apps/changes proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes",
+        "disabled": false,
+        "label": "Upgrade Assistant"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active&filter=all",
+        "disabled": false,
+        "label": "Active"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue&filter=all",
+        "disabled": false,
+        "label": "Past due"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived&filter=all",
+        "disabled": false,
+        "label": "Archived"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue&filter=all",
+        "disabled": false,
+        "label": "All upgrades0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue",
+        "disabled": false,
+        "label": "Upgrades requiring my action0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "owner surface (Agent Studio) →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/upgrade-assistant/",
+        "disabled": false,
+        "label": "Upgrade Assistant capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/changes",
+        "disabled": false,
+        "label": "/__apps/changes proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes",
+        "disabled": false,
+        "label": "Upgrade Assistant"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=active&filter=all",
+        "disabled": false,
+        "label": "Active"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=pastdue&filter=all",
+        "disabled": false,
+        "label": "Past due"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived&filter=all",
+        "disabled": false,
+        "label": "Archived"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived&filter=all",
+        "disabled": false,
+        "label": "All upgrades0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/improvement/changes?lane=archived",
+        "disabled": false,
+        "label": "Upgrades requiring my action0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "owner surface (Agent Studio) →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/upgrade-assistant/",
+        "disabled": false,
+        "label": "Upgrade Assistant capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/changes",
+        "disabled": false,
+        "label": "/__apps/changes proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:43:29.777Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/improvement/changes",
+  "content_address": "5cfccbb538fee3aea5be5ac85ac6614f0bbb581b7e84726cfaeafa395a32a017"
+}

--- a/apps/hypervisor/seed-graphs/ontology/explorer.v1.json
+++ b/apps/hypervisor/seed-graphs/ontology/explorer.v1.json
@@ -1,0 +1,460 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "ontology",
+  "slug": "explorer",
+  "owned_route": "/__ioi/ontology/explorer",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:08:59.214Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://127.0.0.1:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/ontology/explorer#open=0|H2:Object Explorer search|H3:Object type catalog",
+      "url": "/__ioi/ontology/explorer",
+      "title": "Object Explorer",
+      "entry_edge": null,
+      "controls": 10,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "9c2c85483a38511cd2faa4034f5caceb22c86a5b06a6f9c5375693e3e8180223",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "9c2c85483a38511cd2faa4034f5caceb22c86a5b06a6f9c5375693e3e8180223",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "93db0f5a53a6f63f06ee43cbe222e43babb930f8c2e35a6b52264caa43c2069c",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/ontology/explorer?objectType=widget&ontology=ont_18ca2757d28a20f7#open=0|H2:Object Explorer search|H3:Object type catalog",
+      "url": "/__ioi/ontology/explorer?objectType=widget&ontology=ont_18ca2757d28a20f7",
+      "title": "Object Explorer",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 5,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/explorer?objectType=widget&ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "Widget"
+        }
+      },
+      "controls": 15,
+      "disabled_controls": 2,
+      "screenshot": {
+        "sha256": "45d7c0ec3a740f814d993e2ab541d381429affb131e5e49af58a855607093006",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "45d7c0ec3a740f814d993e2ab541d381429affb131e5e49af58a855607093006",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9c94169e5a14283e85f1da8839601493144916ed62a3cd99b7da215e12a88565",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 4,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Ontology scope"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer?objectType=widget&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Widget"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "ODK substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "ODK"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/explorer",
+        "disabled": false,
+        "label": "Object Explorer capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 4,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Ontology scope"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer?objectType=widget&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "ODK substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "ODK"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/explorer",
+        "disabled": false,
+        "label": "Object Explorer capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Manager definition"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Execute action"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Search instances"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:09:02.431Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/ontology/explorer",
+  "content_address": "d6ac5fe0678ea1055347eeb256a63d8484bbb602bb08a7fbcc1d3bb77ffc9952"
+}

--- a/apps/hypervisor/seed-graphs/ontology/schema.retained.v1.json
+++ b/apps/hypervisor/seed-graphs/ontology/schema.retained.v1.json
@@ -1,0 +1,502 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "ontology",
+  "slug": "schema",
+  "owned_route": "/__apps/schema",
+  "capture_route": "/workspace/ontology/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:36:45.569Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/workspace/ontology/home/discover#open=2|DIV:Applications",
+      "url": "/workspace/ontology/home/discover",
+      "title": "Ontology Manager",
+      "entry_edge": null,
+      "controls": 14,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "f83930dc310e5da9cd05d2c60335822b5db7ef50351562dac3a86f767ad75d62",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "a",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/workspace/ontology/home/discover#open=1|DIV:Applications",
+      "url": "/workspace/ontology/home/discover",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 13,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "2e6af38ff444d89627bffc1e2df3fd4252c56bec22a428827b3ed85ae44923b0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:36:49.589Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/ontology/schema",
+  "content_address": "a7c9a0a48f7dbe44ec28c2573e29f0e18ad1da28dd7e0ccf58d2bdb0d7c8723b"
+}

--- a/apps/hypervisor/seed-graphs/ontology/schema.v1.json
+++ b/apps/hypervisor/seed-graphs/ontology/schema.v1.json
@@ -1,0 +1,9314 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "ontology",
+  "slug": "schema",
+  "owned_route": "/__ioi/ontology/manager",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:37:56.647Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager",
+      "title": "Ontology Manager",
+      "entry_edge": null,
+      "controls": 23,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "5135bf6f0c4a93638db21c994cc6c0a63f21a0c3fc2b46e9be99686528171893",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "5135bf6f0c4a93638db21c994cc6c0a63f21a0c3fc2b46e9be99686528171893",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "545e1e3bf00ff6618f4ebfe45d5a8a600bb314eae9194708142f7949e6406fc5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 5,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+          "disabled": false,
+          "label": "New"
+        }
+      },
+      "controls": 25,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "aa594234c06fabe327bdc1ac909b86d791a0e5e897ce344542a037311e90d0e4",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "aa594234c06fabe327bdc1ac909b86d791a0e5e897ce344542a037311e90d0e4",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01287d195e9bdb21756746a042d2067cc25d73f5e3b89685c30719bb26081a23",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 6,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+          "disabled": false,
+          "label": "Discover"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 7,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+          "disabled": false,
+          "label": "History"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n4",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 8,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+          "disabled": false,
+          "label": "Object types1"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n5",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 9,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+          "disabled": false,
+          "label": "Properties0"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n6",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 10,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+          "disabled": false,
+          "label": "Link types0"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n7",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 11,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+          "disabled": false,
+          "label": "Action types0"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n8",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 12,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+          "disabled": false,
+          "label": "Value types0"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n9",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 13,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+          "disabled": false,
+          "label": "Functions0"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n10",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 14,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+          "disabled": false,
+          "label": "Health issues"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n11",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 17,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "probe-reencode"
+        }
+      },
+      "controls": 23,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "5135bf6f0c4a93638db21c994cc6c0a63f21a0c3fc2b46e9be99686528171893",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "5135bf6f0c4a93638db21c994cc6c0a63f21a0c3fc2b46e9be99686528171893",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "545e1e3bf00ff6618f4ebfe45d5a8a600bb314eae9194708142f7949e6406fc5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n12",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 20,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+          "disabled": false,
+          "label": "Widget 0 objects 0 dependents a widget"
+        }
+      },
+      "controls": 32,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "db634bfad889c228bc72300bda36e1b39e84f9acabb424ff1e4596372f1428fe",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "db634bfad889c228bc72300bda36e1b39e84f9acabb424ff1e4596372f1428fe",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "add102468ca5accf433430d318a50bbe35a510587402be55ca5c57c44382732c",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n13",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 25,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "aa594234c06fabe327bdc1ac909b86d791a0e5e897ce344542a037311e90d0e4",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "aa594234c06fabe327bdc1ac909b86d791a0e5e897ce344542a037311e90d0e4",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01287d195e9bdb21756746a042d2067cc25d73f5e3b89685c30719bb26081a23",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n14",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n3",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n15",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n4",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n16",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n17",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n18",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n7",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n19",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n20",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n21",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n22",
+      "kind": "state",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n11",
+        "control": {
+          "index": 16,
+          "tag": "summary",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "probe-reencode v1 ▾"
+        }
+      },
+      "controls": 24,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n23",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types&definitionKind=object-type&definitionId=widget&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types&definitionKind=object-type&definitionId=widget&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n13",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 32,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "db634bfad889c228bc72300bda36e1b39e84f9acabb424ff1e4596372f1428fe",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "db634bfad889c228bc72300bda36e1b39e84f9acabb424ff1e4596372f1428fe",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "add102468ca5accf433430d318a50bbe35a510587402be55ca5c57c44382732c",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n3",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n4",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n5",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n6",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n7",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n8",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n9",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n10",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n0",
+      "control": {
+        "index": 16,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n0",
+      "to": "n11",
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n12",
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "n11",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Create"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "n13",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "n14",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": "n3",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "n15",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "n16",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": "n5",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "n17",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "n18",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "n19",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "n20",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "n21",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n10",
+      "to": "n10",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "n22",
+      "control": {
+        "index": 16,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "n12",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n12",
+      "to": "n12",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 24,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer?objectType=widget&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Explorer"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "— none —"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 28,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Save"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "stringintegerdoublebooleantimestampenum"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Save"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 31,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Open substrate record →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "n23",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n13",
+      "to": "n13",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": "n13",
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Create"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n13",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n14",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n14",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n14",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n14",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": "n14",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n14",
+      "to": "n14",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n14",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n14",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n14",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n14",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "n15",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n15",
+      "to": "n15",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "n16",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n16",
+      "to": "n16",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "n17",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n17",
+      "to": "n17",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "n18",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n18",
+      "to": "n18",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n19",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n19",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n19",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n19",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "n19",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n19",
+      "to": "n19",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n19",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n19",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n19",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n19",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "n20",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n20",
+      "to": "n20",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "n21",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n21",
+      "to": "n21",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "n22",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n22",
+      "to": "n22",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Object types1"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "n23",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n23",
+      "to": "n23",
+      "control": {
+        "index": 17,
+        "tag": "summary",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "probe-reencode v1 ▾"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer",
+        "disabled": false,
+        "label": "Object Explorer →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget 0 objects 0 dependents a widget"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Configure model in substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/schema",
+        "disabled": false,
+        "label": "Ontology Manager ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 24,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/explorer?objectType=widget&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Explorer"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "— none —"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 28,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Save"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "select",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "stringintegerdoublebooleantimestampenum"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Save"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 31,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
+        "disabled": false,
+        "label": "Open substrate record →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:38:30.886Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/ontology/schema",
+  "content_address": "1b07de3dd18a1c8b3fdfcca19eeb50096cddbd5fa179fa10ad48565293fbaf7c"
+}

--- a/apps/hypervisor/seed-graphs/packages/listings.retained.v1.json
+++ b/apps/hypervisor/seed-graphs/packages/listings.retained.v1.json
@@ -1,0 +1,723 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "packages",
+  "slug": "listings",
+  "owned_route": "/__apps/listings",
+  "capture_route": "/workspace/marketplace/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:47:25.167Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/workspace/marketplace/home#open=2|H2:Marketplace|H3:Stores|DIV:Applications",
+      "url": "/workspace/marketplace/home",
+      "title": "Marketplace",
+      "entry_edge": null,
+      "controls": 19,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "df955982d0c8c3a3019d0712c4ac99d889a2b20889edf7a2b2974a79f483d32c",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/workspace/marketplace/home#open=1|H2:Marketplace|H3:Stores|DIV:Applications",
+      "url": "/workspace/marketplace/home",
+      "title": "Marketplace",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 18,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "93bcd42dde1fd0ef2a295abb6b6404d3c2423c573ad85cfa6c36e3d87c19d395",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/workspace/marketplace#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/marketplace",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 13,
+          "tag": "a",
+          "role": null,
+          "href": "/workspace/marketplace",
+          "disabled": false,
+          "label": "Marketplace home page"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/marketplace",
+        "disabled": false,
+        "label": "Marketplace home page"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/marketplace",
+        "disabled": false,
+        "label": "Marketplace"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Installations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Show column options"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/dev-ops",
+        "disabled": false,
+        "label": "DevOps"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/marketplace",
+        "disabled": false,
+        "label": "Marketplace home page"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/marketplace",
+        "disabled": false,
+        "label": "Marketplace"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Installations"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Help"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Show column options"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/dev-ops",
+        "disabled": false,
+        "label": "DevOps"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:47:32.234Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/packages/listings",
+  "content_address": "3ff71d6c8618c1f0744f8bc21782b844a167bc43c70d26ab62705e01da2bf61d"
+}

--- a/apps/hypervisor/seed-graphs/packages/listings.v1.json
+++ b/apps/hypervisor/seed-graphs/packages/listings.v1.json
@@ -1,0 +1,182 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "packages",
+  "slug": "listings",
+  "owned_route": "/__ioi/marketplace/listings",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:45:14.529Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/marketplace/listings#open=0|H1:Marketplace|H2:Marketplace|H3:Stores",
+      "url": "/__ioi/marketplace/listings",
+      "title": "Marketplace",
+      "entry_edge": null,
+      "controls": 8,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "a43667f0b8a46e7e5f22bf82ef1e6f34a5b6c469671cba7f97dd2cf40d26a76c",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "a43667f0b8a46e7e5f22bf82ef1e6f34a5b6c469671cba7f97dd2cf40d26a76c",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "388aefe9a04eb39e50b7e6b882afa0fbbcffd3563974d9c96b253bba68744cf3",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/marketplace/listings",
+        "disabled": false,
+        "label": "Marketplace"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/marketplace",
+        "disabled": false,
+        "label": "Estate Marketplace — governed listing planeListings drafted over real substrate."
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/marketplace",
+        "disabled": false,
+        "label": "Marketplace substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/marketplace",
+        "disabled": false,
+        "label": "Marketplace substrate →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/listings",
+        "disabled": false,
+        "label": "Marketplace capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:45:15.892Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/packages/listings",
+  "content_address": "2517c2d6c47ebf0b49b1d51eeb54b2975e20a65fdb9671c7325a952f10a6fb93"
+}

--- a/apps/hypervisor/seed-graphs/provenance/lineage.retained.v1.json
+++ b/apps/hypervisor/seed-graphs/provenance/lineage.retained.v1.json
@@ -1,0 +1,1821 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "provenance",
+  "slug": "lineage",
+  "owned_route": "/__apps/lineage",
+  "capture_route": "/workspace/monocle/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:47:47.718Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/workspace/monocle/graph?coloring=monocle.color.resource-type#open=2|DIV:Applications",
+      "url": "/workspace/monocle/graph?coloring=monocle.color.resource-type",
+      "title": "Data Lineage",
+      "entry_edge": null,
+      "controls": 58,
+      "disabled_controls": 19,
+      "screenshot": {
+        "sha256": "eec73078bd9f3c6362ea3072fa8fc3116d686346e60e0b92ed8a7b43d29b9701",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/workspace/monocle/graph?coloring=monocle.color.resource-type#open=1|DIV:Applications",
+      "url": "/workspace/monocle/graph?coloring=monocle.color.resource-type",
+      "title": "Data Lineage",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 57,
+      "disabled_controls": 19,
+      "screenshot": {
+        "sha256": "46b68b987552eb000d1b7d9b970b74210def70c35b5c8693825b09e8d742527e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/workspace/monocle#open=1|DIV:What's newUser budgets for AI usageJune 10, 2026Enterprise a",
+      "url": "/workspace/monocle",
+      "title": "IOI",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 13,
+          "tag": "a",
+          "role": null,
+          "href": "/workspace/monocle",
+          "disabled": false,
+          "label": "Data Lineage Home"
+        }
+      },
+      "controls": 2,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c3f82ca67ced9ec060391786d6f5628fdc5259de4d5deeb397a55364921b8e9a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/monocle",
+        "disabled": false,
+        "label": "Data Lineage Home"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Workflow Lineage"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Main"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Fallback branches"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Keyboard shortcuts"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "User settings"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "000"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Save as"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Save and Load Options"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": "button",
+        "href": "https://www.palantir.com/docs/foundry/data-lineage/overview/",
+        "disabled": false,
+        "label": "Read documentation"
+      },
+      "action": "goto",
+      "outcome": "boundary-external-origin"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Layout actions"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Undo"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Redo"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Remove trash/off-branch nodes"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Select nodes"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Add parents or children"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Color nodes"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 30,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Find nodes on graph"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 31,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Remove selected nodes"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 32,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Snap node positions to grid"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 33,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Add text node"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Animate edges between nodes"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Layout nodes by current color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Group nodes by current color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Legend view"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": ""
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Toggle minimap"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in (scroll up)"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out (scroll down)"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit (↑)"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "0 nodes selected"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": true,
+        "label": "Preview"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": true,
+        "label": "SQL scratchpad"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": true,
+        "label": "History"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": true,
+        "label": "Code"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Build timeline"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Data health"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "button",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Expand bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Search Foundry"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "View node properties"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Manage builds"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Manage schedules"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Access information"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Related items"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 57,
+        "tag": "button",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Expand sidebar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/monocle",
+        "disabled": false,
+        "label": "Data Lineage Home"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Workflow Lineage"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Main"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Fallback branches"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Keyboard shortcuts"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "User settings"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "000"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Save as"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Save and Load Options"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "a",
+        "role": "button",
+        "href": "https://www.palantir.com/docs/foundry/data-lineage/overview/",
+        "disabled": false,
+        "label": "Read documentation"
+      },
+      "action": "goto",
+      "outcome": "boundary-external-origin"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Layout actions"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Undo"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Redo"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Remove trash/off-branch nodes"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Select nodes"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Add parents or children"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Color nodes"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Find nodes on graph"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 30,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Remove selected nodes"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 31,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Snap node positions to grid"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 32,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Add text node"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 33,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Animate edges between nodes"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Layout nodes by current color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "Group nodes by current color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Legend view"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": ""
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Toggle minimap"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in (scroll up)"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out (scroll down)"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit (↑)"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "0 nodes selected"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": true,
+        "label": "Preview"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": true,
+        "label": "SQL scratchpad"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": true,
+        "label": "History"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": true,
+        "label": "Code"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Build timeline"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Data health"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 49,
+        "tag": "button",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Expand bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 50,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Search Foundry"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 51,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "View node properties"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Manage builds"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 53,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Manage schedules"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 54,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Access information"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 55,
+        "tag": "div",
+        "role": "tab",
+        "href": null,
+        "disabled": false,
+        "label": "Related items"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 56,
+        "tag": "button",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Expand sidebar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n2",
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "#main-content",
+        "disabled": false,
+        "label": "Skip to main content"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/",
+        "disabled": false,
+        "label": "Back to dashboard"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:47:52.658Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/provenance/lineage",
+  "content_address": "ed9858d10fb2706a653de63317a0ce96a7845b0a60011cd98a8041ebf6ff5f56"
+}

--- a/apps/hypervisor/seed-graphs/provenance/lineage.v1.json
+++ b/apps/hypervisor/seed-graphs/provenance/lineage.v1.json
@@ -1,0 +1,280 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "provenance",
+  "slug": "lineage",
+  "owned_route": "/__ioi/lineage",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:42:08.059Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/lineage#open=0|H1:Data lineage",
+      "url": "/__ioi/lineage",
+      "title": "Data lineage · Hypervisor",
+      "entry_edge": null,
+      "controls": 6,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "09a0d906a67759e05a8b2621d884368c4ffcdf9631fcc04d38fe6230d94d8b59",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "09a0d906a67759e05a8b2621d884368c4ffcdf9631fcc04d38fe6230d94d8b59",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "656f5fce6cc879721c51ad4f7cebc627f73efd7d7fa1b402d29b89286384a4bf",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7#open=0|H1:Data lineage",
+      "url": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+      "title": "Data lineage · Hypervisor",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 3,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "probe-reencode"
+        }
+      },
+      "controls": 6,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "09a0d906a67759e05a8b2621d884368c4ffcdf9631fcc04d38fe6230d94d8b59",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "09a0d906a67759e05a8b2621d884368c4ffcdf9631fcc04d38fe6230d94d8b59",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "656f5fce6cc879721c51ad4f7cebc627f73efd7d7fa1b402d29b89286384a4bf",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/lineage",
+        "disabled": false,
+        "label": "Monocle lineage ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/vertex?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Explore graph"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Open pipeline"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/lineage",
+        "disabled": false,
+        "label": "Monocle reference capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/lineage",
+        "disabled": false,
+        "label": "Monocle lineage ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/vertex?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Explore graph"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Open pipeline"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/lineage",
+        "disabled": false,
+        "label": "Monocle reference capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:42:10.651Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/provenance/lineage",
+  "content_address": "a5e9a92ddb4554ed6ac8e7900fe701247524810763f29a5f92e00bb85a695ed0"
+}

--- a/apps/hypervisor/seed-graphs/provenance/vertex.v1.json
+++ b/apps/hypervisor/seed-graphs/provenance/vertex.v1.json
@@ -1,0 +1,280 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "provenance",
+  "slug": "vertex",
+  "owned_route": "/__ioi/vertex",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:42:18.887Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/vertex#open=0|H1:Vertex",
+      "url": "/__ioi/vertex",
+      "title": "Vertex · Hypervisor",
+      "entry_edge": null,
+      "controls": 6,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "ef7a03155a0e6c4d17a1ecbd94ad8789c1b313822ee21f9c6cea9dffa2fa0c65",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "ef7a03155a0e6c4d17a1ecbd94ad8789c1b313822ee21f9c6cea9dffa2fa0c65",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9839587ef703a0a094daf4e1f1a3c7239cd296e256647470579989747cc1b5a5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/vertex?ontology=ont_18ca2757d28a20f7#open=0|H1:Vertex",
+      "url": "/__ioi/vertex?ontology=ont_18ca2757d28a20f7",
+      "title": "Vertex · Hypervisor",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 3,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/vertex?ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "probe-reencode"
+        }
+      },
+      "controls": 6,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "ef7a03155a0e6c4d17a1ecbd94ad8789c1b313822ee21f9c6cea9dffa2fa0c65",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "ef7a03155a0e6c4d17a1ecbd94ad8789c1b313822ee21f9c6cea9dffa2fa0c65",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9839587ef703a0a094daf4e1f1a3c7239cd296e256647470579989747cc1b5a5",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/vertex",
+        "disabled": false,
+        "label": "Vertex ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage path"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/vertex?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/vertex",
+        "disabled": false,
+        "label": "Vertex reference capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/vertex",
+        "disabled": false,
+        "label": "Vertex ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Lineage path"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/vertex?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencode"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/vertex",
+        "disabled": false,
+        "label": "Vertex reference capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:42:21.227Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/provenance/vertex",
+  "content_address": "1e6fc1981319be5879cc33b3016105ae185c6bbe391505b082fbab2bfc79cdf0"
+}

--- a/apps/hypervisor/seed-graphs/studio/designer.v1.json
+++ b/apps/hypervisor/seed-graphs/studio/designer.v1.json
@@ -1,0 +1,616 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "studio",
+  "slug": "designer",
+  "owned_route": "/__ioi/studio/designer",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:28:31.689Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/studio/designer#open=0|H1:Solution Designer|H3:Solution Designer|H2:Composition truth — probe-reencode 1 concept · 0 components |H3:Concepts (1 object · 0 value · 0 action · 0 link types)|H3:Components (0 mapping · 0 policy view · 0 projection)|H3:Resources (0 object set · 0 surface descriptor)",
+      "url": "/__ioi/studio/designer",
+      "title": "Solution Designer",
+      "entry_edge": null,
+      "controls": 18,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c957716ddc007cf818c2d76a0112fa15ef1a1821975083ce200a8c18f6aacbbd",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "c957716ddc007cf818c2d76a0112fa15ef1a1821975083ce200a8c18f6aacbbd",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "939eab8e8f48f83be856f5c332a7fe6474318e38cc979cd16503359f9f16f36a",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/studio/designer?ontology=ont_18ca2757d28a20f7#open=0|H1:Solution Designer|H3:Solution Designer|H2:Composition truth — probe-reencode 1 concept · 0 components |H3:Concepts (1 object · 0 value · 0 action · 0 link types)|H3:Components (0 mapping · 0 policy view · 0 projection)|H3:Resources (0 object set · 0 surface descriptor)",
+      "url": "/__ioi/studio/designer?ontology=ont_18ca2757d28a20f7",
+      "title": "Solution Designer",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 5,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/studio/designer?ontology=ont_18ca2757d28a20f7",
+          "disabled": false,
+          "label": "probe-reencodeselected ontology://ont_18ca2757d28a20f7 · created Aug 9, 2026 · u"
+        }
+      },
+      "controls": 18,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "c957716ddc007cf818c2d76a0112fa15ef1a1821975083ce200a8c18f6aacbbd",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "c957716ddc007cf818c2d76a0112fa15ef1a1821975083ce200a8c18f6aacbbd",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "939eab8e8f48f83be856f5c332a7fe6474318e38cc979cd16503359f9f16f36a",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/studio/designer",
+        "disabled": false,
+        "label": "Solution Designer"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/studio/designer?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencodeselected ontology://ont_18ca2757d28a20f7 · created Aug 9, 2026 · u"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "pipeline"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/machinery",
+        "disabled": false,
+        "label": "machinery"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/workshop",
+        "disabled": false,
+        "label": "workshop"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio",
+        "disabled": false,
+        "label": "Agent Studio"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/studio/machinery",
+        "disabled": false,
+        "label": "Machinery"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/solution-design/",
+        "disabled": false,
+        "label": "Solution Designer capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/designer",
+        "disabled": false,
+        "label": "/__apps/designer proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/studio/designer",
+        "disabled": false,
+        "label": "Solution Designer"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/studio/designer?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "probe-reencodeselected ontology://ont_18ca2757d28a20f7 · created Aug 9, 2026 · u"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
+        "disabled": false,
+        "label": "Widget"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "pipeline"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/machinery",
+        "disabled": false,
+        "label": "machinery"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/workshop",
+        "disabled": false,
+        "label": "workshop"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio",
+        "disabled": false,
+        "label": "Agent Studio"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/studio/machinery",
+        "disabled": false,
+        "label": "Machinery"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "a",
+        "role": null,
+        "href": "http://localhost:9225/workspace/solution-design/",
+        "disabled": false,
+        "label": "Solution Designer capture"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/designer",
+        "disabled": false,
+        "label": "/__apps/designer proxy lane ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:28:34.053Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/studio/designer",
+  "content_address": "b3512b59fa3a1c8aa76133c2d716a9ee9ac08713673760f1a8b34fe55f817eb3"
+}

--- a/apps/hypervisor/seed-graphs/work/incidents.v1.json
+++ b/apps/hypervisor/seed-graphs/work/incidents.v1.json
@@ -1,0 +1,698 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "work",
+  "slug": "incidents",
+  "owned_route": "/__ioi/missions/incidents",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:03:14.742Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://127.0.0.1:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/missions/incidents#open=0|H1:Issues",
+      "url": "/__ioi/missions/incidents",
+      "title": "Issues — incidents inbox",
+      "entry_edge": null,
+      "controls": 9,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "a18d982a8290d7144cd0f69ba8347d187d0c39beb2bdb80f2adfaf3bc46083f2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "a18d982a8290d7144cd0f69ba8347d187d0c39beb2bdb80f2adfaf3bc46083f2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "f85cc9e419494b10e27ebeae67c7ee5bec85bf46308167c3fb9dc27c60b946b9",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/missions/incidents?lane=open#open=0|H1:Issues",
+      "url": "/__ioi/missions/incidents?lane=open",
+      "title": "Issues — incidents inbox",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 5,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/missions/incidents?lane=open",
+          "disabled": false,
+          "label": "Open0"
+        }
+      },
+      "controls": 9,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "a18d982a8290d7144cd0f69ba8347d187d0c39beb2bdb80f2adfaf3bc46083f2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "a18d982a8290d7144cd0f69ba8347d187d0c39beb2bdb80f2adfaf3bc46083f2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "f85cc9e419494b10e27ebeae67c7ee5bec85bf46308167c3fb9dc27c60b946b9",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/__ioi/missions/incidents?lane=closed#open=0|H1:Issues",
+      "url": "/__ioi/missions/incidents?lane=closed",
+      "title": "Issues — incidents inbox",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 6,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/missions/incidents?lane=closed",
+          "disabled": false,
+          "label": "Closed0"
+        }
+      },
+      "controls": 9,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "d2709ac3c76ad08ae2bd34386cdd55546b7225ba13b7278bdf2be20f1fe41be2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "d2709ac3c76ad08ae2bd34386cdd55546b7225ba13b7278bdf2be20f1fe41be2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "c94a04968ba10192d661899638fb72d3a9e655963a25ee89acf8af11134d9a6e",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "route",
+      "signature": "/__ioi/missions/incidents?lane=all#open=0|H1:Issues",
+      "url": "/__ioi/missions/incidents?lane=all",
+      "title": "Issues — incidents inbox",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 7,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/missions/incidents?lane=all",
+          "disabled": false,
+          "label": "All0"
+        }
+      },
+      "controls": 9,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "3db5c9cdf7505a5c2a02d0c4c8117f5daffa563075d0b74c0d81911eb4d1316b",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "3db5c9cdf7505a5c2a02d0c4c8117f5daffa563075d0b74c0d81911eb4d1316b",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "00d6629fe0d4b3ab858fae785a42d30c9c864a0d2bc4ea81a0f0e07a8fff309b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents",
+        "disabled": false,
+        "label": "Issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=open",
+        "disabled": false,
+        "label": "Open0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n2",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=closed",
+        "disabled": false,
+        "label": "Closed0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": "n3",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=all",
+        "disabled": false,
+        "label": "All0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Missions overview →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents",
+        "disabled": false,
+        "label": "Issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=open",
+        "disabled": false,
+        "label": "Open0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=closed",
+        "disabled": false,
+        "label": "Closed0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=all",
+        "disabled": false,
+        "label": "All0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Missions overview →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents",
+        "disabled": false,
+        "label": "Issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=open",
+        "disabled": false,
+        "label": "Open0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=closed",
+        "disabled": false,
+        "label": "Closed0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=all",
+        "disabled": false,
+        "label": "All0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Missions overview →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents",
+        "disabled": false,
+        "label": "Issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=open",
+        "disabled": false,
+        "label": "Open0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=closed",
+        "disabled": false,
+        "label": "Closed0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=all",
+        "disabled": false,
+        "label": "All0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Missions overview →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:03:19.145Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/work/incidents",
+  "content_address": "5e6978822f34ead237dfdae9983166ecde6261803d320d44fa378984d3ee914c"
+}

--- a/apps/hypervisor/seed-graphs/work/jobs.retained.v1.json
+++ b/apps/hypervisor/seed-graphs/work/jobs.retained.v1.json
@@ -1,0 +1,734 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "work",
+  "slug": "jobs",
+  "owned_route": "/__apps/jobs",
+  "capture_route": "/workspace/job-tracker/",
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": "http://127.0.0.1:9225"
+  },
+  "captured_at": "2026-08-09T16:31:01.712Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/workspace/job-tracker/builds#open=2|DIV:Applications",
+      "url": "/workspace/job-tracker/builds",
+      "title": "Your builds · Builds",
+      "entry_edge": null,
+      "controls": 22,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "b8d7e38505c68e5ac83cad4f1e69ca4382d144a0775867196581429ea42aa901",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "%c ERROR %c foundry.objects.async-select.SelectComponentMechanism %cFailed to resolve selected options for the given optionIds. padding: 2px 0px; background: #E47A2E; color: #f5f8fa; border-radius: 10"
+      ],
+      "posture_matrix": [
+        {
+          "sha256": "233ba9dd6c71ceaef1566d7362d3fba0ffa27a6fea79a2d8cbeec76c77a74d35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "01cc016be4944272fc620228a44e10213042fd93af276e14cf62fcc368ea20a6",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "state",
+      "signature": "/workspace/job-tracker/builds#open=1|DIV:Applications",
+      "url": "/workspace/job-tracker/builds",
+      "title": "Your builds · Builds",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 2,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Collapse Foundry sidebar"
+        }
+      },
+      "controls": 21,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "4ca18a84b49e7e2099f0adeb65e63898bc56eea17cf1476978cac80363bbdb02",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector",
+        "Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 2,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Collapse Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Search…ctrl + J"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=NotificationsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Notifications"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/log-receiver/api/beacon",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift IconWhat's New"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Recent"
+      },
+      "action": "click",
+      "outcome": "blocked-write-attempt",
+      "detail": {
+        "url": "http://127.0.0.1:4173/graphql-gateway/api/graphql?q=RecentsPopoverQuery",
+        "method": "POST"
+      }
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": "Files"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Support"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Account"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Settings"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "000"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Light"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "fe77707c-1590-4b15-9dca-9f92e943d79d"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Clear all filters"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Running"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Finished"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select statuses…"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Skip to content"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Open Foundry sidebar"
+      },
+      "action": "click",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/aip",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "Gift Icon"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/compass",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/workspace/hubble",
+        "disabled": false,
+        "label": ""
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "div",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": ""
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Settings"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": "button",
+        "href": null,
+        "disabled": true,
+        "label": "000"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Light"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "span",
+        "role": "button",
+        "href": null,
+        "disabled": false,
+        "label": "fe77707c-1590-4b15-9dca-9f92e943d79d"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Clear all filters"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "All"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Running"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Finished"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Select statuses…"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:31:05.754Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/work/jobs",
+  "content_address": "26a05569b569f6a0f93d575939007ce2d2804668a7920abe8b9d7d07ef0914b7"
+}

--- a/apps/hypervisor/seed-graphs/work/jobs.v1.json
+++ b/apps/hypervisor/seed-graphs/work/jobs.v1.json
@@ -1,0 +1,924 @@
+{
+  "schema_version": "ioi.hypervisor.seed-interaction-route-graph.v1",
+  "surface": "work",
+  "slug": "jobs",
+  "owned_route": "/__ioi/missions",
+  "capture_route": null,
+  "runtime": {
+    "serve_url": "http://127.0.0.1:4173",
+    "capture_url": null
+  },
+  "captured_at": "2026-08-09T16:28:42.365Z",
+  "quarantine": {
+    "network_policy": "local-only",
+    "corpus_mutation": "denied",
+    "html_injection": "denied",
+    "spa_fallback": "denied",
+    "allowed_origins": [
+      "http://127.0.0.1:4173",
+      "http://localhost:4173",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
+    ],
+    "violations": []
+  },
+  "nodes": [
+    {
+      "id": "n0",
+      "kind": "route",
+      "signature": "/__ioi/missions#open=0|H1:Missions|H3:Run queue|H3:Incidents & blockers",
+      "url": "/__ioi/missions",
+      "title": "Missions · Hypervisor",
+      "entry_edge": null,
+      "controls": 13,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "450276264e6e1a70a5e3707c20176457e973ad7dbe47c087531510fb65f3717a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "1a0c7b09f18c672135971bae8c46480cfcd429e05e9dd4e7e50f33d73daf76de",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "f0e18a93a983ca3e3fb56ae3cf4c3e6b228b613fffa808adc06ba37db3030a98",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n1",
+      "kind": "route",
+      "signature": "/__ioi/missions/incidents#open=0|H1:Issues",
+      "url": "/__ioi/missions/incidents",
+      "title": "Issues — incidents inbox",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 9,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/missions/incidents",
+          "disabled": false,
+          "label": "Open incident inbox"
+        }
+      },
+      "controls": 9,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "a18d982a8290d7144cd0f69ba8347d187d0c39beb2bdb80f2adfaf3bc46083f2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "a18d982a8290d7144cd0f69ba8347d187d0c39beb2bdb80f2adfaf3bc46083f2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "f85cc9e419494b10e27ebeae67c7ee5bec85bf46308167c3fb9dc27c60b946b9",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n2",
+      "kind": "route",
+      "signature": "/__ioi/missions/incidents?lane=open#open=0|H1:Issues",
+      "url": "/__ioi/missions/incidents?lane=open",
+      "title": "Issues — incidents inbox",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 5,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/missions/incidents?lane=open",
+          "disabled": false,
+          "label": "Open0"
+        }
+      },
+      "controls": 9,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "a18d982a8290d7144cd0f69ba8347d187d0c39beb2bdb80f2adfaf3bc46083f2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "a18d982a8290d7144cd0f69ba8347d187d0c39beb2bdb80f2adfaf3bc46083f2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "f85cc9e419494b10e27ebeae67c7ee5bec85bf46308167c3fb9dc27c60b946b9",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n3",
+      "kind": "route",
+      "signature": "/__ioi/missions/incidents?lane=closed#open=0|H1:Issues",
+      "url": "/__ioi/missions/incidents?lane=closed",
+      "title": "Issues — incidents inbox",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 6,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/missions/incidents?lane=closed",
+          "disabled": false,
+          "label": "Closed0"
+        }
+      },
+      "controls": 9,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "d2709ac3c76ad08ae2bd34386cdd55546b7225ba13b7278bdf2be20f1fe41be2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "d2709ac3c76ad08ae2bd34386cdd55546b7225ba13b7278bdf2be20f1fe41be2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "c94a04968ba10192d661899638fb72d3a9e655963a25ee89acf8af11134d9a6e",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n4",
+      "kind": "route",
+      "signature": "/__ioi/missions/incidents?lane=all#open=0|H1:Issues",
+      "url": "/__ioi/missions/incidents?lane=all",
+      "title": "Issues — incidents inbox",
+      "entry_edge": {
+        "from": "n1",
+        "control": {
+          "index": 7,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/missions/incidents?lane=all",
+          "disabled": false,
+          "label": "All0"
+        }
+      },
+      "controls": 9,
+      "disabled_controls": 1,
+      "screenshot": {
+        "sha256": "3db5c9cdf7505a5c2a02d0c4c8117f5daffa563075d0b74c0d81911eb4d1316b",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "3db5c9cdf7505a5c2a02d0c4c8117f5daffa563075d0b74c0d81911eb4d1316b",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "00d6629fe0d4b3ab858fae785a42d30c9c864a0d2bc4ea81a0f0e07a8fff309b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Missions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/operations",
+        "disabled": false,
+        "label": "Operations substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/work-ledger",
+        "disabled": false,
+        "label": "Proof stream"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Refresh mission data"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": "tab",
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "all 0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "n1",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents",
+        "disabled": false,
+        "label": "Open incident inbox"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/operations",
+        "disabled": false,
+        "label": "Operations"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/jobs",
+        "disabled": false,
+        "label": "Builds"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/incidents",
+        "disabled": false,
+        "label": "Issues"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents",
+        "disabled": false,
+        "label": "Issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "n2",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=open",
+        "disabled": false,
+        "label": "Open0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n3",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=closed",
+        "disabled": false,
+        "label": "Closed0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "n4",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=all",
+        "disabled": false,
+        "label": "All0"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Missions overview →"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents",
+        "disabled": false,
+        "label": "Issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=open",
+        "disabled": false,
+        "label": "Open0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=closed",
+        "disabled": false,
+        "label": "Closed0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=all",
+        "disabled": false,
+        "label": "All0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Missions overview →"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents",
+        "disabled": false,
+        "label": "Issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=open",
+        "disabled": false,
+        "label": "Open0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=closed",
+        "disabled": false,
+        "label": "Closed0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=all",
+        "disabled": false,
+        "label": "All0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Missions overview →"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents",
+        "disabled": false,
+        "label": "Issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "New"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=open",
+        "disabled": false,
+        "label": "Open0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=closed",
+        "disabled": false,
+        "label": "Closed0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions/incidents?lane=all",
+        "disabled": false,
+        "label": "All0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/missions",
+        "disabled": false,
+        "label": "Missions overview →"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    }
+  ],
+  "blockers": [],
+  "replay": {
+    "walked_all_edges": true,
+    "walked_at": "2026-08-09T16:28:47.777Z",
+    "problems": []
+  },
+  "complete_interaction_route_graph": true,
+  "shots_dir": ".artifacts/seed-graph-shots/work/jobs",
+  "content_address": "1a515bdf54b1748d7b7e164f520fa7714364272ad893f9ff9cf5aade8a44e967"
+}

--- a/apps/hypervisor/seed-ux-provenance.v1.json
+++ b/apps/hypervisor/seed-ux-provenance.v1.json
@@ -28,7 +28,13 @@
       "baseline_status": "blocked-no-valid-seed",
       "graph_mapping_status": "blocked-no-provenance-source",
       "seed_graph_ready_for_rehome": false,
-      "greenfield_authorization": null,
+      "greenfield_authorization": {
+        "type": "greenfield-authorized-non-parity",
+        "authorized_by": "owner — 2026-08-09 program-repair commissioning (owner-reversible)",
+        "authorized_on": "2026-08-09",
+        "scope": "canon-first UX iteration at the canonical route, per docs/architecture/components/hypervisor/core-clients-surfaces.md",
+        "limits": "greenfield work can never claim seed preservation or parity; the blocked-no-valid-seed baseline stands as the historical record; two recovery passes (history + Palantir corpus) promoted zero candidates and a later-recovered genuine seed re-opens the parity lane and supersedes this authorization"
+      },
       "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
       "sources": []
     },
@@ -39,7 +45,13 @@
       "baseline_status": "blocked-no-valid-seed",
       "graph_mapping_status": "blocked-no-provenance-source",
       "seed_graph_ready_for_rehome": false,
-      "greenfield_authorization": null,
+      "greenfield_authorization": {
+        "type": "greenfield-authorized-non-parity",
+        "authorized_by": "owner — 2026-08-09 program-repair commissioning (owner-reversible)",
+        "authorized_on": "2026-08-09",
+        "scope": "canon-first UX iteration at the canonical route, per docs/architecture/components/hypervisor/core-clients-surfaces.md",
+        "limits": "greenfield work can never claim seed preservation or parity; the blocked-no-valid-seed baseline stands as the historical record; two recovery passes (history + Palantir corpus) promoted zero candidates and a later-recovered genuine seed re-opens the parity lane and supersedes this authorization"
+      },
       "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
       "sources": []
     },
@@ -50,7 +62,13 @@
       "baseline_status": "blocked-no-valid-seed",
       "graph_mapping_status": "blocked-no-provenance-source",
       "seed_graph_ready_for_rehome": false,
-      "greenfield_authorization": null,
+      "greenfield_authorization": {
+        "type": "greenfield-authorized-non-parity",
+        "authorized_by": "owner — 2026-08-09 program-repair commissioning (owner-reversible)",
+        "authorized_on": "2026-08-09",
+        "scope": "canon-first UX iteration at the canonical route, per docs/architecture/components/hypervisor/core-clients-surfaces.md",
+        "limits": "greenfield work can never claim seed preservation or parity; the blocked-no-valid-seed baseline stands as the historical record; two recovery passes (history + Palantir corpus) promoted zero candidates and a later-recovered genuine seed re-opens the parity lane and supersedes this authorization"
+      },
       "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
       "sources": []
     },
@@ -61,7 +79,13 @@
       "baseline_status": "blocked-no-valid-seed",
       "graph_mapping_status": "blocked-no-provenance-source",
       "seed_graph_ready_for_rehome": false,
-      "greenfield_authorization": null,
+      "greenfield_authorization": {
+        "type": "greenfield-authorized-non-parity",
+        "authorized_by": "owner — 2026-08-09 program-repair commissioning (owner-reversible)",
+        "authorized_on": "2026-08-09",
+        "scope": "canon-first UX iteration at the canonical route, per docs/architecture/components/hypervisor/core-clients-surfaces.md",
+        "limits": "greenfield work can never claim seed preservation or parity; the blocked-no-valid-seed baseline stands as the historical record; two recovery passes (history + Palantir corpus) promoted zero candidates and a later-recovered genuine seed re-opens the parity lane and supersedes this authorization"
+      },
       "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
       "sources": []
     },
@@ -83,10 +107,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/work/jobs.v1.json",
           "class": "substrate_bound",
           "owner_mapping_note": "retired owner name: surface-registry.mjs still labels /__ioi/missions with the retired owner 'Missions'; canonical owner is Work per the estate ledger and core-clients-surfaces.md. The registry rename lands with the Work surface packet, not here."
         },
@@ -98,10 +122,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "blocked-missing-capture-corrupted-protected-variant-excluded",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/work/incidents.v1.json",
           "class": "daemon_wired",
           "owner_mapping_note": "retired owner name: surface-registry.mjs still labels /__ioi/missions/incidents with the retired owner 'Missions'; canonical owner is Work per the estate ledger and core-clients-surfaces.md. The registry rename lands with the Work surface packet, not here."
         },
@@ -113,10 +137,10 @@
           "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
           "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/work/jobs.retained.v1.json",
           "disposition": "rebind",
           "audit_route_disposition": "retained-seed"
         },
@@ -145,7 +169,13 @@
       "baseline_status": "blocked-no-valid-seed",
       "graph_mapping_status": "blocked-no-provenance-source",
       "seed_graph_ready_for_rehome": false,
-      "greenfield_authorization": null,
+      "greenfield_authorization": {
+        "type": "greenfield-authorized-non-parity",
+        "authorized_by": "owner — 2026-08-09 program-repair commissioning (owner-reversible)",
+        "authorized_on": "2026-08-09",
+        "scope": "canon-first UX iteration at the canonical route, per docs/architecture/components/hypervisor/core-clients-surfaces.md",
+        "limits": "greenfield work can never claim seed preservation or parity; the blocked-no-valid-seed baseline stands as the historical record; two recovery passes (history + Palantir corpus) promoted zero candidates and a later-recovered genuine seed re-opens the parity lane and supersedes this authorization"
+      },
       "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
       "sources": []
     },
@@ -167,10 +197,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/studio/designer.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -186,7 +216,8 @@
           },
           "graph_file": null,
           "disposition": "rebind",
-          "audit_route_disposition": "retained-seed"
+          "audit_route_disposition": "retained-seed",
+          "graph_capture_note": "graph capture failed: the solution-designer canvas hangs the quarantined crawl past the 500s budget (repeated timeouts at 25- and 80-node caps); graph unrecovered, source stays blocked."
         },
         {
           "kind": "retained-harvest-capture",
@@ -304,10 +335,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/automations/machinery.v1.json",
           "class": "daemon_wired",
           "owner_mapping_note": "OQ-2 open dual-owner record: surface-registry.mjs declares Studio; the 2026-08-09 audit's canonical reading is Automations; neither side is picked to unblock work. manifest.v1.json open_questions OQ-2 and docs/architecture/_meta/canon-to-code-delta.md carry the record."
         },
@@ -319,10 +350,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/automations/monitors.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -338,7 +369,8 @@
           },
           "graph_file": null,
           "disposition": "pattern-harvest",
-          "audit_route_disposition": "retained-seed"
+          "audit_route_disposition": "retained-seed",
+          "graph_capture_note": "graph capture quarantine-inadmissible (AUD-WS-005 true positive): the retained capture app issued 15 POST /graphql-gateway/api/graphql corpus-mutation attempts plus release-notes and log-beacon writes; all were aborted and recorded. The violation-bearing graph stays on disk as typed evidence (seed-graphs/automations/monitors.retained.v1.json) and is never a graph_file."
         },
         {
           "kind": "retained-harvest-capture",
@@ -348,10 +380,10 @@
           "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
           "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/automations/machinery.retained.v1.json",
           "disposition": "pattern-harvest",
           "audit_route_disposition": "retained-seed",
           "owner_mapping_note": "audit correction: current canonical process-graph owner is Automations; estate sweep carries the older Studio mesh assignment"
@@ -376,10 +408,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/ontology/schema.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -390,10 +422,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/ontology/explorer.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -404,10 +436,10 @@
           "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
           "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/ontology/schema.retained.v1.json",
           "disposition": "pattern-harvest",
           "audit_route_disposition": "retained-seed"
         },
@@ -482,7 +514,7 @@
             "evidence_level": "explored_control_graph",
             "complete_interaction_route_graph": false
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/data/sources.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -496,7 +528,7 @@
             "evidence_level": "explored_control_graph",
             "complete_interaction_route_graph": false
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/data/pipeline.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -542,7 +574,7 @@
             "evidence_level": "explored_control_graph",
             "complete_interaction_route_graph": false
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/data/pipeline.retained.v1.json",
           "disposition": "pattern-harvest",
           "audit_route_disposition": "retained-seed"
         },
@@ -585,8 +617,8 @@
       "owner": "Governance",
       "canonical_route": "/governance",
       "baseline_status": "provenance-qualified-executable-seed-present",
-      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
-      "seed_graph_ready_for_rehome": false,
+      "graph_mapping_status": "complete-interaction-route-graphs-present",
+      "seed_graph_ready_for_rehome": true,
       "greenfield_authorization": null,
       "graph_recovery_status": "required-for-every-summary-only-source",
       "sources": [
@@ -598,10 +630,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/governance/approvals.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -612,10 +644,10 @@
           "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
           "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/governance/approvals.retained.v1.json",
           "disposition": "rehome",
           "audit_route_disposition": "rehomed"
         }
@@ -639,10 +671,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "summary_only",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/provenance/lineage.v1.json",
           "class": "substrate_bound"
         },
         {
@@ -653,10 +685,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "summary_only",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/provenance/vertex.v1.json",
           "class": "substrate_bound"
         },
         {
@@ -667,10 +699,10 @@
           "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
           "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
           "graph": {
-            "evidence_level": "summary_only",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/provenance/lineage.retained.v1.json",
           "disposition": "rebind",
           "audit_route_disposition": "retained-seed"
         },
@@ -687,7 +719,8 @@
           },
           "graph_file": null,
           "disposition": "pattern-harvest",
-          "audit_route_disposition": "retained-seed"
+          "audit_route_disposition": "retained-seed",
+          "graph_capture_note": "graph capture failed: the vertex monocle canvas hangs the quarantined crawl past the capture budget; graph unrecovered, source stays blocked."
         },
         {
           "kind": "explicit-dormant-reference",
@@ -723,10 +756,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/evaluations/evalsuites.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -784,8 +817,8 @@
       "owner": "Improvement",
       "canonical_route": "/improvement",
       "baseline_status": "provenance-qualified-executable-seed-present",
-      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
-      "seed_graph_ready_for_rehome": false,
+      "graph_mapping_status": "complete-interaction-route-graphs-present",
+      "seed_graph_ready_for_rehome": true,
       "greenfield_authorization": null,
       "graph_recovery_status": "required-for-every-summary-only-source",
       "sources": [
@@ -797,10 +830,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/improvement/changes.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -811,10 +844,10 @@
           "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
           "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/improvement/changes.retained.v1.json",
           "disposition": "rebind",
           "audit_route_disposition": "retained-seed"
         }
@@ -838,10 +871,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/foundry/models.v1.json",
           "class": "daemon_wired"
         },
         {
@@ -896,10 +929,10 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/packages/listings.v1.json",
           "class": "daemon_wired",
           "owner_mapping_note": "retired owner name: surface-registry.mjs still labels /__ioi/marketplace/listings with the folded owner 'Marketplace'; canonical owner is Packages (marketplace is a Packages mode). The registry rename lands with the Packages surface packet, not here."
         },
@@ -911,10 +944,10 @@
           "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
           "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/packages/listings.retained.v1.json",
           "disposition": "rebind",
           "audit_route_disposition": "retained-seed"
         },
@@ -986,10 +1019,10 @@
           "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
           "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
           "graph": {
-            "evidence_level": "summary_only",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
-          "graph_file": null,
+          "graph_file": "seed-graphs/developer-workspace/notepad.v1.json",
           "disposition": "retire-at-cutover",
           "audit_route_disposition": "retained-seed"
         },

--- a/apps/hypervisor/seed-ux-provenance.v1.json
+++ b/apps/hypervisor/seed-ux-provenance.v1.json
@@ -1,0 +1,1143 @@
+{
+  "schema_version": "ioi.hypervisor.seed-ux-provenance.v1",
+  "doctrine": "Fail-closed seed provenance for the twenty Hypervisor surfaces. A UX baseline is admitted only from an exact tracked provenance record; a canonical W0.1 shell, a generic /__ioi readout, visual resemblance, a control census, or a registration is never a seed. No surface rehome begins until every selected source carries a content-addressed complete interaction/route graph (complete_interaction_route_graph=true, replay-walked), or the surface carries a typed greenfield-authorized-non-parity record. A blocked record documents a gap only and never opens iteration.",
+  "derived_from": {
+    "audit_pack": "internal-docs/audits/2026-08-09-hypervisor-live-ux-workstream-coverage/ (gitignored research evidence)",
+    "audit_commit": "b309cf5e8031bd5faff52b85ea6bd0ad9d8df260",
+    "audit_manifest_schema": "ioi.hypervisor.seed-ux-provenance-manifest.v1",
+    "derived_at": "2026-08-09"
+  },
+  "tracked_provenance_sources": [
+    "apps/hypervisor/ported-seed-preservation.v1.json",
+    "apps/hypervisor/ux-seeds/manifest.json",
+    "apps/hypervisor/harvest-starting-points.json",
+    "apps/hypervisor/harvest-app-parity-matrix.json",
+    "apps/hypervisor/application-operational-depth.json",
+    "apps/hypervisor/scripts/harvest-seed-inventory.mjs"
+  ],
+  "untracked_references": [
+    "internal-docs/implementation/program/estate-disposition.md (gitignored working ledger)"
+  ],
+  "graph_directory": "apps/hypervisor/seed-graphs/",
+  "canonical_surface_count": 20,
+  "surfaces": [
+    {
+      "id": "home",
+      "owner": "Home",
+      "canonical_route": "/home",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "systems",
+      "owner": "Systems",
+      "canonical_route": "/systems",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "projects",
+      "owner": "Projects",
+      "canonical_route": "/projects",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "applications",
+      "owner": "Applications",
+      "canonical_route": "/applications",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "work",
+      "owner": "Work",
+      "canonical_route": "/work",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "jobs",
+          "starting_route": "/__ioi/missions",
+          "canonical_owner": "Work",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "substrate_bound",
+          "owner_mapping_note": "retired owner name: surface-registry.mjs still labels /__ioi/missions with the retired owner 'Missions'; canonical owner is Work per the estate ledger and core-clients-surfaces.md. The registry rename lands with the Work surface packet, not here."
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "incidents",
+          "starting_route": "/__ioi/missions/incidents",
+          "canonical_owner": "Work",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "blocked-missing-capture-corrupted-protected-variant-excluded",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired",
+          "owner_mapping_note": "retired owner name: surface-registry.mjs still labels /__ioi/missions/incidents with the retired owner 'Missions'; canonical owner is Work per the estate ledger and core-clients-surfaces.md. The registry rename lands with the Work surface packet, not here."
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "jobs",
+          "starting_route": "/__apps/jobs",
+          "canonical_owner": "Work",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "incidents",
+          "starting_route": "/__apps/incidents",
+          "canonical_owner": "Work",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is not trustworthy: one file was overwritten with a contact sheet and no immutable genuine render is established"
+        }
+      ]
+    },
+    {
+      "id": "settings",
+      "owner": "Settings",
+      "canonical_route": "/settings",
+      "baseline_status": "blocked-no-valid-seed",
+      "graph_mapping_status": "blocked-no-provenance-source",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "searched-zero-sources-promoted-blocked-no-valid-seed",
+      "sources": []
+    },
+    {
+      "id": "studio",
+      "owner": "Studio",
+      "canonical_route": "/studio",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "designer",
+          "starting_route": "/__ioi/studio/designer",
+          "canonical_owner": "Studio",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "designer",
+          "starting_route": "/__apps/designer",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "workshop",
+          "starting_route": "/__apps/workshop",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay initiates a browser download/redirect"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "module",
+          "starting_route": "/__apps/module",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is Page not found"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "slate",
+          "starting_route": "/__apps/slate",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is blank/global-chrome-only rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "logic",
+          "starting_route": "/__apps/logic",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is global chrome plus Failed to initialize"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "contour",
+          "starting_route": "/__apps/contour",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is global chrome plus Failed to load analysis"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "fusion",
+          "starting_route": "/__apps/fusion",
+          "canonical_owner": "Studio",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-route",
+          "audit_route_disposition": "blocked-missing-runtime",
+          "visual_blocker": "stable replay is a Not Found page"
+        }
+      ]
+    },
+    {
+      "id": "automations",
+      "owner": "Automations",
+      "canonical_route": "/automations",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "machinery",
+          "starting_route": "/__ioi/studio/machinery",
+          "canonical_owner": "Automations",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired",
+          "owner_mapping_note": "OQ-2 open dual-owner record: surface-registry.mjs declares Studio; the 2026-08-09 audit's canonical reading is Automations; neither side is picked to unblock work. manifest.v1.json open_questions OQ-2 and docs/architecture/_meta/canon-to-code-delta.md carry the record."
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "monitors",
+          "starting_route": "/__ioi/automations/monitors",
+          "canonical_owner": "Automations",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "monitors",
+          "starting_route": "/__apps/monitors",
+          "canonical_owner": "Automations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "machinery",
+          "starting_route": "/__apps/machinery",
+          "canonical_owner": "Automations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "owner_mapping_note": "audit correction: current canonical process-graph owner is Automations; estate sweep carries the older Studio mesh assignment"
+        }
+      ]
+    },
+    {
+      "id": "ontology",
+      "owner": "Ontology",
+      "canonical_route": "/ontology",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "schema",
+          "starting_route": "/__ioi/ontology/manager",
+          "canonical_owner": "Ontology",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "explorer",
+          "starting_route": "/__ioi/ontology/explorer",
+          "canonical_owner": "Ontology",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "schema",
+          "starting_route": "/__apps/schema",
+          "canonical_owner": "Ontology",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "explorer",
+          "starting_route": "/__apps/explorer",
+          "canonical_owner": "Ontology",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "objectview",
+          "starting_route": "/__apps/objectview",
+          "canonical_owner": "Ontology",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-capture",
+          "audit_route_disposition": "blocked-missing-capture",
+          "visual_blocker": "stable replay initiates a browser download/redirect"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "objecteditor",
+          "starting_route": "/__apps/objecteditor",
+          "canonical_owner": "Ontology",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-capture",
+          "audit_route_disposition": "blocked-missing-capture",
+          "visual_blocker": "stable replay initiates a browser download/redirect"
+        }
+      ]
+    },
+    {
+      "id": "data",
+      "owner": "Data",
+      "canonical_route": "/data",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "sources",
+          "starting_route": "/__ioi/data/sources",
+          "canonical_owner": "Data",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "pipeline",
+          "starting_route": "/__ioi/pipeline",
+          "canonical_owner": "Data",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "ingest",
+          "starting_route": "/__apps/ingest",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is blank global chrome"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "sources",
+          "starting_route": "/__apps/sources",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is blank global chrome"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "pipeline",
+          "starting_route": "/__apps/pipeline",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "dataset",
+          "starting_route": "/__apps/dataset",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-route",
+          "audit_route_disposition": "blocked-missing-runtime",
+          "visual_blocker": "stable replay is an invalid-resource Not a dataset page"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "inference",
+          "starting_route": "/__apps/inference",
+          "canonical_owner": "Data",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rehome",
+          "audit_route_disposition": "rehomed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        }
+      ]
+    },
+    {
+      "id": "governance",
+      "owner": "Governance",
+      "canonical_route": "/governance",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "approvals",
+          "starting_route": "/__ioi/governance/approvals",
+          "canonical_owner": "Governance",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "approvals",
+          "starting_route": "/__apps/approvals",
+          "canonical_owner": "Governance",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rehome",
+          "audit_route_disposition": "rehomed"
+        }
+      ]
+    },
+    {
+      "id": "provenance",
+      "owner": "Provenance",
+      "canonical_route": "/provenance",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "lineage",
+          "starting_route": "/__ioi/lineage",
+          "canonical_owner": "Provenance",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "substrate_bound"
+        },
+        {
+          "kind": "protected-executable-seed",
+          "slug": "vertex",
+          "starting_route": "/__ioi/vertex",
+          "canonical_owner": "Provenance",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "substrate_bound"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "lineage",
+          "starting_route": "/__apps/lineage",
+          "canonical_owner": "Provenance",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "vertex",
+          "starting_route": "/__apps/vertex",
+          "canonical_owner": "Provenance",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "explicit-dormant-reference",
+          "slug": "lineage",
+          "starting_route": null,
+          "canonical_owner": "Provenance",
+          "provenance_source": "apps/hypervisor/ux-seeds/manifest.json",
+          "visual_evidence_status": null,
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "substrate_bound"
+        }
+      ]
+    },
+    {
+      "id": "evaluations",
+      "owner": "Evaluations",
+      "canonical_route": "/evaluations",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "evalsuites",
+          "starting_route": "/__ioi/evaluations/evalsuites",
+          "canonical_owner": "Evaluations",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "evalsuites",
+          "starting_route": "/__apps/evalsuites",
+          "canonical_owner": "Evaluations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "analysis",
+          "starting_route": "/__apps/analysis",
+          "canonical_owner": "Evaluations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is blank global chrome"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "quiver",
+          "starting_route": "/__apps/quiver",
+          "canonical_owner": "Evaluations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "blocked-missing-route",
+          "audit_route_disposition": "blocked-missing-runtime",
+          "visual_blocker": "stable replay is blank global chrome"
+        }
+      ]
+    },
+    {
+      "id": "improvement",
+      "owner": "Improvement",
+      "canonical_route": "/improvement",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "changes",
+          "starting_route": "/__ioi/improvement/changes",
+          "canonical_owner": "Improvement",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "changes",
+          "starting_route": "/__apps/changes",
+          "canonical_owner": "Improvement",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        }
+      ]
+    },
+    {
+      "id": "foundry",
+      "owner": "Foundry",
+      "canonical_route": "/foundry",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "models",
+          "starting_route": "/__ioi/foundry/models",
+          "canonical_owner": "Foundry",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "models",
+          "starting_route": "/__apps/models",
+          "canonical_owner": "Foundry",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "modelstudio",
+          "starting_route": "/__apps/modelstudio",
+          "canonical_owner": "Foundry",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is global chrome plus Page not found"
+        }
+      ]
+    },
+    {
+      "id": "packages",
+      "owner": "Packages",
+      "canonical_route": "/packages",
+      "baseline_status": "provenance-qualified-executable-seed-present",
+      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "protected-executable-seed",
+          "slug": "listings",
+          "starting_route": "/__ioi/marketplace/listings",
+          "canonical_owner": "Packages",
+          "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
+          "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "daemon_wired",
+          "owner_mapping_note": "retired owner name: surface-registry.mjs still labels /__ioi/marketplace/listings with the folded owner 'Marketplace'; canonical owner is Packages (marketplace is a Packages mode). The registry rename lands with the Packages surface packet, not here."
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "listings",
+          "starting_route": "/__apps/listings",
+          "canonical_owner": "Packages",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "explored_control_graph",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "rebind",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "registry",
+          "starting_route": "/__apps/registry",
+          "canonical_owner": "Packages",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        }
+      ]
+    },
+    {
+      "id": "developer-workspace",
+      "owner": "Developer Workspace",
+      "canonical_route": "/developer-workspace",
+      "baseline_status": "provenance-qualified-substantive-retained-ux-present-full-graph-required",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "workspaces",
+          "starting_route": "/__apps/workspaces",
+          "canonical_owner": "Developer Workspace",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic error-only shell rather than substantive application UX"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "repositories",
+          "starting_route": "/__apps/repositories",
+          "canonical_owner": "Developer Workspace",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay initiates a browser download/redirect"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "notepad",
+          "starting_route": "/__apps/notepad",
+          "canonical_owner": "Developer Workspace",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "selected-provenance-qualified-stable-matrix-present",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "retire-at-cutover",
+          "audit_route_disposition": "retained-seed"
+        },
+        {
+          "kind": "explicit-dormant-reference",
+          "slug": "workspaces",
+          "starting_route": null,
+          "canonical_owner": "Developer Workspace",
+          "provenance_source": "apps/hypervisor/ux-seeds/manifest.json",
+          "visual_evidence_status": null,
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "reference_capture"
+        }
+      ]
+    },
+    {
+      "id": "developer-console",
+      "owner": "Developer Console",
+      "canonical_route": "/developer-console",
+      "baseline_status": "provenance-recorded-retained-source-present-but-visual-and-graph-blocked",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "devconsole",
+          "starting_route": "/__apps/devconsole",
+          "canonical_owner": "Developer Console",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is pure white/blank"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "widgets",
+          "starting_route": "/__apps/widgets",
+          "canonical_owner": "Developer Console",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is pure white/blank"
+        },
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "developer",
+          "starting_route": "/__apps/developer",
+          "canonical_owner": "Developer Console",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "retire-at-cutover",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is pure white/blank"
+        },
+        {
+          "kind": "explicit-dormant-reference",
+          "slug": "widgets",
+          "starting_route": null,
+          "canonical_owner": "Developer Console",
+          "provenance_source": "apps/hypervisor/ux-seeds/manifest.json",
+          "visual_evidence_status": null,
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "class": "reference_capture"
+        }
+      ]
+    },
+    {
+      "id": "environments",
+      "owner": "Environments",
+      "canonical_route": "/environments",
+      "baseline_status": "provenance-recorded-retained-source-present-but-visual-and-graph-blocked",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "map",
+          "starting_route": "/__apps/map",
+          "canonical_owner": "Environments",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "retire-at-cutover",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable matrix is generic failure/error-only rather than substantive application UX"
+        }
+      ]
+    },
+    {
+      "id": "operations",
+      "owner": "Operations",
+      "canonical_route": "/operations",
+      "baseline_status": "provenance-recorded-retained-source-present-but-visual-and-graph-blocked",
+      "graph_mapping_status": "blocked-summary-only-no-complete-interaction-route-graph",
+      "seed_graph_ready_for_rehome": false,
+      "greenfield_authorization": null,
+      "graph_recovery_status": "required-for-every-summary-only-source",
+      "sources": [
+        {
+          "kind": "retained-harvest-capture",
+          "slug": "scheduler",
+          "starting_route": "/__apps/scheduler",
+          "canonical_owner": "Operations",
+          "provenance_source": "internal-docs/implementation/program/estate-disposition.md",
+          "visual_evidence_status": "blocked-text-log-only-no-admissible-render",
+          "graph": {
+            "evidence_level": "summary_only",
+            "complete_interaction_route_graph": false
+          },
+          "graph_file": null,
+          "disposition": "pattern-harvest",
+          "audit_route_disposition": "retained-seed",
+          "visual_blocker": "stable replay is global chrome plus Page not found"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Phase 4 of the 2026-08-09 audit program-repair run (owner-commissioned). Stacked on #225 — retarget to master after it merges.

## What lands
- **26 graph files** under `apps/hypervisor/seed-graphs/` from the first AUD-WS-003 harvest against the live daemon (:8791) / serve (:4173) / capture (:9225) runtimes, captured under launch-enforced AUD-WS-005 quarantine (outbound aborted; corpus writes aborted; serve writes typed as `blocked-write-attempt` edges).
- **25 sources** in `seed-ux-provenance.v1.json` now reference a verified `graph_file` (content-address + quarantine attestation + replay checked by `check:seed-provenance`); **22 replay-complete** within their quarantined read-only allowlist subtree.
- **Gates re-derived, fail-closed:** `governance` and `improvement` reach `seed_graph_ready_for_rehome=true` — the audit baseline was **0/20**. Everything else stays blocked with its exact typed gap.
- **Typed non-completions (never silent):** `data/pipeline` (9+1 blockers: unreachable/download edges), `data/sources` (2 blockers), `automations/monitors` retained — **quarantine true positive**: 15 `POST /graphql-gateway/api/graphql` corpus-mutation attempts + telemetry beacons aborted and recorded; its violation-bearing graph stays on disk as evidence and is never a `graph_file`. `studio/designer` + `provenance/vertex` retained: canvas apps hang the quarantined crawl — `graph_capture_note` records it.
- **Greenfield records:** the five no-seed surfaces carry the owner's typed `greenfield-authorized-non-parity` authorization (2026-08-09 commissioning, owner-reversible, can never claim seed preservation or parity; a recovered genuine seed supersedes it).

## Verification
`npm run check:seed-provenance --workspace=@ioi/hypervisor-app` → green: 20 surfaces, 58 sources, 25 referenced graphs verified (content address recomputed, quarantine attested, replay flags honored), greenfield records typed, secret-leak gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)