### PR TITLE
feat(hypervisor): /automations canonical mount — rehomed spec grammar read-first, daemon-owned verbs only; check:automations-journey (next-legs II Leg 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
           npm run check:governance-journey --workspace=@ioi/hypervisor-app
           npm run check:studio-journey --workspace=@ioi/hypervisor-app
           npm run check:packages-journey --workspace=@ioi/hypervisor-app
+          npm run check:automations-journey --workspace=@ioi/hypervisor-app
           npm run check:projects-saga --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -17,6 +17,7 @@
     "check:governance-journey": "node scripts/verify-hypervisor-governance-journey.mjs",
     "check:studio-journey": "node scripts/verify-hypervisor-studio-journey.mjs",
     "check:packages-journey": "node scripts/verify-hypervisor-packages-journey.mjs",
+    "check:automations-journey": "node scripts/verify-hypervisor-automations-journey.mjs",
     "check:projects-saga": "node scripts/verify-hypervisor-projects-saga.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -31,6 +31,7 @@ import * as sourcesModule from "../surfaces/sources/index.mjs";
 import * as missionsModule from "../surfaces/missions/index.mjs";
 import * as studioModule from "../surfaces/studio/index.mjs";
 import * as packagesModule from "../surfaces/packages/index.mjs";
+import * as automationsModule from "../surfaces/automations/index.mjs";
 
 // Capability model (operational wave): `capabilities` is the AUTHORITY-derived set of acts the
 // surface genuinely supports today (never inferred from pixel certification or daemon_wired);
@@ -83,6 +84,16 @@ export const SURFACES = [
   { slug: "packages", owner: "Packages", title: "Packages", icon: MARKETPLACE_APP_ICON_URI, route: "/__ioi/packages/registry", canonical_route: "/packages", verifier: "scripts/verify-hypervisor-packages-journey.mjs", certification: "n/a", capabilities: ["browse", "select", "inspect", "create", "transition"], operational_state: "act", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "packages-marketplace", owner: "Packages", title: "Packages / Marketplace", icon: MARKETPLACE_APP_ICON_URI, route: "/__ioi/packages/marketplace", canonical_route: "/packages/marketplace", verifier: "scripts/verify-hypervisor-packages-journey.mjs", certification: "n/a", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "monitors", owner: "Automations", title: "Automate", icon: MON_APP_TILE_URI, route: "/__ioi/automations/monitors", verifier: "scripts/verify-hypervisor-app-parity-monitors.mjs", certification: "pixel-certifications/monitors.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
+  // W2.1 next-legs II Leg 4: the Automations surface packet — canonical /automations plus a
+  // FRESH legacy lane /__ioi/automations-cockpit (deliberately NOT nested under
+  // /__ioi/automations/, whose flat :id dispatch would shadow it; every seed lane there keeps
+  // serving untouched until the W4 cutover). The module rehomes the T2 cockpit grammar
+  // READ-FIRST over the shared read client; the daemon-owned verbs (create/patch/delete/run/
+  // webhook-rotate) stay wired through the seed cockpit's own action lanes because the family
+  // returns NO admission receipts yet (the brief's named W2 defect) — so the module declares no
+  // receipted actions and its operational_state stays "inspect" honestly. Evidence: the
+  // automations journey verifier.
+  { slug: "automations", owner: "Automations", title: "Automations", icon: MON_APP_TILE_URI, route: "/__ioi/automations-cockpit", canonical_route: "/automations", verifier: "scripts/verify-hypervisor-automations-journey.mjs", certification: "n/a", capabilities: ["browse", "filter", "select", "inspect"], operational_state: "inspect", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "changes", owner: "Improvement", title: "Upgrade Assistant", icon: CHG_APP_TILE_URI, route: "/__ioi/improvement/changes", verifier: "scripts/verify-hypervisor-app-parity-changes.mjs", certification: "pixel-certifications/changes.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "evalsuites", owner: "Evaluations", title: "AIP Evals", icon: EVL_APP_TILE_URI, route: "/__ioi/evaluations/evalsuites", verifier: "scripts/verify-hypervisor-app-parity-evalsuites.mjs", certification: "pixel-certifications/evalsuites.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
 ];
@@ -185,6 +196,7 @@ bindSurface("studio-home", studioModule);
 // marketplace mounts render the read-first mode); ownership markers stay per-row truthful.
 bindSurface("packages", packagesModule);
 bindSurface("packages-marketplace", packagesModule);
+bindSurface("automations", automationsModule);
 
 // Test-only fault surface (NEVER without the runtime-test flag): gives the action-runtime
 // verifier a module whose action THROWS (route isolation proof) and one that claims success

--- a/apps/hypervisor/scripts/v2-route-shell.mjs
+++ b/apps/hypervisor/scripts/v2-route-shell.mjs
@@ -161,9 +161,10 @@ export const V2_ROUTE_TABLE = [
     kind: "owner application",
     rule: "shell placement and application identity resolve to the same registration",
     waves: "W0.6 (scheduler read) · W1 · W2",
-    build_state: "shell-only (W0.1) — Wave 1 read-first build (surfaces/automations.md §5). The click-capture hijack that rewrote this canonical route into /__ioi/automations was retired at W0.1 (canon wins); the legacy readout stays reachable below",
+    build_state: "W2.1 rehome landed — the bound surface module serves this canonical route (spec list/detail/new read-first over the shared read client; daemon-owned verbs through the seed cockpit lanes; receipts are the W2 lease-client wave per surfaces/automations.md §5). Legacy lanes keep serving until the W4 cutover",
     serving_today: [
-      { href: "/__ioi/automations", label: "Automations readout", note: "project-first automations over the daemon scheduler; rehomes into this route in Wave 1" },
+      { href: "/automations", label: "Automations (canonical)", note: "rehomed module at the canonical route — read-first cockpit over the daemon automations family" },
+      { href: "/__ioi/automations", label: "Automations readout (legacy lane)", note: "keeps serving untouched until the W4 cutover" },
       { href: "/__ioi/automations/monitors", label: "Automate / monitors", note: "protected ported seed (daemon-wired)" },
     ],
   },

--- a/apps/hypervisor/scripts/verify-hypervisor-automations-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-automations-journey.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+// Automations journey verifier (W2.1 §5 PR 1, next-legs II Leg 4).
+//
+// Proves, against an ISOLATED real daemon + serve lane, that the canonical /automations mount
+// rehomes the T2 cockpit grammar READ-FIRST over the daemon automations family, and that every
+// rendered verb is a verb the daemon ACTUALLY owns — journeyed with readback where the route
+// exists, asserted as a TYPED ABSENCE (404 at the daemon, disabled-with-reason in the UI) where
+// it does not. Named gaps, never simulation:
+//   - the family's route inventory is pinned EXACTLY (list/create · get/patch/delete ·
+//     start/runs · webhook/rotate/events · execution get/cancel) — no versions/revisions route,
+//     no separate activate route (pause/resume IS `PATCH {enabled}`), no binding plane;
+//   - spec mutations cross UNRECEIPTED ({ok, automation}, no admission envelope) — the brief's
+//     named W2 defect; the surface renders verbs through the seed cockpit's own lanes and this
+//     verifier records the identity posture it PROBES (gated → typed refusal asserted; ungated →
+//     current truth asserted + FINDING row), never hides it;
+//   - scheduler HEALTH is Operations-owned: the pages must render NO scheduler-health rows
+//     (liveness/heartbeat/tick data) while the per-spec schedule fields stay;
+//   - monitors stays a LINK to the protected seed route; machinery stays OUT (OQ-2 unruled).
+//
+// Exit: 0 pass · 1 fail · 2 blocked (daemon binary missing).
+//   IOI_HYPERVISOR_DAEMON_BINARY  default target/debug/hypervisor-daemon
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+  srv.on("error", reject);
+});
+
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try {
+  fs.accessSync(daemonBinary, fs.constants.X_OK);
+} catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-automations-journey-"));
+let daemon = null;
+let serve = null;
+let daemonPort = 0;
+let DAEMON = "";
+let SERVE = "";
+let SESSION = "";
+
+const SEED_LANE = "/__ioi/automations"; // the T2 cockpit's own wired action lanes (seed truth)
+const FRESH_LANE = "/__ioi/automations-cockpit"; // the module's fresh legacy mount
+
+async function startDaemon() {
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${daemonPort}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1/v1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = "";
+  daemon.stdout.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  await waitFor(`${DAEMON}/healthz`, 30000);
+  return () => log;
+}
+
+// Daemon JSON — cookie=true carries the operator session (the probe rows judge the difference).
+const jd = (p, init, cookie = true) => fetch(`${DAEMON}${p}`, {
+  headers: {
+    ...(init?.body ? { "content-type": "application/json" } : {}),
+    ...(cookie && SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+  },
+  ...init,
+}).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+  .catch(() => ({ status: 0, body: {} }));
+
+// A served page, optionally with the operator session.
+const pageText = (p, { authenticated = true } = {}) => fetch(`${SERVE}${p}`, {
+  headers: authenticated && SESSION ? { cookie: `ioi_session=${SESSION}` } : {},
+}).then(async (r) => ({ status: r.status, text: await r.text(), headers: r.headers }))
+  .catch(() => ({ status: 0, text: "", headers: new Headers() }));
+
+// A form POST on a seed cockpit lane (the wiring the rendered verbs use) — redirect captured.
+async function seedPost(tail, fields, { authenticated = true, json = null } = {}) {
+  const r = await fetch(`${SERVE}${SEED_LANE}${tail}`, {
+    method: "POST",
+    headers: {
+      "content-type": json ? "application/json" : "application/x-www-form-urlencoded",
+      ...(authenticated && SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+    },
+    body: json ? JSON.stringify(json) : new URLSearchParams(fields).toString(),
+    redirect: "manual",
+  }).catch(() => null);
+  return { status: r?.status ?? 0, location: r?.headers?.get("location") || "" };
+}
+
+const specGet = async (id) => (await jd(`/v1/hypervisor/automations/${encodeURIComponent(id)}`)).body;
+
+function automationFamilyRoutes(index) {
+  return (index.families ?? [])
+    .flatMap((family) => family.paths ?? [])
+    .filter((row) => row.path.startsWith("/v1/hypervisor/automations") || row.path.startsWith("/v1/hypervisor/automation-executions"))
+    .map((row) => ({ path: row.path, methods: [...row.methods].sort() }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+// Scheduler-health data markers that must NEVER render on this surface (Operations owns them).
+const SCHEDULER_HEALTH_TOKENS = ["tick_seq", "last_tick_at", "no_heartbeat_recorded", "liveness", "misfire", "scheduler-heartbeat"];
+const rendersNoSchedulerHealth = (text) => SCHEDULER_HEALTH_TOKENS.every((t) => !text.includes(t));
+
+async function run() {
+  daemonPort = await freePort();
+  DAEMON = `http://127.0.0.1:${daemonPort}`;
+  const daemonLogFn = await startDaemon();
+  const token = daemonLogFn().match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  if (token) {
+    const boot = await jd("/v1/hypervisor/auth/bootstrap", {
+      method: "POST",
+      body: JSON.stringify({ token, password: "automations-journey-bootstrap-v1", email: "automations-journey@ioi.local" }),
+    });
+    SESSION = boot.body?.session_token ?? "";
+  }
+  ok("operator bootstrap yields an authenticated session", SESSION.startsWith("ioi_sess_"), SESSION.slice(0, 12));
+
+  // -- TYPED ABSENCE (mechanical): the owned verb set is pinned EXACTLY -------
+  const index = await jd("/v1");
+  const familyRoutes = automationFamilyRoutes(index.body);
+  const expectedRoutes = [
+    { path: "/v1/hypervisor/automation-executions/:id", methods: ["GET"] },
+    { path: "/v1/hypervisor/automation-executions/:id/cancel", methods: ["POST"] },
+    { path: "/v1/hypervisor/automations", methods: ["GET", "POST"] },
+    { path: "/v1/hypervisor/automations/:id", methods: ["DELETE", "GET", "PATCH"] },
+    { path: "/v1/hypervisor/automations/:id/runs", methods: ["GET", "POST"] },
+    { path: "/v1/hypervisor/automations/:id/start", methods: ["POST"] },
+    { path: "/v1/hypervisor/automations/:id/webhook", methods: ["POST"] },
+    { path: "/v1/hypervisor/automations/:id/webhook-events", methods: ["GET"] },
+    { path: "/v1/hypervisor/automations/:id/webhook-rotate", methods: ["POST"] },
+  ].sort((left, right) => left.path.localeCompare(right.path));
+  ok("owned-verb inventory pinned: the automations family is EXACTLY list/create · get/patch/delete · start/runs · webhook/rotate/events · execution get/cancel — no versions/revisions, no separate activate, no binding plane",
+    JSON.stringify(familyRoutes) === JSON.stringify(expectedRoutes)
+      && !JSON.stringify(index.body).includes("/v1/hypervisor/automations/:id/versions")
+      && !JSON.stringify(index.body).includes("/v1/hypervisor/automations/:id/activate"),
+    JSON.stringify(familyRoutes.map((r) => r.path)));
+
+  const servePort = await freePort();
+  const productUiPort = await freePort();
+  SERVE = `http://127.0.0.1:${servePort}`;
+  serve = spawn(process.execPath, [path.join(HERE, "serve-product-ui.mjs")], {
+    cwd: APP,
+    env: {
+      ...process.env,
+      PORT: String(servePort),
+      PRODUCT_UI_PORT: String(productUiPort),
+      IOI_PRODUCT_UI_PUBLIC: path.join(APP, "product-ui", "owned", "public"),
+      IOI_HYPERVISOR_DAEMON_URL: DAEMON,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await waitFor(`${SERVE}/automations`, 30000);
+
+  // -- canonical mount: rehomed grammar, honest-empty, boundaries held --------
+  const landing = await pageText("/automations");
+  ok("canonical /automations 200s as the module's own mount (ownership headers name the served route)",
+    landing.status === 200 && landing.headers.get("x-ioi-surface-route") === "/automations" && landing.headers.get("x-ioi-surface-owner") === "Automations",
+    `status ${landing.status} route ${landing.headers.get("x-ioi-surface-route")}`);
+  ok("the rehomed grammar renders with its owner-surface contract intact (heading anchor + durable-orchestration framing + daemon-truth claim) and HONEST-EMPTY (no fixture rows)",
+    landing.text.includes('id="automations-owner"') && landing.text.includes("Durable orchestration")
+      && landing.text.includes("daemon truth") && landing.text.includes("No daemon automations yet"),
+    "");
+  ok("the Monitors reference stays a LINK to the protected seed route (and the wizard capture stays a linked reference, never rows)",
+    landing.text.includes('href="/__ioi/automations/monitors"') && landing.text.includes('href="/__apps/monitors"'),
+    "");
+  ok("machinery stays OUT entirely (OQ-2 unruled — no registry transfer, no state-machines read, no machinery link)",
+    !landing.text.includes("machinery") && !landing.text.includes("Machinery")
+      && !landing.text.includes("state-machines") && !landing.text.includes("state_machines"),
+    "");
+  ok("scheduler-health rows are ABSENT (Operations-owned boundary NAMED as a link, never rendered as data)",
+    rendersNoSchedulerHealth(landing.text) && landing.text.includes("Operations-owned") && landing.text.includes('href="/__ioi/operations"'),
+    "");
+  ok("the named absences render disabled-with-reason (Versions + monitor wizard) — typed, machine-readable, never simulated",
+    landing.text.includes("data-ioi-disabled-reason") && landing.text.includes("no daemon route exists")
+      && landing.text.includes(">Versions<") && landing.text.includes("Monitor wizard"),
+    "");
+  const freshLane = await pageText(FRESH_LANE);
+  ok("the fresh legacy lane serves the same module with its own truthful marker",
+    freshLane.status === 200 && freshLane.headers.get("x-ioi-surface-route") === FRESH_LANE
+      && freshLane.headers.get("x-ioi-surface-owner") === "Automations" && freshLane.text.includes('id="automations-owner"'),
+    `status ${freshLane.status} route ${freshLane.headers.get("x-ioi-surface-route")}`);
+  const seedReadout = await pageText(SEED_LANE);
+  const seedMonitors = await pageText("/__ioi/automations/monitors");
+  ok("the seed lanes keep serving untouched (seed preservation: T2 cockpit + protected monitors)",
+    seedReadout.status === 200 && seedReadout.text.includes("Automations") && seedMonitors.status === 200,
+    `statuses ${seedReadout.status}/${seedMonitors.status}`);
+  const newForm = await pageText("/automations?view=new");
+  ok("the New-automation view renders project-first (project_ref REQUIRED) and posts through the seed cockpit's own create lane — no second mutation path",
+    newForm.status === 200 && newForm.text.includes("New automation") && newForm.text.includes("project_ref")
+      && newForm.text.includes(`action="${SEED_LANE}"`),
+    "");
+
+  // -- a real project (the automation's REQUIRED durable container) -----------
+  const created = await fetch(`${SERVE}/api/ioi.v1.ProjectService/CreateProject`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(SESSION ? { cookie: `ioi_session=${SESSION}` } : {}) },
+    body: JSON.stringify({ name: "automations-journey", initializer: { specs: [{ git: { remoteUri: "https://example.invalid/automations/journey.git" } }] } }),
+  }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) })).catch(() => ({ status: 0, body: {} }));
+  const projectId = created.body?.project?.id || created.body?.project?.projectId || "";
+  ok("a real project admits as the durable container", created.status === 200 && projectId.length > 0, projectId || `status ${created.status}`);
+  const noProject = await jd("/v1/hypervisor/automations", { method: "POST", body: JSON.stringify({ name: "orphan" }) });
+  ok("a container-less create refuses TYPED (automation_project_ref_required — the project linkage is the family's own rule)",
+    noProject.status === 400 && noProject.body?.error?.code === "automation_project_ref_required",
+    `${noProject.status}/${noProject.body?.error?.code}`);
+
+  // -- identity posture: probed HONESTLY, recorded not hidden -----------------
+  const anonCreate = await jd("/v1/hypervisor/automations", {
+    method: "POST",
+    body: JSON.stringify({ project_ref: projectId, name: "anon-posture-probe", steps: [] }),
+  }, false);
+  if (anonCreate.status === 401 || anonCreate.status === 403) {
+    ok("an unauthenticated spec mutation refuses TYPED (the family is identity-gated)",
+      !!(anonCreate.body?.error?.code || anonCreate.body?.code || anonCreate.body?.reason),
+      `${anonCreate.status}/${anonCreate.body?.error?.code || anonCreate.body?.code || anonCreate.body?.reason}`);
+  } else {
+    ok("current truth asserted: an unauthenticated spec mutation CROSSES (201, record admitted) under loopback dev posture — the family is ungated",
+      anonCreate.status === 201 && !!anonCreate.body?.automation?.automation_id,
+      `status ${anonCreate.status}`);
+    ok("FINDING(typed): automations writes cross with no identity envelope (loopback dev posture; W1.1/G-2 pull)", true,
+      "handle_automation_create/patch/delete resolve no principal; executor_identity defaults to operator; replies carry no admission receipt (the W2 lease-client pull)");
+    const probeId = anonCreate.body?.automation?.automation_id || "";
+    if (probeId) await jd(`/v1/hypervisor/automations/${encodeURIComponent(probeId)}`, { method: "DELETE" });
+  }
+
+  // -- create through the served grammar (session-carried), round-trip readback
+  const createRes = await seedPost("", {
+    project_ref: projectId,
+    name: "journey-nightly",
+    description: "journey spec",
+    schedule_type: "interval",
+    interval_n: "5",
+    interval_unit: "minutes",
+    step_kind: "command",
+    step_body: "echo journey-effect",
+    max_concurrency: "1",
+    failure_policy: "continue",
+  });
+  const automationId = decodeURIComponent((createRes.location.split("/").at(-1) || "").split("?")[0]);
+  ok("create crosses through the seed cockpit lane with the session cookie (302 → the new spec)",
+    createRes.status === 302 && automationId.startsWith("auto_"),
+    createRes.location.slice(0, 100));
+  let spec = await specGet(automationId);
+  ok("trigger/condition/effect ROUND-TRIP exactly as the family stores them: trigger_kind time + schedule_spec {every_minutes:5} (the condition) + steps [{kind:command}] (the effect) + project linkage",
+    spec.ok === true
+      && spec.automation?.trigger_kind === "time"
+      && JSON.stringify(spec.automation?.schedule_spec) === JSON.stringify({ every_minutes: 5 })
+      && Array.isArray(spec.automation?.steps) && spec.automation.steps.length === 1
+      && spec.automation.steps[0].kind === "command" && spec.automation.steps[0].command === "echo journey-effect"
+      && spec.automation?.enabled === true
+      && (spec.automation?.project_ref === projectId || spec.automation?.project_id === projectId),
+    JSON.stringify({ trigger: spec.automation?.trigger_kind, sched: spec.automation?.schedule_spec }));
+  ok("spec mutations answer WITHOUT an admission receipt — the named W2 defect is current daemon truth (asserted, not styled around)",
+    spec.ok === true && !JSON.stringify(spec).includes("receipt_ref") && !JSON.stringify(spec).includes("agentgres"),
+    "");
+
+  const listPage = await pageText(`/automations?project=${encodeURIComponent(projectId)}`);
+  // The trigger pill keeps the SEED grammar's own precedence (the `trigger` object — which the
+  // create handler defaults to {kind:"manual"} beside trigger_kind:"time" — wins over
+  // trigger_kind), rehomed verbatim; the stored trigger_kind truth is asserted on the round-trip
+  // row above and rendered on the detail grid.
+  ok("the canonical list renders the admitted spec (project filter lane + enabled pill + the spec id, seed card grammar verbatim)",
+    listPage.status === 200 && listPage.text.includes("journey-nightly") && listPage.text.includes(">enabled<")
+      && listPage.text.includes(automationId),
+    "");
+  let detail = await pageText(`/automations?automation=${encodeURIComponent(automationId)}`);
+  ok("the canonical detail renders the spec grid + the daemon-owned verbs (Run now / Pause via the seed lanes) + the declared step",
+    detail.status === 200 && detail.text.includes("every 5m") && detail.text.includes("Run now")
+      && detail.text.includes("Pause schedule") && detail.text.includes("echo journey-effect")
+      && detail.text.includes(`action="${SEED_LANE}/${encodeURIComponent(automationId)}/run"`),
+    "");
+  ok("the detail's typed absences render disabled-with-reason (Versions + Session/GoalRun lineage) and scheduler-health rows stay absent",
+    detail.text.includes(">Versions<") && detail.text.includes("Serving Session / GoalRun lineage")
+      && detail.text.includes("no daemon fields exist") && rendersNoSchedulerHealth(detail.text),
+    "");
+
+  // -- daemon typed absences probed directly ----------------------------------
+  const versions = await jd(`/v1/hypervisor/automations/${encodeURIComponent(automationId)}/versions`);
+  const activate = await jd(`/v1/hypervisor/automations/${encodeURIComponent(automationId)}/activate`, { method: "POST", body: "{}" });
+  ok("version/revision family ABSENT at the daemon — typed 404, never simulated", versions.status === 404, `status ${versions.status}`);
+  ok("no separate activate route — typed 404 (activation IS `PATCH {enabled}`, the family's own lane)", activate.status === 404, `status ${activate.status}`);
+
+  // -- pause / resume journey (the PATCH {enabled} lane) ----------------------
+  const paused = await seedPost(`/${encodeURIComponent(automationId)}/pause`, {});
+  spec = await specGet(automationId);
+  ok("pause crosses (302) and reads back: enabled false + next_run_at reset (the scheduler skips disabled specs)",
+    paused.status === 302 && spec.automation?.enabled === false && spec.automation?.next_run_at === null,
+    `enabled ${spec.automation?.enabled}`);
+  detail = await pageText(`/automations?automation=${encodeURIComponent(automationId)}`);
+  ok("the canonical detail renders the paused truth (disabled pill + Resume verb)",
+    detail.status === 200 && detail.text.includes(">disabled<") && detail.text.includes("Resume schedule"),
+    "");
+  const resumed = await seedPost(`/${encodeURIComponent(automationId)}/resume`, {});
+  spec = await specGet(automationId);
+  ok("resume crosses (302) and reads back enabled true", resumed.status === 302 && spec.automation?.enabled === true, "");
+
+  // -- run now: a REAL execution over a REAL environment ----------------------
+  const ran = await seedPost(`/${encodeURIComponent(automationId)}/run`, {});
+  let runs = [];
+  for (let attempt = 0; attempt < 20; attempt++) {
+    runs = (await jd(`/v1/hypervisor/automations/${encodeURIComponent(automationId)}/runs`)).body?.runs || [];
+    if (runs.length && ["done", "failed", "stopped"].includes(runs[0]?.status)) break;
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  const exec = runs[0] || {};
+  ok("run-now crosses through the seed lane and run HISTORY records the execution: terminal `done`, 1 step done, a real environment_id",
+    ran.status === 302 && exec.status === "done" && exec.counts?.done === 1 && String(exec.environment_id || "").length > 0,
+    JSON.stringify({ status: exec.status, counts: exec.counts }));
+  const execRead = await jd(`/v1/hypervisor/automation-executions/${encodeURIComponent(exec.execution_id || "")}`);
+  ok("the execution readback route answers the same record (the run drawer's read)",
+    execRead.body?.ok === true && execRead.body?.execution?.status === "done",
+    "");
+  const ledger = await jd("/v1/hypervisor/work-ledger");
+  const ledgerEntries = Array.isArray(ledger.body) ? ledger.body : (ledger.body?.entries || ledger.body?.work_ledger || []);
+  const ledgerHit = ledgerEntries.find((e) => JSON.stringify(e).includes(exec.execution_id || "@"));
+  ok("the unified proof stream carries the run with its transcript state_root (readback proof — the family's real evidence lane)",
+    !!ledgerHit && JSON.stringify(ledgerHit).includes("state_root"),
+    "");
+  detail = await pageText(`/automations?automation=${encodeURIComponent(automationId)}`);
+  ok("the canonical run pane renders the execution with its terminal state and proof link",
+    detail.status === 200 && detail.text.includes(exec.execution_id || "@") && detail.text.includes("last run · done")
+      && detail.text.includes(`/__ioi/run-timeline/${encodeURIComponent(exec.execution_id || "")}`),
+    "");
+
+  // -- webhook: rotate (hash-at-rest) + rejected trigger is a RECEIPTED event -
+  const rotated = await jd(`/v1/hypervisor/automations/${encodeURIComponent(automationId)}/webhook-rotate`, { method: "POST" });
+  const webhookToken = rotated.body?.webhook_token || "";
+  spec = await specGet(automationId);
+  ok("webhook-rotate mints a show-once token: plaintext returned exactly once, only its hash persists on the spec",
+    webhookToken.length > 20 && !!spec.automation?.webhook_token_hash
+      && !!spec.automation?.webhook_url && !JSON.stringify(spec).includes(webhookToken),
+    "");
+  const badTrigger = await fetch(`${DAEMON}/v1/hypervisor/automations/${encodeURIComponent(automationId)}/webhook`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "X-IOI-Trigger-Token": "bogus-token" },
+    body: JSON.stringify({ event: "ping" }),
+  }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) })).catch(() => ({ status: 0, body: {} }));
+  const events = await jd(`/v1/hypervisor/automations/${encodeURIComponent(automationId)}/webhook-events`);
+  const rejectedEvent = (events.body?.events || []).find((e) => e.accepted === false);
+  ok("a bad-token webhook trigger refuses TYPED (401 invalid_token) and the refusal is a RECEIPTED audit event",
+    badTrigger.status === 401 && badTrigger.body?.reason === "invalid_token"
+      && !!rejectedEvent && !!rejectedEvent.receipt_id && events.body?.rejected_count === 1,
+    JSON.stringify({ status: badTrigger.status, receipt: rejectedEvent?.receipt_id }));
+  detail = await pageText(`/automations?automation=${encodeURIComponent(automationId)}`);
+  ok("the canonical webhook band renders the endpoint truth + the receipted rejected event (its receipt id verbatim)",
+    detail.status === 200 && detail.text.includes("X-IOI-Trigger-Token") && detail.text.includes(">rejected<")
+      && detail.text.includes(rejectedEvent?.receipt_id || "@"),
+    "");
+
+  // -- delete journey (throwaway spec — the canonical page stays honest after)
+  const throwaway = await jd("/v1/hypervisor/automations", {
+    method: "POST",
+    body: JSON.stringify({ project_ref: projectId, name: "journey-throwaway", steps: [] }),
+  });
+  const throwawayId = throwaway.body?.automation?.automation_id || "";
+  const deleted = await seedPost(`/${encodeURIComponent(throwawayId)}/delete`, {});
+  const deletedGet = await specGet(throwawayId);
+  const deletedPage = await pageText(`/automations?automation=${encodeURIComponent(throwawayId)}`);
+  ok("delete crosses through the seed lane and the record is GONE — daemon readback ok:false, canonical page renders the honest not-found (nothing inferred)",
+    throwaway.status === 201 && deleted.status === 302 && deletedGet.ok === false
+      && deletedPage.status === 200 && deletedPage.text.includes("Automation not found"),
+    "");
+
+  // -- restart: the spec + its history survive and the mount re-renders -------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  await startDaemon();
+  spec = await specGet(automationId);
+  const runsAfter = (await jd(`/v1/hypervisor/automations/${encodeURIComponent(automationId)}/runs`)).body?.runs || [];
+  ok("the spec survives a daemon restart with its exact fields (schedule, steps, webhook posture) and its run history intact",
+    spec.ok === true && JSON.stringify(spec.automation?.schedule_spec) === JSON.stringify({ every_minutes: 5 })
+      && spec.automation?.steps?.[0]?.command === "echo journey-effect"
+      && !!spec.automation?.webhook_token_hash
+      && runsAfter.some((r) => r.execution_id === exec.execution_id),
+    "");
+  let reload = { status: 0, text: "" };
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await new Promise((r) => setTimeout(r, 1500));
+    reload = await pageText(`/automations?automation=${encodeURIComponent(automationId)}`);
+    if (reload.status === 200 && reload.text.includes("journey-nightly")) break;
+  }
+  ok("the canonical mount re-renders the surviving spec after restart",
+    reload.status === 200 && reload.text.includes("journey-nightly") && reload.text.includes("every 5m"),
+    `status ${reload.status}`);
+
+  // -- 3-posture matrix -------------------------------------------------------
+  let pw = null;
+  try { pw = await import("playwright"); } catch { pw = null; }
+  if (!pw) {
+    ok("posture matrix skipped — playwright unavailable", false, "install playwright to run the browser matrix");
+  } else {
+    const browser = await pw.chromium.launch();
+    for (const [name, opts] of [
+      ["light-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "light" }],
+      ["dark-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "dark" }],
+      ["narrow-reduced-motion", { viewport: { width: 390, height: 844 }, colorScheme: "light", reducedMotion: "reduce" }],
+    ]) {
+      const ctx = await browser.newContext(opts);
+      const page = await ctx.newPage();
+      const errors = [];
+      page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+      const resp = await page.goto(`${SERVE}/automations`, { waitUntil: "networkidle", timeout: 45000 }).catch(() => null);
+      const body = resp ? await page.evaluate(() => document.body.innerText) : "";
+      await page.keyboard.press("Tab");
+      const focused = resp ? await page.evaluate(() => document.activeElement?.tagName ?? "") : "";
+      ok(`posture ${name}: renders, keyboard-focusable, zero console errors`,
+        resp && resp.status() === 200 && body.length > 0 && errors.length === 0 && focused !== "" && focused !== "BODY",
+        errors[0]?.slice(0, 100) ?? `focus ${focused}`);
+      await ctx.close();
+    }
+    await browser.close();
+  }
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  cleanup();
+  process.exit(1);
+});
+
+function cleanup() {
+  try { serve?.kill("SIGTERM"); } catch { /* gone */ }
+  try { daemon?.kill("SIGTERM"); } catch { /* gone */ }
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* keep */ }
+}

--- a/apps/hypervisor/surfaces/automations/index.mjs
+++ b/apps/hypervisor/surfaces/automations/index.mjs
@@ -1,0 +1,475 @@
+// Automations — the canonical /automations surface packet (W2.1 §5 PR 1, next-legs II Leg 4).
+//
+// One module, two mounts (canonical /automations + the fresh legacy lane
+// /__ioi/automations-cockpit), REHOMING the T2 cockpit grammar READ-FIRST over the daemon
+// automations family: spec list (project-first cards), spec detail (spec grid, read-only
+// pipeline projection, steps, run history, webhook trigger band, canvas), and the New-automation
+// form — every read through the shared read client (typed degradation, honest-empty, zero
+// fixture rows).
+//
+// VERBS — only what the daemon actually owns, and only through the lanes that already own them.
+// The family's owned verb set (hypervisor-daemon.rs router, orchestration_routes.rs):
+//   create            POST   /v1/hypervisor/automations            (project_ref REQUIRED)
+//   patch             PATCH  /v1/hypervisor/automations/:id        (pause/resume = {enabled};
+//                                                                   there is NO separate
+//                                                                   activate/pause route — the
+//                                                                   enabled flag IS the lane)
+//   delete            DELETE /v1/hypervisor/automations/:id
+//   run now           POST   /v1/hypervisor/automations/:id/runs   (alias :id/start)
+//   run history       GET    /v1/hypervisor/automations/:id/runs
+//   webhook trigger   POST   /v1/hypervisor/automations/:id/webhook (own-token auth)
+//   webhook rotate    POST   /v1/hypervisor/automations/:id/webhook-rotate (show-once token)
+//   webhook events    GET    /v1/hypervisor/automations/:id/webhook-events (receipted rows)
+//   execution read    GET    /v1/hypervisor/automation-executions/:id (+ POST :id/cancel)
+// The rendered forms post to the seed cockpit's OWN action lanes (/__ioi/automations…) — the
+// wiring the T2 grammar ships today. This packet adds NO second mutation path: spec mutations on
+// this family cross UNRECEIPTED (the daemon returns {ok, automation} with no admission
+// envelope), which is the brief's NAMED DEFECT (surfaces/automations.md §6 — the fix is the W2
+// lease-client wave WITH the daemon receipt family, never a surface-side invention). Declaring
+// module actions would launder that gap through the fail-closed action runtime; stating it is
+// the honest ceiling of this leg.
+//
+// TYPED ABSENCES stated, never simulated:
+//   - spec versioning/revisions: NO daemon route (HypervisorAutomationSpec revisioning +
+//     AutomationInstallationBinding are the W3 backend build, canon :3856-3897) — the Versions
+//     control renders disabled with the machine-readable reason.
+//   - run→Session/GoalRun lineage: execution records carry environment_id only (no
+//     session_refs/goal_run_refs, no subject_attachments anywhere in daemon code) — the lineage
+//     control renders disabled naming the W3 lineage build.
+//   - monitor grammar (condition-over-object-set → effect): trigger kinds are
+//     manual/time/webhook only; no object-set trigger family exists — named on the list band.
+//
+// BOUNDARIES held:
+//   - Scheduler HEALTH is Operations-owned (/__ioi/operations + /v1/hypervisor/scheduler/status)
+//     — this surface renders NO scheduler-health rows (no liveness, no heartbeat, no tick data);
+//     per-spec schedule fields (schedule_spec/next_run_at/last_run_at) are spec truth and stay.
+//   - Monitors ("Automate") stays a LINK to the protected seed route /__ioi/automations/monitors.
+//   - Machinery/process-graphs stay OUT entirely — OQ-2 (machinery ownership) is unruled; no
+//     registry transfer, no state-machines read, no rehome here.
+import { escHtml } from "../kit.mjs";
+
+const esc = escHtml;
+const enc = encodeURIComponent;
+const LEGACY_ROUTE = "/__ioi/automations-cockpit";
+const CANONICAL_ROUTE = "/automations";
+// The seed cockpit's wired action lanes (seed preservation: these keep serving until the W4
+// cutover and are the ONLY mutation path this packet renders — no second spine).
+const SEED_LANE = "/__ioi/automations";
+
+export const meta = {
+  slug: "automations",
+  route: LEGACY_ROUTE,
+  verifier: "scripts/verify-hypervisor-automations-journey.mjs",
+  certification: "n/a",
+};
+
+const VERSIONS_GAP_REASON = "no daemon route exists — the automations family owns no spec revisioning/versions route (flat mutable ioi.hypervisor.automation-workflow.v1 record; content-hashed revisions + registry_status + AutomationInstallationBinding are the W3 backend build per surfaces/automations.md §5); typed absence, never simulated";
+const LINEAGE_GAP_REASON = "no daemon fields exist — automation-execution records carry environment_id only (no session_refs/goal_run_refs, no subject_attachments row anywhere in daemon code); run→Session/GoalRun lineage is the W3 lineage build; typed absence, never simulated";
+const MONITOR_GRAMMAR_GAP_REASON = "no daemon route exists — trigger kinds are manual/time/webhook only; the condition-over-object-set trigger family (over /v1/hypervisor/odk/materialized-object-sets) and the effect library are the W3 monitor-grammar build; the wizard stays on the protected monitors seed, disabled in place";
+const UNRECEIPTED_DEFECT_NOTE = "Named defect (W2 pull): spec mutations on this family cross UNRECEIPTED — the daemon answers {ok, automation} with no admission receipt. The verbs above post through the seed cockpit lanes (the wiring that exists); the W2 lease-client wave lands receipts WITH the daemon receipt family. Nothing here invents a second mutation path.";
+
+// ---------------------------------------------------------------------------------------------
+// load — every read is a typed-degradation projection through the shared read client, riding the
+// request-scoped daemon capability when the runtime supplies one (the caller's own envelope is
+// the read identity; anonymous stays anonymous — under the family's current loopback-dev posture
+// reads answer unauthenticated, and that truth is recorded as the journey verifier's FINDING row,
+// never masked here).
+export async function load(ctx) {
+  const { createReadClient } = await import("../read-client.mjs");
+  const client = typeof ctx.daemonFetch === "function"
+    ? createReadClient({ daemon: "", fetchImpl: ctx.daemonFetch })
+    : createReadClient({ daemon: ctx.daemon });
+  const sp = ctx.url.searchParams;
+  const model = {
+    project: (sp.get("project") || "").trim(),
+    automationId: (sp.get("automation") || "").trim(),
+    view: (sp.get("view") || "").trim(),
+  };
+  model.projects = await client.read("/v1/hypervisor/projects");
+  if (model.view === "new") return model;
+  if (model.automationId) {
+    model.automation = await client.read(`/v1/hypervisor/automations/${enc(model.automationId)}`);
+    model.runs = await client.read(`/v1/hypervisor/automations/${enc(model.automationId)}/runs`);
+    model.webhookEvents = await client.read(`/v1/hypervisor/automations/${enc(model.automationId)}/webhook-events`);
+    return model;
+  }
+  model.automations = await client.read(`/v1/hypervisor/automations${model.project ? `?project_ref=${enc(model.project)}` : ""}`);
+  return model;
+}
+
+// ---------------------------------------------------------------------------------------------
+// render helpers — the cockpit grammar's own vocabulary plus the packet's typed-degradation and
+// disabled-named-gap fragments.
+const degraded = (result) => `<div class="empty">unavailable — <code>${esc(result?.code || "daemon_unavailable")}</code> (${esc(result?.message || "the plane did not answer")})</div>`;
+const disabledCtl = (label, reason) => `<button class="act ghost" type="button" disabled data-ioi-disabled-reason="${esc(reason)}">${esc(label)}</button>`;
+const rowsOf = (result, key) => (result?.ok ? (Array.isArray(result.payload?.[key]) ? result.payload[key] : []) : null);
+
+function projectsById(model) {
+  const byId = {};
+  for (const p of rowsOf(model.projects, "projects") || []) byId[p.project_id] = p;
+  return byId;
+}
+function projectName(a, byId) {
+  const pid = a.project_ref || a.project_id || "";
+  return (byId[pid] && byId[pid].name) || pid || "—";
+}
+function scheduleHuman(sched) {
+  if (!sched || typeof sched !== "object") return "manual (no schedule)";
+  if (sched.type === "cron" || sched.cron) return `cron ${sched.cron} (${sched.timezone || "UTC"})`;
+  if (sched.every_hours) return `every ${sched.every_hours}h`;
+  if (sched.every_minutes) return `every ${sched.every_minutes}m`;
+  if (sched.every_seconds || sched.interval_seconds) return `every ${sched.every_seconds || sched.interval_seconds}s`;
+  return "scheduled";
+}
+// The one boundary note this surface renders about scheduling health — a LINK, never data rows.
+const OPERATIONS_BOUNDARY_NOTE = `<p class="sub" style="margin:14px 0 0">Scheduler health is <b>Operations-owned</b> — tick heartbeat and execution-health rows render on <a href="/__ioi/operations">Operations</a>, never here. The schedule fields on each spec (its own <code>schedule_spec</code> / next / last run) are spec truth and stay.</p>`;
+
+// ---- list view ----------------------------------------------------------------------------------
+function listView(model, base) {
+  const byId = projectsById(model);
+  const automations = rowsOf(model.automations, "automations");
+  const filtName = model.project ? projectName({ project_ref: model.project }, byId) : "";
+  const newHref = `${base}?view=new${model.project ? `&project=${enc(model.project)}` : ""}`;
+  const count = automations === null ? 0 : automations.length;
+  // Owner-surface contract preserved from the T2 readout: daemon automation records are the truth
+  // (real specs, triggers, steps, projects); the captured monitor wizard is a SECONDARY reference
+  // grammar — a linked walkthrough, never rows here.
+  const head = `<h1 id="automations-owner">Automations</h1>
+    <p class="sub">Durable orchestration — each automation is a daemon-owned spec that hangs off a project, runs over a real environment, and records a tamper-evident transcript. The <b>${count}</b> record${count === 1 ? "" : "s"} below ${model.project ? `(filtered to <b>${esc(filtName)}</b> · <a href="${base}">show all</a>)` : "across all projects"} are daemon truth. <span class="sub">The <a href="/__ioi/automations/monitors">Automate overview →</a> is the certified reference-faithful landing over this same plane (#51). The <a href="/__apps/monitors">monitor-wizard capture ↗</a> is a secondary reference grammar for authoring condition→effect monitors — a linked walkthrough, not a rebound surface; its example rows are never shown here as daemon automations.</span></p>
+    <div class="row"><a class="act" href="${newHref}">+ New automation</a><a class="act ghost" href="/__apps/monitors">Monitor-wizard capture (reference) →</a></div>`;
+  let body = "";
+  if (automations === null) {
+    body = degraded(model.automations);
+  } else if (!automations.length) {
+    body = `<div class="empty">No daemon automations yet${model.project ? " for this project" : ""} — create one to get started. (The monitor-wizard capture stays a reference; it never fabricates automations here.)</div>`;
+  } else {
+    body = automations.map((a) => {
+      const enabled = a.enabled !== false;
+      const steps = Array.isArray(a.steps) ? a.steps.length : 0;
+      const model_ = a.model || "default model";
+      const trigger = (a.trigger && (a.trigger.kind || a.trigger.trigger_kind)) || a.trigger_kind || "manual";
+      return `<a class="card automation-card" href="${base}?automation=${enc(a.automation_id)}"><div class="main">
+        <div class="name">${esc(a.name || a.automation_id)}<span class="pill ${enabled ? "ok" : "muted"}">${enabled ? "enabled" : "disabled"}</span><span class="pill muted">${esc(trigger)}</span></div>
+        <div class="meta">${esc(projectName(a, byId))} · ${esc(String(model_))} · ${steps} step${steps === 1 ? "" : "s"} · <code style="font-size:10.5px">${esc(a.automation_id)}</code></div>
+        </div><span class="act ghost">Open →</span></a>`;
+    }).join("");
+  }
+  const gaps = `<h2 id="named-absences">What this family does not own yet</h2>
+    <div class="gapcard">
+      ${disabledCtl("Versions", VERSIONS_GAP_REASON)} ${disabledCtl("Monitor wizard (condition → effect)", MONITOR_GRAMMAR_GAP_REASON)}
+      <p class="sub" style="margin:8px 0 0;text-transform:none;letter-spacing:0">There is no separate activate/pause route either — pause/resume IS <code>PATCH {enabled}</code> on the spec, the family's own lane, wired on each detail page. ${esc(UNRECEIPTED_DEFECT_NOTE)}</p>
+    </div>${OPERATIONS_BOUNDARY_NOTE}`;
+  return head + body + gaps;
+}
+
+// ---- detail view --------------------------------------------------------------------------------
+function detailView(model, base) {
+  const d = model.automation;
+  if (!d?.ok) return `<h2>Automation ${esc(model.automationId)}</h2>${degraded(d)}`;
+  if (d.payload?.ok === false || !d.payload?.automation) {
+    return `<p><a href="${base}">← Automations</a></p><h1>Automation not found</h1><div class="empty">not found — <code>${esc(d.payload?.reason || d.payload?.error?.code || "automation not found")}</code>. Nothing is inferred; the id may have been deleted.</div>`;
+  }
+  const a = d.payload.automation;
+  const byId = projectsById(model);
+  const runs = rowsOf(model.runs, "runs");
+  const id = a.automation_id;
+  const enabled = a.enabled !== false;
+  const pid = a.project_ref || a.project_id || "";
+  const v = (x) => (x == null || x === "" ? "—" : (typeof x === "string" ? esc(x) : esc(JSON.stringify(x))));
+  const connectors = Array.isArray(a.connector_refs) && a.connector_refs.length ? a.connector_refs.map((c) => `<code>${esc(String(c))}</code>`).join(" ") : "—";
+  const steps = Array.isArray(a.steps) && a.steps.length
+    ? `<h2>Steps</h2>` + a.steps.map((s, i) => `<div class="card"><div class="main"><div class="name">${i + 1}. ${esc(s.kind || "step")}</div><div class="meta"><code>${esc((s.prompt || s.command || s.title || "").slice(0, 200))}</code></div></div></div>`).join("")
+    : `<h2>Steps</h2><div class="empty">No steps declared.</div>`;
+  // Read-only pipeline projection (the 09-pipeline-builder grammar donation): trigger → declared
+  // steps → latest run outcome → proof. Rendered from spec + run records only.
+  const latest = (runs || [])[0];
+  const pnodes = [
+    [`trigger · ${a.trigger_kind || "manual"}`, "muted"],
+    ...(Array.isArray(a.steps) ? a.steps.map((s, i) => [`${i + 1} · ${s.kind || "step"}`, "ok"]) : []),
+    latest ? [`last run · ${latest.status || "—"}`, latest.status === "done" ? "ok" : latest.status === "failed" ? "warn" : "muted"] : ["no runs yet", "muted"],
+  ];
+  const pipeline = `<div id="auto-pipeline" style="margin:0 0 16px"><div class="sub" style="margin:0 0 6px;text-transform:uppercase;letter-spacing:.04em;font-size:11px">Pipeline <span style="text-transform:none;letter-spacing:0">— read-only view of the declared spec; the authoring canvas below edits via the daemon, it does not become the automation</span></div>
+    <div style="display:flex;flex-wrap:wrap;gap:6px;align-items:center">${pnodes.map(([label, cls], i) => `${i ? `<span style="color:#5f626b">→</span>` : ""}<span class="pill ${cls}" style="padding:5px 12px">${esc(label)}</span>`).join("")}${latest ? ` <a href="/__ioi/run-timeline/${enc(latest.execution_id || "")}" target="_blank" rel="noopener" style="margin-left:6px">proof ↗</a>` : ""}</div></div>`;
+  const runRows = runs === null
+    ? degraded(model.runs)
+    : (runs.length
+      ? `<table><thead><tr><th>Run</th><th>Status</th><th>Started</th><th>Steps (done/failed)</th><th>Proof</th></tr></thead><tbody>` +
+        runs.map((r) => {
+          const c = r.counts || {};
+          const st = r.status || "—";
+          const pill = st === "done" ? "ok" : st === "failed" ? "warn" : "muted";
+          return `<tr><td><code>${esc(r.execution_id || "")}</code></td><td><span class="pill ${pill}">${esc(st)}</span></td><td>${esc(r.started_at || "")}</td><td>${c.done || 0}/${c.failed || 0}</td><td><a href="/__ioi/run-timeline/${enc(r.execution_id || "")}" target="_blank" rel="noopener">timeline ↗</a></td></tr>`;
+        }).join("") + `</tbody></table>`
+      : `<div class="empty">No runs yet — use “Run now”.</div>`);
+  const runGaps = `<div class="gapcard" style="margin-top:14px">
+      ${disabledCtl("Serving Session / GoalRun lineage", LINEAGE_GAP_REASON)} ${disabledCtl("Versions", VERSIONS_GAP_REASON)}
+    </div>`;
+  const sched = a.schedule_spec && typeof a.schedule_spec === "object" ? a.schedule_spec : null;
+  const schedHuman = scheduleHuman(sched);
+  const back = `<p><a href="${base}${pid ? `?project=${enc(pid)}` : ""}">← Automations</a></p>`;
+  // Lifecycle verbs — the daemon-owned set, posted through the seed cockpit lanes (the wiring
+  // that owns them today; the 302 lands on the legacy detail, the same grammar).
+  const pauseResume = sched
+    ? (enabled
+        ? `<form class="inline" method="post" action="${SEED_LANE}/${enc(id)}/pause"><button class="act ghost" type="submit">⏸ Pause schedule</button></form>`
+        : `<form class="inline" method="post" action="${SEED_LANE}/${enc(id)}/resume"><button class="act" type="submit">▶ Resume schedule</button></form>`)
+    : "";
+  const actions = `<div class="row">
+    <form class="inline" method="post" action="${SEED_LANE}/${enc(id)}/run"><button class="act" type="submit">▶ Run now</button></form>
+    ${pauseResume}
+    <a class="act ghost" href="/projects/${enc(pid)}" target="_blank" rel="noopener">Open project ↗</a>
+    <form class="inline" method="post" action="${SEED_LANE}/${enc(id)}/delete" onsubmit="return confirm('Delete this automation?')"><button class="act danger" type="submit">Delete</button></form>
+  </div>`;
+  const spec = `<dl class="grid">
+    <dt>Project</dt><dd><a href="/projects/${enc(pid)}" target="_blank" rel="noopener">${esc(projectName(a, byId))}</a> <code>${esc(pid)}</code></dd>
+    <dt>Trigger</dt><dd>${v(a.trigger_kind || "manual")}</dd>
+    <dt>Schedule</dt><dd>${esc(schedHuman)}${sched ? ` · ${enabled ? "active" : "paused"}` : ""}</dd>
+    <dt>Next run</dt><dd>${v(a.next_run_at)}</dd>
+    <dt>Last run</dt><dd>${v(a.last_run_at)}</dd>
+    <dt>Agent</dt><dd>${v(a.agent_ref)}</dd>
+    <dt>Model</dt><dd>${v(a.model)}</dd>
+    <dt>Reasoning</dt><dd>${v(a.reasoning)}</dd>
+    <dt>Harness</dt><dd>${v(a.harness_profile_ref)}</dd>
+    <dt>Connectors</dt><dd>${connectors}</dd>
+    <dt>Memory</dt><dd>${v(a.memory_profile_ref)}</dd>
+    <dt>Authority policy</dt><dd>${v(a.authority_policy_ref)}</dd>
+    <dt>Runtime policy</dt><dd>${v(a.default_runtime_policy_ref)}</dd>
+    <dt>Env class</dt><dd>${v(a.environment_class_id)}</dd>
+  </dl>`;
+  // Webhook trigger band — endpoint + receipted event feed reads; rotate stays show-once on the
+  // seed lane (the secret is revealed exactly once there and only its hash persists).
+  const wev = model.webhookEvents?.ok ? model.webhookEvents.payload : null;
+  const evRows = ((wev?.events) || []).slice(0, 10).map((e) => {
+    const acc = e.accepted === true;
+    return `<tr><td>${esc(e.received_at || "")}</td><td><span class="pill ${acc ? "ok" : "warn"}">${acc ? "accepted" : "rejected"}</span></td><td>${esc(e.reason || "")}</td><td>${e.receipt_id ? `<code>${esc(e.receipt_id)}</code>` : "—"}</td><td>${e.run_ref ? `<a href="/__ioi/run-timeline/${enc(e.run_ref)}" target="_blank" rel="noopener">timeline ↗</a>` : "—"}</td></tr>`;
+  }).join("");
+  const eventsTable = model.webhookEvents?.ok
+    ? (evRows ? `<table><thead><tr><th>Received</th><th>Result</th><th>Reason</th><th>Receipt</th><th>Run</th></tr></thead><tbody>${evRows}</tbody></table>` : `<div class="empty">No trigger events yet.</div>`)
+    : degraded(model.webhookEvents);
+  const webhookSection = a.webhook_url
+    ? `<h2>Webhook trigger</h2>
+       <dl class="grid">
+         <dt>Endpoint</dt><dd><code>POST ${esc(a.webhook_url)}</code></dd>
+         <dt>Auth</dt><dd>header <code>X-IOI-Trigger-Token: &lt;secret&gt;</code> · secret shown once on rotate</dd>
+         <dt>Triggers</dt><dd>${wev ? `${wev.accepted_count || 0} accepted · ${wev.rejected_count || 0} rejected` : "—"}</dd>
+       </dl>
+       <div class="row"><form class="inline" method="post" action="${SEED_LANE}/${enc(id)}/webhook-rotate"><button class="act ghost" type="submit">↻ Rotate secret</button></form></div>
+       ${eventsTable}`
+    : `<h2>Webhook trigger</h2><p class="sub">Trigger this automation from an external service with an authenticated webhook (the secret is sealed; only its hash is stored — it is shown exactly once, on the rotate reveal).</p>
+       <form class="inline" method="post" action="${SEED_LANE}/${enc(id)}/webhook-rotate"><button class="act" type="submit">Enable webhook trigger</button></form>`;
+  // Canvas — the spec editor projection, rehomed with its seed wiring: saves PATCH the daemon
+  // record through the seed lane (the family's owned patch verb; unreceipted — the named defect).
+  const schedType = sched ? ((sched.type === "cron" || sched.cron) ? "cron" : "interval") : "manual";
+  const intN = sched ? (sched.every_hours || sched.every_minutes || sched.every_seconds || sched.interval_seconds || "") : "";
+  const intU = sched ? (sched.every_hours ? "hours" : (sched.every_seconds || sched.interval_seconds) ? "seconds" : "minutes") : "minutes";
+  const cronExpr = sched && sched.cron ? sched.cron : "";
+  const cronTz = (sched && sched.timezone) || "UTC";
+  const cronTzOpts = ["UTC", "-08:00", "-07:00", "-06:00", "-05:00", "-04:00", "+01:00", "+02:00", "+05:30", "+08:00", "+09:00", "+10:00"]
+    .map((z) => `<option value="${z}"${z === cronTz ? " selected" : ""}>${z === "UTC" ? "UTC (+00:00)" : "UTC" + z}</option>`).join("");
+  const lastRun = (runs && runs[0]) || null;
+  const runCls = lastRun ? (lastRun.status === "done" ? "ok" : lastRun.status === "failed" ? "warn" : "") : "";
+  const triggerSummary = schedHuman + (a.webhook_url ? " + webhook" : "");
+  const agentSummary = `${a.model || "default model"}${a.reasoning ? " · " + a.reasoning : ""}`;
+  const connSummary = Array.isArray(a.connector_refs) && a.connector_refs.length ? a.connector_refs.join(", ") : "none";
+  const memSummary = a.memory_profile_ref || "default";
+  const authSummary = a.authority_policy_ref || "default";
+  const stepCount = Array.isArray(a.steps) ? a.steps.length : 0;
+  const deliverySummary = `${stepCount} step${stepCount === 1 ? "" : "s"}${lastRun ? " · last run " + (lastRun.status || "") : ""}`;
+  const cnode = (key, icon, title, summary, cls) => `<div class="cnode ${cls || ""}" data-node="${key}" onclick="ioiNode('${key}')"><div class="ct">${icon} ${esc(title)}</div><div class="cs">${esc(summary)}</div></div>`;
+  const cgraph = `<div class="cgraph">
+    <div class="clane">${cnode("trigger", "⏱", "Trigger", triggerSummary, runCls)}</div><div class="cedge">→</div>
+    <div class="clane">${cnode("agent", "🤖", "Agent run", agentSummary, runCls)}</div><div class="cedge">→</div>
+    <div class="clane">${cnode("connectors", "🔌", "Connectors", connSummary, "")}${cnode("memory", "🧠", "Memory", memSummary, "")}${cnode("authority", "🛡", "Authority", authSummary, "")}</div><div class="cedge">→</div>
+    <div class="clane">${cnode("delivery", "📤", "Delivery", deliverySummary, "")}</div>
+  </div>`;
+  const fi = (cid, label, value, ph) => `<div class="field"><label>${label}</label><input id="${cid}" value="${esc(value || "")}" placeholder="${ph || ""}"></div>`;
+  const firstStep = (Array.isArray(a.steps) && a.steps[0]) || {};
+  const inspectors =
+    `<div class="cinsp" id="insp-trigger" style="display:none"><h3>Trigger</h3>
+       <div class="field"><label>Type</label><select id="cv-sched-type" onchange="cvSchedToggle()"><option value="manual"${schedType === "manual" ? " selected" : ""}>Manual only</option><option value="interval"${schedType === "interval" ? " selected" : ""}>Interval</option><option value="cron"${schedType === "cron" ? " selected" : ""}>Cron</option></select></div>
+       <div id="cv-int" style="display:${schedType === "interval" ? "block" : "none"}"><div class="field"><label>Run every</label><input id="cv-interval-n" type="number" min="0" value="${schedType === "interval" ? esc(String(intN || 0)) : "15"}"></div><div class="field"><label>Unit</label><select id="cv-interval-unit"><option value="minutes"${intU === "minutes" ? " selected" : ""}>minutes</option><option value="hours"${intU === "hours" ? " selected" : ""}>hours</option><option value="seconds"${intU === "seconds" ? " selected" : ""}>seconds</option></select></div></div>
+       <div id="cv-crn" style="display:${schedType === "cron" ? "block" : "none"}"><div class="field"><label>Cron</label><input id="cv-cron" value="${esc(cronExpr)}" placeholder="0 9 * * 1-5" oninput="cvCronPreview()"></div><div class="field"><label>Timezone</label><select id="cv-cron-tz" onchange="cvCronPreview()">${cronTzOpts}</select></div><div class="sub" style="margin:0" id="cv-cron-preview"></div></div>
+       <div class="row"><button class="act" onclick="ioiNodeSave('trigger')">Save</button> <span class="cmsg" id="msg-trigger"></span></div></div>` +
+    `<div class="cinsp" id="insp-agent" style="display:none"><h3>Agent run</h3>${fi("cv-model", "Model", a.model, "qwen2.5:7b")}<div class="field"><label>Reasoning</label><select id="cv-reasoning"><option value=""${!a.reasoning ? " selected" : ""}>(default)</option><option value="low"${a.reasoning === "low" ? " selected" : ""}>low</option><option value="medium"${a.reasoning === "medium" ? " selected" : ""}>medium</option><option value="high"${a.reasoning === "high" ? " selected" : ""}>high</option></select></div>${fi("cv-agent", "Agent ref", a.agent_ref, "agent:default")}${fi("cv-harness", "Harness profile", a.harness_profile_ref, "harness:…")}<div class="row"><button class="act" onclick="ioiNodeSave('agent')">Save</button> <span class="cmsg" id="msg-agent"></span></div></div>` +
+    `<div class="cinsp" id="insp-connectors" style="display:none"><h3>Connectors</h3>${fi("cv-connectors", "Connector refs (comma-separated)", Array.isArray(a.connector_refs) ? a.connector_refs.join(", ") : "", "connector:github, connector:linear")}<div class="row"><button class="act" onclick="ioiNodeSave('connectors')">Save</button> <span class="cmsg" id="msg-connectors"></span></div></div>` +
+    `<div class="cinsp" id="insp-memory" style="display:none"><h3>Memory</h3>${fi("cv-memory", "Memory profile ref", a.memory_profile_ref, "memory:project-default")}<div class="row"><button class="act" onclick="ioiNodeSave('memory')">Save</button> <span class="cmsg" id="msg-memory"></span></div></div>` +
+    `<div class="cinsp" id="insp-authority" style="display:none"><h3>Authority</h3>${fi("cv-authority", "Authority policy ref", a.authority_policy_ref, "authority:operator")}${fi("cv-runtime", "Runtime policy ref", a.default_runtime_policy_ref, "runtime-policy:local")}<div class="row"><button class="act" onclick="ioiNodeSave('authority')">Save</button> <span class="cmsg" id="msg-authority"></span></div></div>` +
+    `<div class="cinsp" id="insp-delivery" style="display:none"><h3>Delivery (first step)</h3><div class="field"><label>Step kind</label><select id="cv-step-kind"><option value="agent"${firstStep.kind !== "command" ? " selected" : ""}>agent (prompt)</option><option value="command"${firstStep.kind === "command" ? " selected" : ""}>command (shell)</option></select></div><div class="field"><label>Step body</label><textarea id="cv-step-body">${esc(firstStep.prompt || firstStep.command || "")}</textarea></div><div class="row"><button class="act" onclick="ioiNodeSave('delivery')">Save</button> <span class="cmsg" id="msg-delivery"></span></div></div>` +
+    `<div class="cinsp" id="insp-none"><h3>Canvas</h3><p class="sub" style="margin:0">Click a node to edit it. Saving writes the automation spec via the daemon — the Canvas edits the automation, it does not become the automation.</p></div>`;
+  const canvas = `<div class="canvas">${cgraph}<div>${inspectors}</div></div>`;
+  const canvasScript = `<script>
+    function ioiTab(t){['overview','runs','webhook','canvas'].forEach(function(k){var p=document.getElementById('panel-'+k);if(p)p.style.display=(k===t)?'block':'none';var b=document.querySelector('.tab[data-tab="'+k+'"]');if(b)b.classList.toggle('active',k===t);});}
+    function val(id){var e=document.getElementById(id);return e?e.value:'';}
+    function ioiNode(key){var none=document.getElementById('insp-none');if(none)none.style.display='none';['trigger','agent','connectors','memory','authority','delivery'].forEach(function(k){var n=document.querySelector('[data-node="'+k+'"]');if(n)n.classList.toggle('sel',k===key);var i=document.getElementById('insp-'+k);if(i)i.style.display=(k===key)?'block':'none';});}
+    function cvSchedToggle(){var t=val('cv-sched-type'),i=document.getElementById('cv-int'),c=document.getElementById('cv-crn');if(i)i.style.display=t==='interval'?'block':'none';if(c)c.style.display=t==='cron'?'block':'none';}
+    function cvCronPreview(){var c=(val('cv-cron')||'').trim(),tz=val('cv-cron-tz'),el=document.getElementById('cv-cron-preview');if(!el)return;if(!c){el.textContent='';return;}fetch('${SEED_LANE}/cron-preview?cron='+encodeURIComponent(c)+'&tz='+encodeURIComponent(tz)+'&n=3').then(function(r){return r.json();}).then(function(d){el.textContent=d.ok?('next: '+d.runs.join('  ·  ')):('⚠ '+d.error);});}
+    function ioiNodeSave(node){var body={};
+      if(node==='trigger'){var t=val('cv-sched-type');if(t==='interval'){var n=parseInt(val('cv-interval-n')||'0',10)||0,u=val('cv-interval-unit');body.schedule_spec=n>0?(u==='hours'?{every_hours:n}:u==='seconds'?{every_seconds:n}:{every_minutes:n}):null;}else if(t==='cron'){var cc=(val('cv-cron')||'').trim();body.schedule_spec=cc?{type:'cron',cron:cc,timezone:val('cv-cron-tz')}:null;}else{body.schedule_spec=null;}}
+      else if(node==='agent'){body.model=val('cv-model')||null;body.reasoning=val('cv-reasoning')||null;body.agent_ref=val('cv-agent')||null;body.harness_profile_ref=val('cv-harness')||null;}
+      else if(node==='connectors'){body.connector_refs=(val('cv-connectors')||'').split(',').map(function(s){return s.trim();}).filter(Boolean);}
+      else if(node==='memory'){body.memory_profile_ref=val('cv-memory')||null;}
+      else if(node==='authority'){body.authority_policy_ref=val('cv-authority')||null;body.default_runtime_policy_ref=val('cv-runtime')||null;}
+      else if(node==='delivery'){var sk=val('cv-step-kind'),sb=(val('cv-step-body')||'').trim();body.steps=sb?[sk==='command'?{kind:'command',command:sb}:{kind:'agent',prompt:sb}]:[];}
+      var msg=document.getElementById('msg-'+node);if(msg)msg.textContent='saving…';
+      fetch('${SEED_LANE}/${enc(id)}/patch',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)}).then(function(r){return r.json();}).then(function(d){if(d&&d.ok===false){if(msg)msg.textContent='⚠ '+((d.error&&d.error.message)||d.reason||'invalid');}else{location.reload();}}).catch(function(){if(msg)msg.textContent='save failed';});}
+  </script>`;
+  return `${back}<h1>${esc(a.name || id)}<span class="pill ${enabled ? "ok" : "muted"}">${enabled ? "enabled" : "disabled"}</span></h1>
+    <p class="sub">${esc(a.description || "")}</p>${pipeline}${actions}
+    <div class="tabs">
+      <button class="tab active" data-tab="overview" onclick="ioiTab('overview')">Overview</button>
+      <button class="tab" data-tab="runs" onclick="ioiTab('runs')">Runs</button>
+      <button class="tab" data-tab="webhook" onclick="ioiTab('webhook')">Webhook</button>
+      <button class="tab" data-tab="canvas" onclick="ioiTab('canvas')">Canvas</button>
+    </div>
+    <div class="tab-panel" id="panel-overview">${spec}${steps}${runGaps}${OPERATIONS_BOUNDARY_NOTE}</div>
+    <div class="tab-panel" id="panel-runs" style="display:none"><h2>Run history</h2>${runRows}${runGaps}</div>
+    <div class="tab-panel" id="panel-webhook" style="display:none">${webhookSection}</div>
+    <div class="tab-panel" id="panel-canvas" style="display:none">${canvas}</div>
+    ${canvasScript}`;
+}
+
+// ---- new-automation view ------------------------------------------------------------------------
+function newView(model, base) {
+  const projects = rowsOf(model.projects, "projects");
+  const projectId = model.project;
+  const backHref = `${base}${projectId ? `?project=${enc(projectId)}` : ""}`;
+  if (projects === null) {
+    return `<p><a href="${backHref}">← Automations</a></p><h1>New automation</h1>${degraded(model.projects)}<p class="sub">The project plane did not answer — an automation must hang off a project (<code>project_ref</code> is required), so the form is withheld rather than guessed.</p>`;
+  }
+  const opts = projects.map((p) => `<option value="${esc(p.project_id)}"${p.project_id === projectId ? " selected" : ""}>${esc(p.name || p.project_id)}</option>`).join("");
+  const tzOptions = ["UTC", "-08:00", "-07:00", "-06:00", "-05:00", "-04:00", "+01:00", "+02:00", "+05:30", "+08:00", "+09:00", "+10:00"]
+    .map((z) => `<option value="${z}">${z === "UTC" ? "UTC (+00:00)" : "UTC" + z}</option>`).join("");
+  const projectField = projects.length
+    ? `<div class="field"><label>Project (required — the automation's durable container)</label><select name="project_ref" required>${opts}</select></div>`
+    : `<div class="field"><label>Project</label><input name="project_ref" value="${esc(projectId)}" placeholder="project:my-app" required></div>`;
+  return `<p><a href="${backHref}">← Automations</a></p>
+    <h1>New automation</h1><p class="sub">A project-scoped spec the daemon runs over a real environment. Start with one step; you can run it manually right away. The create posts through the seed cockpit lane — the daemon-owned create verb; the reply carries no admission receipt (the named W2 defect).</p>
+    <form method="post" action="${SEED_LANE}">
+      ${projectField}
+      <div class="field"><label>Name</label><input name="name" placeholder="Nightly CONTRIBUTING note" required></div>
+      <div class="field"><label>Description</label><input name="description" placeholder="What this automation does"></div>
+      <div class="field"><label>Schedule</label>
+        <select name="schedule_type" id="ioi-sched-type" onchange="ioiSchedToggle()">
+          <option value="manual">Manual only</option>
+          <option value="interval">Interval</option>
+          <option value="cron">Cron</option>
+        </select>
+      </div>
+      <div id="ioi-sched-interval" style="display:none">
+        <div class="two">
+          <div class="field"><label>Run every</label><input name="interval_n" type="number" min="0" value="15"></div>
+          <div class="field"><label>Unit</label><select name="interval_unit"><option value="minutes">minutes</option><option value="hours">hours</option><option value="seconds">seconds</option></select></div>
+        </div>
+      </div>
+      <div id="ioi-sched-cron" style="display:none">
+        <div class="two">
+          <div class="field"><label>Cron (min hour dom month dow)</label><input name="cron" id="ioi-cron-expr" placeholder="0 9 * * 1-5" oninput="ioiCronPreview()"></div>
+          <div class="field"><label>Timezone</label><select name="cron_tz" id="ioi-cron-tz" onchange="ioiCronPreview()">${tzOptions}</select></div>
+        </div>
+        <div class="field"><label>Next runs (UTC)</label><div id="ioi-cron-preview" class="sub" style="margin:0">enter a cron expression…</div></div>
+      </div>
+      <div class="two">
+        <div class="field"><label>Model</label><input name="model" placeholder="qwen2.5:7b"></div>
+        <div class="field"><label>Reasoning</label><select name="reasoning"><option value="">(default)</option><option value="low">low</option><option value="medium">medium</option><option value="high">high</option></select></div>
+      </div>
+      <div class="two">
+        <div class="field"><label>Max concurrency</label><input name="max_concurrency" type="number" min="1" value="1"></div>
+        <div class="field"><label>On failure</label><select name="failure_policy"><option value="continue">continue scheduling</option><option value="disable">disable on failure</option></select></div>
+      </div>
+      <div class="field"><label>Agent ref</label><input name="agent_ref" placeholder="agent:default"></div>
+      <div class="two">
+        <div class="field"><label>Connector refs (comma-separated)</label><input name="connector_refs" placeholder="connector:github, connector:linear"></div>
+        <div class="field"><label>Memory profile ref</label><input name="memory_profile_ref" placeholder="memory:project-default"></div>
+      </div>
+      <div class="two">
+        <div class="field"><label>Step kind</label><select name="step_kind"><option value="agent">agent (prompt)</option><option value="command">command (shell)</option></select></div>
+        <div class="field"><label>&nbsp;</label><div class="sub" style="margin:0;font-size:12px">First step runs when you click Run now.</div></div>
+      </div>
+      <div class="field"><label>Step body</label><textarea name="step_body" placeholder="e.g. Write a CONTRIBUTING.md for this repo."></textarea></div>
+      <div class="row"><button class="act" type="submit">Create automation</button></div>
+    </form>
+    <script>
+      function ioiSchedToggle(){var t=document.getElementById('ioi-sched-type').value;document.getElementById('ioi-sched-interval').style.display=(t==='interval')?'block':'none';document.getElementById('ioi-sched-cron').style.display=(t==='cron')?'block':'none';}
+      function ioiCronPreview(){var c=document.getElementById('ioi-cron-expr').value.trim(),tz=document.getElementById('ioi-cron-tz').value,el=document.getElementById('ioi-cron-preview');if(!c){el.textContent='enter a cron expression…';return;}fetch('${SEED_LANE}/cron-preview?cron='+encodeURIComponent(c)+'&tz='+encodeURIComponent(tz)+'&n=3').then(function(r){return r.json();}).then(function(d){el.textContent=d.ok?('next: '+d.runs.join('  ·  ')):('⚠ '+d.error);}).catch(function(){el.textContent='preview unavailable';});}
+    </script>`;
+}
+
+// ---------------------------------------------------------------------------------------------
+export function render(model, ctx) {
+  const base = ctx.url.pathname.startsWith("/__ioi/") ? LEGACY_ROUTE : CANONICAL_ROUTE;
+  let title = "Automations";
+  let inner = "";
+  if (model.view === "new") {
+    title = "New automation";
+    inner = newView(model, base);
+  } else if (model.automationId) {
+    const record = model.automation?.ok && model.automation.payload?.automation ? model.automation.payload.automation : null;
+    title = record?.name || "Automation";
+    inner = detailView(model, base);
+  } else {
+    inner = listView(model, base);
+  }
+  // The seed cockpit shell's CSS, carried verbatim so the rehomed grammar keeps its pixels; the
+  // legacy /__ioi/automations lanes keep their own copy untouched until the W4 cutover.
+  const css = `:root{color-scheme:dark}
+  body{margin:0;background:#0c0d10;color:#e6e7ea;font:14px/1.55 -apple-system,Segoe UI,Roboto,sans-serif}
+  .wrap{max-width:920px;margin:0 auto;padding:40px 24px 80px}
+  a{color:#8ab4ff}
+  .brand{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#6f7280;margin-bottom:8px}
+  h1{font-size:26px;margin:0 0 6px;letter-spacing:-.02em}
+  .sub{color:#9a9da6;margin:0 0 22px;max-width:680px}
+  .row{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin:0 0 22px}
+  .act{padding:8px 14px;border-radius:8px;border:0;background:#fff;color:#111;font:inherit;font-weight:600;text-decoration:none;cursor:pointer}
+  .act:hover{background:#eee}
+  .act.ghost{background:transparent;color:#cbd0da;border:1px solid #2a2c33}
+  .act.ghost:hover{color:#fff;border-color:#3a3d45}
+  .act.danger{background:transparent;color:#e06a6a;border:1px solid #5c2a2a}
+  .act.danger:hover{background:#2a1212}
+  .act[disabled]{opacity:.45;cursor:not-allowed}
+  h2{font-size:13px;letter-spacing:.04em;text-transform:uppercase;color:#878a93;margin:26px 0 10px;font-weight:600}
+  .card{display:flex;align-items:center;gap:14px;padding:14px 16px;border:1px solid #24262d;border-radius:12px;background:#15171c;margin-bottom:8px;text-decoration:none;color:inherit}
+  a.card:hover{border-color:#3a82f6;background:#191b21}
+  .card .main{flex:1;min-width:0}
+  .card .name{font-weight:600;color:#fff}
+  .card .meta{color:#878a93;font-size:12.5px;margin-top:3px}
+  .pill{display:inline-block;padding:2px 9px;border-radius:999px;font-size:11px;border:1px solid;white-space:nowrap;margin-left:8px}
+  .ok{color:#46c277;border-color:#235c3b;background:#11281b}
+  .warn{color:#d6a13a;border-color:#5c4a23;background:#28220f}
+  .muted{color:#9a9da6;border-color:#2a2c33}
+  .empty{color:#6f7280;padding:18px;border:1px dashed #24262d;border-radius:12px}
+  .gapcard{padding:14px 16px;border:1px dashed #5c4a23;border-radius:12px;background:#15130c;margin:0 0 18px}
+  .grid{display:grid;grid-template-columns:160px 1fr;gap:8px 16px;padding:16px;border:1px solid #24262d;border-radius:12px;background:#15171c;margin:0 0 18px}
+  .grid dt{color:#878a93;font-size:12.5px}
+  .grid dd{margin:0;color:#e6e7ea}
+  code{font-size:11.5px;color:#aab;background:#0e0f13;padding:1px 5px;border-radius:4px}
+  pre{background:#0e0f13;border:1px solid #24262d;border-radius:8px;padding:12px;overflow:auto;font:11.5px/1.5 ui-monospace,monospace;color:#cdd1d8;white-space:pre-wrap;word-break:break-all}
+  table{width:100%;border-collapse:collapse;font-size:13px}
+  th{text-align:left;color:#878a93;font-weight:600;font-size:11.5px;text-transform:uppercase;letter-spacing:.04em;padding:6px 10px;border-bottom:1px solid #24262d}
+  td{padding:8px 10px;border-bottom:1px solid #1b1d23}
+  .tabs{display:flex;gap:4px;border-bottom:1px solid #24262d;margin:22px 0 18px}
+  .tab{background:transparent;border:0;border-bottom:2px solid transparent;color:#9a9da6;font:inherit;font-weight:600;padding:9px 14px;cursor:pointer}
+  .tab:hover{color:#e6e7ea}
+  .tab.active{color:#fff;border-bottom-color:#3a82f6}
+  .canvas{display:grid;grid-template-columns:1fr 300px;gap:18px;align-items:start}
+  .cgraph{display:flex;align-items:center;gap:6px;overflow-x:auto;padding:10px;border:1px solid #24262d;border-radius:12px;background:#101216;min-height:200px}
+  .clane{display:flex;flex-direction:column;gap:10px}
+  .cedge{color:#4a4d55;font-size:20px;flex:0 0 auto}
+  .cnode{min-width:150px;max-width:180px;padding:11px 13px;border:1px solid #2a2c33;border-radius:10px;background:#15171c;cursor:pointer}
+  .cnode:hover{border-color:#3a82f6}
+  .cnode.sel{border-color:#3a82f6;box-shadow:0 0 0 1px #3a82f6 inset}
+  .cnode.ok{border-left:3px solid #46c277}
+  .cnode.warn{border-left:3px solid #d6a13a}
+  .cnode .ct{font-weight:600;color:#fff;font-size:12.5px}
+  .cnode .cs{color:#878a93;font-size:11.5px;margin-top:4px;word-break:break-word}
+  .cinsp{padding:14px;border:1px solid #24262d;border-radius:12px;background:#15171c}
+  .cinsp h3{margin:0 0 10px;font-size:13px}
+  .cmsg{font-size:12px;color:#d6a13a}
+  .field{margin:0 0 14px}
+  .field label{display:block;color:#c7c9cf;font-size:12.5px;margin-bottom:5px}
+  .field input,.field select,.field textarea{width:100%;box-sizing:border-box;padding:10px;border-radius:9px;border:1px solid #2a2c33;background:#0e0f13;color:#e6e7ea;font:inherit}
+  .field textarea{min-height:84px;resize:vertical}
+  .two{display:grid;grid-template-columns:1fr 1fr;gap:0 16px}
+  form.inline{display:inline}
+  @media(max-width:760px){.grid{grid-template-columns:120px 1fr}.canvas{grid-template-columns:1fr}table{display:block;overflow-x:auto;max-width:100%}}`;
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${esc(title)} · Hypervisor</title><style>${css}</style></head><body><div class="wrap"><div class="brand">IOI Hypervisor</div>${inner}</div></body></html>`;
+}

--- a/docs/architecture/_meta/shipped-products.v1.json
+++ b/docs/architecture/_meta/shipped-products.v1.json
@@ -59,6 +59,7 @@
         "inventory_version": 1,
         "routes": [
           "/",
+          "/__ioi/automations-cockpit",
           "/__ioi/automations/monitors",
           "/__ioi/data/sources",
           "/__ioi/evaluations/evalsuites",
@@ -106,8 +107,8 @@
           "/work/new-session",
           "/work/sessions"
         ],
-        "expected_count": 47,
-        "sha256": "6a9f21e6edfc7e621e25020f7b89d894fa816be839fd02761ba01306ef500328",
+        "expected_count": 48,
+        "sha256": "a07ccd566c3f5e9bdd9d1a588d73518fb12ae8e866e183a492ed59b682ebb78a",
         "browser_verification_id": "served-surface-smoke"
       },
       "state_authority_mode": "daemon_authoritative_projection",


### PR DESCRIPTION
STACKED on #236 (`w2.1/odk-identity`) — the Automations journey packet (W2.1 §5 PR 1, next-legs II Leg 4).

## What lands

- **`apps/hypervisor/surfaces/automations/index.mjs`** — one module, two mounts: canonical `/automations` + fresh legacy lane `/__ioi/automations-cockpit` (deliberately not nested under `/__ioi/automations/`, whose flat `:id` dispatch would shadow it; every seed lane keeps serving untouched until W4). Rehomes the T2 cockpit grammar READ-FIRST over the shared read client — typed degradation, honest-empty, zero fixtures: project-first spec cards, spec detail (grid, read-only pipeline projection, steps, run history, webhook band, canvas), New-automation form.
- **Verbs = only what the daemon owns, through the lanes that already own them.** Owned inventory (pinned mechanically in the verifier): list/create · get/patch/delete · start/runs · webhook/rotate/events · execution get/cancel. Pause/resume IS `PATCH {enabled}` — no separate activate route exists. The rendered forms post through the seed cockpit's own action lanes: the family returns **no admission receipts** (`{ok, automation}`), the brief's named W2 defect — declaring module actions would launder that through the fail-closed action runtime, so the registry row stays `operational_state: "inspect"` honestly and this packet adds **no second mutation path**.
- **Typed absences, never simulation:** no versions/revisions route, no separate activate route, no object-set monitor-trigger family, no run→Session/GoalRun lineage fields — daemon 404s asserted, controls disabled with `data-ioi-disabled-reason` naming each missing family.
- **Boundaries held:** scheduler HEALTH is Operations-owned — the surface renders no liveness/heartbeat/tick rows (asserted); Monitors stays a **link** to the protected seed `/__ioi/automations/monitors`; machinery stays **out** entirely (OQ-2 unruled — no registry transfer, no state-machines read).
- **`check:automations-journey` (39/39)** wired into package.json + the CI first-surface-journeys step: canonical grammar + ownership markers; create bound to a real project through the served lane with the session cookie; trigger/condition/effect round-trip exactly as the family stores them; pause/resume/run-now journeyed with readback (real execution over a real environment; work-ledger `state_root` proof); webhook rotate show-once + bad-token refusal recorded as a **receipted** audit event; delete journeyed; restart survival + re-render; 3-posture browser matrix.
- **Identity posture, probed honestly:** the family is **ungated** under loopback dev posture (anonymous `POST /v1/hypervisor/automations` → 201) — asserted as current truth with the finding row: `FINDING(typed): automations writes cross with no identity envelope (loopback dev posture; W1.1/G-2 pull)`.
- **`shipped-products.v1.json`**: fresh legacy lane joins the served browser-route inventory (47 → 48, digest recomputed); `/automations` was already shipped and is now module-served. `v2-route-shell.mjs` row records the landed rehome.

## Verified

`check:automations-journey` 39/39 · regressions green: ontology 36/36, governance 20/20, studio 33/33, packages 35/35, projects-saga 11/11, `test:hypervisor-app-clients`, `test:hypervisor-route-shell`, `check:source-neutral`, `check:seed-provenance`, `check:owned-product-ui`, `check:shell-parity` 6/6, `check:ported-seed` 413/413 · root lint + typecheck exit 0 · `validate-shipped-products` post-build lane green · product-surfaces smoke green on both new mounts x 3 postures (the vendored-SPA `/` WatchEvents ERR_ABORTED flake is pre-existing on master; noted, not fenced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)