### PR TITLE
feat(hypervisor): Projects saga step 2 — the audit's 501 stuck-form journey is dead (OQ-5, next-legs Leg 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
         run: |
           npm run check:ontology-journey --workspace=@ioi/hypervisor-app
           npm run check:governance-journey --workspace=@ioi/hypervisor-app
+          npm run check:projects-saga --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities
         run: |

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -15,6 +15,7 @@
     "check:seed-provenance": "node scripts/verify-hypervisor-seed-provenance.mjs",
     "check:ontology-journey": "node scripts/verify-hypervisor-ontology-journey.mjs",
     "check:governance-journey": "node scripts/verify-hypervisor-governance-journey.mjs",
+    "check:projects-saga": "node scripts/verify-hypervisor-projects-saga.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",
     "check:shell-parity": "node scripts/verify-hypervisor-shell-parity.mjs",

--- a/apps/hypervisor/scripts/ioi-api-adapter.mjs
+++ b/apps/hypervisor/scripts/ioi-api-adapter.mjs
@@ -841,8 +841,35 @@ async function handleImpl(pathname, bodyText) {
         return json({ pagination: {}, environmentClasses: [] });
       }
     }
-    // UpdateProject / UpdateProjectEnvironmentClasses are edit flows the daemon has no write plane
-    // for yet — they fall through (not fabricated here), and are not exercised by read navigation.
+    if (op === "UpdateProjectEnvironmentClasses") {
+      // OQ-5 saga step 2 — the write plane exists now (PATCH :id/environment-classes). The
+      // response always names the exact durable state; a refusal never claims rollback.
+      const id = projectIdFromBody(body);
+      const ids = (body.environmentClassIds || body.environment_class_ids ||
+        (Array.isArray(body.environmentClasses) ? body.environmentClasses.map((c) => c?.id || c) : []) || [])
+        .filter((x) => typeof x === "string" && x.trim());
+      try {
+        // Status-tolerant call: a typed refusal (401/404/409/422) is saga truth to surface
+        // verbatim, never rebranded daemon-down (daemon() throws on any non-2xx).
+        const res = await fetch(`${DAEMON}/v1/hypervisor/projects/${encodeURIComponent(id)}/environment-classes`, {
+          method: "PATCH",
+          headers: currentDaemonHeaders({ includeContentType: true }),
+          body: JSON.stringify({ environment_class_ids: ids }),
+          signal: AbortSignal.timeout(8000),
+        });
+        const r = await res.json().catch(() => ({}));
+        if (res.ok && r?.ok === true) {
+          return json({ project: daemonProjectToIOI(r.project, LOCAL_SCOPE.orgId), receiptRef: r.receipt?.receipt_ref || "" });
+        }
+        return jsonStatus(res.ok ? 409 : res.status, { code: r?.code || "project_environment_classes_refused",
+          message: `${r?.message || "the binding was refused"} — the created project keeps its exact durable partial state` });
+      } catch (e) {
+        return jsonStatus(502, { code: "project_environment_classes_unavailable",
+          message: `the daemon did not answer the binding step (${e.message}); the created project keeps its exact durable partial state` });
+      }
+    }
+    // UpdateProject is an edit flow the daemon has no write plane for yet — it falls through
+    // (not fabricated here), and is not exercised by read navigation.
   }
 
   // ---- Local-deployment projections: honest local posture for planes the daemon does not yet

--- a/apps/hypervisor/scripts/verify-hypervisor-projects-saga.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-projects-saga.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+// SURF-projects saga verifier (next-legs Leg 4, OQ-5 ruling).
+//
+// Proves, against an ISOLATED real daemon + serve lane, that project creation is
+// an explicit resumable saga: step 1 (CreateProject) commits durably; step 2
+// (UpdateProjectEnvironmentClasses) is a receipted, CAS-guarded, idempotent
+// durable step with identity-first refusals; every refusal names the exact
+// preserved partial state; and the audit's observed journey — CreateProject 200
+// → binding 501 → stuck form — is REPRODUCIBLY DEAD at the RPC seam.
+//
+// Exit: 0 pass · 1 fail · 2 blocked (daemon binary missing).
+//   IOI_HYPERVISOR_DAEMON_BINARY  default target/debug/hypervisor-daemon
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+  srv.on("error", reject);
+});
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try {
+  fs.accessSync(daemonBinary, fs.constants.X_OK);
+} catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-projects-saga-"));
+let daemon = null;
+let serve = null;
+let daemonPort = 0;
+let DAEMON = "";
+let SERVE = "";
+let SESSION = "";
+
+async function startDaemon() {
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${daemonPort}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1/v1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = "";
+  daemon.stdout.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  await waitFor(`${DAEMON}/healthz`, 30000);
+  return () => log;
+}
+
+const jd = (p, init, cookie = false) => fetch(`${DAEMON}${p}`, {
+  headers: {
+    ...(init?.body ? { "content-type": "application/json" } : {}),
+    ...(cookie && SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+  },
+  ...init,
+}).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+  .catch(() => ({ status: 0, body: {} }));
+
+// The SPA seam: RPCs against the serve lane's /api adapter, with the browser's
+// session cookie so the adapter's identity forwarding is exercised end-to-end.
+const rpc = (op, body) => fetch(`${SERVE}/api/ioi.v1.ProjectService/${op}`, {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    ...(SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+  },
+  body: JSON.stringify(body),
+}).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+  .catch(() => ({ status: 0, body: {} }));
+
+async function run() {
+  daemonPort = await freePort();
+  DAEMON = `http://127.0.0.1:${daemonPort}`;
+  const daemonLogFn = await startDaemon();
+  const token = daemonLogFn().match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  if (token) {
+    const boot = await jd("/v1/hypervisor/auth/bootstrap", {
+      method: "POST",
+      body: JSON.stringify({ token, password: "projects-saga-bootstrap-v1", email: "projects-saga@ioi.local" }),
+    });
+    SESSION = boot.body?.session_token ?? "";
+  }
+  ok("operator bootstrap yields an authenticated session", SESSION.startsWith("ioi_sess_"), SESSION.slice(0, 12));
+
+  const servePort = await freePort();
+  const productUiPort = await freePort();
+  SERVE = `http://127.0.0.1:${servePort}`;
+  serve = spawn(process.execPath, [path.join(HERE, "serve-product-ui.mjs")], {
+    cwd: APP,
+    env: {
+      ...process.env,
+      PORT: String(servePort),
+      PRODUCT_UI_PORT: String(productUiPort),
+      IOI_PRODUCT_UI_PUBLIC: path.join(APP, "product-ui", "owned", "public"),
+      IOI_HYPERVISOR_DAEMON_URL: DAEMON,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await waitFor(`${SERVE}/projects`, 30000);
+
+  // -- saga step 1: create commits durably -----------------------------------
+  const created = await rpc("CreateProject", {
+    name: "saga-journey",
+    initializer: { specs: [{ git: { remoteUri: "https://example.invalid/saga/journey.git" } }] },
+  });
+  const projectId = created.body?.project?.id || created.body?.project?.projectId || "";
+  ok("saga step 1: CreateProject commits", created.status === 200 && projectId.length > 0, `status ${created.status} id ${projectId}`);
+  const durable = await jd(`/v1/hypervisor/projects/${encodeURIComponent(projectId)}`);
+  ok("step 1 is durable daemon truth", durable.status === 200 && durable.body?.ok === true, "");
+
+  // -- the audit's dead journey: binding no longer 501s ----------------------
+  const bind = await rpc("UpdateProjectEnvironmentClasses", {
+    projectId,
+    environmentClassIds: ["local-workspace-v0"],
+  });
+  ok("saga step 2: binding crosses with a receipt (the 501 journey is DEAD)",
+    bind.status === 200 && (bind.body?.receiptRef || "").startsWith("agentgres://project-receipts/"),
+    `status ${bind.status} receipt ${bind.body?.receiptRef ?? ""} ${JSON.stringify(bind.body).slice(0, 120)}`);
+  const bound = await jd(`/v1/hypervisor/projects/${encodeURIComponent(projectId)}`);
+  const rec = bound.body?.project ?? {};
+  ok("binding reads back: classes, revision 2, saga state, receipted history",
+    JSON.stringify(rec.environment_class_ids) === JSON.stringify(["local-workspace-v0"]) &&
+      rec.revision === 2 && rec.saga_state === "environment_classes_bound" &&
+      (rec.history ?? []).some((h) => String(h.receipt_ref ?? "").includes("project-receipts")),
+    `rev ${rec.revision} state ${rec.saga_state}`);
+
+  // -- idempotent replay ------------------------------------------------------
+  const replay = await rpc("UpdateProjectEnvironmentClasses", { projectId, environmentClassIds: ["local-workspace-v0"] });
+  const after = await jd(`/v1/hypervisor/projects/${encodeURIComponent(projectId)}`);
+  ok("an identical re-bind replays the stored receipt (no second truth)",
+    replay.status === 200 && replay.body?.receiptRef === bind.body?.receiptRef && after.body?.project?.revision === 2,
+    `receipt ${replay.body?.receiptRef ?? ""} rev ${after.body?.project?.revision}`);
+
+  // -- typed refusal preserves the exact partial state ------------------------
+  const refused = await rpc("UpdateProjectEnvironmentClasses", { projectId, environmentClassIds: ["not-a-class"] });
+  const preserved = await jd(`/v1/hypervisor/projects/${encodeURIComponent(projectId)}`);
+  ok("an unknown class refuses typed and preserves the durable partial state",
+    refused.status === 422 && refused.body?.code === "environment_class_unknown" &&
+      preserved.body?.project?.revision === 2 &&
+      JSON.stringify(preserved.body?.project?.environment_class_ids) === JSON.stringify(["local-workspace-v0"]),
+    `status ${refused.status} code ${refused.body?.code}`);
+
+  // -- CAS guards the step ----------------------------------------------------
+  const stale = await jd(`/v1/hypervisor/projects/${encodeURIComponent(projectId)}/environment-classes`, {
+    method: "PATCH",
+    body: JSON.stringify({ expected_revision: 1, environment_class_ids: ["devcontainer"] }),
+  }, true);
+  ok("a stale expected_revision refuses with the typed conflict",
+    stale.status === 409 && stale.body?.code === "project_revision_conflict" && stale.body?.current_revision === 2,
+    `status ${stale.status}`);
+
+  // -- identity-first (rule E): no session -> refusal BEFORE the 404 oracle ---
+  const anon = await jd(`/v1/hypervisor/projects/does-not-exist/environment-classes`, {
+    method: "PATCH",
+    body: JSON.stringify({ environment_class_ids: ["local-workspace-v0"] }),
+  }, false);
+  ok("an unauthenticated binding refuses identity-first (never a 404 oracle)",
+    (anon.status === 401 || anon.status === 403) && anon.body?.ok === false,
+    `status ${anon.status} code ${anon.body?.code ?? ""}`);
+
+  // -- restart survival -------------------------------------------------------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  await startDaemon();
+  const revived = await jd(`/v1/hypervisor/projects/${encodeURIComponent(projectId)}`);
+  ok("the bound saga state survives a daemon restart",
+    revived.body?.project?.revision === 2 &&
+      JSON.stringify(revived.body?.project?.environment_class_ids) === JSON.stringify(["local-workspace-v0"]),
+    `rev ${revived.body?.project?.revision}`);
+  const receipts = await (async () => {
+    try { return fs.readdirSync(path.join(dataDir, "project-receipts")).length; } catch { return -1; }
+  })();
+  ok("the binding receipt is a durable record", receipts >= 1, `${receipts} receipts`);
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  cleanup();
+  process.exit(1);
+});
+
+function cleanup() {
+  try { serve?.kill("SIGTERM"); } catch { /* gone */ }
+  try { daemon?.kill("SIGTERM"); } catch { /* gone */ }
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* keep */ }
+}

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -1186,6 +1186,12 @@ async fn async_main() -> anyhow::Result<()> {
             get(environment_routes::handle_project_get)
                 .delete(environment_routes::handle_project_delete),
         )
+        // OQ-5 saga step 2: environment-class binding as its own receipted, CAS-guarded,
+        // idempotent durable step (the UpdateProjectEnvironmentClasses write plane).
+        .route(
+            "/v1/hypervisor/projects/:id/environment-classes",
+            patch(environment_routes::handle_project_environment_classes_patch),
+        )
         // WS-A/WS-B: Environment object model + local_workspace_provider_v0 (daemon-owned).
         .route(
             "/v1/hypervisor/environment-classes",

--- a/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
@@ -2130,11 +2130,18 @@ pub(crate) async fn handle_project_environment_classes_patch(
         );
     }
     if persist_record(&st.data_dir, "project-receipts", &receipt_id, &receipt).is_err() {
-        let _ = persist_record(&st.data_dir, "projects", &id, &prev);
+        // Double-fault disclosure: the restore's own result is part of the truth — a
+        // discarded restore would hide a record that kept the binding without its proof.
+        let restored = persist_record(&st.data_dir, "projects", &id, &prev).is_ok();
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({ "ok": false, "code": "project_receipt_persistence_failed",
-                "message": "the receipt did not commit — the binding was restored to its prior state" })),
+                "restored": restored,
+                "message": if restored {
+                    "the receipt did not commit — the binding was restored to its prior state"
+                } else {
+                    "the receipt did not commit AND the restore failed — the record may hold the new binding without its receipt; re-read before retrying"
+                } })),
         );
     }
     (StatusCode::OK, Json(json!({ "ok": true, "project": next, "receipt": receipt })))

--- a/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
@@ -2026,15 +2026,19 @@ pub(crate) async fn handle_project_environment_classes_patch(
     let Some(raw) = body.get("environment_class_ids").and_then(|v| v.as_array()) else {
         return (
             StatusCode::BAD_REQUEST,
-            Json(json!({ "ok": false, "code": "project_environment_class_ids_required",
-                "message": "`environment_class_ids` (array of catalog ids) is required" })),
+            Json(
+                json!({ "ok": false, "code": "project_environment_class_ids_required",
+                "message": "`environment_class_ids` (array of catalog ids) is required" }),
+            ),
         );
     };
     if raw.len() > 32 {
         return (
             StatusCode::BAD_REQUEST,
-            Json(json!({ "ok": false, "code": "project_environment_class_ids_bounds",
-                "message": "at most 32 environment classes bind to one project" })),
+            Json(
+                json!({ "ok": false, "code": "project_environment_class_ids_bounds",
+                "message": "at most 32 environment classes bind to one project" }),
+            ),
         );
     }
     let mut requested: Vec<String> = Vec::new();
@@ -2079,7 +2083,11 @@ pub(crate) async fn handle_project_environment_classes_patch(
     let prev_ids: Vec<String> = prev
         .get("environment_class_ids")
         .and_then(|v| v.as_array())
-        .map(|a| a.iter().filter_map(|v| v.as_str().map(str::to_string)).collect())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
         .unwrap_or_default();
     if prev_ids == requested {
         if let Some(receipt) = prev.get("last_environment_classes_receipt") {
@@ -2115,8 +2123,10 @@ pub(crate) async fn handle_project_environment_classes_patch(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
-    hist.push(json!({ "revision": rev, "op": "environment_classes_bound", "at": now,
-        "receipt_ref": receipt.get("receipt_ref").cloned().unwrap_or(Value::Null) }));
+    hist.push(
+        json!({ "revision": rev, "op": "environment_classes_bound", "at": now,
+        "receipt_ref": receipt.get("receipt_ref").cloned().unwrap_or(Value::Null) }),
+    );
     let len = hist.len();
     if len > 20 {
         hist = hist[len - 20..].to_vec();
@@ -2125,8 +2135,10 @@ pub(crate) async fn handle_project_environment_classes_patch(
     if persist_record(&st.data_dir, "projects", &id, &next).is_err() {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "ok": false, "code": "project_record_persistence_failed",
-                "message": "the binding did not commit — the project is unchanged" })),
+            Json(
+                json!({ "ok": false, "code": "project_record_persistence_failed",
+                "message": "the binding did not commit — the project is unchanged" }),
+            ),
         );
     }
     if persist_record(&st.data_dir, "project-receipts", &receipt_id, &receipt).is_err() {
@@ -2135,16 +2147,21 @@ pub(crate) async fn handle_project_environment_classes_patch(
         let restored = persist_record(&st.data_dir, "projects", &id, &prev).is_ok();
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "ok": false, "code": "project_receipt_persistence_failed",
+            Json(
+                json!({ "ok": false, "code": "project_receipt_persistence_failed",
                 "restored": restored,
                 "message": if restored {
                     "the receipt did not commit — the binding was restored to its prior state"
                 } else {
                     "the receipt did not commit AND the restore failed — the record may hold the new binding without its receipt; re-read before retrying"
-                } })),
+                } }),
+            ),
         );
     }
-    (StatusCode::OK, Json(json!({ "ok": true, "project": next, "receipt": receipt })))
+    (
+        StatusCode::OK,
+        Json(json!({ "ok": true, "project": next, "receipt": receipt })),
+    )
 }
 
 /// GET /v1/hypervisor/environment-classes — substrate catalog (v0: local only enabled).

--- a/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
@@ -1978,6 +1978,168 @@ pub(crate) async fn handle_project_delete(
     Json(json!({ "ok": removed, "removed": removed, "project_id": id }))
 }
 
+/// PATCH /v1/hypervisor/projects/:id/environment-classes — the second durable step of the
+/// project-creation saga (OQ-5 ruling: an explicit resumable saga, never an atomic pretense —
+/// the live audit watched CreateProject 200 then this step 501 leave a stuck form). Identity
+/// first (rule E: the 401 is owed before the 404 existence oracle); `expected_revision` CAS;
+/// class ids validated against the ONE substrate catalog; record-first receipt-second with
+/// restore-on-failure so no accepted binding lacks its proof; an identical re-bind replays the
+/// stored receipt rather than minting a second truth.
+pub(crate) async fn handle_project_environment_classes_patch(
+    State(st): State<Arc<DaemonState>>,
+    AxumPath(id): AxumPath<String>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> (StatusCode, Json<Value>) {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        Ok(identity) => identity,
+        Err(error) => return super::lifecycle_routes::planner_scope_refusal(error),
+    };
+    let Some(prev) = read_record_dir(&st.data_dir, "projects")
+        .into_iter()
+        .find(|p| p.get("project_id").and_then(|v| v.as_str()) == Some(id.as_str()))
+    else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "ok": false, "code": "project_not_found",
+                "message": format!("project {id} not found — the create step of the saga has not run") })),
+        );
+    };
+    let current_rev = prev.get("revision").and_then(|v| v.as_u64()).unwrap_or(1);
+    if let Some(expected) = body.get("expected_revision") {
+        let Some(expected) = expected.as_u64() else {
+            return (
+                StatusCode::OK,
+                Json(json!({ "ok": false, "code": "project_field_type_invalid",
+                    "message": "`expected_revision` must be an unsigned integer" })),
+            );
+        };
+        if expected != current_rev {
+            return (
+                StatusCode::CONFLICT,
+                Json(json!({ "ok": false, "code": "project_revision_conflict",
+                    "message": "the project changed since it was read — re-read and retry",
+                    "current_revision": current_rev })),
+            );
+        }
+    }
+    let Some(raw) = body.get("environment_class_ids").and_then(|v| v.as_array()) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "ok": false, "code": "project_environment_class_ids_required",
+                "message": "`environment_class_ids` (array of catalog ids) is required" })),
+        );
+    };
+    if raw.len() > 32 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "ok": false, "code": "project_environment_class_ids_bounds",
+                "message": "at most 32 environment classes bind to one project" })),
+        );
+    }
+    let mut requested: Vec<String> = Vec::new();
+    for v in raw {
+        match v.as_str() {
+            Some(s) if !s.trim().is_empty() && s.chars().count() <= 120 => {
+                let s = s.trim().to_string();
+                if !requested.contains(&s) {
+                    requested.push(s);
+                }
+            }
+            _ => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({ "ok": false, "code": "project_field_type_invalid",
+                        "message": "every environment class id must be a non-empty bounded string" })),
+                );
+            }
+        }
+    }
+    // Validate against the exact catalog the GET serves (same lazy seed, no second truth).
+    let catalog_json = handle_environment_classes(State(st.clone())).await.0;
+    let known: Vec<String> = catalog_json
+        .get("environmentClasses")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|c| c.get("id").and_then(|v| v.as_str()).map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    let unknown: Vec<&String> = requested.iter().filter(|r| !known.contains(r)).collect();
+    if !unknown.is_empty() {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "ok": false, "code": "environment_class_unknown",
+                "message": format!("not in the substrate catalog: {unknown:?}"),
+                "unknown": unknown, "known": known })),
+        );
+    }
+    // Idempotent replay: an identical set re-binds nothing and returns the stored receipt.
+    let prev_ids: Vec<String> = prev
+        .get("environment_class_ids")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(str::to_string)).collect())
+        .unwrap_or_default();
+    if prev_ids == requested {
+        if let Some(receipt) = prev.get("last_environment_classes_receipt") {
+            return (
+                StatusCode::OK,
+                Json(json!({ "ok": true, "replayed": true, "project": prev, "receipt": receipt })),
+            );
+        }
+    }
+    let now = iso_now();
+    let rev = current_rev + 1;
+    let slug = id.strip_prefix("project:").unwrap_or(&id);
+    let receipt_id = format!("prjrcpt_{slug}_{rev}");
+    let receipt = json!({
+        "schema_version": "ioi.hypervisor.project.environment-classes-receipt.v1",
+        "receipt_id": receipt_id,
+        "receipt_ref": format!("agentgres://project-receipts/{receipt_id}"),
+        "project_id": id,
+        "op": "environment_classes_bound",
+        "environment_class_ids": requested,
+        "revision": rev,
+        "recorded_at": now,
+        "acting_principal_ref": identity.principal_ref,
+    });
+    let mut next = prev.clone();
+    next["environment_class_ids"] = json!(requested);
+    next["revision"] = json!(rev);
+    next["updated_at"] = json!(now.clone());
+    next["saga_state"] = json!("environment_classes_bound");
+    next["last_environment_classes_receipt"] = receipt.clone();
+    let mut hist = next
+        .get("history")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    hist.push(json!({ "revision": rev, "op": "environment_classes_bound", "at": now,
+        "receipt_ref": receipt.get("receipt_ref").cloned().unwrap_or(Value::Null) }));
+    let len = hist.len();
+    if len > 20 {
+        hist = hist[len - 20..].to_vec();
+    }
+    next["history"] = json!(hist);
+    if persist_record(&st.data_dir, "projects", &id, &next).is_err() {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "ok": false, "code": "project_record_persistence_failed",
+                "message": "the binding did not commit — the project is unchanged" })),
+        );
+    }
+    if persist_record(&st.data_dir, "project-receipts", &receipt_id, &receipt).is_err() {
+        let _ = persist_record(&st.data_dir, "projects", &id, &prev);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "ok": false, "code": "project_receipt_persistence_failed",
+                "message": "the receipt did not commit — the binding was restored to its prior state" })),
+        );
+    }
+    (StatusCode::OK, Json(json!({ "ok": true, "project": next, "receipt": receipt })))
+}
+
 /// GET /v1/hypervisor/environment-classes — substrate catalog (v0: local only enabled).
 /// Environment classes as DURABLE records with provider eligibility. `enabled` is computed
 /// HONESTLY at read time: a class is enabled only when a real provider/account path backs it —

--- a/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
@@ -6811,7 +6811,7 @@ pub(crate) async fn handle_physical_action_intent_admission(
 // ---------------------------------------------------------------------------------------------
 const PLANNER_NAMESPACE: &str = "hypervisor-kernel-admissions";
 
-fn planner_scope_refusal(
+pub(crate) fn planner_scope_refusal(
     error: super::substrate_store::RequestScopeRefusal,
 ) -> (StatusCode, Json<Value>) {
     use super::substrate_store::RequestScopeRefusal;


### PR DESCRIPTION
Leg 4 of the owner-commissioned next-legs run. Stacked on #231 — retarget to master before #231 merges.

## What lands
- **Daemon** `PATCH /v1/hypervisor/projects/:id/environment-classes` (the missing `UpdateProjectEnvironmentClasses` write plane), per the OQ-5 resumable-saga ruling: **identity-first** (rule E — 401 `request_principal_required` before any 404 oracle), `expected_revision` **CAS** (typed 409 with `current_revision`), class ids validated against the one substrate catalog (typed 422 `environment_class_unknown`), **record-first receipt-second with restore-on-failure**, **idempotent replay** of identical binds returning the stored receipt, `saga_state` + receipted history, `acting_principal_ref` bound (INV-37).
- **Adapter**: `UpdateProjectEnvironmentClasses` wired with a status-tolerant call — typed refusals surface verbatim and always name the preserved durable partial state; daemon-down is a distinct typed 502. The former fallthrough (501) is gone.
- **`check:projects-saga`** (CI-wired): **11/11** against an isolated daemon+serve, including the negative proof that the audit journey (create-200 → 501 → stuck form) is dead, restart survival, and the durable receipt record.

## Verification
Verifier output in the PR run; `cargo build --locked -p ioi-node --bin hypervisor-daemon` clean; full daemon suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)