### PR TITLE
feat(hypervisor): ODK ontology writes are identity-first — rule E gated, principal-bound receipts; serve forwards the session (W1.1/G-2 finding closed; next-legs II Leg 3)

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
@@ -81,17 +81,23 @@ async function startDaemon() {
   return () => log;
 }
 
-const jd = (p, init) => fetch(`${DAEMON}${p}`, init ? { headers: { "content-type": "application/json" }, ...init } : undefined)
+// Ontology writes are identity-first (rule E — the W1.1/G-2 finding is CLOSED): every
+// authoring crossing carries the bootstrap operator's session; the daemon refuses an
+// anonymous write typed-401 BEFORE any record load. Reads stay ungated.
+let SESSION = "";
+const sessionCookie = () => (SESSION ? { cookie: `ioi_session=${SESSION}` } : {});
+
+const jd = (p, init) => fetch(`${DAEMON}${p}`, init ? { headers: { "content-type": "application/json", ...sessionCookie() }, ...init } : undefined)
   .then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
   .catch(() => ({ status: 0, body: {} }));
 
 const pageText = (p) => fetch(`${SERVE}${p}`).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
 
 const MANAGER_ACTIONS = `${"/__ioi/ontology/manager"}/actions`;
-async function act(id, data) {
+async function act(id, data, { anonymous = false } = {}) {
   const r = await fetch(`${SERVE}${MANAGER_ACTIONS}/${id}`, {
     method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
+    headers: { "content-type": "application/x-www-form-urlencoded", ...(anonymous ? {} : sessionCookie()) },
     body: new URLSearchParams(data).toString(),
     redirect: "manual",
   }).catch(() => null);
@@ -105,14 +111,17 @@ async function run() {
   DAEMON = `http://127.0.0.1:${daemonPort}`;
   const daemonLogFn = await startDaemon();
 
-  // Operator bootstrap mirrors scripts/smoke-product-surfaces.mjs.
+  // Operator bootstrap mirrors scripts/smoke-product-surfaces.mjs; the yielded session is
+  // now the AUTHORING identity every write below carries (identity-first ontology writes).
   const token = daemonLogFn().match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
   if (token) {
-    await jd("/v1/hypervisor/auth/bootstrap", {
+    const boot = await jd("/v1/hypervisor/auth/bootstrap", {
       method: "POST",
       body: JSON.stringify({ token, password: "ontology-journey-bootstrap-v1", email: "ontology-journey@ioi.local" }),
     });
+    SESSION = boot.body?.session_token ?? "";
   }
+  ok("operator bootstrap yields an authenticated session", SESSION.startsWith("ioi_sess_"), SESSION.slice(0, 12));
 
   const servePort = await freePort();
   const productUiPort = await freePort();
@@ -201,6 +210,10 @@ async function run() {
   ok("Explorer scope selector resolves the ontology", scoped.status === 200 && scoped.text.includes(domain), "");
   const history = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}/history`);
   ok("history records the mutation trail", history.status === 200 && JSON.stringify(history.body).length > 2, `status ${history.status}`);
+  const historyReceipts = Array.isArray(history.body?.receipts) ? history.body.receipts : [];
+  ok("receipts bind the resolved acting principal (INV-37)",
+    historyReceipts.length > 0 && historyReceipts.every((r) => typeof r.acting_principal_ref === "string" && r.acting_principal_ref.startsWith("user://")),
+    historyReceipts[0]?.acting_principal_ref ?? "no receipts");
   const health = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}/health`);
   ok("health answers for the authored ontology", health.status === 200, `status ${health.status}`);
 
@@ -210,9 +223,32 @@ async function run() {
   const savedSet = await jd("/v1/hypervisor/odk/materialized-object-sets", { method: "POST", body: JSON.stringify({ name: "x" }) });
   ok("saved-set authoring absent — named gap typed, not simulated", savedSet.status === 404 || savedSet.status === 405, `status ${savedSet.status}`);
 
-  // -- identity posture: current contract, recorded not hidden ---------------
-  ok("FINDING(typed): ontology writes cross with no identity envelope (loopback dev posture; W1.1/G-2 pull)", true,
-    "handle_odk_ontology_create/patch take no HeaderMap; module ignores daemonFetch");
+  // -- identity gate (W1.1/G-2 finding CLOSED): anonymous authoring refuses typed ----
+  // Rule E — the refusal is owed BEFORE any record load: the serve action lane without a
+  // session and a direct daemon write without identity both answer the typed
+  // request_principal_required, never a silent success and never a 404 existence oracle.
+  const anonAct = await act("upsert-object-type", { ontology: ontId, def_id: "obj_anon", name: "Anon" }, { anonymous: true });
+  ok("anonymous serve action refuses typed (request_principal_required, no receipt)",
+    anonAct.status === 303 && anonAct.q.get("refused") === "request_principal_required" && !anonAct.q.get("acted") && !anonAct.q.get("receipt"),
+    anonAct.location.slice(0, 130));
+  const anonCreate = await fetch(`${DAEMON}/v1/hypervisor/odk/domain-ontologies`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ domain: "anon-domain" }),
+  }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) })).catch(() => ({ status: 0, body: {} }));
+  ok("anonymous direct daemon create answers typed 401 request_principal_required",
+    anonCreate.status === 401 && anonCreate.body?.ok === false && anonCreate.body?.code === "request_principal_required",
+    `status ${anonCreate.status} code ${anonCreate.body?.code}`);
+  const anonPatch = await fetch(`${DAEMON}/v1/hypervisor/odk/domain-ontologies/${ontId}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ description: "anon write" }),
+  }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) })).catch(() => ({ status: 0, body: {} }));
+  ok("anonymous direct daemon patch answers typed 401 before the record load (rule E)",
+    anonPatch.status === 401 && anonPatch.body?.code === "request_principal_required",
+    `status ${anonPatch.status} code ${anonPatch.body?.code}`);
+  const unchanged = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`);
+  ok("anonymous attempts changed nothing", unchanged.status === 200 && unchanged.body?.ontology?.revision === expectedRev, `rev ${unchanged.body?.ontology?.revision}`);
 
   // -- restart survival -------------------------------------------------------
   daemon.kill("SIGTERM");

--- a/apps/hypervisor/surfaces/ontology-manager/index.mjs
+++ b/apps/hypervisor/surfaces/ontology-manager/index.mjs
@@ -90,11 +90,20 @@ const ONT_RECEIPT_EXTRACTOR = (payload) =>
     ? payload.ontology_receipt.receipt_ref
     : "";
 
-export async function handleAction({ action, fields, daemon, url }) {
+export async function handleAction({ action, fields, daemonFetch, url }) {
   const { createAuthorityClient } = await import("../authority-client.mjs");
   const { createReadClient } = await import("../read-client.mjs");
-  const authority = createAuthorityClient({ daemon });
-  const reader = createReadClient({ daemon });
+  // W1.1/G-2 finding closed — authoring crossings carry the CALLER's identity. The runtime hands
+  // this module the request-scoped daemon capability (DEF-IDENT-1: bounded envelope, module-
+  // authored identity headers refused); riding it as fetchImpl with daemon:"" keeps every path
+  // daemon-relative (the capability refuses absolute destinations) while the authority client's
+  // typed-refusal ladder stays intact — the daemon's 401 request_principal_required surfaces as a
+  // named refusal, never a silent success. No capability, no mutation (approvals precedent).
+  if (typeof daemonFetch !== "function") {
+    return { kind: "failure", http: 500, code: "identity_capability_missing", message: "the action runtime supplied no request-scoped daemon capability — refusing to author without the caller's identity" };
+  }
+  const authority = createAuthorityClient({ daemon: "", fetchImpl: daemonFetch });
+  const reader = createReadClient({ daemon: "", fetchImpl: daemonFetch });
   // One typed mapping from a crossWithLease outcome to the module's action result — the
   // credential/challenge/receipt vocabulary renders identically for every authoring action.
   const fromCrossing = (crossed, onSuccess) => {

--- a/crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs
@@ -754,12 +754,14 @@ fn validate_object_model(com: &Value) -> Result<Value, VErr> {
 }
 
 /// Build an ontology receipt (PURE — nothing persists here; #62 proof discipline). The receipt
-/// carries only record-derived fields + the op/summary — never request material.
+/// carries only record-derived fields + the op/summary + the RESOLVED acting principal (INV-37:
+/// every mutation receipt names who acted) — never raw request material.
 fn build_ontology_receipt(
     ontology_ref: &str,
     op: &str,
     summary: &str,
     now: &str,
+    acting_principal_ref: &str,
 ) -> (String, Value) {
     let id = format!("ontr_{:x}", nanos());
     let receipt_ref = format!("agentgres://odk-ontology-receipt/{id}");
@@ -771,6 +773,7 @@ fn build_ontology_receipt(
         "op": op,
         "outcome": "ok",
         "summary": summary,
+        "acting_principal_ref": acting_principal_ref,
         "at": now
     });
     (id, rec)
@@ -862,8 +865,16 @@ pub(crate) async fn handle_odk_ontology_list(
 /// carries revision 1 + a create receipt + a readiness health projection.
 pub(crate) async fn handle_odk_ontology_create(
     State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> (StatusCode, Json<Value>) {
+    // W1.1/G-2 finding closed — identity FIRST (rule E): an anonymous caller is owed the typed
+    // refusal before any validation runs, so no field-shape probe exists for unauthenticated
+    // callers. An ontology write is an authored mutation, not an anonymous append.
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        Ok(identity) => identity,
+        Err(error) => return odk_scope_refusal(error),
+    };
     let domain = body
         .get("domain")
         .and_then(|v| v.as_str())
@@ -901,8 +912,13 @@ pub(crate) async fn handle_odk_ontology_create(
     let now = iso_now();
     let oref = format!("ontology://{id}");
     // #62 proof discipline: build record + receipt PURE, then finalize atomically-with-rollback.
-    let (receipt_id, receipt) =
-        build_ontology_receipt(&oref, "created", "DomainOntology draft created", &now);
+    let (receipt_id, receipt) = build_ontology_receipt(
+        &oref,
+        "created",
+        "DomainOntology draft created",
+        &now,
+        &identity.principal_ref,
+    );
     let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
     let record = json!({
         "schema_version": "ioi.hypervisor.odk.domain-ontology.v1",
@@ -951,8 +967,15 @@ pub(crate) async fn handle_odk_ontology_get(
 pub(crate) async fn handle_odk_ontology_patch(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
+    headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> (StatusCode, Json<Value>) {
+    // W1.1/G-2 finding closed — identity FIRST (rule E): the refusal is owed BEFORE the record
+    // load, so an unauthenticated caller can never use the 404 as an existence oracle.
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        Ok(identity) => identity,
+        Err(error) => return odk_scope_refusal(error),
+    };
     let Some(prev) = load(&st.data_dir, KIND_ONT, &id) else {
         return (
             StatusCode::NOT_FOUND,
@@ -1046,7 +1069,8 @@ pub(crate) async fn handle_odk_ontology_patch(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    let (receipt_id, receipt) = build_ontology_receipt(&oref, "patched", &summary, &now);
+    let (receipt_id, receipt) =
+        build_ontology_receipt(&oref, "patched", &summary, &now, &identity.principal_ref);
     let receipt_ref = receipt.get("receipt_ref").cloned().unwrap_or(Value::Null);
     // Append a bounded history entry + carry the receipt ref.
     let mut hist = o
@@ -1091,19 +1115,39 @@ pub(crate) async fn handle_odk_ontology_patch(
 pub(crate) async fn handle_odk_ontology_delete(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
-) -> Json<Value> {
-    Json(delete_ontology_receipted(&st.data_dir, &id))
+    headers: HeaderMap,
+) -> (StatusCode, Json<Value>) {
+    // W1.1/G-2 finding closed — identity FIRST (rule E): the refusal is owed BEFORE the record
+    // load inside the receipted delete, so an anonymous caller gets no existence oracle. All
+    // authenticated outcomes keep their 200 body shapes exactly.
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        Ok(identity) => identity,
+        Err(error) => return odk_scope_refusal(error),
+    };
+    (
+        StatusCode::OK,
+        Json(delete_ontology_receipted(
+            &st.data_dir,
+            &id,
+            &identity.principal_ref,
+        )),
+    )
 }
 
 /// The receipted-delete body, separated from the axum handler so the rollback discipline is
 /// directly testable (same shape as `finalize_ontology_persist`'s test).
-fn delete_ontology_receipted(data_dir: &str, id: &str) -> Value {
+fn delete_ontology_receipted(data_dir: &str, id: &str, acting_principal_ref: &str) -> Value {
     let Some(prev) = load(data_dir, KIND_ONT, id) else {
         return json!({ "ok": false, "removed": false, "id": id, "reason": "ontology not found" });
     };
     let oref = prev.get("ref").and_then(|v| v.as_str()).unwrap_or("");
-    let (receipt_id, receipt) =
-        build_ontology_receipt(oref, "deleted", "DomainOntology deleted", &iso_now());
+    let (receipt_id, receipt) = build_ontology_receipt(
+        oref,
+        "deleted",
+        "DomainOntology deleted",
+        &iso_now(),
+        acting_principal_ref,
+    );
     if !remove_record(data_dir, KIND_ONT, id) {
         return json!({
             "ok": false, "removed": false, "id": id,
@@ -2241,7 +2285,10 @@ mod odk_tests {
         std::fs::create_dir_all(&dir).unwrap();
         let data_dir = dir.to_str().unwrap();
         let now = "2026-01-01T00:00:00Z";
-        let (rid, receipt) = build_ontology_receipt("ontology://ont_x", "created", "s", now);
+        let (rid, receipt) =
+            build_ontology_receipt("ontology://ont_x", "created", "s", now, "user://tester");
+        // INV-37: the receipt names the resolved acting principal.
+        assert_eq!(receipt["acting_principal_ref"], json!("user://tester"));
         let record =
             json!({ "id": "ont_x", "ref": "ontology://ont_x", "revision": 1, "status": "draft" });
         // Block the receipts dir with a plain file → receipt persist fails.
@@ -2291,7 +2338,7 @@ mod odk_tests {
             json!({ "id": "ont_d", "ref": "ontology://ont_d", "revision": 1, "status": "draft" });
 
         // A missing ontology reports honestly and attests nothing — there was no mutation.
-        let missing = delete_ontology_receipted(data_dir, "ont_absent");
+        let missing = delete_ontology_receipted(data_dir, "ont_absent", "user://tester");
         assert_eq!(missing["ok"], json!(false));
         assert_eq!(missing["removed"], json!(false));
         assert!(read_record_dir(data_dir, KIND_ONT_RECEIPT).is_empty());
@@ -2299,7 +2346,7 @@ mod odk_tests {
         // Receipt persist blocked → the record must be RESTORED; no unreceipted deletion survives.
         persist_record(data_dir, KIND_ONT, "ont_d", &record).unwrap();
         std::fs::write(dir.join(KIND_ONT_RECEIPT), b"blocker").unwrap();
-        let blocked = delete_ontology_receipted(data_dir, "ont_d");
+        let blocked = delete_ontology_receipted(data_dir, "ont_d", "user://tester");
         assert_eq!(blocked["ok"], json!(false));
         assert_eq!(blocked["removed"], json!(false));
         assert!(
@@ -2313,7 +2360,7 @@ mod odk_tests {
 
         // Happy path: the record is gone AND a `deleted` receipt exists naming the ontology.
         std::fs::remove_file(dir.join(KIND_ONT_RECEIPT)).unwrap();
-        let ok = delete_ontology_receipted(data_dir, "ont_d");
+        let ok = delete_ontology_receipted(data_dir, "ont_d", "user://tester");
         assert_eq!(ok["ok"], json!(true));
         assert_eq!(ok["removed"], json!(true));
         assert!(load(data_dir, KIND_ONT, "ont_d").is_none());
@@ -2321,6 +2368,7 @@ mod odk_tests {
         assert_eq!(receipts.len(), 1, "exactly one delete receipt");
         assert_eq!(receipts[0]["op"], json!("deleted"));
         assert_eq!(receipts[0]["ontology_ref"], json!("ontology://ont_d"));
+        assert_eq!(receipts[0]["acting_principal_ref"], json!("user://tester"));
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Closes the ontology identity-envelope finding (next-legs II Leg 3; the W1.1/G-2 pull). Stacked on `w2.1/packages-ui` (#235).

## The authorized change (minimal — NOT an admission migration)

**Daemon** — `crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs`: the three DOMAIN-ONTOLOGY write handlers (`handle_odk_ontology_create`, `handle_odk_ontology_patch`, `handle_odk_ontology_delete`) were identity-UNGATED. They now take `HeaderMap` and resolve identity FIRST via `substrate_store::resolve_request_identity`, refusing through the file's existing `odk_scope_refusal` helper — rule E: the typed 401 `request_principal_required` is owed BEFORE any record load, so anonymous callers get no 404 existence oracle and no field-shape probe. Receipts now bind `acting_principal_ref` from the resolved identity (INV-37) via a minimally extended `build_ontology_receipt`.

Preserved exactly: revision CAS (`expected_revision`), local receipts + atomic-with-rollback finalization, response shapes (delete's authenticated outcomes keep their 200 bodies; the handler signature widens only to carry the 401), the 200+ok:false refusal idiom. Descriptor handlers untouched (already gated); ontology is NOT migrated onto `odk_admit`.

**Serve** — `apps/hypervisor/surfaces/ontology-manager/index.mjs`: `handleAction` previously built `createAuthorityClient({ daemon })` → bare fetch, no identity — every authoring action would have broken. It now rides the request-scoped daemon capability the dispatcher already hands modules (DEF-IDENT-1): both shared clients are bound with `{ daemon: "", fetchImpl: daemonFetch }`, keeping every path daemon-relative (the capability refuses absolute destinations and module-authored identity headers) while `createAuthorityClient`'s typed-refusal ladder stays intact. Missing capability fails closed with typed `identity_capability_missing` (approvals/packages precedent). No `runSurfaceAction` change was needed — the existing envelope discipline already provides everything.

The legacy `/__ioi/odk` substrate lanes ride the ambient-request `daemonFetch`, which already forwards the caller's cookie — no change needed there.

## Verifiers (both green against the rebuilt daemon)

- `verify-hypervisor-ontology-journey.mjs` — **36/36**. The bootstrap session now rides every authoring crossing (serve action POSTs + direct daemon writes). The old `FINDING(typed)` pass row is REPLACED by the gate assertions: anonymous serve action → `refused=request_principal_required` with no receipt; anonymous direct daemon create AND patch → typed 401 `request_principal_required` (patch proven before the record load); state proven unchanged after the anonymous attempts; history receipts assert `acting_principal_ref` (`user://…`) on every receipt.
- `verify-hypervisor-studio-journey.mjs` — **33/33**. No change needed: its `jd` helper already sends the operator session cookie on the setup ontology create; the run proves the previously-ungated route now admits it.

## Gates

- `cargo build` clean; `cargo fmt --all --check` clean
- `cargo test --locked -p ioi-node --bin hypervisor-daemon odk` — 27 passed / 0 failed
- `check:architecture-contracts`, `check:architecture-docs`, `check:mutation-foundation` (census unmoved — no new direct persists), `check:mutation-handlers`, `check:admission-evidence` (H-census 177/177 baseline holds — the ratchet did not react, no baseline move needed), `check:source-neutral`, `test:hypervisor-app-clients` (20/20) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
