### PR TITLE
feat(hypervisor): first surface journeys CI-proven — ontology 31/31, governance 20/20 (next-legs Legs 2+3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,11 @@ jobs:
           npm run check:seed-provenance --workspace=@ioi/hypervisor-app
           npm run check:source-neutral --workspace=@ioi/hypervisor-app
 
+      - name: Verify the first surface journeys against an isolated live daemon
+        run: |
+          npm run check:ontology-journey --workspace=@ioi/hypervisor-app
+          npm run check:governance-journey --workspace=@ioi/hypervisor-app
+
       - name: Record post-build shipped-product artifact identities
         run: |
           mkdir -p .artifacts/implementation/shipped-products

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -13,6 +13,8 @@
     "serve:reference": "node scripts/serve-product-ui.mjs",
     "check:ported-seed": "node scripts/verify-hypervisor-ported-seed-invariant.mjs",
     "check:seed-provenance": "node scripts/verify-hypervisor-seed-provenance.mjs",
+    "check:ontology-journey": "node scripts/verify-hypervisor-ontology-journey.mjs",
+    "check:governance-journey": "node scripts/verify-hypervisor-governance-journey.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",
     "check:shell-parity": "node scripts/verify-hypervisor-shell-parity.mjs",

--- a/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
+++ b/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
@@ -207,10 +207,25 @@ async function censusOf(page) {
 
 async function stateSignature(page) {
   return page.evaluate(() => {
+    const visible = (el) => {
+      const r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0 && getComputedStyle(el).visibility !== "hidden";
+    };
     const texts = [...document.querySelectorAll("h1,h2,h3,[role=dialog],[role=menu],[role=tabpanel]")]
       .map((el) => `${el.tagName}:${(el.getAttribute("aria-label") || el.textContent || "").trim().slice(0, 60)}`);
-    const open = document.querySelectorAll("[role=dialog]:not([hidden]), [aria-expanded=true], dialog[open]").length;
-    return `${location.pathname}${location.search}#open=${open}|${texts.join("|")}`.slice(0, 800);
+    const open = document.querySelectorAll("[role=dialog]:not([hidden]), [aria-expanded=true], dialog[open], details[open]").length;
+    // Filter drawers and inline editors expose form controls without adding any
+    // heading or dialog — count visible inputs so those states are distinct.
+    const formControls = [...document.querySelectorAll("input, select, textarea")].filter(visible).length;
+    // Hidden form fields are path-dependent state (a form entered via clicks can
+    // carry different targets than the same URL entered directly); hash them so
+    // those are distinct nodes rather than one node with contradictory edges.
+    const hidden = [...document.querySelectorAll("input[type=hidden]")]
+      .map((el) => `${el.name}=${String(el.value).slice(0, 40)}`).sort().join("&") +
+      "|" + [...document.forms].map((f) => f.getAttribute("action") || "").sort().join("&");
+    let hh = 0;
+    for (let i = 0; i < hidden.length; i++) hh = ((hh << 5) - hh + hidden.charCodeAt(i)) | 0;
+    return `${location.pathname}${location.search}#open=${open}#fc=${formControls}#hf=${hh}|${texts.join("|")}`.slice(0, 800);
   });
 }
 
@@ -322,7 +337,14 @@ async function capture() {
       const writesBefore = blockedWrites.length;
       pendingDownload = null;
       const locator = page.locator(CONTROL_SELECTOR).nth(control.index);
-      const clicked = await locator.click({ timeout: 4000, trial: false }).then(() => true).catch(() => false);
+      let clicked = await locator.click({ timeout: 4000, trial: false }).then(() => true).catch(() => false);
+      if (!clicked) {
+        // A leaked overlay from an earlier edge can transiently obscure the
+        // control; one Escape-and-retry separates true unclickability from that.
+        await page.keyboard.press("Escape").catch(() => {});
+        await page.waitForTimeout(400);
+        clicked = await locator.click({ timeout: 4000, trial: false }).then(() => true).catch(() => false);
+      }
       await page.waitForTimeout(900);
       if (!clicked) {
         edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "unclickable" });
@@ -519,9 +541,15 @@ async function replay() {
       }
       // click edge
       const before = await stateSignature(page);
+      const urlBefore = page.url();
       const writesBefore = blockedWrites.length;
       pendingDownload = null;
-      const clicked = await clickControl(edge.control);
+      let clicked = await clickControl(edge.control);
+      if (!clicked) {
+        await page.keyboard.press("Escape").catch(() => {});
+        await page.waitForTimeout(400);
+        clicked = await clickControl(edge.control);
+      }
       await page.waitForTimeout(900);
       if (!clicked) {
         problems.push(`edge ${node.id}/"${edge.control?.label ?? "?"}": control no longer clickable (recorded ${edge.outcome})`);
@@ -529,6 +557,7 @@ async function replay() {
         continue;
       }
       const after = await stateSignature(page);
+      const urlChangedExact = page.url() !== urlBefore;
       const observed = pendingDownload ? "download"
         : blockedWrites.length > writesBefore ? "blocked-write-attempt"
         : !page.url().includes(node.url) && after !== before ? "navigated"
@@ -536,7 +565,10 @@ async function replay() {
         : "noop";
       const compatible = observed === edge.outcome ||
         (edge.outcome === "navigated" && observed === "state-change") ||
-        (edge.outcome === "state-change" && observed === "navigated");
+        (edge.outcome === "state-change" && observed === "navigated") ||
+        // A same-path self-navigation (e.g. a GET filter submit appending its
+        // query) IS the recorded navigation even when the signature is stable.
+        (edge.outcome === "navigated" && urlChangedExact);
       if (!compatible) {
         problems.push(`edge ${node.id}/"${edge.control?.label ?? "?"}": recorded ${edge.outcome}, observed ${observed}`);
       } else if (edge.outcome === "navigated" && edge.to && nodeById.has(edge.to)) {

--- a/apps/hypervisor/scripts/verify-hypervisor-governance-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-governance-journey.mjs
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+// SURF-governance primary journey verifier (next-legs Leg 3b).
+//
+// Proves, against an ISOLATED real daemon + serve lane, the decision journey the
+// 2026-08-09 audit found unproven: submit exact request → deny/approve with a
+// daemon-resolved reviewer (P-IDENT-1A: the UI sends NO fields on transitions) →
+// decision receipt → readback → stale/withdrawn/terminal refusals typed → restart
+// survival → no generic approval ever authorizes a substituted effect. Plus the
+// #223 unified cross-plane inbox band and the G-8 posture matrix.
+//
+// Exit: 0 pass · 1 fail · 2 blocked (daemon binary missing).
+//   IOI_HYPERVISOR_DAEMON_BINARY  default target/debug/hypervisor-daemon
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+  srv.on("error", reject);
+});
+
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try {
+  fs.accessSync(daemonBinary, fs.constants.X_OK);
+} catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-governance-journey-"));
+let daemon = null;
+let serve = null;
+let daemonPort = 0;
+let DAEMON = "";
+let SERVE = "";
+
+async function startDaemon() {
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${daemonPort}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1/v1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = "";
+  daemon.stdout.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  await waitFor(`${DAEMON}/healthz`, 30000);
+  return () => log;
+}
+
+const jd = (p, init) => fetch(`${DAEMON}${p}`, init ? { headers: { "content-type": "application/json" }, ...init } : undefined)
+  .then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+  .catch(() => ({ status: 0, body: {} }));
+
+const pageText = (p) => fetch(`${SERVE}${p}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+
+// The approvals module dispatches transitions on the legacy action lane; the UI
+// posts NO reviewer fields — identity is daemon-derived from the forwarded
+// session cookie (P-IDENT-1A + rule E: 401 before any effect), and confirm=1 is
+// the explicit-confirmation contract for destructive transitions.
+let SESSION = "";
+async function transition(id, verb) {
+  const r = await fetch(`${SERVE}/__ioi/governance/approvals/${id}/transition`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      ...(SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+    },
+    body: new URLSearchParams({ transition: verb, confirm: "1" }).toString(),
+    redirect: "manual",
+  }).catch(() => null);
+  const location = r?.headers?.get("location") || "";
+  const q = new URLSearchParams(location.split("?")[1]?.split("#")[0] ?? "");
+  return { status: r?.status ?? 0, location, q };
+}
+
+const submit = (subject, kind, reason) => jd("/v1/hypervisor/governance/approval-requests", {
+  method: "POST",
+  body: JSON.stringify({ subject_ref: subject, request_kind: kind, reason }),
+});
+
+const statusOf = async (id) => {
+  const r = await jd(`/v1/hypervisor/governance/approval-requests/${id}`);
+  return r.body?.approval_request?.status ?? r.body?.status ?? "";
+};
+
+async function run() {
+  daemonPort = await freePort();
+  DAEMON = `http://127.0.0.1:${daemonPort}`;
+  const daemonLogFn = await startDaemon();
+  const token = daemonLogFn().match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  if (token) {
+    const boot = await jd("/v1/hypervisor/auth/bootstrap", {
+      method: "POST",
+      body: JSON.stringify({ token, password: "governance-journey-bootstrap-v1", email: "governance-journey@ioi.local" }),
+    });
+    SESSION = boot.body?.session_token ?? "";
+  }
+  ok("operator bootstrap yields an authenticated session", SESSION.startsWith("ioi_sess_"), SESSION.slice(0, 12));
+
+  const servePort = await freePort();
+  const productUiPort = await freePort();
+  SERVE = `http://127.0.0.1:${servePort}`;
+  serve = spawn(process.execPath, [path.join(HERE, "serve-product-ui.mjs")], {
+    cwd: APP,
+    env: {
+      ...process.env,
+      PORT: String(servePort),
+      PRODUCT_UI_PORT: String(productUiPort),
+      IOI_PRODUCT_UI_PUBLIC: path.join(APP, "product-ui", "owned", "public"),
+      IOI_HYPERVISOR_DAEMON_URL: DAEMON,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await waitFor(`${SERVE}/governance/approvals`, 30000);
+
+  // -- submit exact requests -------------------------------------------------
+  const a = await submit("system:journey-alpha", "deployment_change", "approve-path fixture");
+  const b = await submit("system:journey-beta", "deployment_change", "reject-path fixture");
+  const c = await submit("system:journey-gamma", "deployment_change", "withdrawn-path fixture");
+  const idA = a.body?.approval_request?.id ?? "";
+  const idB = b.body?.approval_request?.id ?? "";
+  const idC = c.body?.approval_request?.id ?? "";
+  ok("three exact approval requests submit", idA && idB && idC, `${idA} ${idB} ${idC}`);
+
+  // -- inbox projection + canonical render ----------------------------------
+  const inbox = await jd("/v1/hypervisor/governance/approvals-inbox");
+  const pendingTotal = inbox.body?.pending_total ?? inbox.body?.inbox?.pending_total ?? 0;
+  ok("unified approvals-inbox counts the pending requests", inbox.status === 200 && pendingTotal >= 3, `pending_total ${pendingTotal}`);
+  const canonical = await pageText("/governance/approvals");
+  ok("canonical /governance/approvals renders rows + the cross-plane band",
+    canonical.status === 200 && canonical.text.includes("ap-crossplane") && canonical.text.includes(idA),
+    `status ${canonical.status}`);
+
+  // -- approve: daemon-resolved reviewer, receipt, readback -------------------
+  const approved = await transition(idA, "approve");
+  ok("approve crosses with a decision receipt", approved.status === 303 && approved.q.get("acted") === "approve" && (approved.q.get("receipt") || "").length > 0, approved.location.slice(0, 130));
+  ok("approved request reads back approved", (await statusOf(idA)) === "approved");
+  const recA = await jd(`/v1/hypervisor/governance/approval-requests/${idA}`);
+  const receipts = JSON.stringify(recA.body);
+  ok("the decision is receipted on the record itself", receipts.includes("receipt"), "");
+
+  // -- reject with readback ---------------------------------------------------
+  const rejected = await transition(idB, "reject");
+  ok("reject crosses with a decision receipt", rejected.status === 303 && rejected.q.get("acted") === "reject" && (rejected.q.get("receipt") || "").length > 0, rejected.location.slice(0, 130));
+  ok("rejected request reads back rejected", (await statusOf(idB)) === "rejected");
+
+  // -- terminal/stale transitions refuse typed --------------------------------
+  const dblApprove = await transition(idB, "approve");
+  ok("approving a terminal request refuses typed", dblApprove.status === 303 && (dblApprove.q.get("refused") || "").length > 0, dblApprove.location.slice(0, 130));
+
+  // -- revoke an approved decision -------------------------------------------
+  const revoked = await transition(idA, "revoke");
+  ok("revoke crosses with a decision receipt", revoked.status === 303 && revoked.q.get("acted") === "revoke" && (revoked.q.get("receipt") || "").length > 0, revoked.location.slice(0, 130));
+  ok("revoked request reads back revoked", (await statusOf(idA)) === "revoked");
+
+  // -- withdrawn: decided elsewhere/deleted → typed refusal -------------------
+  await jd(`/v1/hypervisor/governance/approval-requests/${idC}`, { method: "DELETE" });
+  const stale = await transition(idC, "approve");
+  ok("a withdrawn request refuses typed, never fabricates a decision", stale.status === 303 && (stale.q.get("refused") || "").length > 0, stale.location.slice(0, 130));
+
+  // -- no generic approval: the decision bound exactly one subject ------------
+  ok("no substituted effect: B stayed rejected and C stayed gone while A moved",
+    (await statusOf(idB)) === "rejected" && (await statusOf(idC)) === "",
+    "");
+
+  // -- restart survival -------------------------------------------------------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  await startDaemon();
+  ok("decisions survive a daemon restart", (await statusOf(idA)) === "revoked" && (await statusOf(idB)) === "rejected", "");
+  // The surface is an inbox: the default view is pending, decided rows live
+  // under their status views (?status=...). Terminal rows render without
+  // transition forms, so the subject + terminal marker is the render proof.
+  let reload = { status: 0, text: "" };
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await new Promise((r) => setTimeout(r, 1500));
+    reload = await pageText("/governance/approvals?status=all");
+    if (reload.status === 200 && reload.text.includes("journey-alpha")) break;
+  }
+  ok("canonical mount re-renders decided state after restart (status=all view)",
+    reload.status === 200 && reload.text.includes("journey-alpha") && reload.text.includes("journey-beta"),
+    `status ${reload.status}`);
+  const revokedView = await pageText("/governance/approvals?status=revoked");
+  ok("the revoked status view lists exactly the revoked decision",
+    revokedView.status === 200 && revokedView.text.includes("journey-alpha") && !revokedView.text.includes("journey-beta"),
+    "");
+
+  // -- G-8 posture matrix -----------------------------------------------------
+  let pw = null;
+  try { pw = await import("playwright"); } catch { pw = null; }
+  if (!pw) {
+    ok("posture matrix skipped — playwright unavailable", false, "install playwright to run the browser matrix");
+  } else {
+    const browser = await pw.chromium.launch();
+    for (const [name, opts] of [
+      ["light-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "light" }],
+      ["dark-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "dark" }],
+      ["narrow-reduced-motion", { viewport: { width: 390, height: 844 }, colorScheme: "light", reducedMotion: "reduce" }],
+    ]) {
+      const ctx = await browser.newContext(opts);
+      const page = await ctx.newPage();
+      const errors = [];
+      page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+      const resp = await page.goto(`${SERVE}/governance/approvals`, { waitUntil: "networkidle", timeout: 45000 }).catch(() => null);
+      const body = resp ? await page.evaluate(() => document.body.innerText) : "";
+      await page.keyboard.press("Tab");
+      const focused = resp ? await page.evaluate(() => document.activeElement?.tagName ?? "") : "";
+      ok(`posture ${name}: renders, keyboard-focusable, zero console errors`,
+        resp && resp.status() === 200 && body.length > 0 && errors.length === 0 && focused !== "" && focused !== "BODY",
+        errors[0]?.slice(0, 100) ?? `focus ${focused}`);
+      await ctx.close();
+    }
+    await browser.close();
+  }
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  cleanup();
+  process.exit(1);
+});
+
+function cleanup() {
+  try { serve?.kill("SIGTERM"); } catch { /* gone */ }
+  try { daemon?.kill("SIGTERM"); } catch { /* gone */ }
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* keep */ }
+}

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+// SURF-ontology primary journey verifier (next-legs Leg 3a).
+//
+// Proves, against an ISOLATED real daemon + serve lane (never the shared dev
+// processes), the brief §5 acceptance that #219/#222 left open: create /
+// version-discipline / read / search-filter / denial / CAS-conflict-and-
+// recovery / receipt / reload / restart-survival journeys, plus the typed
+// named-gap assertions for the daemon families that do not exist (proposals,
+// saved-set authoring) — absence is asserted, never papered over.
+//
+// Exit: 0 pass · 1 fail · 2 blocked (daemon binary or product bundle missing).
+//
+//   IOI_HYPERVISOR_DAEMON_BINARY  default target/debug/hypervisor-daemon
+//   node apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+  srv.on("error", reject);
+});
+
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try {
+  fs.accessSync(daemonBinary, fs.constants.X_OK);
+} catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-ontology-journey-"));
+let daemon = null;
+let serve = null;
+let daemonPort = 0;
+let DAEMON = "";
+let SERVE = "";
+
+async function startDaemon() {
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${daemonPort}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1/v1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = "";
+  daemon.stdout.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  await waitFor(`${DAEMON}/healthz`, 30000);
+  return () => log;
+}
+
+const jd = (p, init) => fetch(`${DAEMON}${p}`, init ? { headers: { "content-type": "application/json" }, ...init } : undefined)
+  .then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+  .catch(() => ({ status: 0, body: {} }));
+
+const pageText = (p) => fetch(`${SERVE}${p}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+
+const MANAGER_ACTIONS = `${"/__ioi/ontology/manager"}/actions`;
+async function act(id, data) {
+  const r = await fetch(`${SERVE}${MANAGER_ACTIONS}/${id}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(data).toString(),
+    redirect: "manual",
+  }).catch(() => null);
+  const location = r?.headers?.get("location") || "";
+  const q = new URLSearchParams(location.split("?")[1]?.split("#")[0] ?? "");
+  return { status: r?.status ?? 0, location, q };
+}
+
+async function run() {
+  daemonPort = await freePort();
+  DAEMON = `http://127.0.0.1:${daemonPort}`;
+  const daemonLogFn = await startDaemon();
+
+  // Operator bootstrap mirrors scripts/smoke-product-surfaces.mjs.
+  const token = daemonLogFn().match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  if (token) {
+    await jd("/v1/hypervisor/auth/bootstrap", {
+      method: "POST",
+      body: JSON.stringify({ token, password: "ontology-journey-bootstrap-v1", email: "ontology-journey@ioi.local" }),
+    });
+  }
+
+  const servePort = await freePort();
+  const productUiPort = await freePort();
+  SERVE = `http://127.0.0.1:${servePort}`;
+  serve = spawn(process.execPath, [path.join(HERE, "serve-product-ui.mjs")], {
+    cwd: APP,
+    env: {
+      ...process.env,
+      PORT: String(servePort),
+      PRODUCT_UI_PORT: String(productUiPort),
+      IOI_PRODUCT_UI_PUBLIC: path.join(APP, "product-ui", "owned", "public"),
+      IOI_HYPERVISOR_DAEMON_URL: DAEMON,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await waitFor(`${SERVE}/ontology/schema`, 30000);
+
+  // -- canonical mounts render the preserved grammar -------------------------
+  const schemaPage = await pageText("/ontology/schema");
+  ok("canonical /ontology/schema renders the Manager", schemaPage.status === 200 && schemaPage.text.includes("og-inspector"), `status ${schemaPage.status}`);
+  const explorePage = await pageText("/ontology/explore");
+  ok("canonical /ontology/explore renders the Explorer", explorePage.status === 200 && explorePage.text.includes("oe-inspector"), `status ${explorePage.status}`);
+
+  // -- create ---------------------------------------------------------------
+  const domain = `journey-${Date.now().toString(36)}`;
+  const created = await act("create-ontology", { domain, version: "1.0.0", description: "journey ontology" });
+  const ontId = created.q.get("record") || "";
+  ok("create-ontology crosses with a receipt", created.status === 303 && created.q.get("acted") === "create-ontology" && (created.q.get("receipt") || "").length > 0, created.location.slice(0, 140));
+  const afterCreate = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`);
+  ok("created ontology reads back at revision 1", afterCreate.status === 200 && afterCreate.body?.ontology?.revision === 1 && afterCreate.body?.ontology?.domain === domain, `rev ${afterCreate.body?.ontology?.revision}`);
+
+  // -- version discipline: five upserts + metadata, each a receipted revision -
+  const steps = [
+    ["upsert-object-type", { ontology: ontId, def_id: "obj_journey", name: "JourneyObject", description: "typed object" }],
+    ["upsert-property", { ontology: ontId, object_type_id: "obj_journey", def_id: "prop_name", name: "name", value_type: "string", required: "on" }],
+    ["upsert-object-type", { ontology: ontId, def_id: "obj_journey", name: "JourneyObject", description: "typed object", title_property: "prop_name" }],
+    ["upsert-value-type", { ontology: ontId, def_id: "vt_stage", name: "Stage", base: "enum", enum_values: "draft,active" }],
+    ["upsert-link-type", { ontology: ontId, def_id: "lnk_owner", name: "owns", from: "obj_journey", to: "obj_journey", cardinality: "one_to_many" }],
+    ["upsert-action-type", { ontology: ontId, def_id: "act_review", name: "review", kind: "modify_object", applies_to: "obj_journey" }],
+    ["update-metadata", { ontology: ontId, domain, version: "1.1.0", description: "journey ontology amended" }],
+  ];
+  let expectedRev = 1;
+  for (const [actionId, fields] of steps) {
+    const res = await act(actionId, fields);
+    expectedRev += 1;
+    ok(`${actionId} crosses with a receipt`, res.status === 303 && res.q.get("acted") === actionId && (res.q.get("receipt") || "").length > 0, res.location.slice(0, 140));
+  }
+  const afterSteps = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`);
+  const com = afterSteps.body?.ontology?.canonical_object_model ?? {};
+  ok("revision advanced once per mutation", afterSteps.body?.ontology?.revision === expectedRev, `rev ${afterSteps.body?.ontology?.revision}, expected ${expectedRev}`);
+  ok("canonical object model holds the authored definitions",
+    JSON.stringify(com).includes("obj_journey") && JSON.stringify(com).includes("vt_stage") && JSON.stringify(com).includes("lnk_owner"),
+    Object.keys(com).join(","));
+
+  // -- receipts are durable objects -----------------------------------------
+  let receiptCount = 0;
+  try {
+    receiptCount = fs.readdirSync(path.join(dataDir, "odk-ontology-receipts")).length;
+  } catch { receiptCount = -1; }
+  ok("every mutation left a durable receipt", receiptCount >= expectedRev, `${receiptCount} receipts on disk`);
+
+  // -- CAS conflict and recovery --------------------------------------------
+  const stale = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ expected_revision: 1, description: "stale write" }),
+  });
+  ok("stale expected_revision refuses with the typed conflict", stale.status === 409 && JSON.stringify(stale.body).includes("odk_revision_conflict"), `status ${stale.status}`);
+  const recovered = await act("upsert-object-type", { ontology: ontId, def_id: "obj_recovered", name: "Recovered", description: "post-conflict" });
+  expectedRev += 1;
+  ok("a fresh read-and-write recovers after the conflict", recovered.status === 303 && (recovered.q.get("receipt") || "").length > 0, recovered.location.slice(0, 120));
+
+  // -- typed refusal surfaces its REAL code through the UI lane ---------------
+  const masked = await act("upsert-object-type", { ontology: ontId, def_id: "obj_journey", name: "JourneyObject", title_property: "prop_missing" });
+  ok("a plane refusal keeps its typed code through the UI (never receipt_missing)",
+    masked.status === 303 && masked.q.get("refused") === "ontology_ref_unresolved",
+    masked.location.slice(0, 130));
+
+  // -- denial ----------------------------------------------------------------
+  const denied = await act("upsert-object-type", { ontology: "ont-does-not-exist", def_id: "x", name: "X" });
+  ok("missing ontology denies with the typed refusal", denied.status === 303 && denied.q.get("refused") === "odk_ontology_not_found", denied.location.slice(0, 120));
+
+  // -- read / search-filter / health / history -------------------------------
+  const filtered = await pageText(`/ontology/schema?ontology=${encodeURIComponent(ontId)}&section=object-types`);
+  ok("Manager reads back the authored type through the canonical mount", filtered.status === 200 && filtered.text.includes("JourneyObject"), "");
+  const scoped = await pageText(`/ontology/explore?ontology=${encodeURIComponent(ontId)}`);
+  ok("Explorer scope selector resolves the ontology", scoped.status === 200 && scoped.text.includes(domain), "");
+  const history = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}/history`);
+  ok("history records the mutation trail", history.status === 200 && JSON.stringify(history.body).length > 2, `status ${history.status}`);
+  const health = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}/health`);
+  ok("health answers for the authored ontology", health.status === 200, `status ${health.status}`);
+
+  // -- named gaps stay typed, never faked ------------------------------------
+  const proposals = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}/proposals`);
+  ok("proposal family absent — named gap typed, not simulated", proposals.status === 404 || proposals.status === 405, `status ${proposals.status}`);
+  const savedSet = await jd("/v1/hypervisor/odk/materialized-object-sets", { method: "POST", body: JSON.stringify({ name: "x" }) });
+  ok("saved-set authoring absent — named gap typed, not simulated", savedSet.status === 404 || savedSet.status === 405, `status ${savedSet.status}`);
+
+  // -- identity posture: current contract, recorded not hidden ---------------
+  ok("FINDING(typed): ontology writes cross with no identity envelope (loopback dev posture; W1.1/G-2 pull)", true,
+    "handle_odk_ontology_create/patch take no HeaderMap; module ignores daemonFetch");
+
+  // -- restart survival -------------------------------------------------------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  await startDaemon();
+  const afterRestart = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`);
+  ok("ontology survives a daemon restart at the same revision",
+    afterRestart.status === 200 && afterRestart.body?.ontology?.revision === expectedRev,
+    `rev ${afterRestart.body?.ontology?.revision}, expected ${expectedRev}`);
+  let receiptsAfter = 0;
+  try { receiptsAfter = fs.readdirSync(path.join(dataDir, "odk-ontology-receipts")).length; } catch { receiptsAfter = -1; }
+  ok("receipts survive the restart", receiptsAfter >= receiptCount && receiptCount > 0, `${receiptsAfter} receipts`);
+  const reload = await pageText(`/ontology/schema?ontology=${encodeURIComponent(ontId)}`);
+  ok("canonical mount re-renders the authored ontology after restart", reload.status === 200 && reload.text.includes(domain), "");
+
+  // -- G-8 posture matrix (browser) ------------------------------------------
+  let pw = null;
+  try { pw = await import("playwright"); } catch { pw = null; }
+  if (!pw) {
+    ok("posture matrix skipped — playwright unavailable", false, "install playwright to run the browser matrix");
+  } else {
+    const browser = await pw.chromium.launch();
+    for (const [name, opts] of [
+      ["light-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "light" }],
+      ["dark-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "dark" }],
+      ["narrow-reduced-motion", { viewport: { width: 390, height: 844 }, colorScheme: "light", reducedMotion: "reduce" }],
+    ]) {
+      const ctx = await browser.newContext(opts);
+      const page = await ctx.newPage();
+      const errors = [];
+      page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+      const resp = await page.goto(`${SERVE}/ontology/schema?ontology=${encodeURIComponent(ontId)}`, { waitUntil: "networkidle", timeout: 45000 }).catch(() => null);
+      const body = resp ? await page.evaluate(() => document.body.innerText) : "";
+      await page.keyboard.press("Tab");
+      const focused = resp ? await page.evaluate(() => document.activeElement?.tagName ?? "") : "";
+      ok(`posture ${name}: renders, keyboard-focusable, zero console errors`,
+        resp && resp.status() === 200 && body.includes(domain) && errors.length === 0 && focused !== "" && focused !== "BODY",
+        errors[0]?.slice(0, 100) ?? `focus ${focused}`);
+      await ctx.close();
+    }
+    await browser.close();
+  }
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  cleanup();
+  process.exit(1);
+});
+
+function cleanup() {
+  try { serve?.kill("SIGTERM"); } catch { /* gone */ }
+  try { daemon?.kill("SIGTERM"); } catch { /* gone */ }
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* keep */ }
+}

--- a/apps/hypervisor/seed-graphs/data/pipeline.v1.json
+++ b/apps/hypervisor/seed-graphs/data/pipeline.v1.json
@@ -8,7 +8,7 @@
     "serve_url": "http://127.0.0.1:4173",
     "capture_url": null
   },
-  "captured_at": "2026-08-09T16:41:07.742Z",
+  "captured_at": "2026-08-10T01:21:19.780Z",
   "quarantine": {
     "network_policy": "local-only",
     "corpus_mutation": "denied",
@@ -12740,9 +12740,9 @@
       "edge n3/\"Pipeline: probe-reencode ▾\": control unresolved (unclickable at capture and at replay)",
       "edge n4/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)"
     ],
-    "walked_at": "2026-08-09T23:42:01.976Z"
+    "walked_at": "2026-08-10T01:26:28.277Z"
   },
   "complete_interaction_route_graph": false,
   "shots_dir": ".artifacts/seed-graph-shots/data/pipeline",
-  "content_address": "35e52c093418deaf0b8d0af294b643bfd06581db298d7726cb599ec7a919e94c"
+  "content_address": "60d34da15fd3c761648f868d3c1294f1e5f681d67ee79dce440e6c3cfc310eee"
 }

--- a/apps/hypervisor/seed-graphs/data/sources.v1.json
+++ b/apps/hypervisor/seed-graphs/data/sources.v1.json
@@ -5,18 +5,20 @@
   "owned_route": "/__ioi/data/sources",
   "capture_route": null,
   "runtime": {
-    "serve_url": "http://127.0.0.1:4173",
+    "serve_url": "http://127.0.0.1:4641",
     "capture_url": null
   },
-  "captured_at": "2026-08-09T16:10:16.935Z",
+  "captured_at": "2026-08-10T01:51:29.151Z",
   "quarantine": {
     "network_policy": "local-only",
     "corpus_mutation": "denied",
     "html_injection": "denied",
     "spa_fallback": "denied",
     "allowed_origins": [
-      "http://127.0.0.1:4173",
-      "http://127.0.0.1:9225"
+      "http://127.0.0.1:4641",
+      "http://localhost:4641",
+      "http://127.0.0.1:9225",
+      "http://localhost:9225"
     ],
     "violations": []
   },
@@ -24,7 +26,7 @@
     {
       "id": "n0",
       "kind": "route",
-      "signature": "/__ioi/data/sources#open=0|H1:Data Connection|H3:Data Connection|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
+      "signature": "/__ioi/data/sources#open=0#fc=0|H1:Data Connection|H3:Data Connection|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
       "url": "/__ioi/data/sources",
       "title": "Data Connection",
       "entry_edge": null,
@@ -49,7 +51,7 @@
     {
       "id": "n1",
       "kind": "route",
-      "signature": "/__ioi/data/sources?declare=1#open=0|H1:Data Connection|H3:Data Connection|H2:Declare a new data source a validated, receipted registry re|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
+      "signature": "/__ioi/data/sources?declare=1#open=0#fc=5|H1:Data Connection|H3:Data Connection|H2:Declare a new data source a validated, receipted registry re|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
       "url": "/__ioi/data/sources?declare=1",
       "title": "Data Connection",
       "entry_edge": {
@@ -292,7 +294,7 @@
         "label": "Data Connection capture"
       },
       "action": "goto",
-      "outcome": "boundary-external-origin"
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n0",
@@ -580,7 +582,7 @@
         "label": "Data Connection capture"
       },
       "action": "goto",
-      "outcome": "boundary-external-origin"
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n1",
@@ -625,9 +627,9 @@
     "problems": [
       "edge n1/\"postgres — endpoint requiredmysql — endpoint requiredrest_api — endpoint require\": recorded state-change, observed noop"
     ],
-    "walked_at": "2026-08-09T23:38:57.469Z"
+    "walked_at": "2026-08-10T01:51:40.592Z"
   },
   "complete_interaction_route_graph": false,
   "shots_dir": ".artifacts/seed-graph-shots/data/sources",
-  "content_address": "cee86d36feb0ac24deb58bf761bce2500a9496cda3013dbec258004d5e03659b"
+  "content_address": "0c2e9ecfe40ff76da323913c0cb52c982962b0eab5543b4e94c78b7ecc3fade5"
 }

--- a/apps/hypervisor/seed-graphs/ontology/schema.v1.json
+++ b/apps/hypervisor/seed-graphs/ontology/schema.v1.json
@@ -5,18 +5,18 @@
   "owned_route": "/__ioi/ontology/manager",
   "capture_route": null,
   "runtime": {
-    "serve_url": "http://127.0.0.1:4173",
+    "serve_url": "http://127.0.0.1:4647",
     "capture_url": null
   },
-  "captured_at": "2026-08-09T16:37:56.647Z",
+  "captured_at": "2026-08-10T02:02:51.790Z",
   "quarantine": {
     "network_policy": "local-only",
     "corpus_mutation": "denied",
     "html_injection": "denied",
     "spa_fallback": "denied",
     "allowed_origins": [
-      "http://127.0.0.1:4173",
-      "http://localhost:4173",
+      "http://127.0.0.1:4647",
+      "http://localhost:4647",
       "http://127.0.0.1:9225",
       "http://localhost:9225"
     ],
@@ -26,24 +26,24 @@
     {
       "id": "n0",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
+      "signature": "/__ioi/ontology/manager#open=0#fc=1#hf=124|",
       "url": "/__ioi/ontology/manager",
       "title": "Ontology Manager",
       "entry_edge": null,
-      "controls": 23,
+      "controls": 17,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "5135bf6f0c4a93638db21c994cc6c0a63f21a0c3fc2b46e9be99686528171893",
+        "sha256": "09a0d53facb0ba17fab9acacc952d2018c20311e621da8831b89b0c92ff16645",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "5135bf6f0c4a93638db21c994cc6c0a63f21a0c3fc2b46e9be99686528171893",
+          "sha256": "09a0d53facb0ba17fab9acacc952d2018c20311e621da8831b89b0c92ff16645",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "545e1e3bf00ff6618f4ebfe45d5a8a600bb314eae9194708142f7949e6406fc5",
+          "sha256": "cd378c2be44f2c8e6b0c09fd15f0987fb5c46877030f872fe942ac1e66b8277c",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -51,8 +51,8 @@
     {
       "id": "n1",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+      "signature": "/__ioi/ontology/manager?section=create#open=0#fc=5#hf=1634794649|",
+      "url": "/__ioi/ontology/manager?section=create",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -60,25 +60,25 @@
           "index": 5,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+          "href": "/__ioi/ontology/manager?section=create",
           "disabled": false,
           "label": "New"
         }
       },
-      "controls": 25,
+      "controls": 19,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "aa594234c06fabe327bdc1ac909b86d791a0e5e897ce344542a037311e90d0e4",
+        "sha256": "1269d4798f4ef6cf96d1fd13ffbe4c3cac30f4f0b69179eddf26e7b07e03b229",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "aa594234c06fabe327bdc1ac909b86d791a0e5e897ce344542a037311e90d0e4",
+          "sha256": "1269d4798f4ef6cf96d1fd13ffbe4c3cac30f4f0b69179eddf26e7b07e03b229",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "01287d195e9bdb21756746a042d2067cc25d73f5e3b89685c30719bb26081a23",
+          "sha256": "3600a19e2a6c31a2704ffde42ced25b59f1cded2a6819a6f27341d1f7583a1c2",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -86,8 +86,8 @@
     {
       "id": "n2",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+      "signature": "/__ioi/ontology/manager?section=discover#open=0#fc=2#hf=-337893819|",
+      "url": "/__ioi/ontology/manager?section=discover",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -95,25 +95,25 @@
           "index": 6,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+          "href": "/__ioi/ontology/manager?section=discover",
           "disabled": false,
           "label": "Discover"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -121,8 +121,8 @@
     {
       "id": "n3",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+      "signature": "/__ioi/ontology/manager?section=configuration#open=0#fc=2#hf=-1970407374|",
+      "url": "/__ioi/ontology/manager?section=configuration",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -130,25 +130,25 @@
           "index": 7,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+          "href": "/__ioi/ontology/manager?section=configuration",
           "disabled": false,
           "label": "History"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -156,8 +156,8 @@
     {
       "id": "n4",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+      "signature": "/__ioi/ontology/manager?section=object-types#open=0#fc=2#hf=-186047289|",
+      "url": "/__ioi/ontology/manager?section=object-types",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -165,25 +165,25 @@
           "index": 8,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+          "href": "/__ioi/ontology/manager?section=object-types",
           "disabled": false,
-          "label": "Object types1"
+          "label": "Object types0"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -191,8 +191,8 @@
     {
       "id": "n5",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+      "signature": "/__ioi/ontology/manager?section=properties#open=0#fc=2#hf=306510223|",
+      "url": "/__ioi/ontology/manager?section=properties",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -200,25 +200,25 @@
           "index": 9,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+          "href": "/__ioi/ontology/manager?section=properties",
           "disabled": false,
           "label": "Properties0"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -226,8 +226,8 @@
     {
       "id": "n6",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+      "signature": "/__ioi/ontology/manager?section=link-types#open=0#fc=2#hf=849017922|",
+      "url": "/__ioi/ontology/manager?section=link-types",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -235,25 +235,25 @@
           "index": 10,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+          "href": "/__ioi/ontology/manager?section=link-types",
           "disabled": false,
           "label": "Link types0"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -261,8 +261,8 @@
     {
       "id": "n7",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+      "signature": "/__ioi/ontology/manager?section=action-types#open=0#fc=2#hf=1069004158|",
+      "url": "/__ioi/ontology/manager?section=action-types",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -270,25 +270,25 @@
           "index": 11,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+          "href": "/__ioi/ontology/manager?section=action-types",
           "disabled": false,
           "label": "Action types0"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -296,8 +296,8 @@
     {
       "id": "n8",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+      "signature": "/__ioi/ontology/manager?section=value-types#open=0#fc=2#hf=-203055271|",
+      "url": "/__ioi/ontology/manager?section=value-types",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -305,25 +305,25 @@
           "index": 12,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+          "href": "/__ioi/ontology/manager?section=value-types",
           "disabled": false,
           "label": "Value types0"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -331,8 +331,8 @@
     {
       "id": "n9",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+      "signature": "/__ioi/ontology/manager?section=functions#open=0#fc=2#hf=1204822999|",
+      "url": "/__ioi/ontology/manager?section=functions",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -340,25 +340,25 @@
           "index": 13,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+          "href": "/__ioi/ontology/manager?section=functions",
           "disabled": false,
           "label": "Functions0"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -366,8 +366,8 @@
     {
       "id": "n10",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+      "signature": "/__ioi/ontology/manager?section=health#open=0#fc=2#hf=-2072917064|",
+      "url": "/__ioi/ontology/manager?section=health",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n0",
@@ -375,25 +375,25 @@
           "index": 14,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+          "href": "/__ioi/ontology/manager?section=health",
           "disabled": false,
           "label": "Health issues"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+        "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -401,78 +401,8 @@
     {
       "id": "n11",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-      "title": "Ontology Manager",
-      "entry_edge": {
-        "from": "n0",
-        "control": {
-          "index": 17,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-          "disabled": false,
-          "label": "probe-reencode"
-        }
-      },
-      "controls": 23,
-      "disabled_controls": 0,
-      "screenshot": {
-        "sha256": "5135bf6f0c4a93638db21c994cc6c0a63f21a0c3fc2b46e9be99686528171893",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "5135bf6f0c4a93638db21c994cc6c0a63f21a0c3fc2b46e9be99686528171893",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "545e1e3bf00ff6618f4ebfe45d5a8a600bb314eae9194708142f7949e6406fc5",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n12",
-      "kind": "route",
-      "signature": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-      "title": "Ontology Manager",
-      "entry_edge": {
-        "from": "n0",
-        "control": {
-          "index": 20,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-          "disabled": false,
-          "label": "Widget 0 objects 0 dependents a widget"
-        }
-      },
-      "controls": 32,
-      "disabled_controls": 0,
-      "screenshot": {
-        "sha256": "db634bfad889c228bc72300bda36e1b39e84f9acabb424ff1e4596372f1428fe",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "db634bfad889c228bc72300bda36e1b39e84f9acabb424ff1e4596372f1428fe",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "add102468ca5accf433430d318a50bbe35a510587402be55ca5c57c44382732c",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n13",
-      "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=create&q=#open=0#fc=5#hf=1634794649|",
+      "url": "/__ioi/ontology/manager?ontology=&section=create&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n2",
@@ -485,29 +415,29 @@
           "label": "Filter"
         }
       },
-      "controls": 25,
+      "controls": 19,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "aa594234c06fabe327bdc1ac909b86d791a0e5e897ce344542a037311e90d0e4",
+        "sha256": "1269d4798f4ef6cf96d1fd13ffbe4c3cac30f4f0b69179eddf26e7b07e03b229",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "aa594234c06fabe327bdc1ac909b86d791a0e5e897ce344542a037311e90d0e4",
+          "sha256": "1269d4798f4ef6cf96d1fd13ffbe4c3cac30f4f0b69179eddf26e7b07e03b229",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "01287d195e9bdb21756746a042d2067cc25d73f5e3b89685c30719bb26081a23",
+          "sha256": "3600a19e2a6c31a2704ffde42ced25b59f1cded2a6819a6f27341d1f7583a1c2",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n14",
+      "id": "n12",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=discover&q=#open=0#fc=2#hf=-337893819|",
+      "url": "/__ioi/ontology/manager?ontology=&section=discover&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n3",
@@ -520,29 +450,29 @@
           "label": "Filter"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n15",
+      "id": "n13",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=configuration&q=#open=0#fc=2#hf=-1970407374|",
+      "url": "/__ioi/ontology/manager?ontology=&section=configuration&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n4",
@@ -555,29 +485,29 @@
           "label": "Filter"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n16",
+      "id": "n14",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=object-types&q=#open=0#fc=2#hf=-186047289|",
+      "url": "/__ioi/ontology/manager?ontology=&section=object-types&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n5",
@@ -590,29 +520,29 @@
           "label": "Filter"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n17",
+      "id": "n15",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=properties&q=#open=0#fc=2#hf=306510223|",
+      "url": "/__ioi/ontology/manager?ontology=&section=properties&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n6",
@@ -625,29 +555,29 @@
           "label": "Filter"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n18",
+      "id": "n16",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=link-types&q=#open=0#fc=2#hf=849017922|",
+      "url": "/__ioi/ontology/manager?ontology=&section=link-types&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n7",
@@ -660,29 +590,29 @@
           "label": "Filter"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n19",
+      "id": "n17",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=action-types&q=#open=0#fc=2#hf=1069004158|",
+      "url": "/__ioi/ontology/manager?ontology=&section=action-types&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n8",
@@ -695,29 +625,29 @@
           "label": "Filter"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n20",
+      "id": "n18",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=value-types&q=#open=0#fc=2#hf=-203055271|",
+      "url": "/__ioi/ontology/manager?ontology=&section=value-types&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n9",
@@ -730,29 +660,29 @@
           "label": "Filter"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n21",
+      "id": "n19",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=functions&q=#open=0#fc=2#hf=1204822999|",
+      "url": "/__ioi/ontology/manager?ontology=&section=functions&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n10",
@@ -765,57 +695,32 @@
           "label": "Filter"
         }
       },
-      "controls": 24,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "02767a4ad410b3f94aae6538faaabaa038515fd06e60057078f1b810d8462879",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "5f9b58adb8728bd71f0b500f38ebd7bd10898d74e57c5323f5a1714aa9d5fc60",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n22",
-      "kind": "state",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health&q=",
+      "id": "n20",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=&section=health&q=#open=0#fc=2#hf=-2072917064|",
+      "url": "/__ioi/ontology/manager?ontology=&section=health&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n11",
-        "control": {
-          "index": 16,
-          "tag": "summary",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "probe-reencode v1 ▾"
-        }
-      },
-      "controls": 24,
-      "disabled_controls": 0,
-      "screenshot": {
-        "sha256": "3e5cc7ddb1205a26e0d50abcfbfe07e05aef7abc3bc8886ba24b242011dac18e",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n23",
-      "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types&definitionKind=object-type&definitionId=widget&q=#open=0|H2:Object types recently modified in|H2:Properties 0|H2:Value types 0|H2:Link types 0|H2:Action types 0|H2:Functions 0|H2:Health issues|H2:Ontology configuration",
-      "url": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types&definitionKind=object-type&definitionId=widget&q=",
-      "title": "Ontology Manager",
-      "entry_edge": {
-        "from": "n13",
         "control": {
           "index": 16,
           "tag": "button",
@@ -825,20 +730,20 @@
           "label": "Filter"
         }
       },
-      "controls": 32,
+      "controls": 18,
       "disabled_controls": 0,
       "screenshot": {
-        "sha256": "db634bfad889c228bc72300bda36e1b39e84f9acabb424ff1e4596372f1428fe",
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "db634bfad889c228bc72300bda36e1b39e84f9acabb424ff1e4596372f1428fe",
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "add102468ca5accf433430d318a50bbe35a510587402be55ca5c57c44382732c",
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -922,7 +827,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -936,7 +841,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -950,7 +855,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -964,9 +869,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "navigated"
@@ -978,7 +883,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -992,7 +897,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -1006,7 +911,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -1020,7 +925,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -1034,7 +939,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -1048,7 +953,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -1062,7 +967,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -1071,98 +976,14 @@
     },
     {
       "from": "n0",
-      "to": "n0",
+      "to": null,
       "control": {
         "index": 16,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n0",
-      "to": "n11",
-      "control": {
-        "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 18,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n0",
-      "to": "n12",
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
@@ -1251,7 +1072,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -1265,7 +1086,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -1279,7 +1100,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -1293,9 +1114,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -1307,7 +1128,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -1321,7 +1142,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -1335,7 +1156,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -1349,7 +1170,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -1363,7 +1184,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -1377,7 +1198,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -1391,7 +1212,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -1400,7 +1221,7 @@
     },
     {
       "from": "n1",
-      "to": "n1",
+      "to": null,
       "control": {
         "index": 16,
         "tag": "button",
@@ -1410,102 +1231,18 @@
         "label": "Filter"
       },
       "action": "click",
-      "outcome": "noop"
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n1",
-      "to": "n11",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n1",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n1",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
@@ -1514,7 +1251,7 @@
       "from": "n1",
       "to": "n1",
       "control": {
-        "index": 24,
+        "index": 18,
         "tag": "button",
         "role": null,
         "href": null,
@@ -1608,7 +1345,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -1622,7 +1359,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -1636,7 +1373,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -1650,9 +1387,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -1664,7 +1401,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -1678,7 +1415,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -1692,7 +1429,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -1706,7 +1443,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -1720,7 +1457,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -1734,7 +1471,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -1748,7 +1485,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -1757,7 +1494,7 @@
     },
     {
       "from": "n2",
-      "to": "n13",
+      "to": "n11",
       "control": {
         "index": 16,
         "tag": "button",
@@ -1771,98 +1508,14 @@
     },
     {
       "from": "n2",
-      "to": "n2",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n2",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
@@ -1951,7 +1604,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -1965,7 +1618,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -1979,7 +1632,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -1993,9 +1646,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -2007,7 +1660,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -2021,7 +1674,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -2035,7 +1688,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -2049,7 +1702,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -2063,7 +1716,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -2077,7 +1730,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -2091,7 +1744,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -2100,6 +1753,524 @@
     },
     {
       "from": "n3",
+      "to": "n12",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=object-types",
+        "disabled": false,
+        "label": "Object types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": "n13",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=object-types",
+        "disabled": false,
+        "label": "Object types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
       "to": "n14",
       "control": {
         "index": 16,
@@ -2113,112 +2284,28 @@
       "outcome": "navigated"
     },
     {
-      "from": "n3",
-      "to": "n3",
+      "from": "n5",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
+      "from": "n5",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": null,
       "control": {
         "index": 0,
@@ -2232,7 +2319,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": null,
       "control": {
         "index": 1,
@@ -2246,7 +2333,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": null,
       "control": {
         "index": 2,
@@ -2260,7 +2347,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": null,
       "control": {
         "index": 3,
@@ -2274,7 +2361,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 4,
@@ -2288,13 +2375,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -2302,13 +2389,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -2316,13 +2403,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -2330,27 +2417,27 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -2358,13 +2445,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -2372,13 +2459,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -2386,13 +2473,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -2400,13 +2487,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -2414,13 +2501,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -2428,13 +2515,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -2442,7 +2529,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n6",
       "to": "n15",
       "control": {
         "index": 16,
@@ -2456,112 +2543,28 @@
       "outcome": "navigated"
     },
     {
-      "from": "n4",
-      "to": "n4",
+      "from": "n6",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n4",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n4",
+      "from": "n6",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": null,
       "control": {
         "index": 0,
@@ -2575,7 +2578,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": null,
       "control": {
         "index": 1,
@@ -2589,7 +2592,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": null,
       "control": {
         "index": 2,
@@ -2603,7 +2606,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": null,
       "control": {
         "index": 3,
@@ -2617,7 +2620,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 4,
@@ -2631,13 +2634,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -2645,13 +2648,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -2659,13 +2662,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -2673,27 +2676,27 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -2701,13 +2704,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -2715,13 +2718,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -2729,13 +2732,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -2743,13 +2746,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -2757,13 +2760,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -2771,13 +2774,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -2785,7 +2788,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n7",
       "to": "n16",
       "control": {
         "index": 16,
@@ -2799,112 +2802,28 @@
       "outcome": "navigated"
     },
     {
-      "from": "n5",
-      "to": "n5",
+      "from": "n7",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n5",
+      "from": "n7",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": null,
       "control": {
         "index": 0,
@@ -2918,7 +2837,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": null,
       "control": {
         "index": 1,
@@ -2932,7 +2851,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": null,
       "control": {
         "index": 2,
@@ -2946,7 +2865,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": null,
       "control": {
         "index": 3,
@@ -2960,7 +2879,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 4,
@@ -2974,13 +2893,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -2988,13 +2907,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -3002,13 +2921,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -3016,27 +2935,27 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -3044,13 +2963,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -3058,13 +2977,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -3072,13 +2991,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -3086,13 +3005,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -3100,13 +3019,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -3114,13 +3033,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -3128,7 +3047,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n8",
       "to": "n17",
       "control": {
         "index": 16,
@@ -3142,112 +3061,28 @@
       "outcome": "navigated"
     },
     {
-      "from": "n6",
-      "to": "n6",
+      "from": "n8",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n6",
+      "from": "n8",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": null,
       "control": {
         "index": 0,
@@ -3261,7 +3096,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": null,
       "control": {
         "index": 1,
@@ -3275,7 +3110,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": null,
       "control": {
         "index": 2,
@@ -3289,7 +3124,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": null,
       "control": {
         "index": 3,
@@ -3303,7 +3138,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 4,
@@ -3317,13 +3152,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -3331,13 +3166,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -3345,13 +3180,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -3359,27 +3194,27 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -3387,13 +3222,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -3401,13 +3236,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -3415,13 +3250,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -3429,13 +3264,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -3443,13 +3278,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -3457,13 +3292,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -3471,7 +3306,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n9",
       "to": "n18",
       "control": {
         "index": 16,
@@ -3485,112 +3320,28 @@
       "outcome": "navigated"
     },
     {
-      "from": "n7",
-      "to": "n7",
+      "from": "n9",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n7",
+      "from": "n9",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 0,
@@ -3604,7 +3355,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 1,
@@ -3618,7 +3369,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 2,
@@ -3632,7 +3383,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 3,
@@ -3646,7 +3397,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 4,
@@ -3660,13 +3411,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -3674,13 +3425,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -3688,13 +3439,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -3702,27 +3453,27 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -3730,13 +3481,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -3744,13 +3495,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -3758,13 +3509,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -3772,13 +3523,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -3786,13 +3537,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -3800,13 +3551,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -3814,7 +3565,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n10",
       "to": "n19",
       "control": {
         "index": 16,
@@ -3828,112 +3579,28 @@
       "outcome": "navigated"
     },
     {
-      "from": "n8",
-      "to": "n8",
+      "from": "n10",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n8",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n8",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n8",
+      "from": "n10",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 0,
@@ -3947,7 +3614,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 1,
@@ -3961,7 +3628,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 2,
@@ -3975,7 +3642,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 3,
@@ -3989,7 +3656,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 4,
@@ -4003,13 +3670,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -4017,13 +3684,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -4031,13 +3698,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -4045,27 +3712,27 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -4073,13 +3740,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -4087,13 +3754,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -4101,13 +3768,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -4115,13 +3782,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -4129,13 +3796,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -4143,13 +3810,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -4157,7 +3824,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n11",
       "to": "n20",
       "control": {
         "index": 16,
@@ -4171,1578 +3838,24 @@
       "outcome": "navigated"
     },
     {
-      "from": "n9",
-      "to": "n9",
-      "control": {
-        "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n9",
-      "to": "visited",
-      "control": {
-        "index": 18,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n9",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n9",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "View all"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 4,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
-        "disabled": false,
-        "label": "New"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 6,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
-        "disabled": false,
-        "label": "Discover"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 7,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "History"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Object types1"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
-        "disabled": false,
-        "label": "Properties0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 10,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
-        "disabled": false,
-        "label": "Link types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 11,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
-        "disabled": false,
-        "label": "Action types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 12,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
-        "disabled": false,
-        "label": "Value types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 13,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
-        "disabled": false,
-        "label": "Functions0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 14,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
-        "disabled": false,
-        "label": "Health issues"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 15,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "Ontology configuration"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "n21",
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Filter"
-      },
-      "action": "click",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n10",
-      "to": "n10",
-      "control": {
-        "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 18,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n10",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
       "from": "n11",
       "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n11",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n11",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n11",
-      "to": null,
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "View all"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 4,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
-        "disabled": false,
-        "label": "New"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 6,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
-        "disabled": false,
-        "label": "Discover"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 7,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "History"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Object types1"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
-        "disabled": false,
-        "label": "Properties0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 10,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
-        "disabled": false,
-        "label": "Link types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 11,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
-        "disabled": false,
-        "label": "Action types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 12,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
-        "disabled": false,
-        "label": "Value types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 13,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
-        "disabled": false,
-        "label": "Functions0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 14,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
-        "disabled": false,
-        "label": "Health issues"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 15,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "Ontology configuration"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": "n22",
-      "control": {
-        "index": 16,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "state-change"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
       "control": {
         "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
+        "label": "Create an ontology →"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n11",
-      "to": null,
+      "to": "n11",
       "control": {
         "index": 18,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n11",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n11",
-      "to": "visited",
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n11",
-      "to": null,
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n11",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n11",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "View all"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 4,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
-        "disabled": false,
-        "label": "New"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 6,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
-        "disabled": false,
-        "label": "Discover"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 7,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "History"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Object types1"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
-        "disabled": false,
-        "label": "Properties0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 10,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
-        "disabled": false,
-        "label": "Link types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 11,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
-        "disabled": false,
-        "label": "Action types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 12,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
-        "disabled": false,
-        "label": "Value types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 13,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
-        "disabled": false,
-        "label": "Functions0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 14,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
-        "disabled": false,
-        "label": "Health issues"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 15,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "Ontology configuration"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": "n12",
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Filter"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n12",
-      "to": "n12",
-      "control": {
-        "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 18,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": "visited",
-      "control": {
-        "index": 24,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 25,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer?objectType=widget&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Explorer"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 26,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Pipeline"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 27,
-        "tag": "select",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "— none —"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 28,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Save"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 29,
-        "tag": "select",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "stringintegerdoublebooleantimestampenum"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 30,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Save"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n12",
-      "to": null,
-      "control": {
-        "index": 31,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Open substrate record →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n12",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n13",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n13",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n13",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n13",
-      "to": null,
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "View all"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 4,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
-        "disabled": false,
-        "label": "New"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 6,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
-        "disabled": false,
-        "label": "Discover"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 7,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "History"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Object types1"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
-        "disabled": false,
-        "label": "Properties0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 10,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
-        "disabled": false,
-        "label": "Link types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 11,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
-        "disabled": false,
-        "label": "Action types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 12,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
-        "disabled": false,
-        "label": "Value types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 13,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
-        "disabled": false,
-        "label": "Functions0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 14,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
-        "disabled": false,
-        "label": "Health issues"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 15,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "Ontology configuration"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": "n23",
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Filter"
-      },
-      "action": "click",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n13",
-      "to": "n13",
-      "control": {
-        "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 18,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n13",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n13",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n13",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n13",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n13",
-      "to": "n13",
-      "control": {
-        "index": 24,
         "tag": "button",
         "role": null,
         "href": null,
@@ -5753,6 +3866,524 @@
       "outcome": "noop"
     },
     {
+      "from": "n11",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=object-types",
+        "disabled": false,
+        "label": "Object types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "n12",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=object-types",
+        "disabled": false,
+        "label": "Object types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": "n13",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
       "from": "n13",
       "to": "back-stack",
       "control": null,
@@ -5836,7 +4467,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -5850,7 +4481,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -5864,7 +4495,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -5878,9 +4509,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -5892,7 +4523,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -5906,7 +4537,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -5920,7 +4551,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -5934,7 +4565,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -5948,7 +4579,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -5962,7 +4593,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -5976,7 +4607,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -5999,98 +4630,14 @@
     },
     {
       "from": "n14",
-      "to": "n14",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n14",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n14",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n14",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n14",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n14",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n14",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
@@ -6179,7 +4726,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -6193,7 +4740,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -6207,7 +4754,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -6221,9 +4768,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -6235,7 +4782,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -6249,7 +4796,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -6263,7 +4810,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -6277,7 +4824,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -6291,7 +4838,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -6305,7 +4852,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -6319,7 +4866,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -6342,98 +4889,14 @@
     },
     {
       "from": "n15",
-      "to": "n15",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n15",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n15",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n15",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n15",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n15",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n15",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
@@ -6522,7 +4985,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -6536,7 +4999,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -6550,7 +5013,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -6564,9 +5027,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -6578,7 +5041,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -6592,7 +5055,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -6606,7 +5069,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -6620,7 +5083,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -6634,7 +5097,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -6648,7 +5111,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -6662,7 +5125,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -6685,98 +5148,14 @@
     },
     {
       "from": "n16",
-      "to": "n16",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n16",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n16",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n16",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n16",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n16",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n16",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
@@ -6865,7 +5244,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -6879,7 +5258,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -6893,7 +5272,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -6907,9 +5286,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -6921,7 +5300,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -6935,7 +5314,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -6949,7 +5328,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -6963,7 +5342,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -6977,7 +5356,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -6991,7 +5370,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -7005,7 +5384,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -7028,98 +5407,14 @@
     },
     {
       "from": "n17",
-      "to": "n17",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n17",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n17",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n17",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n17",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n17",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n17",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
@@ -7208,7 +5503,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -7222,7 +5517,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -7236,7 +5531,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -7250,9 +5545,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -7264,7 +5559,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -7278,7 +5573,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -7292,7 +5587,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -7306,7 +5601,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -7320,7 +5615,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -7334,7 +5629,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -7348,7 +5643,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -7371,98 +5666,14 @@
     },
     {
       "from": "n18",
-      "to": "n18",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n18",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n18",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n18",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n18",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n18",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n18",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
@@ -7551,7 +5762,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -7565,7 +5776,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -7579,7 +5790,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -7593,9 +5804,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -7607,7 +5818,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -7621,7 +5832,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -7635,7 +5846,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -7649,7 +5860,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -7663,7 +5874,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -7677,7 +5888,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -7691,7 +5902,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -7714,98 +5925,14 @@
     },
     {
       "from": "n19",
-      "to": "n19",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n19",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n19",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n19",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n19",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n19",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n19",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
@@ -7894,7 +6021,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
+        "href": "/__ioi/ontology/manager?section=create",
         "disabled": false,
         "label": "New"
       },
@@ -7908,7 +6035,7 @@
         "index": 6,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
+        "href": "/__ioi/ontology/manager?section=discover",
         "disabled": false,
         "label": "Discover"
       },
@@ -7922,7 +6049,7 @@
         "index": 7,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "History"
       },
@@ -7936,9 +6063,9 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
+        "href": "/__ioi/ontology/manager?section=object-types",
         "disabled": false,
-        "label": "Object types1"
+        "label": "Object types0"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -7950,7 +6077,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
+        "href": "/__ioi/ontology/manager?section=properties",
         "disabled": false,
         "label": "Properties0"
       },
@@ -7964,7 +6091,7 @@
         "index": 10,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
+        "href": "/__ioi/ontology/manager?section=link-types",
         "disabled": false,
         "label": "Link types0"
       },
@@ -7978,7 +6105,7 @@
         "index": 11,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
+        "href": "/__ioi/ontology/manager?section=action-types",
         "disabled": false,
         "label": "Action types0"
       },
@@ -7992,7 +6119,7 @@
         "index": 12,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
+        "href": "/__ioi/ontology/manager?section=value-types",
         "disabled": false,
         "label": "Value types0"
       },
@@ -8006,7 +6133,7 @@
         "index": 13,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
+        "href": "/__ioi/ontology/manager?section=functions",
         "disabled": false,
         "label": "Functions0"
       },
@@ -8020,7 +6147,7 @@
         "index": 14,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
+        "href": "/__ioi/ontology/manager?section=health",
         "disabled": false,
         "label": "Health issues"
       },
@@ -8034,7 +6161,7 @@
         "index": 15,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
+        "href": "/__ioi/ontology/manager?section=configuration",
         "disabled": false,
         "label": "Ontology configuration"
       },
@@ -8057,1245 +6184,20 @@
     },
     {
       "from": "n20",
-      "to": "n20",
+      "to": null,
       "control": {
         "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n20",
-      "to": "visited",
-      "control": {
-        "index": 18,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n20",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
+        "label": "Create an ontology →"
       },
       "action": "goto",
       "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n20",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n20",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n20",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n20",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n20",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n21",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n21",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n21",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n21",
-      "to": null,
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "View all"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 4,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
-        "disabled": false,
-        "label": "New"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 6,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
-        "disabled": false,
-        "label": "Discover"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 7,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "History"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Object types1"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
-        "disabled": false,
-        "label": "Properties0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 10,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
-        "disabled": false,
-        "label": "Link types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 11,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
-        "disabled": false,
-        "label": "Action types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 12,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
-        "disabled": false,
-        "label": "Value types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 13,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
-        "disabled": false,
-        "label": "Functions0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 14,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
-        "disabled": false,
-        "label": "Health issues"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 15,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "Ontology configuration"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": "n21",
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Filter"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n21",
-      "to": "n21",
-      "control": {
-        "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 18,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n21",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n21",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n21",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n21",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n21",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n22",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n22",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n22",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n22",
-      "to": null,
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "View all"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 4,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
-        "disabled": false,
-        "label": "New"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 6,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
-        "disabled": false,
-        "label": "Discover"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 7,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "History"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Object types1"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
-        "disabled": false,
-        "label": "Properties0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 10,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
-        "disabled": false,
-        "label": "Link types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 11,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
-        "disabled": false,
-        "label": "Action types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 12,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
-        "disabled": false,
-        "label": "Value types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 13,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
-        "disabled": false,
-        "label": "Functions0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 14,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
-        "disabled": false,
-        "label": "Health issues"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 15,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "Ontology configuration"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": "n22",
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Filter"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n22",
-      "to": "n22",
-      "control": {
-        "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 18,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n22",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n22",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n22",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n22",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n22",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "View all"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 4,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=create",
-        "disabled": false,
-        "label": "New"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 6,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
-        "disabled": false,
-        "label": "Discover"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 7,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "History"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Object types1"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=properties",
-        "disabled": false,
-        "label": "Properties0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 10,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=link-types",
-        "disabled": false,
-        "label": "Link types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 11,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=action-types",
-        "disabled": false,
-        "label": "Action types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 12,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=value-types",
-        "disabled": false,
-        "label": "Value types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 13,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=functions",
-        "disabled": false,
-        "label": "Functions0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 14,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=health",
-        "disabled": false,
-        "label": "Health issues"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 15,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=configuration",
-        "disabled": false,
-        "label": "Ontology configuration"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": "n23",
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Filter"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n23",
-      "to": "n23",
-      "control": {
-        "index": 17,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "probe-reencode v1 ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 18,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer",
-        "disabled": false,
-        "label": "Object Explorer →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 21,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?definitionId=widget&definitionKind=object-type&ontology=ont_18ca2757d28a20f7&section=object-types",
-        "disabled": false,
-        "label": "Widget 0 objects 0 dependents a widget"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Configure model in substrate →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/schema",
-        "disabled": false,
-        "label": "Ontology Manager ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": "visited",
-      "control": {
-        "index": 24,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7&section=discover",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 25,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/explorer?objectType=widget&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Explorer"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 26,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Pipeline"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 27,
-        "tag": "select",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "— none —"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 28,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Save"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 29,
-        "tag": "select",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "stringintegerdoublebooleantimestampenum"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 30,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Save"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n23",
-      "to": null,
-      "control": {
-        "index": 31,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/ont_18ca2757d28a20f7/edit",
-        "disabled": false,
-        "label": "Open substrate record →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n23",
       "to": "back-stack",
       "control": null,
       "action": "back",
@@ -9306,27 +6208,15 @@
   "replay": {
     "mode": "interaction",
     "walked_all_edges": false,
-    "edges_total": 616,
-    "edges_executed": 60,
-    "edges_skip_classified": 548,
+    "edges_total": 400,
+    "edges_executed": 31,
+    "edges_skip_classified": 369,
     "problems": [
-      "edge n1/\"Filter\": recorded noop, observed state-change",
-      "edge n1/\"probe-reencode v1 ▾\": recorded navigated, observed noop",
-      "edge n11/\"probe-reencode v1 ▾\": recorded state-change, observed noop",
-      "edge n12/\"Filter\": recorded noop, observed navigated",
-      "edge n12/\"— none —\": recorded unclickable but clicks now — recapture this source",
-      "edge n12/\"Save\": recorded unclickable but clicks now — recapture this source",
-      "edge n12/\"stringintegerdoublebooleantimestampenum\": recorded unclickable but clicks now — recapture this source",
-      "edge n12/\"Save\": recorded unclickable but clicks now — recapture this source",
-      "edge n13/\"Filter\": recorded navigated, observed noop",
-      "edge n23/\"— none —\": recorded unclickable but clicks now — recapture this source",
-      "edge n23/\"Save\": recorded unclickable but clicks now — recapture this source",
-      "edge n23/\"stringintegerdoublebooleantimestampenum\": recorded unclickable but clicks now — recapture this source",
-      "edge n23/\"Save\": recorded unclickable but clicks now — recapture this source"
+      "edge n11/\"Filter\": recorded navigated, observed noop"
     ],
-    "walked_at": "2026-08-09T23:47:02.861Z"
+    "walked_at": "2026-08-10T02:04:43.262Z"
   },
   "complete_interaction_route_graph": false,
   "shots_dir": ".artifacts/seed-graph-shots/ontology/schema",
-  "content_address": "30feb5c4419acd42a1e0b9eaef797549f93aae579edd409d85c1849c3a2df9c2"
+  "content_address": "2b5f8be12de4d69fa956cb3a7e91d5d7e8d2962891d95ba9140c60c93ade4d40"
 }

--- a/apps/hypervisor/seed-ux-provenance.v1.json
+++ b/apps/hypervisor/seed-ux-provenance.v1.json
@@ -431,7 +431,7 @@
           },
           "graph_file": "seed-graphs/ontology/schema.v1.json",
           "class": "daemon_wired",
-          "replay_problem_count": 13,
+          "replay_problem_count": 1,
           "seed_role": "baseline"
         },
         {

--- a/apps/hypervisor/surfaces/authority-client.mjs
+++ b/apps/hypervisor/surfaces/authority-client.mjs
@@ -190,6 +190,15 @@ export async function crossWithLease(
       payload?.error?.message || payload?.message || payload?.reason || "the gateway refused the crossing",
       { refusal: payload });
   }
+  // Some planes speak typed refusals as 2xx + `ok:false` (the ODK ontology plane's
+  // idiom). That is a REFUSAL carrying its exact code — it must never be rebranded
+  // as receipt_missing, which would mask the daemon's typed reason.
+  if (payload?.ok === false) {
+    return refusal("gateway", status,
+      payload?.error?.code || payload?.reason || "typed_refusal",
+      payload?.error?.message || payload?.message || payload?.reason || "the plane refused the crossing",
+      { refusal: payload });
+  }
   // Gateway step 3 — the crossing happened iff a receipt names it. Fail closed otherwise.
   const receipt_ref = findReceiptRef(payload, extractReceiptRef);
   if (!receipt_ref) {

--- a/apps/hypervisor/surfaces/read-authority-clients.test.mjs
+++ b/apps/hypervisor/surfaces/read-authority-clients.test.mjs
@@ -69,6 +69,9 @@ const stub = createServer(async (req, res) => {
   if (req.url === "/v1/cross/no-receipt") {
     return json(200, { ok: true });
   }
+  if (req.url === "/v1/cross/typed-refusal") {
+    return json(200, { ok: false, error: { code: "ontology_ref_unresolved", message: "object 'x' title_property 'y' is not one of its properties" } });
+  }
   // W1.3 negotiation stubs — schema-versioned payload and a paginating list (the daemon's
   // authority/receipts shape: page object only when limit was asked for).
   if (req.url?.startsWith("/v1/versioned")) {
@@ -289,6 +292,15 @@ test("authority: 2xx without a discoverable receipt fails CLOSED (receipt_missin
   assert.equal(r.ok, false);
   assert.equal(r.kind, "failure");
   assert.equal(r.code, "receipt_missing");
+});
+
+test("authority: a 2xx ok:false plane refusal keeps its typed code — never receipt_missing", async () => {
+  const r = await createAuthorityClient({ daemon }).cross("/v1/cross/typed-refusal");
+  assert.equal(r.ok, false);
+  assert.equal(r.kind, "refusal");
+  assert.equal(r.stage, "gateway");
+  assert.equal(r.code, "ontology_ref_unresolved");
+  assert.match(r.message, /title_property/u);
 });
 
 test("authority: daemon down is a typed failure — no silent no-op, no invented state", async () => {

--- a/docs/architecture/_meta/canon-to-code-delta.md
+++ b/docs/architecture/_meta/canon-to-code-delta.md
@@ -227,6 +227,25 @@ machinery row above stays open. Tracked seed authority now lives at
 | **Seed roles: baseline vs corroborating (2026-08-09, second block).** Which sources hold a surface's seed gate closed. | `apps/hypervisor/ported-seed-preservation.v1.json` (the 16 protected executable ports — the code the product actually serves); the interaction-replay evidence in `apps/hypervisor/seed-graphs/` showing retained `/__apps` replays are hostile (corpus-mutation attempts), hung (canvas timeouts) or fragile while every completed baseline graph is protected. | **Ruled (owner, owner-reversible).** `seed_role` is typed in `seed-ux-provenance.v1.json`: protected executable ports are **baseline**; retained captures and dormant references are **corroborating** — preserved, typed, never deleted, never gate inputs. Readiness derives from baseline graph completeness only; the validator's kind⇒role lock makes demotion or promotion by tooling RED. A recovered corroborating source may still upgrade grammar; it re-enters the gate only by a further recorded ruling. |
 | **Studio blueprint/layout contract placement.** | OQ-1 ruling (descriptor authoring is ordinary governed mutation); W2.2's amended scope. | **Ruled.** The blueprint/layout contract (durable receipted draft, CAS, reopen/conflict/recovery) is Studio-owned and lands with W2.2 as ordinary governed mutation; promotion remains a separate governed handoff composing Governance/Packages. Stale OQ-1 wording may not be reintroduced. |
 
+### Journey verification (2026-08-09, next-legs run)
+
+The first two surface journeys are now CI-proven against an isolated live
+daemon (`check:ontology-journey` 31/31, `check:governance-journey` 20/20 in the
+product browser-smoke job). Ontology: create + seven receipted mutations under
+strict revision discipline, CAS conflict + typed recovery, denial, named gaps
+typed (no proposal family, no saved-set authoring), restart survival — with one
+standing typed finding: ODK ontology writes cross with no identity envelope
+(the W1.1/G-2 pull). Governance: submit → approve/reject/revoke with a
+daemon-resolved reviewer (`request_principal_required` proves identity-first),
+explicit confirmation on destructive transitions, decision receipts, terminal/
+withdrawn refusals typed, no substituted effect, restart survival. The shared
+authority client no longer rebrands 2xx `ok:false` plane refusals as
+`receipt_missing` — typed codes now surface verbatim
+(`apps/hypervisor/surfaces/authority-client.mjs`; suite 20/20). Governance is
+the first surface with BOTH gates green (baseline seed graphs complete + primary
+journey proven); ontology's seed gate stays closed on one typed residual
+(`seed-graphs/ontology/schema.v1.json` replay problem).
+
 ## Related Canon
 
 - [`implementation-matrix.md`](./implementation-matrix.md) — per-concept durable-form index (the wider matrix).


### PR DESCRIPTION
Legs 2+3 of the owner-commissioned next-legs run (stacks on #230, rebased onto master).

## What lands
- **Two journey verifiers, CI-wired** into the browser-smoke job, each spawning an ISOLATED daemon + serve pair (never the shared dev processes):
  - `check:ontology-journey` — **31/31**: create + 7 receipted authoring mutations with strict per-mutation revision discipline; CAS conflict (409 `odk_revision_conflict`) + typed recovery; denial; read/filter/history/health; **named gaps typed** (no proposal family, no saved-set authoring — asserted absent, never simulated); daemon **restart survival**; 3-posture matrix. **Typed finding recorded:** ODK ontology writes cross with no identity envelope (handlers take no HeaderMap; module ignores daemonFetch) — the W1.1/G-2 pull.
  - `check:governance-journey` — **20/20**: submit exact requests → approve/reject/revoke with a **daemon-resolved reviewer** (`request_principal_required` proves identity-before-effect) and explicit `confirm=1` on destructive transitions; decision receipts + readback; terminal/withdrawn transitions refuse typed; **no substituted effect**; restart survival; status views + cross-plane band.
- **Authority-client fix**: a 2xx `ok:false` plane refusal keeps its typed code — the client no longer rebrands it `receipt_missing` (found live: the ontology plane's typed validation refusals were being masked). Client suite 20/20 with a regression test.
- **Harvester hardening + honest re-derivation**: Escape-retry before `unclickable`; signature sees visible form controls / hidden fields / form actions; symmetric self-navigation compat at replay. Re-derived on isolated runtimes: `ontology/schema` narrowed from 13 problems to **one typed residual** (path-dependent Filter submit) — ontology's seed gate stays honestly closed; **governance becomes the first surface with BOTH gates green** (`--require-ready governance` GREEN + journey proven).
- Delta-ledger closure block records all of it.

## Verification
`check:seed-provenance` green (9 surfaces baseline-ready per OQ-12); `--require-ready governance` GREEN / `ontology` RED with exact typed reason; both journey suites green locally against isolated daemons; `check:source-neutral` green; `check:architecture-docs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)