### PR TITLE
feat(hypervisor): /packages canonical mount — registry + marketplace read-first, lifecycle actions over the closed daemon family; check:packages-journey (W2.3, next-legs II Leg 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,7 @@ jobs:
           npm run check:ontology-journey --workspace=@ioi/hypervisor-app
           npm run check:governance-journey --workspace=@ioi/hypervisor-app
           npm run check:studio-journey --workspace=@ioi/hypervisor-app
+          npm run check:packages-journey --workspace=@ioi/hypervisor-app
           npm run check:projects-saga --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -16,6 +16,7 @@
     "check:ontology-journey": "node scripts/verify-hypervisor-ontology-journey.mjs",
     "check:governance-journey": "node scripts/verify-hypervisor-governance-journey.mjs",
     "check:studio-journey": "node scripts/verify-hypervisor-studio-journey.mjs",
+    "check:packages-journey": "node scripts/verify-hypervisor-packages-journey.mjs",
     "check:projects-saga": "node scripts/verify-hypervisor-projects-saga.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",

--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -10110,7 +10110,14 @@ async function handleEstateRequest(req, res, body) {
       const hit = boundSurface(pathname, req.method);
       if (hit) {
         const url = new URL(req.url, "http://x");
-        const ctx = { url, daemon: DAEMON, embed: url.searchParams.get("embed") === "1" };
+        // W2.3 / DEF-IDENT-1 extension: module READS get the same request-scoped daemon
+        // capability the action lane hands out. Identity-first daemon families (the packages
+        // registry refuses even reads without a principal) can only render truthfully when the
+        // caller's own envelope rides the read — the flat GET branches already forward it via
+        // the ambient daemonFetch, so this closes the same gap for bound modules. Anonymous
+        // stays anonymous: the capability carries the request's identity or nothing, so a
+        // signed-out render shows the family's typed refusal, never another caller's truth.
+        const ctx = { url, daemon: DAEMON, embed: url.searchParams.get("embed") === "1", daemonFetch: moduleActionDaemonCapability() };
         const model = hit.impl.load ? await hit.impl.load(ctx) : null;
         const rendered = hit.impl.render(model, ctx);
         // ctx.embed gates the module's own rail emission; the estate-wide embed choke point

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -30,6 +30,7 @@ import * as approvalsModule from "../surfaces/approvals/index.mjs";
 import * as sourcesModule from "../surfaces/sources/index.mjs";
 import * as missionsModule from "../surfaces/missions/index.mjs";
 import * as studioModule from "../surfaces/studio/index.mjs";
+import * as packagesModule from "../surfaces/packages/index.mjs";
 
 // Capability model (operational wave): `capabilities` is the AUTHORITY-derived set of acts the
 // surface genuinely supports today (never inferred from pixel certification or daemon_wired);
@@ -71,6 +72,16 @@ export const SURFACES = [
   // end-to-end live journey), not a pixel certification.
   { slug: "studio-home", owner: "Studio", title: "Studio", icon: DSG_APP_TILE_URI, route: "/__ioi/studio/workbench", canonical_route: "/studio", verifier: "scripts/verify-hypervisor-studio-journey.mjs", certification: "n/a", capabilities: ["browse", "select", "inspect", "create", "update", "transition"], operational_state: "act", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "machinery", owner: "Studio", title: "Machinery", icon: MCH_APP_TILE_URI, route: "/__ioi/studio/machinery", verifier: "scripts/verify-hypervisor-app-parity-studio-machinery.mjs", certification: "pixel-certifications/machinery.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
+  // W2.3 (next-legs II Leg 2): the Packages surface packet — ONE module, two mounts, over the
+  // CLOSED /v1/hypervisor/packages daemon family. A FRESH legacy action lane
+  // (/__ioi/packages/registry — the /__ioi/marketplace* seed lanes keep serving untouched until
+  // their W4 cutover) plus the canonical /packages mount. The second row is the OPTIONAL
+  // Marketplace mode at its canonical /packages/marketplace route (canon: "Packages /
+  // Marketplace" — a mode of the Packages owner, never a second package owner; owner stays
+  // "Packages", the module is the same, and the row exists so the canonical mode route is
+  // module-served with truthful ownership markers). Evidence: the packages journey verifier.
+  { slug: "packages", owner: "Packages", title: "Packages", icon: MARKETPLACE_APP_ICON_URI, route: "/__ioi/packages/registry", canonical_route: "/packages", verifier: "scripts/verify-hypervisor-packages-journey.mjs", certification: "n/a", capabilities: ["browse", "select", "inspect", "create", "transition"], operational_state: "act", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
+  { slug: "packages-marketplace", owner: "Packages", title: "Packages / Marketplace", icon: MARKETPLACE_APP_ICON_URI, route: "/__ioi/packages/marketplace", canonical_route: "/packages/marketplace", verifier: "scripts/verify-hypervisor-packages-journey.mjs", certification: "n/a", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "monitors", owner: "Automations", title: "Automate", icon: MON_APP_TILE_URI, route: "/__ioi/automations/monitors", verifier: "scripts/verify-hypervisor-app-parity-monitors.mjs", certification: "pixel-certifications/monitors.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "changes", owner: "Improvement", title: "Upgrade Assistant", icon: CHG_APP_TILE_URI, route: "/__ioi/improvement/changes", verifier: "scripts/verify-hypervisor-app-parity-changes.mjs", certification: "pixel-certifications/changes.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "evalsuites", owner: "Evaluations", title: "AIP Evals", icon: EVL_APP_TILE_URI, route: "/__ioi/evaluations/evalsuites", verifier: "scripts/verify-hypervisor-app-parity-evalsuites.mjs", certification: "pixel-certifications/evalsuites.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
@@ -170,6 +181,10 @@ bindSurface("approvals", approvalsModule);
 bindSurface("sources", sourcesModule);
 bindSurface("missions", missionsModule);
 bindSurface("studio-home", studioModule);
+// Packages: BOTH rows bind the one module — the module branches on the served pathname (the
+// marketplace mounts render the read-first mode); ownership markers stay per-row truthful.
+bindSurface("packages", packagesModule);
+bindSurface("packages-marketplace", packagesModule);
 
 // Test-only fault surface (NEVER without the runtime-test flag): gives the action-runtime
 // verifier a module whose action THROWS (route isolation proof) and one that claims success

--- a/apps/hypervisor/scripts/verify-hypervisor-packages-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-packages-journey.mjs
@@ -1,0 +1,524 @@
+#!/usr/bin/env node
+// Packages lifecycle journey verifier (W2.3 bar, next-legs II Leg 2).
+//
+// Proves, against an ISOLATED real daemon + serve lane, the full chain the closed
+// /v1/hypervisor/packages daemon family actually owns — candidate → immutable release →
+// installation binding (FORCED DISABLED — the assertion is the binding truth, never
+// launchability) → uninstall — through the UI action lane where the verbs exist there and
+// direct daemon calls for setup/readback. Identity-first refusals, exact-head CAS conflicts
+// (typed AND rendered verbatim), idempotent replay returning the original receipt, restart
+// reconstruction, the canonical /packages + /packages/marketplace mounts, and the 3-posture
+// browser matrix.
+//
+// W2.3's recall bar is stated as TYPED ABSENCE, not simulated: the daemon owns NO
+// deprecate/disable/recall/revoke verb (surface_package_disposition is write-once "active" at
+// release admission; the registered enum names "recalled" but no route can set it), and the
+// product-surface compiler projection consumes NO package-registry state (so no installed
+// package can gain — or lose — launcher eligibility). Both absences are asserted mechanically:
+// the route inventory is EXACTLY the seven-route family, and the projection's
+// application_entries never contain the installed package's surface_ref. Eligibility loss is
+// proven through the one removal verb that DOES exist: uninstall immediately revokes the
+// binding (disabled_reason_codes gains surface_installation_uninstalled, launch_eligible stays
+// false).
+//
+// The owner scope is the daemon's own whoami answer, never a verifier constant.
+//
+// Exit: 0 pass · 1 fail · 2 blocked (daemon binary missing).
+//   IOI_HYPERVISOR_DAEMON_BINARY  default target/debug/hypervisor-daemon
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+  srv.on("error", reject);
+});
+
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try {
+  fs.accessSync(daemonBinary, fs.constants.X_OK);
+} catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-packages-journey-"));
+let daemon = null;
+let serve = null;
+let daemonPort = 0;
+let DAEMON = "";
+let SERVE = "";
+let SESSION = "";
+
+const PKG = "packages-journey-app";
+const INST = "primary";
+const LANE = "/__ioi/packages/registry";
+
+async function startDaemon() {
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${daemonPort}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1/v1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = "";
+  daemon.stdout.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  await waitFor(`${DAEMON}/healthz`, 30000);
+  return () => log;
+}
+
+// Daemon JSON with the operator session (the family is identity-first on reads AND writes).
+const jd = (p, init) => fetch(`${DAEMON}${p}`, {
+  headers: {
+    "content-type": "application/json",
+    ...(SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+  },
+  ...init,
+}).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+  .catch(() => ({ status: 0, body: {} }));
+
+// A served page, optionally carrying the operator session — the module's reads ride the
+// request's own identity envelope, so the SAME page is registry truth for the operator and a
+// typed refusal band for an anonymous caller.
+const pageText = (p, { authenticated = true } = {}) => fetch(`${SERVE}${p}`, {
+  headers: authenticated && SESSION ? { cookie: `ioi_session=${SESSION}` } : {},
+}).then(async (r) => ({ status: r.status, text: await r.text(), headers: r.headers }))
+  .catch(() => ({ status: 0, text: "", headers: new Headers() }));
+
+// A module action POST on the legacy lane: form-encoded, PRG 303, result in the redirect query.
+async function act(tail, fields, { authenticated = true } = {}) {
+  const r = await fetch(`${SERVE}${LANE}${tail}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      ...(authenticated && SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+    },
+    body: new URLSearchParams(fields).toString(),
+    redirect: "manual",
+  }).catch(() => null);
+  const location = r?.headers?.get("location") || "";
+  const q = new URLSearchParams(location.split("?")[1]?.split("#")[0] ?? "");
+  return { status: r?.status ?? 0, location, q };
+}
+
+const pkgGet = async () => (await jd(`/v1/hypervisor/packages/${PKG}`)).body;
+const relGet = async (digest) => (await jd(`/v1/hypervisor/packages/${PKG}/releases/${encodeURIComponent(digest)}`)).body;
+const instGet = async (digest) => (await jd(`/v1/hypervisor/packages/${PKG}/releases/${encodeURIComponent(digest)}/installations/${INST}`)).body;
+
+function packageFamilyRoutes(index) {
+  return (index.families ?? [])
+    .flatMap((family) => family.paths ?? [])
+    .filter((row) => row.path.startsWith("/v1/hypervisor/packages"))
+    .map((row) => ({ path: row.path, methods: [...row.methods].sort() }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function run() {
+  daemonPort = await freePort();
+  DAEMON = `http://127.0.0.1:${daemonPort}`;
+  const daemonLogFn = await startDaemon();
+  const token = daemonLogFn().match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  if (token) {
+    const boot = await jd("/v1/hypervisor/auth/bootstrap", {
+      method: "POST",
+      body: JSON.stringify({ token, password: "packages-journey-bootstrap-v1", email: "packages-journey@ioi.local" }),
+    });
+    SESSION = boot.body?.session_token ?? "";
+  }
+  ok("operator bootstrap yields an authenticated session", SESSION.startsWith("ioi_sess_"), SESSION.slice(0, 12));
+
+  const who = (await jd("/v1/hypervisor/auth/whoami")).body || {};
+  const OWNER = (who.principal?.tenant_refs || []).find((t) => typeof t === "string" && t.startsWith("org://")) || "";
+  ok("the session authenticates a principal with an org:// owner tenant to admit under", !!OWNER, OWNER || "no owner tenant");
+
+  // -- TYPED ABSENCE (mechanical): the admitted family is EXACTLY the seven candidate/release/
+  // installation routes — no recall/disposition/enable verb exists to lose eligibility through.
+  const index = await jd("/v1");
+  const familyRoutes = packageFamilyRoutes(index.body);
+  const expectedRoutes = [
+    { path: "/v1/hypervisor/packages", methods: ["GET", "POST"] },
+    { path: "/v1/hypervisor/packages/:package_id", methods: ["GET"] },
+    { path: "/v1/hypervisor/packages/:package_id/releases", methods: ["GET", "POST"] },
+    { path: "/v1/hypervisor/packages/:package_id/releases/:release_digest", methods: ["GET"] },
+    { path: "/v1/hypervisor/packages/:package_id/releases/:release_digest/installations", methods: ["GET", "POST"] },
+    { path: "/v1/hypervisor/packages/:package_id/releases/:release_digest/installations/:installation_id", methods: ["GET"] },
+    { path: "/v1/hypervisor/packages/:package_id/releases/:release_digest/installations/:installation_id/uninstall", methods: ["POST"] },
+  ].sort((left, right) => left.path.localeCompare(right.path));
+  ok("recall verb TYPED ABSENCE: the package family route inventory is exactly the seven-route candidate/release/installation slice (no recall/deprecate/revoke/enable route exists)",
+    JSON.stringify(familyRoutes) === JSON.stringify(expectedRoutes),
+    JSON.stringify(familyRoutes.map((r) => r.path)));
+
+  const servePort = await freePort();
+  const productUiPort = await freePort();
+  SERVE = `http://127.0.0.1:${servePort}`;
+  serve = spawn(process.execPath, [path.join(HERE, "serve-product-ui.mjs")], {
+    cwd: APP,
+    env: {
+      ...process.env,
+      PORT: String(servePort),
+      PRODUCT_UI_PORT: String(productUiPort),
+      IOI_PRODUCT_UI_PUBLIC: path.join(APP, "product-ui", "owned", "public"),
+      IOI_HYPERVISOR_DAEMON_URL: DAEMON,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await waitFor(`${SERVE}/packages`, 30000);
+
+  // -- canonical mounts render with truthful ownership -----------------------
+  const anonLanding = await pageText("/packages", { authenticated: false });
+  ok("canonical /packages 200s as the module's own mount (ownership headers)",
+    anonLanding.status === 200 && anonLanding.headers.get("x-ioi-surface-route") === "/packages" && anonLanding.headers.get("x-ioi-surface-owner") === "Packages",
+    `status ${anonLanding.status} route ${anonLanding.headers.get("x-ioi-surface-route")}`);
+  ok("an ANONYMOUS /packages render shows the family's typed identity refusal, never fabricated rows (identity-first reads)",
+    anonLanding.text.includes("request_principal_required") && anonLanding.text.includes("Packages"),
+    "");
+  const mkt = await pageText("/packages/marketplace", { authenticated: false });
+  ok("canonical /packages/marketplace renders the read-first Marketplace MODE under the Packages owner",
+    mkt.status === 200 && mkt.headers.get("x-ioi-surface-route") === "/packages/marketplace" && mkt.headers.get("x-ioi-surface-owner") === "Packages"
+      && mkt.text.includes("Packages / Marketplace") && mkt.text.includes("never becomes a second package owner"),
+    `status ${mkt.status} route ${mkt.headers.get("x-ioi-surface-route")}`);
+  ok("the marketplace mode is HONEST-EMPTY over the empty substrate (no fixture listings) with the ladder named to its owner lane",
+    mkt.text.includes("No marketplace listings") && mkt.text.includes('data-ioi-disabled-reason='),
+    "");
+  const legacyRegistry = await pageText(LANE, { authenticated: false });
+  const legacyMkt = await pageText("/__ioi/packages/marketplace", { authenticated: false });
+  ok("the fresh legacy lanes serve the same module with their own truthful markers",
+    legacyRegistry.status === 200 && legacyRegistry.headers.get("x-ioi-surface-route") === LANE
+      && legacyMkt.status === 200 && legacyMkt.headers.get("x-ioi-surface-route") === "/__ioi/packages/marketplace",
+    "");
+  const seedListings = await pageText("/__ioi/marketplace/listings", { authenticated: false });
+  ok("the /__ioi/marketplace/listings seed lane keeps serving untouched (seed preservation)",
+    seedListings.status === 200, `status ${seedListings.status}`);
+
+  // -- ODK source mesh fixtures (direct daemon setup — the packaging lane's admission inputs) --
+  const ont = await jd("/v1/hypervisor/odk/domain-ontologies", {
+    method: "POST",
+    body: JSON.stringify({ domain: "packages-journey", owner_ref: OWNER, idempotency_key: "packages-journey-ont-1" }),
+  });
+  const ontRef = ont.body?.ontology?.ref || "";
+  const sd = await jd("/v1/hypervisor/odk/surface-descriptors", {
+    method: "POST",
+    body: JSON.stringify({ name: "Packages journey surface", composition_pattern: "domain_app", ontology_ref: ontRef, owner_ref: OWNER, idempotency_key: "packages-journey-sd-1" }),
+  });
+  const sdRef = sd.body?.surface_descriptor?.ref || "";
+  const man = await jd("/v1/hypervisor/odk/manifests", {
+    method: "POST",
+    body: JSON.stringify({ name: "Packages journey manifest", ontology_refs: [ontRef], recipe_refs: [], surface_descriptor_refs: [sdRef], owner_ref: OWNER, idempotency_key: "packages-journey-man-1" }),
+  });
+  const manRef = man.body?.manifest?.ref || "";
+  const dapp = await jd("/v1/hypervisor/domain-apps", {
+    method: "POST",
+    body: JSON.stringify({ name: "Packages journey app", surface_descriptor_ref: sdRef, odk_manifest_ref: manRef, owner_ref: OWNER, idempotency_key: "packages-journey-dapp-1" }),
+  });
+  const dappRef = dapp.body?.domain_app?.domain_app_ref || "";
+  ok("the ODK source mesh admits (ontology → domain_app descriptor → manifest → draft DomainApp)",
+    ont.status === 201 && sd.status === 201 && man.status === 201 && dapp.status === 201 && !!dappRef,
+    dappRef || `statuses ${ont.status}/${sd.status}/${man.status}/${dapp.status}`);
+
+  // -- identity-first refusal through the UI action lane ----------------------
+  const anonAdmit = await act("/actions/admit-candidate", {
+    owner_ref: OWNER, package_id: PKG, domain_app_ref: dappRef,
+    idempotency_key: "packages-journey-candidate-1", return: LANE,
+  }, { authenticated: false });
+  ok("an unauthenticated candidate admission refuses TYPED (request_principal_required, no record)",
+    anonAdmit.status === 303 && anonAdmit.q.get("refused") === "request_principal_required",
+    anonAdmit.q.get("refused") || "");
+
+  // -- candidate admission through the UI action lane -------------------------
+  const admitted = await act("/actions/admit-candidate", {
+    owner_ref: OWNER, package_id: PKG, domain_app_ref: dappRef,
+    idempotency_key: "packages-journey-candidate-1", return: LANE,
+  });
+  const candidateReceipt = admitted.q.get("receipt") || "";
+  ok("candidate admission crosses with admission evidence (303 acted + receipt:// + record)",
+    admitted.status === 303 && admitted.q.get("acted") === "admit-candidate" && candidateReceipt.startsWith("receipt://") && admitted.q.get("record") === PKG,
+    admitted.location.slice(0, 140));
+  let candidate = await pkgGet();
+  const candidateHead = candidate.package?.agentgres?.head || "";
+  const snaps = candidate.package?.record?.source_snapshots || {};
+  ok("the admitted candidate freezes the source mesh content-addressed and NAMES the missing registration",
+    candidate.ok === true && candidate.package?.record?.registration_state === "absent"
+      && candidate.package?.record?.surface_class === "extension_application"
+      && [snaps.domain_app_content_hash, snaps.odk_manifest_content_hash, snaps.surface_descriptor_content_hash].every((v) => /^sha256:[0-9a-f]{64}$/u.test(v || ""))
+      && !!candidateHead,
+    `head ${String(candidateHead).slice(0, 14)}…`);
+
+  // -- idempotent replay through the UI lane returns the ORIGINAL receipt -----
+  const replay = await act("/actions/admit-candidate", {
+    owner_ref: OWNER, package_id: PKG, domain_app_ref: dappRef,
+    idempotency_key: "packages-journey-candidate-1", return: LANE,
+  });
+  ok("an exact candidate retry REPLAYS: same receipt_ref, replayed result, head unchanged",
+    replay.status === 303 && replay.q.get("receipt") === candidateReceipt && replay.q.get("result") === "replayed"
+      && (await pkgGet()).package?.agentgres?.head === candidateHead,
+    `${replay.q.get("result")} ${replay.q.get("receipt")?.slice(0, 40)}`);
+
+  // -- the operator's registry pages render admitted truth --------------------
+  const catalogPage = await pageText("/packages");
+  ok("the authenticated /packages catalog renders the candidate with its registration-absent truth",
+    catalogPage.status === 200 && catalogPage.text.includes(PKG) && catalogPage.text.includes("registration absent"),
+    "");
+  const pkgPage = await pageText(`/packages?pkg=${PKG}`);
+  ok("the package detail seeds the exact admitted head into the release CAS form",
+    pkgPage.status === 200 && pkgPage.text.includes(`name="expected_package_head" value="${candidateHead}"`)
+      && pkgPage.text.includes(candidate.package?.record?.candidate_content_hash || "@"),
+    "");
+
+  // -- immutable release through the UI action lane ---------------------------
+  const releaseCut = await act(`/${PKG}/cut-release`, {
+    idempotency_key: "packages-journey-release-1",
+    expected_package_head: candidateHead,
+    surface_distribution: "private_registry",
+    surface_capability_depth: "propose",
+    object_contract_refs: "object-model://packages-journey",
+    action_contract_refs: "action://packages-journey/propose",
+    evidence_refs: "artifact://packages-journey/conformance",
+    return: `${LANE}?pkg=${PKG}`,
+  });
+  const releaseDigest = releaseCut.q.get("record") || "";
+  ok("release admission crosses with admission evidence (303 acted + receipt + content-addressed digest)",
+    releaseCut.status === 303 && releaseCut.q.get("acted") === "cut-release"
+      && (releaseCut.q.get("receipt") || "").startsWith("receipt://") && /^sha256:[0-9a-f]{64}$/u.test(releaseDigest),
+    releaseCut.location.slice(0, 140));
+  let release = await relGet(releaseDigest);
+  const releaseHead = release.release?.agentgres?.head || "";
+  ok("the release is immutable canonical truth: admitted + active disposition, candidate receipt bound as evidence",
+    release.ok === true && release.release?.record?.surface_admission_state === "admitted"
+      && release.release?.record?.surface_package_disposition === "active"
+      && (release.release?.record?.evidence_refs || []).includes(candidateReceipt)
+      && !!releaseHead,
+    "");
+
+  // -- CAS conflict: typed AND rendered verbatim ------------------------------
+  const staleRelease = await act(`/${PKG}/cut-release`, {
+    idempotency_key: "packages-journey-release-stale",
+    expected_package_head: `sha256:${"0".repeat(64)}`,
+    surface_distribution: "private_registry",
+    surface_capability_depth: "propose",
+    object_contract_refs: "object-model://packages-journey",
+    action_contract_refs: "action://packages-journey/propose",
+    return: `${LANE}?pkg=${PKG}`,
+  });
+  ok("a stale expected_package_head refuses TYPED (package_expected_head_conflict)",
+    staleRelease.status === 303 && staleRelease.q.get("refused") === "package_expected_head_conflict",
+    staleRelease.q.get("refused") || "");
+  const stalePage = await pageText(staleRelease.location.split("#")[0]);
+  const releasesAfterStale = await jd(`/v1/hypervisor/packages/${PKG}/releases`);
+  ok("the CAS refusal renders VERBATIM with the fresh-head remedy, state unchanged (still exactly one release)",
+    stalePage.status === 200 && stalePage.text.includes("package_expected_head_conflict")
+      && stalePage.text.includes("re-open") && stalePage.text.includes("state unchanged")
+      && (releasesAfterStale.body?.releases || []).length === 1,
+    "");
+
+  // -- installation: contract narrowing enforced, then the disabled binding ---
+  const widening = await act(`/${PKG}/install`, {
+    idempotency_key: "packages-journey-install-widening",
+    release_digest: releaseDigest,
+    expected_release_head: releaseHead,
+    installation_id: "widening",
+    visibility: "organization",
+    allowed_object_contract_refs: "object-model://packages-journey",
+    allowed_action_refs: "action://not-in-release",
+    return: `${LANE}?pkg=${PKG}&rel=${encodeURIComponent(releaseDigest)}`,
+  });
+  ok("an installation that would WIDEN the release contract set refuses typed (package_installation_contract_widening)",
+    widening.status === 303 && widening.q.get("refused") === "package_installation_contract_widening",
+    widening.q.get("refused") || "");
+  const installed = await act(`/${PKG}/install`, {
+    idempotency_key: "packages-journey-install-1",
+    release_digest: releaseDigest,
+    expected_release_head: releaseHead,
+    installation_id: INST,
+    visibility: "organization",
+    allowed_object_contract_refs: "object-model://packages-journey",
+    allowed_action_refs: "action://packages-journey/propose",
+    return: `${LANE}?pkg=${PKG}&rel=${encodeURIComponent(releaseDigest)}`,
+  });
+  ok("installation crosses with admission evidence (303 acted + receipt + binding id)",
+    installed.status === 303 && installed.q.get("acted") === "install-release"
+      && (installed.q.get("receipt") || "").startsWith("receipt://") && installed.q.get("record") === INST,
+    installed.location.slice(0, 140));
+  let binding = await instGet(releaseDigest);
+  const installationHead = binding.installation?.agentgres?.head || "";
+  ok("the binding is REAL and FORCED DISABLED — the asserted truth is the binding, never launchability: installed + disabled + launch_eligible:false + the daemon's exact reason codes + registration absent",
+    binding.ok === true
+      && binding.installation?.record?.surface_installation_state === "installed"
+      && binding.installation?.record?.surface_enablement_state === "disabled"
+      && binding.installation?.launch_eligible === false
+      && JSON.stringify(binding.installation?.disabled_reason_codes) === JSON.stringify(["extension_application_registration_absent", "surface_serving_binding_absent"])
+      && binding.installation?.registration_state === "absent"
+      && !!installationHead,
+    JSON.stringify(binding.installation?.disabled_reason_codes));
+  const instPage = await pageText(`/packages?pkg=${PKG}&rel=${encodeURIComponent(releaseDigest)}&inst=${INST}`);
+  ok("the installation page renders the forced-disabled truth VERBATIM plus the recall + launcher named gaps (typed absences stated, not styled around)",
+    instPage.status === 200
+      && instPage.text.includes("launch_eligible: false")
+      && instPage.text.includes("extension_application_registration_absent")
+      && instPage.text.includes("surface_serving_binding_absent")
+      && instPage.text.includes('data-ioi-disabled-reason=')
+      && instPage.text.includes("typed absence"),
+    "");
+
+  // -- launcher projection TYPED ABSENCE --------------------------------------
+  const projection = await jd("/v1/hypervisor/product-surface-projections", { method: "POST", body: JSON.stringify({}) });
+  const projectionJson = JSON.stringify(projection.body);
+  ok("launcher projection TYPED ABSENCE: the product-surface compiler projects its estate but consumes NO package-registry state — the installed package's surface_ref never enters application_entries (no launcher eligibility exists to lose)",
+    projection.status === 200 && Array.isArray(projection.body?.application_entries) && projection.body.application_entries.length > 0
+      && !projectionJson.includes(`surface://extensions/${PKG}`),
+    `entries ${projection.body?.application_entries?.length ?? "none"}`);
+
+  // -- restart: the registry reconstructs from admitted truth -----------------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  await startDaemon();
+  candidate = await pkgGet();
+  release = await relGet(releaseDigest);
+  binding = await instGet(releaseDigest);
+  ok("candidate, release, and installation reconstruct after a daemon restart with EXACT heads",
+    candidate.package?.agentgres?.head === candidateHead
+      && release.release?.agentgres?.head === releaseHead
+      && binding.installation?.agentgres?.head === installationHead,
+    "");
+  let reload = { status: 0, text: "" };
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await new Promise((r) => setTimeout(r, 1500));
+    reload = await pageText(`/packages?pkg=${PKG}`);
+    if (reload.status === 200 && reload.text.includes(PKG)) break;
+  }
+  ok("the canonical registry view re-renders admitted state after restart",
+    reload.status === 200 && reload.text.includes(PKG) && reload.text.includes(candidateHead),
+    `status ${reload.status}`);
+
+  // -- eligibility loss through the ONE removal verb the family owns ----------
+  const uninstalled = await act(`/${PKG}/uninstall`, {
+    idempotency_key: "packages-journey-uninstall-1",
+    release_digest: releaseDigest,
+    installation_id: INST,
+    expected_installation_head: installationHead,
+    return: `${LANE}?pkg=${PKG}&rel=${encodeURIComponent(releaseDigest)}&inst=${INST}`,
+  });
+  const uninstallReceipt = uninstalled.q.get("receipt") || "";
+  ok("uninstall crosses under exact-head CAS (303 acted + receipt, result uninstalled)",
+    uninstalled.status === 303 && uninstalled.q.get("acted") === "uninstall"
+      && uninstallReceipt.startsWith("receipt://") && uninstalled.q.get("result") === "uninstalled",
+    uninstalled.location.slice(0, 140));
+  binding = await instGet(releaseDigest);
+  const uninstalledHead = binding.installation?.agentgres?.head || "";
+  // NOTE (derived from package_registry_routes.rs render_installation): the uninstall EVENT
+  // payload records the additional reason code surface_installation_uninstalled, but the
+  // family's read projection renders the structural reason pair on every revision — so the
+  // assertion is the truth the daemon actually answers: terminal state + immutable revision +
+  // launch_eligible pinned false + the head advanced.
+  ok("uninstall IMMEDIATELY revokes the binding (the family's one removal verb): state uninstalled, immutable revision 2, launch_eligible stays false, head advanced",
+    binding.installation?.record?.surface_installation_state === "uninstalled"
+      && binding.installation?.record?.revision === 2
+      && binding.installation?.record?.surface_enablement_state === "disabled"
+      && binding.installation?.launch_eligible === false
+      && !!uninstalledHead && uninstalledHead !== installationHead,
+    `state ${binding.installation?.record?.surface_installation_state} rev ${binding.installation?.record?.revision}`);
+  const uninstallReplay = await act(`/${PKG}/uninstall`, {
+    idempotency_key: "packages-journey-uninstall-1",
+    release_digest: releaseDigest,
+    installation_id: INST,
+    expected_installation_head: uninstalledHead,
+    return: `${LANE}?pkg=${PKG}&rel=${encodeURIComponent(releaseDigest)}&inst=${INST}`,
+  });
+  ok("an exact uninstall retry REPLAYS the original transition (same receipt, head unchanged)",
+    uninstallReplay.status === 303 && uninstallReplay.q.get("receipt") === uninstallReceipt
+      && (await instGet(releaseDigest)).installation?.agentgres?.head === uninstalledHead,
+    uninstallReplay.q.get("receipt")?.slice(0, 40) || "");
+  const staleUninstall = await act(`/${PKG}/uninstall`, {
+    idempotency_key: "packages-journey-uninstall-stale",
+    release_digest: releaseDigest,
+    installation_id: INST,
+    expected_installation_head: installationHead,
+    return: `${LANE}?pkg=${PKG}&rel=${encodeURIComponent(releaseDigest)}&inst=${INST}`,
+  });
+  ok("a stale uninstall head under a NEW key refuses typed (package_expected_head_conflict)",
+    staleUninstall.status === 303 && staleUninstall.q.get("refused") === "package_expected_head_conflict",
+    staleUninstall.q.get("refused") || "");
+  const instPageAfter = await pageText(`/packages?pkg=${PKG}&rel=${encodeURIComponent(releaseDigest)}&inst=${INST}`);
+  ok("the uninstalled binding renders its terminal truth (uninstalled state + launch_eligible false + the immutable-history band)",
+    instPageAfter.status === 200 && instPageAfter.text.includes("uninstalled")
+      && instPageAfter.text.includes("launch_eligible: false")
+      && instPageAfter.text.includes("Already uninstalled"),
+    "");
+
+  // -- 3-posture matrix -------------------------------------------------------
+  let pw = null;
+  try { pw = await import("playwright"); } catch { pw = null; }
+  if (!pw) {
+    ok("posture matrix skipped — playwright unavailable", false, "install playwright to run the browser matrix");
+  } else {
+    const browser = await pw.chromium.launch();
+    for (const [name, opts] of [
+      ["light-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "light" }],
+      ["dark-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "dark" }],
+      ["narrow-reduced-motion", { viewport: { width: 390, height: 844 }, colorScheme: "light", reducedMotion: "reduce" }],
+    ]) {
+      const ctx = await browser.newContext(opts);
+      const page = await ctx.newPage();
+      const errors = [];
+      page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+      const resp = await page.goto(`${SERVE}/packages`, { waitUntil: "networkidle", timeout: 45000 }).catch(() => null);
+      const body = resp ? await page.evaluate(() => document.body.innerText) : "";
+      await page.keyboard.press("Tab");
+      const focused = resp ? await page.evaluate(() => document.activeElement?.tagName ?? "") : "";
+      ok(`posture ${name}: renders, keyboard-focusable, zero console errors`,
+        resp && resp.status() === 200 && body.length > 0 && errors.length === 0 && focused !== "" && focused !== "BODY",
+        errors[0]?.slice(0, 100) ?? `focus ${focused}`);
+      await ctx.close();
+    }
+    await browser.close();
+  }
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  cleanup();
+  process.exit(1);
+});
+
+function cleanup() {
+  try { serve?.kill("SIGTERM"); } catch { /* gone */ }
+  try { daemon?.kill("SIGTERM"); } catch { /* gone */ }
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* keep */ }
+}

--- a/apps/hypervisor/surfaces/packages/index.mjs
+++ b/apps/hypervisor/surfaces/packages/index.mjs
@@ -1,0 +1,576 @@
+// Packages — the canonical /packages surface packet (W2.3 bar, next-legs II Leg 2).
+//
+// One module, two mounts, over the CLOSED daemon package family (MEF-CLOSED-003 — exactly seven
+// /v1/hypervisor/packages/* routes: candidate create/list/get, release create/list/get,
+// installation create/list/get, uninstall):
+//
+//   registry     — /packages (+ fresh legacy lane /__ioi/packages/registry): the package
+//                  lifecycle projection. Candidates (frozen ODK source meshes), immutable
+//                  content-addressed HypervisorSurfaceReleaseRecords, and installation bindings
+//                  rendered with their FORCED-DISABLED truth verbatim: surface_enablement_state
+//                  "disabled", launch_eligible:false, and the daemon's exact
+//                  disabled_reason_codes — never a launchability claim.
+//   marketplace  — /packages/marketplace (+ /__ioi/packages/marketplace): the OPTIONAL Packages
+//                  mode (canon: a Marketplace entry point resolves to "Packages / Marketplace"
+//                  and never becomes a second package owner). READ-FIRST in this packet: the
+//                  daemon's marketplace overview + listing plane rendered honestly (honest-empty
+//                  when the substrate has no listings); the governed draft→candidate→review→
+//                  publish ladder keeps operating on its legacy owner lane until the
+//                  marketplace-actions leg, and its controls render DISABLED here with the
+//                  machine-readable reason.
+//
+// The family's admission contract, derived from the Rust (package_registry_routes.rs) + the
+// package-registry smoke — the module speaks it exactly:
+//   - identity-first: EVERY route (reads included) resolves the caller's principal before any
+//     field is read; an anonymous call is a typed 401 request_principal_required. Module reads
+//     therefore ride the request-scoped daemon capability (ctx.daemonFetch) so the caller's own
+//     session is the read identity; an anonymous page render shows the typed refusal band, never
+//     fabricated rows.
+//   - owner-scoped: candidate create carries owner_ref (org://…); release + installation writes
+//     derive the owner from the admitted candidate/release.
+//   - caller idempotency: every mutation carries idempotency_key; an exact retry REPLAYS
+//     (replayed:true, same head, same receipt_ref); the same key over different bytes refuses.
+//   - exact-head CAS: release create carries expected_package_head, installation create
+//     expected_release_head, uninstall expected_installation_head — a stale head is a typed 409
+//     package_expected_head_conflict.
+//   - admission evidence or nothing: a 2xx is believed only when the reply carries the family
+//     record under its declared schema_version PLUS agentgres.receipt_ref. Anything less fails
+//     CLOSED. Typed refusals render verbatim.
+//
+// NAMED GAPS this module states instead of faking (W2.3: recall lands WITH the registry — and
+// the registry the daemon owns today has NO recall):
+//   - deprecate / disable / recall / revoke: no daemon verb exists. surface_package_disposition
+//     is write-once "active" at release admission; the registered contract enum names
+//     deprecated/superseded/recalled but no route can set them. The verbs render disabled with
+//     data-ioi-disabled-reason, never wired to an invented path.
+//   - launcher eligibility: the product-surface compiler projection consumes NO package-registry
+//     state (its records are compiled-in), so an installed package can never appear in a launch
+//     surface — the typed absence is stated on the binding, beside its launch_eligible:false.
+//   - enable / registration / serving: installs are born disabled and the family owns no verb to
+//     change that; the missing extension_application registration is named by the daemon's own
+//     disabled_reason_codes, rendered verbatim.
+import { escHtml } from "../kit.mjs";
+
+const esc = escHtml;
+const enc = encodeURIComponent;
+const LEGACY_ROUTE = "/__ioi/packages/registry";
+const LEGACY_MARKETPLACE_ROUTE = "/__ioi/packages/marketplace";
+const CANONICAL_ROUTE = "/packages";
+const CANONICAL_MARKETPLACE_ROUTE = "/packages/marketplace";
+
+export const meta = {
+  slug: "packages",
+  route: LEGACY_ROUTE,
+  verifier: "scripts/verify-hypervisor-packages-journey.mjs",
+  certification: "n/a",
+};
+
+const CANDIDATE_SCHEMA = "ioi.hypervisor.package_candidate.v1";
+const RELEASE_SCHEMA = "ioi.hypervisor.surface_release_record.v1";
+const INSTALLATION_SCHEMA = "ioi.hypervisor.surface_installation_binding.v1";
+const PACKAGES_PLANE = "/v1/hypervisor/packages";
+
+const RECALL_GAP_REASON = "no daemon verb exists — the closed /v1/hypervisor/packages family owns no deprecate/disable/recall/revoke route; surface_package_disposition is write-once 'active' at release admission (the registered enum names 'recalled' but no route can set it); the verb lands with the W3.c compiler-hook packet, never invented surface-side";
+const ENABLE_GAP_REASON = "no daemon verb exists — installation bindings are born surface_enablement_state 'disabled' (extension_application registration absent) and the family owns no enable/registration/serving route";
+const LAUNCHER_GAP_NOTE = "Launcher eligibility (typed absence): the product-surface compiler projection consumes no package-registry state today — no installed package can appear in any launch surface, and launch_eligible:false above is the admitted truth of this binding, not a UI decision.";
+const MARKETPLACE_LADDER_REASON = "marketplace ladder actions (draft/patch/delete, publish candidate, review decide, publish, offer) operate on the /__ioi/marketplace legacy owner lane until the marketplace-actions leg — this mode is read-first";
+
+// ---------------------------------------------------------------------------------------------
+// load — every read is a typed-degradation projection through the shared read client, carried on
+// the REQUEST-scoped daemon capability when the runtime supplies one (the packages family is
+// identity-first on reads; a plain unauthenticated fetch would render every pane as a 401 band
+// even for a signed-in operator). Anonymous stays anonymous: the capability forwards only the
+// caller's own envelope, so a signed-out render shows the typed refusal, never another caller's truth.
+export async function load(ctx) {
+  const { createReadClient } = await import("../read-client.mjs");
+  const client = typeof ctx.daemonFetch === "function"
+    ? createReadClient({ daemon: "", fetchImpl: ctx.daemonFetch })
+    : createReadClient({ daemon: ctx.daemon });
+  const sp = ctx.url.searchParams;
+  if (isMarketplaceMount(ctx.url.pathname)) {
+    const results = await client.readMany({
+      overview: "/v1/hypervisor/marketplace/overview",
+      listings: "/v1/hypervisor/marketplace/listings",
+    });
+    return { mode: "marketplace", results };
+  }
+  const results = await client.readMany({
+    packages: PACKAGES_PLANE,
+    domain_apps: "/v1/hypervisor/domain-apps",
+  });
+  const model = { mode: "registry", results };
+  const pkg = (sp.get("pkg") || "").trim();
+  const rel = (sp.get("rel") || "").trim();
+  const inst = (sp.get("inst") || "").trim();
+  if (pkg) {
+    model.candidate = await client.read(`${PACKAGES_PLANE}/${enc(pkg)}`);
+    model.releases = await client.read(`${PACKAGES_PLANE}/${enc(pkg)}/releases`);
+  }
+  if (pkg && rel) {
+    model.release = await client.read(`${PACKAGES_PLANE}/${enc(pkg)}/releases/${enc(rel)}`);
+    model.installations = await client.read(`${PACKAGES_PLANE}/${enc(pkg)}/releases/${enc(rel)}/installations`);
+  }
+  if (pkg && rel && inst) {
+    model.installation = await client.read(`${PACKAGES_PLANE}/${enc(pkg)}/releases/${enc(rel)}/installations/${enc(inst)}`);
+  }
+  return model;
+}
+
+function isMarketplaceMount(pathname) {
+  return pathname === CANONICAL_MARKETPLACE_ROUTE || pathname === LEGACY_MARKETPLACE_ROUTE;
+}
+
+// ---------------------------------------------------------------------------------------------
+// actions — ONLY the lifecycle verbs the daemon actually owns. There is deliberately no
+// deprecate/disable/recall/revoke/enable action here: declaring one would invent an authority
+// path the daemon refuses to own (the named gaps render disabled in the views instead).
+const PKG_AUTHORITY = { plane: "hypervisor.packages", operation: "POST /v1/hypervisor/packages" };
+const REL_AUTHORITY = { plane: "hypervisor.packages", operation: "POST /v1/hypervisor/packages/:package_id/releases (expected_package_head CAS)" };
+const INST_AUTHORITY = { plane: "hypervisor.packages", operation: "POST /v1/hypervisor/packages/:package_id/releases/:release_digest/installations (expected_release_head CAS)" };
+const UNINST_AUTHORITY = { plane: "hypervisor.packages", operation: "POST .../installations/:installation_id/uninstall (expected_installation_head CAS, idempotent replay)" };
+export const actions = [
+  { id: "admit-candidate", method: "POST", route: "/actions/admit-candidate", fields: ["owner_ref", "package_id", "domain_app_ref", "idempotency_key"], context: [], authority: PKG_AUTHORITY, receipt: CANDIDATE_SCHEMA, confirm: false, success: "return-to-surface", refusal: "typed-banner" },
+  { id: "cut-release", method: "POST", route: "/:id/cut-release", fields: ["idempotency_key", "expected_package_head", "surface_distribution", "surface_capability_depth", "object_contract_refs", "action_contract_refs", "evidence_refs"], fieldMax: 4096, context: ["id"], authority: REL_AUTHORITY, receipt: RELEASE_SCHEMA, confirm: false, success: "return-to-surface", refusal: "typed-banner" },
+  { id: "install-release", method: "POST", route: "/:id/install", fields: ["idempotency_key", "release_digest", "expected_release_head", "installation_id", "project_ref", "visibility", "allowed_object_contract_refs", "allowed_action_refs"], fieldMax: 4096, context: ["id"], authority: INST_AUTHORITY, receipt: INSTALLATION_SCHEMA, confirm: false, success: "return-to-surface", refusal: "typed-banner" },
+  { id: "uninstall", method: "POST", route: "/:id/uninstall", fields: ["idempotency_key", "release_digest", "installation_id", "expected_installation_head"], context: ["id"], authority: UNINST_AUTHORITY, receipt: INSTALLATION_SCHEMA, confirm: false, success: "return-to-surface", refusal: "typed-banner" },
+];
+
+// The authored ref-list fields arrive as one text blob; the daemon wants exact JSON arrays.
+// Splitting on whitespace/commas is SHAPE only — uniqueness, prefixes, and subset-of-release
+// narrowing are the daemon's judgments and its typed refusals render verbatim.
+const refList = (value) => String(value ?? "").split(/[\s,]+/u).map((part) => part.trim()).filter(Boolean);
+
+export async function handleAction({ action, id, fields, daemonFetch }) {
+  if (typeof daemonFetch !== "function") {
+    return { kind: "failure", http: 500, code: "identity_capability_missing", message: "the action runtime supplied no request-scoped daemon capability — refusing to mutate without the caller's identity" };
+  }
+  let path = "";
+  const body = { idempotency_key: fields.idempotency_key };
+  let redirect = `${LEGACY_ROUTE}`;
+  if (action.id === "admit-candidate") {
+    path = PACKAGES_PLANE;
+    body.package_id = fields.package_id;
+    body.owner_ref = fields.owner_ref;
+    body.domain_app_ref = fields.domain_app_ref;
+    redirect = `${LEGACY_ROUTE}?pkg=${enc(fields.package_id || "")}`;
+  } else if (action.id === "cut-release") {
+    path = `${PACKAGES_PLANE}/${enc(id)}/releases`;
+    body.expected_package_head = fields.expected_package_head;
+    body.surface_distribution = fields.surface_distribution;
+    body.surface_capability_depth = fields.surface_capability_depth;
+    body.object_contract_refs = refList(fields.object_contract_refs);
+    body.action_contract_refs = refList(fields.action_contract_refs);
+    body.evidence_refs = refList(fields.evidence_refs);
+    redirect = `${LEGACY_ROUTE}?pkg=${enc(id)}`;
+  } else if (action.id === "install-release") {
+    path = `${PACKAGES_PLANE}/${enc(id)}/releases/${enc(fields.release_digest || "")}/installations`;
+    body.installation_id = fields.installation_id;
+    body.expected_release_head = fields.expected_release_head;
+    body.project_ref = fields.project_ref ? fields.project_ref : null;
+    body.visibility = fields.visibility;
+    body.allowed_object_contract_refs = refList(fields.allowed_object_contract_refs);
+    body.allowed_action_refs = refList(fields.allowed_action_refs);
+    redirect = `${LEGACY_ROUTE}?pkg=${enc(id)}&rel=${enc(fields.release_digest || "")}&inst=${enc(fields.installation_id || "")}`;
+  } else if (action.id === "uninstall") {
+    path = `${PACKAGES_PLANE}/${enc(id)}/releases/${enc(fields.release_digest || "")}/installations/${enc(fields.installation_id || "")}/uninstall`;
+    body.expected_installation_head = fields.expected_installation_head;
+    redirect = `${LEGACY_ROUTE}?pkg=${enc(id)}&rel=${enc(fields.release_digest || "")}&inst=${enc(fields.installation_id || "")}`;
+  } else {
+    return { kind: "failure", http: 500, code: "action_unknown", message: `undeclared action '${action.id}'` };
+  }
+  const response = await daemonFetch(path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }).catch(() => null);
+  if (!response) return { kind: "failure", http: 502, code: "daemon_unavailable", message: "the daemon did not answer — nothing was changed" };
+  const payload = await response.json().catch(() => null);
+  if (!payload) return { kind: "failure", http: 502, code: "daemon_reply_unreadable", message: `the daemon answered ${response.status} without a readable body — do not trust the mutation` };
+  if (payload.ok !== true) {
+    // The daemon's typed refusal, VERBATIM — {error:{code,message}} on this family's validation
+    // and scope refusals; flat {code,message} kept for shared-foundation shapes.
+    const code = payload.error?.code || payload.code || `http_${response.status}`;
+    let message = payload.error?.message || payload.message || payload.reason || "refused — state unchanged";
+    if (code === "package_expected_head_conflict" || code === "event_stream_expected_head_conflict") {
+      message = `${message} — the record moved; re-open it to get the fresh admitted head, then re-submit`;
+    }
+    return { kind: "refusal", http: response.status || 409, code, message };
+  }
+  // Admission evidence or nothing: the family envelope ({package|release|installation}) must
+  // carry the record under the DECLARED schema plus agentgres.receipt_ref. Fail closed otherwise.
+  const envelope = payload.package || payload.release || payload.installation || null;
+  const record = envelope?.record || null;
+  const receiptRef = typeof envelope?.agentgres?.receipt_ref === "string" ? envelope.agentgres.receipt_ref : "";
+  if (!record || record.schema_version !== action.receipt || !receiptRef.startsWith("receipt://")) {
+    return { kind: "failure", http: 502, code: "receipt_missing", message: `the mutation answered 2xx without the ${action.receipt} record + agentgres receipt_ref admission evidence — failing closed (do not trust the mutation)` };
+  }
+  const replayed = envelope.agentgres?.replayed === true;
+  let created = "";
+  let status = "";
+  if (action.id === "admit-candidate") {
+    created = record.package_id || "";
+    status = replayed ? "replayed" : (record.status || "candidate");
+    redirect = `${LEGACY_ROUTE}?pkg=${enc(created)}`;
+  } else if (action.id === "cut-release") {
+    const digest = String(record.release_ref || "").split("/release/").at(-1) || "";
+    created = digest;
+    status = replayed ? "replayed" : `${record.surface_admission_state || ""}/${record.surface_package_disposition || ""}`;
+    redirect = `${LEGACY_ROUTE}?pkg=${enc(id)}&rel=${enc(digest)}`;
+  } else {
+    created = fields.installation_id || String(record.installation_ref || "").split("/").at(-1) || "";
+    status = replayed ? "replayed" : (record.surface_installation_state || "");
+  }
+  return { kind: "success", status, created, receipt_ref: receiptRef, redirect };
+}
+
+// ---------------------------------------------------------------------------------------------
+// render helpers (the studio module's grammar — pills, typed degradation, disabled named gaps)
+const pill = (cls, label) => `<span class="pill ${cls}">${esc(label)}</span>`;
+const code = (v) => (v ? `<code>${esc(String(v))}</code>` : "—");
+const shortHash = (h) => { const s = String(h || ""); return s.length > 22 ? `${s.slice(0, 22)}…` : s; };
+const degraded = (result) => `<div class="empty">unavailable — <code>${esc(result?.code || "daemon_unavailable")}</code> (${esc(result?.message || "the plane did not answer")})</div>`;
+const rowsOf = (result, key) => (result?.ok ? (Array.isArray(result.payload?.[key]) ? result.payload[key] : []) : null);
+const disabledCtl = (label, reason) => `<button class="act ghost" type="button" disabled data-ioi-disabled-reason="${esc(reason)}">${esc(label)}</button>`;
+const mintKey = () => `packages-ui-${globalThis.crypto.randomUUID()}`;
+const reasonCodes = (codes) => (Array.isArray(codes) && codes.length ? codes.map((c) => `<code>${esc(c)}</code>`).join(" ") : "—");
+
+function banner(sp) {
+  const acted = sp.get("acted") || "";
+  const receipt = sp.get("receipt") || "";
+  const refused = sp.get("refused") || "";
+  const reason = sp.get("reason") || "";
+  const result = sp.get("result") || "";
+  const record = sp.get("record") || "";
+  if (acted && receipt) {
+    return `<div id="ap-result" class="banner ok-banner" tabindex="-1"><b>${esc(acted)}</b> recorded${result ? ` — <b>${esc(result)}</b>` : ""}${record ? ` · record <code>${esc(record)}</code>` : ""} · receipt <code>${esc(receipt)}</code> · <a href="/__ioi/work-ledger">proof stream</a></div>`;
+  }
+  if (refused) {
+    return `<div id="ap-result" class="banner no-banner" tabindex="-1">refused: <code>${esc(refused)}</code>${reason ? ` — ${esc(reason)}` : ""} · <b>state unchanged</b></div>`;
+  }
+  return "";
+}
+
+// One installation binding row/grid fragment — the FORCED-DISABLED truth rendered verbatim:
+// the daemon's own enablement state, launch_eligible, and exact disabled_reason_codes.
+function bindingTruth(entry) {
+  const record = entry.record || {};
+  return `${pill(record.surface_installation_state === "installed" ? "ok" : "muted", record.surface_installation_state || "—")}
+    ${pill("warn", record.surface_enablement_state || "—")}
+    ${pill(entry.launch_eligible === false ? "warn" : "muted", `launch_eligible: ${String(entry.launch_eligible)}`)}
+    <div class="sub" style="margin:4px 0 0;text-transform:none;letter-spacing:0">reasons: ${reasonCodes(entry.disabled_reason_codes)}</div>`;
+}
+
+// ---- Registry landing ---------------------------------------------------------------------------
+function catalogView(model, base) {
+  const rows = rowsOf(model.results.packages, "packages");
+  const domainApps = rowsOf(model.results.domain_apps, "domain_apps");
+  const list = rows === null
+    ? degraded(model.results.packages)
+    : (rows.length
+      ? `<table><thead><tr><th>Package</th><th>Owner</th><th>Status</th><th>Registration</th><th>Candidate hash</th></tr></thead><tbody>${rows.map((p) => {
+        const r = p.record || {};
+        return `<tr>
+          <td><a href="${base}?pkg=${enc(r.package_id || "")}"><b>${esc(r.package_id || "—")}</b></a><div style="color:#878a93;font-size:11.5px"><code>${esc(r.package_ref || "")}</code></div></td>
+          <td>${code(r.owner_ref)}</td>
+          <td>${pill("muted", r.status || "—")}</td>
+          <td>${pill("warn", `registration ${r.registration_state || "absent"}`)}</td>
+          <td><code title="${esc(r.candidate_content_hash || "")}">${esc(shortHash(r.candidate_content_hash))}</code></td>
+        </tr>`;
+      }).join("")}</tbody></table>`
+      : `<div class="empty">No package candidates yet — freeze one below. A candidate snapshots one draft DomainApp + its ODK manifest + surface descriptor content-addressed; it creates no registration, route, process, or launch eligibility.</div>`);
+  const appOptions = domainApps === null
+    ? null
+    : domainApps.filter((d) => (d.status || "") === "draft" && d.odk_manifest_ref && d.surface_descriptor_ref);
+  const form = appOptions === null
+    ? `<div class="empty">${model.results.domain_apps?.ok === false ? `The DomainApp plane is unavailable (<code>${esc(model.results.domain_apps?.code || "daemon_unavailable")}</code>) — admission is disabled rather than guessed.` : "unavailable"}</div>`
+    : (appOptions.length
+      ? `<form class="aform" method="post" action="${LEGACY_ROUTE}/actions/admit-candidate">
+          <input type="hidden" name="idempotency_key" value="${esc(mintKey())}">
+          <input type="hidden" name="return" value="${esc(LEGACY_ROUTE)}">
+          <label class="fl">Owner (org://…)<input name="owner_ref" placeholder="org://…" required title="The single org:// that owns this package. The daemon admits the candidate under it and refuses a caller who holds no authority over it."></label>
+          <label class="fl">Package id (globally unique, lowercase)<input name="package_id" maxlength="128" pattern="[a-z0-9][a-z0-9._-]*" required></label>
+          <label class="fl">DomainApp (draft, with ODK manifest + descriptor bound)<select name="domain_app_ref">${appOptions.map((d) => `<option value="${esc(d.domain_app_ref || "")}">${esc(d.name || d.domain_app_ref || "")}</option>`).join("")}</select></label>
+          <button class="act" type="submit">Admit candidate</button>
+          <span class="sub" style="margin:0;text-transform:none;letter-spacing:0">idempotent: an exact retry replays the original admission (same head, same receipt)</span>
+        </form>`
+      : `<div class="empty">Candidate admission needs a <b>draft</b> DomainApp with a bound ODK manifest and a <code>domain_app</code> surface descriptor — none exists yet. Author the source mesh in the <a href="/__ioi/odk">ODK workbench</a> first.</div>`);
+  return `<h2 id="catalog">Package candidates</h2>
+    <p class="sub" style="margin:-4px 0 12px">The daemon's owner-filtered package inventory, reconstructed from admitted Agentgres truth on every read. A candidate freezes exact DomainApp/manifest/descriptor bytes; releases and installs hang off it below.</p>
+    ${list}
+    <h3 style="margin:18px 0 6px;font-size:13px">Admit a package candidate</h3>${form}
+    <h2 id="lifecycle-ceiling">Lifecycle ceiling</h2>
+    <div class="gapcard">
+      <p class="sub" style="margin:0 0 8px;text-transform:none;letter-spacing:0">The closed daemon family ends at <b>uninstall</b>. What does NOT exist yet, stated rather than faked:</p>
+      ${disabledCtl("Deprecate", RECALL_GAP_REASON)} ${disabledCtl("Recall", RECALL_GAP_REASON)} ${disabledCtl("Revoke", RECALL_GAP_REASON)} ${disabledCtl("Enable", ENABLE_GAP_REASON)}
+      <p class="sub" style="margin:8px 0 0;text-transform:none;letter-spacing:0">${esc(LAUNCHER_GAP_NOTE)}</p>
+    </div>`;
+}
+
+// ---- Candidate detail + releases ---------------------------------------------------------------
+function candidateView(model, base, pkg) {
+  const d = model.candidate;
+  if (!d?.ok || d.payload?.ok !== true || !d.payload.package) {
+    return `<h2>Package ${esc(pkg)}</h2>${d?.ok && d.payload?.ok === false ? `<div class="empty">not found — <code>${esc(d.payload?.error?.code || "package_candidate_not_found")}</code></div>` : degraded(d)}`;
+  }
+  const p = d.payload.package;
+  const r = p.record || {};
+  const head = p.agentgres?.head || "";
+  const snaps = r.source_snapshots || {};
+  const releases = rowsOf(model.releases, "releases");
+  const relList = releases === null
+    ? degraded(model.releases)
+    : (releases.length
+      ? `<table><thead><tr><th>Release</th><th>Distribution</th><th>Depth</th><th>Admission</th><th>Disposition</th><th>Evidence</th></tr></thead><tbody>${releases.map((rel) => {
+        const rr = rel.record || {};
+        const digest = String(rr.release_ref || "").split("/release/").at(-1) || "";
+        return `<tr>
+          <td><a href="${base}?pkg=${enc(pkg)}&rel=${enc(digest)}"><code>${esc(shortHash(digest))}</code></a></td>
+          <td>${pill("muted", rr.surface_distribution || "—")}</td>
+          <td>${pill("muted", rr.surface_capability_depth || "—")}</td>
+          <td>${pill(rr.surface_admission_state === "admitted" ? "ok" : "muted", rr.surface_admission_state || "—")}</td>
+          <td>${pill(rr.surface_package_disposition === "active" ? "ok" : "warn", rr.surface_package_disposition || "—")}</td>
+          <td>${(rr.evidence_refs || []).length} ref(s)</td>
+        </tr>`;
+      }).join("")}</tbody></table>`
+      : `<div class="empty">No releases yet — cut one below against the exact candidate head. A release is immutable and content-addressed; admitting it registers, installs, serves, and authorizes nothing.</div>`);
+  const casNote = head
+    ? `<span class="sub" style="margin:0;text-transform:none;letter-spacing:0">compare-and-swap against admitted candidate head <code>${esc(shortHash(head))}</code></span>`
+    : `<span class="sub" style="margin:0;text-transform:none;letter-spacing:0">no admitted head is readable — release admission is disabled rather than guessed</span>`;
+  const dis = head ? "" : " disabled";
+  return `<h2 id="candidate-detail">Package detail</h2>
+    <dl class="grid">
+      <dt>Package</dt><dd><b>${esc(r.package_id || "—")}</b> · ${code(r.package_ref)}</dd>
+      <dt>Candidate ref</dt><dd>${code(r.package_candidate_ref)}</dd>
+      <dt>Owner</dt><dd>${code(r.owner_ref)}</dd>
+      <dt>Surface</dt><dd>${code(r.surface_ref)} ${pill("muted", r.surface_class || "—")}</dd>
+      <dt>Status</dt><dd>${pill("muted", r.status || "—")} ${pill("warn", `registration ${r.registration_state || "absent"}`)}</dd>
+      <dt>Source snapshots</dt><dd>
+        domain-app <code title="${esc(snaps.domain_app_content_hash || "")}">${esc(shortHash(snaps.domain_app_content_hash))}</code><br>
+        odk-manifest <code title="${esc(snaps.odk_manifest_content_hash || "")}">${esc(shortHash(snaps.odk_manifest_content_hash))}</code><br>
+        descriptor <code title="${esc(snaps.surface_descriptor_content_hash || "")}">${esc(shortHash(snaps.surface_descriptor_content_hash))}</code></dd>
+      <dt>Candidate hash</dt><dd><code data-testid="pkg-candidate-hash">${esc(r.candidate_content_hash || "—")}</code></dd>
+      <dt>Admitted head</dt><dd><code data-testid="pkg-admitted-head">${esc(head || "—")}</code></dd>
+      <dt>Receipt</dt><dd>${code(p.agentgres?.receipt_ref)}</dd>
+      <dt>Nonclaim</dt><dd class="sub" style="text-transform:none;letter-spacing:0;margin:0">${esc(r.nonclaim || "—")}</dd>
+    </dl>
+    <h3 style="margin:16px 0 6px;font-size:13px">Releases</h3>${relList}
+    <h3 style="margin:16px 0 6px;font-size:13px">Cut an immutable release</h3>
+    <form class="aform" method="post" action="${LEGACY_ROUTE}/${enc(pkg)}/cut-release">
+      <input type="hidden" name="idempotency_key" value="${esc(mintKey())}">
+      <input type="hidden" name="return" value="${esc(`${LEGACY_ROUTE}?pkg=${enc(pkg)}`)}">
+      ${head ? `<input type="hidden" name="expected_package_head" value="${esc(head)}">` : ""}
+      <label class="fl">Distribution<select name="surface_distribution"${dis}>${["private_registry", "organization_catalog", "direct_package", "marketplace", "bundled"].map((v) => `<option value="${v}">${v.replace(/_/g, " ")}</option>`).join("")}</select></label>
+      <label class="fl">Capability depth<select name="surface_capability_depth"${dis}>${["browse", "inspect", "propose", "act", "workflow_complete"].map((v) => `<option value="${v}"${v === "propose" ? " selected" : ""}>${v.replace(/_/g, " ")}</option>`).join("")}</select></label>
+      <label class="fl">Object contract refs (whitespace/comma separated)<textarea name="object_contract_refs" rows="2" placeholder="object-model://…"${dis}></textarea></label>
+      <label class="fl">Action contract refs<textarea name="action_contract_refs" rows="2" placeholder="action://…"${dis}></textarea></label>
+      <label class="fl">Evidence refs (artifact:// evidence:// receipt:// — the candidate's own receipt is bound automatically)<textarea name="evidence_refs" rows="2" placeholder="artifact://…"${dis}></textarea></label>
+      <button class="act" type="submit"${dis}>Cut release</button> ${casNote}
+    </form>`;
+}
+
+// ---- Release detail + installations ------------------------------------------------------------
+function releaseView(model, base, pkg, rel) {
+  const d = model.release;
+  if (!d?.ok || d.payload?.ok !== true || !d.payload.release) {
+    return `<h2>Release ${esc(shortHash(rel))}</h2>${d?.ok && d.payload?.ok === false ? `<div class="empty">not found — <code>${esc(d.payload?.error?.code || "package_release_not_found")}</code></div>` : degraded(d)}`;
+  }
+  const envelope = d.payload.release;
+  const rr = envelope.record || {};
+  const head = envelope.agentgres?.head || "";
+  const installations = rowsOf(model.installations, "installations");
+  const instList = installations === null
+    ? degraded(model.installations)
+    : (installations.length
+      ? `<table><thead><tr><th>Installation</th><th>Binding truth</th><th>Visibility</th><th>Rev</th></tr></thead><tbody>${installations.map((entry) => {
+        const ir = entry.record || {};
+        const iid = String(ir.installation_ref || "").split("/").at(-1) || "";
+        return `<tr>
+          <td><a href="${base}?pkg=${enc(pkg)}&rel=${enc(rel)}&inst=${enc(iid)}"><b>${esc(iid)}</b></a><div style="color:#878a93;font-size:11.5px"><code>${esc(ir.installation_ref || "")}</code></div></td>
+          <td>${bindingTruth(entry)}</td>
+          <td>${pill("muted", ir.visibility || "—")}</td>
+          <td>${esc(String(ir.revision ?? "—"))}</td>
+        </tr>`;
+      }).join("")}</tbody></table>`
+      : `<div class="empty">No installation bindings for this release yet — bind one below. An installation is REAL and immediately <b>disabled</b>: the daemon refuses to claim launchability it does not own.</div>`);
+  const casNote = head
+    ? `<span class="sub" style="margin:0;text-transform:none;letter-spacing:0">compare-and-swap against admitted release head <code>${esc(shortHash(head))}</code></span>`
+    : `<span class="sub" style="margin:0;text-transform:none;letter-spacing:0">no admitted head is readable — installation is disabled rather than guessed</span>`;
+  const dis = head ? "" : " disabled";
+  return `<h2 id="release-detail">Release detail <span class="sub" style="text-transform:none;letter-spacing:0;font-weight:400">— immutable, content-addressed</span></h2>
+    <dl class="grid">
+      <dt>Release ref</dt><dd><code data-testid="rel-ref">${esc(rr.release_ref || "—")}</code></dd>
+      <dt>Package</dt><dd><a href="${base}?pkg=${enc(pkg)}">${code(rr.package_ref)}</a></dd>
+      <dt>Surface</dt><dd>${code(rr.surface_ref)}</dd>
+      <dt>Distribution · depth</dt><dd>${pill("muted", rr.surface_distribution || "—")} ${pill("muted", rr.surface_capability_depth || "—")}</dd>
+      <dt>Admission</dt><dd>${pill(rr.surface_admission_state === "admitted" ? "ok" : "muted", rr.surface_admission_state || "—")} ${pill(rr.surface_package_disposition === "active" ? "ok" : "warn", rr.surface_package_disposition || "—")} <span class="sub" style="margin:0;text-transform:none;letter-spacing:0">disposition is write-once at admission — no daemon verb can change it yet</span></dd>
+      <dt>Object contracts</dt><dd>${(rr.object_contract_refs || []).map((v) => code(v)).join("<br>") || "—"}</dd>
+      <dt>Action contracts</dt><dd>${(rr.action_contract_refs || []).map((v) => code(v)).join("<br>") || "—"}</dd>
+      <dt>Evidence</dt><dd>${(rr.evidence_refs || []).map((v) => code(v)).join("<br>") || "—"}</dd>
+      <dt>Candidate binding</dt><dd>${code(envelope.package_candidate_ref)}<br><span class="sub" style="margin:0;text-transform:none;letter-spacing:0">admitted against candidate head</span> ${code(envelope.package_candidate_head)}</dd>
+      <dt>Admitted head</dt><dd><code data-testid="rel-admitted-head">${esc(head || "—")}</code></dd>
+      <dt>Registration</dt><dd>${pill("warn", `registration ${envelope.registration_state || "absent"}`)}</dd>
+    </dl>
+    <div class="gapcard">
+      ${disabledCtl("Deprecate", RECALL_GAP_REASON)} ${disabledCtl("Recall", RECALL_GAP_REASON)} ${disabledCtl("Revoke", RECALL_GAP_REASON)}
+      <p class="sub" style="margin:8px 0 0;text-transform:none;letter-spacing:0">Recall semantics (canon): removing launch eligibility immediately and exposing affected installs is the W3.c compiler hook — it must land WITH the verb. Today the registered enum names <code>recalled</code> but the closed family owns no route that sets it; these controls stay disabled instead of pretending.</p>
+    </div>
+    <h3 style="margin:16px 0 6px;font-size:13px">Installation bindings</h3>${instList}
+    <h3 style="margin:16px 0 6px;font-size:13px">Install this exact release</h3>
+    <form class="aform" method="post" action="${LEGACY_ROUTE}/${enc(pkg)}/install">
+      <input type="hidden" name="idempotency_key" value="${esc(mintKey())}">
+      <input type="hidden" name="return" value="${esc(`${LEGACY_ROUTE}?pkg=${enc(pkg)}&rel=${enc(rel)}`)}">
+      <input type="hidden" name="release_digest" value="${esc(rel)}">
+      ${head ? `<input type="hidden" name="expected_release_head" value="${esc(head)}">` : ""}
+      <label class="fl">Installation id (lowercase)<input name="installation_id" maxlength="128" pattern="[a-z0-9][a-z0-9._-]*" required${dis}></label>
+      <label class="fl">Visibility<select name="visibility"${dis}>${["private", "organization", "permissioned", "public"].map((v) => `<option value="${v}"${v === "organization" ? " selected" : ""}>${v}</option>`).join("")}</select></label>
+      <label class="fl">Project (project://…, optional)<input name="project_ref" maxlength="300" placeholder="project://…"${dis}></label>
+      <label class="fl">Allowed object contracts (may only NARROW the release set)<textarea name="allowed_object_contract_refs" rows="2"${dis}>${esc((rr.object_contract_refs || []).join("\n"))}</textarea></label>
+      <label class="fl">Allowed action refs (may only NARROW the release set)<textarea name="allowed_action_refs" rows="2"${dis}>${esc((rr.action_contract_refs || []).join("\n"))}</textarea></label>
+      <button class="act" type="submit"${dis}>Install (binding is created disabled)</button> ${casNote}
+    </form>`;
+}
+
+// ---- Installation detail -----------------------------------------------------------------------
+function installationView(model, base, pkg, rel, inst) {
+  const d = model.installation;
+  if (!d?.ok || d.payload?.ok !== true || !d.payload.installation) {
+    return `<h2>Installation ${esc(inst)}</h2>${d?.ok && d.payload?.ok === false ? `<div class="empty">not found — <code>${esc(d.payload?.error?.code || "package_installation_not_found")}</code></div>` : degraded(d)}`;
+  }
+  const entry = d.payload.installation;
+  const ir = entry.record || {};
+  const head = entry.agentgres?.head || "";
+  const uninstalled = ir.surface_installation_state === "uninstalled";
+  const casNote = head
+    ? `<span class="sub" style="margin:0;text-transform:none;letter-spacing:0">compare-and-swap against admitted installation head <code>${esc(shortHash(head))}</code></span>`
+    : `<span class="sub" style="margin:0;text-transform:none;letter-spacing:0">no admitted head is readable — uninstall is disabled rather than guessed</span>`;
+  const dis = head && !uninstalled ? "" : " disabled";
+  return `<h2 id="installation-detail">Installation binding</h2>
+    <dl class="grid">
+      <dt>Installation</dt><dd><code data-testid="inst-ref">${esc(ir.installation_ref || "—")}</code></dd>
+      <dt>Release</dt><dd><a href="${base}?pkg=${enc(pkg)}&rel=${enc(rel)}">${code(ir.release_ref)}</a></dd>
+      <dt>Org · project</dt><dd>${code(ir.org_ref)} ${ir.project_ref ? code(ir.project_ref) : `<span class="sub" style="margin:0;text-transform:none;letter-spacing:0">org-wide</span>`}</dd>
+      <dt>Binding truth</dt><dd data-testid="inst-binding-truth">${bindingTruth(entry)}</dd>
+      <dt>Registration</dt><dd>${pill("warn", `registration ${entry.registration_state || "absent"}`)}</dd>
+      <dt>Visibility · revision</dt><dd>${pill("muted", ir.visibility || "—")} · rev ${esc(String(ir.revision ?? "—"))}</dd>
+      <dt>Allowed objects</dt><dd>${(ir.allowed_object_contract_refs || []).map((v) => code(v)).join("<br>") || "—"}</dd>
+      <dt>Allowed actions</dt><dd>${(ir.allowed_action_refs || []).map((v) => code(v)).join("<br>") || "—"}</dd>
+      <dt>Admitted head</dt><dd><code data-testid="inst-admitted-head">${esc(head || "—")}</code></dd>
+      <dt>Nonclaim</dt><dd class="sub" style="text-transform:none;letter-spacing:0;margin:0">${esc(entry.record?.nonclaim || d.payload.installation?.nonclaim || "The binding claims no runtime, route, or launch authority.")}</dd>
+    </dl>
+    <div class="gapcard">
+      ${disabledCtl("Enable", ENABLE_GAP_REASON)} ${disabledCtl("Recall release", RECALL_GAP_REASON)}
+      <p class="sub" style="margin:8px 0 0;text-transform:none;letter-spacing:0">${esc(LAUNCHER_GAP_NOTE)}</p>
+    </div>
+    <h3 style="margin:16px 0 6px;font-size:13px">Uninstall</h3>
+    ${uninstalled ? `<div class="empty">Already uninstalled (revision ${esc(String(ir.revision ?? ""))}) — the transition is immutable history; re-submitting the original uninstall replays it.</div>` : ""}
+    <form class="aform" method="post" action="${LEGACY_ROUTE}/${enc(pkg)}/uninstall">
+      <input type="hidden" name="idempotency_key" value="${esc(mintKey())}">
+      <input type="hidden" name="return" value="${esc(`${LEGACY_ROUTE}?pkg=${enc(pkg)}&rel=${enc(rel)}&inst=${enc(inst)}`)}">
+      <input type="hidden" name="release_digest" value="${esc(rel)}">
+      <input type="hidden" name="installation_id" value="${esc(inst)}">
+      ${head ? `<input type="hidden" name="expected_installation_head" value="${esc(head)}">` : ""}
+      <button class="act" type="submit"${dis}>Uninstall (removes only the local binding)</button> ${casNote}
+    </form>`;
+}
+
+// ---- Marketplace mode --------------------------------------------------------------------------
+function marketplaceView(model, registryBase) {
+  const overview = model.results.overview;
+  const listings = rowsOf(model.results.listings, "listings");
+  const m = overview?.ok ? (overview.payload?.marketplace || {}) : null;
+  const counts = m === null
+    ? degraded(overview)
+    : `<dl class="grid">
+        <dt>Listings</dt><dd>${esc(String(m.listings ?? 0))} (${esc(String(m.published ?? 0))} published)</dd>
+        <dt>Publish candidates</dt><dd>${esc(String(m.publish_candidates ?? 0))}</dd>
+        <dt>Admission reviews</dt><dd>${esc(String(m.admission_reviews ?? 0))}</dd>
+        <dt>Managed-instance offers</dt><dd>${esc(String(m.managed_instance_offers ?? 0))} <span class="sub" style="margin:0;text-transform:none;letter-spacing:0">(drafts only — never instantiated here)</span></dd>
+        <dt>Publish invariant</dt><dd class="sub" style="text-transform:none;letter-spacing:0;margin:0">${esc(overview.payload?.status_note || "—")}</dd>
+      </dl>`;
+  const list = listings === null
+    ? degraded(model.results.listings)
+    : (listings.length
+      ? `<table><thead><tr><th>Listing</th><th>Kind</th><th>Status</th><th>Public state</th><th>Updated</th></tr></thead><tbody>${listings.map((l) => `<tr>
+          <td><b>${esc(l.name || l.id || "—")}</b><div style="color:#878a93;font-size:11.5px"><code>${esc(l.ref || l.id || "")}</code></div></td>
+          <td>${pill("muted", l.listing_kind || "—")}</td>
+          <td>${pill(l.status === "published" ? "ok" : "muted", l.status || "—")}</td>
+          <td>${pill(l.public_state === "published" ? "ok" : "muted", l.public_state || "draft")}</td>
+          <td>${esc(l.updated_at || "—")}</td>
+        </tr>`).join("")}</tbody></table>`
+      : `<div class="empty">No marketplace listings — the substrate is genuinely empty, not hidden. A listing drafts over real substrate on the governed lane; distribution metadata only, never an install.</div>`);
+  return `<h2 id="marketplace-overview">Marketplace substrate</h2>
+    <p class="sub" style="margin:-4px 0 12px"><b>Packages / Marketplace</b> — the optional discovery mode of the Packages owner (canon: a Marketplace entry point resolves here and never becomes a second package owner; marketplace admission is NOT package admission). This mode is <b>read-first</b>: real listing-plane truth below, verbs on their owner lane.</p>
+    ${counts}
+    <h3 style="margin:16px 0 6px;font-size:13px">Listings</h3>${list}
+    <div class="gapcard">
+      ${disabledCtl("Draft listing", MARKETPLACE_LADDER_REASON)} ${disabledCtl("Publish", MARKETPLACE_LADDER_REASON)} ${disabledCtl("Review", MARKETPLACE_LADDER_REASON)}
+      <p class="sub" style="margin:8px 0 0;text-transform:none;letter-spacing:0">The governed draft→candidate→review→publish ladder keeps operating on <a href="/__ioi/marketplace">the /__ioi/marketplace owner lane</a> (storefront seed: <a href="/__ioi/marketplace/listings">listings</a>) until the marketplace-actions leg. Installing from a listing re-enters through the <a href="${registryBase}">package registry</a> — never a storefront-side install runtime.</p>
+    </div>`;
+}
+
+// ---------------------------------------------------------------------------------------------
+export function render(model, ctx) {
+  const sp = ctx.url.searchParams;
+  const onLegacyMount = ctx.url.pathname.startsWith("/__ioi/");
+  const registryBase = onLegacyMount ? LEGACY_ROUTE : CANONICAL_ROUTE;
+  const marketplaceBase = onLegacyMount ? LEGACY_MARKETPLACE_ROUTE : CANONICAL_MARKETPLACE_ROUTE;
+  const marketplace = model.mode === "marketplace";
+  const nav = `<nav class="tabs" aria-label="Packages">
+    <a class="tab${marketplace ? "" : " active"}" href="${registryBase}">Registry</a>
+    <a class="tab${marketplace ? " active" : ""}" href="${marketplaceBase}">Marketplace</a>
+  </nav>`;
+  let bodyHtml = "";
+  let title = "Packages";
+  if (marketplace) {
+    title = "Packages / Marketplace";
+    bodyHtml = `<h1>Packages / Marketplace</h1>
+      <p class="sub">Optional mode of the <a href="${registryBase}">Packages</a> owner application — browse the real listing plane; package admission, releases, and installs live in the registry.</p>
+      ${marketplaceView(model, registryBase)}`;
+  } else {
+    const pkg = (sp.get("pkg") || "").trim();
+    const rel = (sp.get("rel") || "").trim();
+    const inst = (sp.get("inst") || "").trim();
+    const head = `<h1>Packages</h1>
+      <p class="sub">The local lifecycle owner for reusable release material — package candidates, immutable admitted releases, and installation bindings over the closed daemon registry (<code>/v1/hypervisor/packages</code>). Admission grants no runtime, no registration, no launch eligibility; what is absent is named, never simulated. Marketplace is the <a href="${marketplaceBase}">optional mode</a>.</p>`;
+    if (pkg && rel && inst) bodyHtml = head + installationView(model, registryBase, pkg, rel, inst);
+    else if (pkg && rel) bodyHtml = head + releaseView(model, registryBase, pkg, rel);
+    else if (pkg) bodyHtml = head + candidateView(model, registryBase, pkg);
+    else bodyHtml = head + catalogView(model, registryBase);
+  }
+  const css = `:root{color-scheme:dark}
+  body{margin:0;background:#0c0d10;color:#e6e7ea;font:14px/1.55 -apple-system,Segoe UI,Roboto,sans-serif}
+  .wrap{max-width:1180px;margin:0 auto;padding:32px 24px 80px}
+  a{color:#8ab4ff}
+  h1{font-size:26px;margin:0 0 6px;letter-spacing:-.02em}
+  .sub{color:#9a9da6;margin:0 0 22px;max-width:820px}
+  h2{font-size:13px;letter-spacing:.04em;text-transform:uppercase;color:#878a93;margin:26px 0 10px;font-weight:600}
+  .act{padding:8px 14px;border-radius:8px;border:0;background:#fff;color:#111;font:inherit;font-weight:600;text-decoration:none;cursor:pointer}
+  .act.ghost{background:transparent;color:#cbd0da;border:1px solid #2a2c33}
+  .act[disabled]{opacity:.45;cursor:not-allowed}
+  .pill{display:inline-block;padding:2px 9px;border-radius:999px;font-size:11px;border:1px solid;white-space:nowrap;margin-left:4px}
+  .ok{color:#46c277;border-color:#235c3b;background:#11281b}
+  .warn{color:#d6a13a;border-color:#5c4a23;background:#28220f}
+  .muted{color:#9a9da6;border-color:#2a2c33}
+  .empty{color:#6f7280;padding:18px;border:1px dashed #24262d;border-radius:12px}
+  .gapcard{padding:14px 16px;border:1px dashed #5c4a23;border-radius:12px;background:#15130c;margin:0 0 18px}
+  .grid{display:grid;grid-template-columns:200px 1fr;gap:8px 16px;padding:16px;border:1px solid #24262d;border-radius:12px;background:#15171c;margin:0 0 18px}
+  .grid dt{color:#878a93;font-size:12.5px}
+  .grid dd{margin:0;color:#e6e7ea;word-break:break-all}
+  code{font-size:11.5px;color:#aab;background:#0e0f13;padding:1px 5px;border-radius:4px}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin:0 0 14px}
+  th{text-align:left;color:#878a93;font-weight:600;font-size:11.5px;text-transform:uppercase;letter-spacing:.04em;padding:6px 10px;border-bottom:1px solid #24262d}
+  td{padding:8px 10px;border-bottom:1px solid #1b1d23;vertical-align:top}
+  .tabs{display:flex;gap:4px;border-bottom:1px solid #24262d;margin:0 0 18px;flex-wrap:wrap}
+  .tab{border-bottom:2px solid transparent;color:#9a9da6;font-weight:600;padding:9px 14px;text-decoration:none}
+  .tab.active{color:#fff;border-bottom-color:#3a82f6}
+  .aform{display:flex;flex-direction:column;gap:10px;max-width:640px;padding:14px 16px;border:1px solid #24262d;border-radius:12px;background:#15171c;margin:0 0 16px}
+  .fl{display:flex;flex-direction:column;gap:4px;color:#878a93;font-size:12px}
+  .fl input,.fl textarea,.fl select{padding:8px;border-radius:8px;border:1px solid #2a2c33;background:#0e0f13;color:#e6e7ea;font:inherit}
+  .banner{margin:0 0 14px;padding:9px 12px;border-radius:8px;font-size:12.5px;line-height:1.5;outline:none}
+  .banner code{word-break:break-all}
+  .ok-banner{border:1px solid #235c3b;background:#11281b;color:#46c277}
+  .no-banner{border:1px solid #5c4a23;background:#28220f;color:#d6a13a}
+  @media(max-width:760px){.grid{grid-template-columns:130px 1fr}table{display:block;overflow-x:auto;max-width:100%}}`;
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${esc(title)} · Hypervisor</title><style>${css}</style></head>
+<body><div class="wrap">${nav}${banner(sp)}${bodyHtml}</div></body></html>`;
+}

--- a/docs/architecture/_meta/shipped-products.v1.json
+++ b/docs/architecture/_meta/shipped-products.v1.json
@@ -70,6 +70,8 @@
           "/__ioi/missions/incidents",
           "/__ioi/ontology/explorer",
           "/__ioi/ontology/manager",
+          "/__ioi/packages/marketplace",
+          "/__ioi/packages/registry",
           "/__ioi/pipeline",
           "/__ioi/studio/designer",
           "/__ioi/studio/machinery",
@@ -104,8 +106,8 @@
           "/work/new-session",
           "/work/sessions"
         ],
-        "expected_count": 45,
-        "sha256": "1ad3b34f2fb9005aa7bf7348bc2fb01e6eb05f92a3aa101c634403dad480db75",
+        "expected_count": 47,
+        "sha256": "6a9f21e6edfc7e621e25020f7b89d894fa816be839fd02761ba01306ef500328",
         "browser_verification_id": "served-surface-smoke"
       },
       "state_authority_mode": "daemon_authoritative_projection",


### PR DESCRIPTION
STACKED on #234 (`w2.1/studio-ui`) — retarget to `master` after #234 merges. Do not merge before that.

## What this is

The Packages lifecycle packet (manifest unit W2.3 bar, next-legs II Leg 2): one surface module, two mounts, over the CLOSED seven-route `/v1/hypervisor/packages` daemon family — no daemon changes.

- **`/packages`** (+ fresh legacy action lane `/__ioi/packages/registry`): candidate catalog + admit form, candidate detail with CAS-seeded release cut, immutable release detail with install, installation detail with uninstall. Installation bindings render their **forced-disabled truth verbatim** — `installed` + `disabled` + `launch_eligible: false` + the daemon's exact `disabled_reason_codes` (`extension_application_registration_absent`, `surface_serving_binding_absent`) — never a launchability claim.
- **`/packages/marketplace`** (+ `/__ioi/packages/marketplace`): the optional **Packages / Marketplace** mode, read-first — real marketplace overview + listing plane, honest-empty over the empty substrate; the governed publish ladder stays on its `/__ioi/marketplace` owner lane and its controls render disabled with the machine-readable reason. Never a second package owner.

## The family's contract, spoken exactly (derived from `package_registry_routes.rs` + the package-registry smoke)

- **Identity-first on reads AND writes** — anonymous → typed 401 `request_principal_required`. Module loads therefore receive the request-scoped daemon capability (`ctx.daemonFetch`, the same envelope the action lane already hands out), so an authenticated caller sees registry truth and an anonymous render shows the typed refusal band.
- **Owner-scoped**: `owner_ref` (org://) on candidate create; releases/installs derive the owner from the admitted predecessor.
- **Caller idempotency**: exact retry replays (same head, same `receipt_ref`); rendered as `replayed`.
- **Exact-head CAS**: `expected_package_head` / `expected_release_head` / `expected_installation_head`; stale → typed 409 `package_expected_head_conflict`, rendered verbatim with the fresh-head remedy.
- **Admission evidence or nothing**: success is believed only with the record under its declared `schema_version` + `agentgres.receipt_ref` (`receipt://…`); a 2xx without either fails closed.

## Recall-eligibility: what was PROVEN vs what is TYPED ABSENCE

The W2.3 bar ("recall lands WITH the registry; a recalled package immediately loses launch eligibility") lands as typed absence + the eligibility-loss proof the daemon actually owns:

- **No recall verb exists** — `surface_package_disposition` is write-once `"active"` at release admission; the registered enum names `recalled` but no route can set it (no PATCH/DELETE anywhere on the packages tree; marketplace routes never touch package state; governance `request_recall` operates on `release-control://`, not package releases). Asserted **mechanically**: the `/v1` route inventory is pinned to the exact seven-route family. UI renders Deprecate/Recall/Revoke/Enable disabled with `data-ioi-disabled-reason`.
- **No launcher projection consumes package state** — `product-surface-projections` performs the right eligibility join but over compiled-in records; nothing reads the `hypervisor-package-registry` namespace. Asserted: `application_entries` (15 projected) never contain the installed package's `surface://extensions/…` ref.
- **Eligibility loss through the one removal verb that exists**: uninstall immediately revokes the binding — immutable revision 2, `uninstalled`, `launch_eligible` stays false, head advanced. (The uninstall event payload additionally records `surface_installation_uninstalled`, but the family's read projection hardcodes the structural reason pair — the verifier asserts what the daemon actually answers.)

## Evidence

- `check:packages-journey` **35/35** (isolated daemon+serve): full candidate → release → install → uninstall chain through the UI action lane; unauthenticated mutation typed refusal; CAS conflict typed + rendered, state unchanged; idempotent replay returns the original receipt (candidate AND uninstall); contract-widening install refused `package_installation_contract_widening`; both typed-absence assertions above; restart reconstruction with exact heads; canonical + legacy mounts with truthful ownership markers; `/__ioi/marketplace*` seed lanes untouched; 3-posture matrix.
- Regression: `check:studio-journey` **33/33** (the serve `ctx.daemonFetch` extension is additive).
- `test:hypervisor-app-clients`, `test:hypervisor-route-shell`, `check:source-neutral`, `check:seed-provenance`, `check:owned-product-ui`, `check:shell-parity` (6/6), `check:ported-seed` (413/413) — all green.
- `smoke-product-surfaces`: manifest inventory re-validated (45 → 47 routes, digest recomputed); all four packages mounts green in all 3 postures. The full-sweep run hit the known vendored-SPA `/` `WatchEvents net::ERR_ABORTED` flake — it reproduces intermittently on the untouched main checkout (one crash, one pass, same route) and is **not fenced** here.

## Deviations (narrated)

1. `serve-product-ui.mjs` (+9 lines): module GET loads now receive the request-scoped daemon capability. Required because this is the first canonical mount over an identity-first-on-reads family; mirrors DEF-IDENT-1's action-lane mechanics and the flat GET branches' ambient `daemonFetch`. Anonymous stays anonymous.
2. Two registry rows for one module: `/packages/marketplace` is a registered v2 route the smoke pins with ownership contracts; a second row (owner **Packages**, title "Packages / Marketplace") is the existing mechanism that lets the canonical mode route be module-served with truthful markers — the mode never becomes a second owner.
3. The verifier does not assert `surface_installation_uninstalled` in the read projection (daemon's `render_installation` hardcodes the structural pair); it asserts the terminal state + revision + `launch_eligible:false` + head advance instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)