### PR TITLE
feat(hypervisor): automations writes are identity-first — rule E gated, principal-bound execution identity (closes the #237 finding; next-legs III Leg 1)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -730,6 +730,18 @@ function renderConnectionsCockpit(connectors, scmConnectors, leases, devFacts) {
 // Doctrine: an automation is project-scoped DURABLE work (spec + runs + receipts + authority/memory/
 // connectors + proof), not an org-scoped workflow. This owned surface renders the daemon
 // /v1/hypervisor/automations plane natively; the SPA's org-scoped WorkflowService surface is NOT canonical.
+// Typed identity-refusal passthrough for the automations action lanes (#237 finding closed):
+// when the daemon refuses a write for want of a principal (401/403), the lane surfaces THAT
+// refusal — the daemon's status + machine-readable code — instead of the old blind 302 that
+// pretended the verb crossed. daemonFetch already forwards the caller's cookie (DEF-IDENT-1),
+// so an authenticated browser session never lands here.
+function automationsRefusalPage(res, status, j, backHref) {
+  const code = (j && (j.code || (j.error && j.error.code))) || "request_refused";
+  const message = (j && (j.message || (j.error && j.error.message))) || "the daemon refused this action";
+  res.writeHead(status, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" });
+  res.end(automationsShell("Refused", `<div class="empty" data-ioi-refusal-code="${CX_ESC(code)}">Refused: <code>${CX_ESC(code)}</code> — ${CX_ESC(message)}</div><p><a href="${backHref}">← back</a></p>`));
+}
+
 function automationsShell(title, inner) {
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${CX_ESC(title)} · Hypervisor</title>
 <style>
@@ -984,7 +996,7 @@ function renderAutomationDetail(a, runs, projectsById, webhook) {
       else if(node==='authority'){body.authority_policy_ref=val('cv-authority')||null;body.default_runtime_policy_ref=val('cv-runtime')||null;}
       else if(node==='delivery'){var sk=val('cv-step-kind'),sb=(val('cv-step-body')||'').trim();body.steps=sb?[sk==='command'?{kind:'command',command:sb}:{kind:'agent',prompt:sb}]:[];}
       var msg=document.getElementById('msg-'+node);if(msg)msg.textContent='saving…';
-      fetch('/__ioi/automations/${encodeURIComponent(id)}/patch',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)}).then(function(r){return r.json();}).then(function(d){if(d&&d.ok===false){if(msg)msg.textContent='⚠ '+((d.error&&d.error.message)||d.reason||'invalid');}else{location.reload();}}).catch(function(){if(msg)msg.textContent='save failed';});}
+      fetch('/__ioi/automations/${encodeURIComponent(id)}/patch',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)}).then(function(r){return r.json();}).then(function(d){if(d&&d.ok===false){if(msg)msg.textContent='⚠ '+((d.error&&d.error.message)||d.message||d.reason||'invalid');}else{location.reload();}}).catch(function(){if(msg)msg.textContent='save failed';});}
   </script>`;
   const inner = `${back}<h1>${CX_ESC(a.name || id)}<span class="pill ${enabled ? "ok" : "muted"}">${enabled ? "enabled" : "disabled"}</span></h1>
     <p class="sub">${CX_ESC(a.description || "")}</p>${pipeline}${actions}
@@ -8832,6 +8844,10 @@ async function handleEstateRequest(req, res, body) {
       const r = await daemonFetch(`/v1/hypervisor/automations`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(payload) });
       const j = await r.json().catch(() => ({}));
       const newId = j.automation && j.automation.automation_id;
+      if (r.status === 401 || r.status === 403) {
+        automationsRefusalPage(res, r.status, j, `/__ioi/automations/new${payload.project_ref ? "?project=" + encodeURIComponent(payload.project_ref) : ""}`);
+        return;
+      }
       if (r.status >= 400 || !newId) {
         res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
         res.end(automationsShell("New automation", `<div class="empty">Create failed: ${CX_ESC((j.error && j.error.message) || ("HTTP " + r.status))}</div><p><a href="/__ioi/automations/new${payload.project_ref ? "?project=" + encodeURIComponent(payload.project_ref) : ""}">← back</a></p>`));
@@ -8877,28 +8893,43 @@ async function handleEstateRequest(req, res, body) {
         ? "/__ioi/operations" : `/__ioi/automations/${encodeURIComponent(id)}`;
       if (action === "run" && req.method === "POST") {
         // Manual run: the daemon executor creates an env, runs the steps, and records a transcript.
-        await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}/runs`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" }).catch(() => {});
+        const r = await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}/runs`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" }).catch(() => null);
+        if (r && (r.status === 401 || r.status === 403)) {
+          automationsRefusalPage(res, r.status, await r.json().catch(() => ({})), `/__ioi/automations/${encodeURIComponent(id)}`);
+          return;
+        }
         res.writeHead(302, { Location: backTo, "Cache-Control": "no-cache" });
         res.end();
         return;
       }
       if ((action === "pause" || action === "resume") && req.method === "POST") {
         // Pause/resume the schedule = PATCH enabled (the daemon scheduler skips disabled specs).
-        await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ enabled: action === "resume" }) }).catch(() => {});
+        const r = await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ enabled: action === "resume" }) }).catch(() => null);
+        if (r && (r.status === 401 || r.status === 403)) {
+          automationsRefusalPage(res, r.status, await r.json().catch(() => ({})), `/__ioi/automations/${encodeURIComponent(id)}`);
+          return;
+        }
         res.writeHead(302, { Location: backTo, "Cache-Control": "no-cache" });
         res.end();
         return;
       }
       if (action === "patch" && req.method === "POST") {
-        // Canvas inspector save → daemon PATCH (returns JSON so the canvas can surface validation errors).
-        const r = await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: body.toString() || "{}" }).then((x) => x.json()).catch(() => ({ ok: false, error: { message: "daemon unavailable" } }));
-        res.writeHead(200, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-cache" });
+        // Canvas inspector save → daemon PATCH (returns JSON so the canvas can surface validation
+        // errors; an identity refusal passes through with the daemon's own status + typed code).
+        const rr = await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: body.toString() || "{}" }).catch(() => null);
+        const r = rr ? await rr.json().catch(() => ({ ok: false, error: { message: "daemon unavailable" } })) : { ok: false, error: { message: "daemon unavailable" } };
+        res.writeHead(rr && (rr.status === 401 || rr.status === 403) ? rr.status : 200, { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-cache" });
         res.end(JSON.stringify(r));
         return;
       }
       if (action === "webhook-rotate" && req.method === "POST") {
         // Mint/rotate the trigger secret and reveal it ONCE (only its hash is persisted).
-        const r = await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}/webhook-rotate`, { method: "POST" }).then((x) => x.json()).catch(() => ({}));
+        const rr = await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}/webhook-rotate`, { method: "POST" }).catch(() => null);
+        if (rr && (rr.status === 401 || rr.status === 403)) {
+          automationsRefusalPage(res, rr.status, await rr.json().catch(() => ({})), `/__ioi/automations/${encodeURIComponent(id)}`);
+          return;
+        }
+        const r = rr ? await rr.json().catch(() => ({})) : {};
         const token = r.webhook_token || "";
         const url = `${publicBase(req)}/v1/hypervisor/automations/${encodeURIComponent(id)}/webhook`;
         const reveal = token
@@ -8919,7 +8950,11 @@ async function handleEstateRequest(req, res, body) {
       if (action === "delete" && req.method === "POST") {
         const a = await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}`).then((r) => r.json()).catch(() => ({}));
         const pid = a.automation && (a.automation.project_ref || a.automation.project_id);
-        await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}`, { method: "DELETE" }).catch(() => {});
+        const r = await daemonFetch(`/v1/hypervisor/automations/${encodeURIComponent(id)}`, { method: "DELETE" }).catch(() => null);
+        if (r && (r.status === 401 || r.status === 403)) {
+          automationsRefusalPage(res, r.status, await r.json().catch(() => ({})), `/__ioi/automations/${encodeURIComponent(id)}`);
+          return;
+        }
         res.writeHead(302, { Location: `/__ioi/automations${pid ? "?project=" + encodeURIComponent(pid) : ""}`, "Cache-Control": "no-cache" });
         res.end();
         return;

--- a/apps/hypervisor/scripts/verify-hypervisor-automations-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-automations-journey.mjs
@@ -10,9 +10,11 @@
 //     start/runs · webhook/rotate/events · execution get/cancel) — no versions/revisions route,
 //     no separate activate route (pause/resume IS `PATCH {enabled}`), no binding plane;
 //   - spec mutations cross UNRECEIPTED ({ok, automation}, no admission envelope) — the brief's
-//     named W2 defect; the surface renders verbs through the seed cockpit's own lanes and this
-//     verifier records the identity posture it PROBES (gated → typed refusal asserted; ungated →
-//     current truth asserted + FINDING row), never hides it;
+//     named W2 defect stays current truth; the IDENTITY finding is CLOSED (#237 → next-legs III
+//     Leg 1): every write verb is identity-first (rule E — anonymous callers answer a typed 401
+//     request_principal_required BEFORE any record load or field validation, on the daemon lane
+//     AND through the serve action lanes), and the stored spec/execution bind the RESOLVED
+//     acting principal (INV-37) with executor_identity defaulting to it, never "operator";
 //   - scheduler HEALTH is Operations-owned: the pages must render NO scheduler-health rows
 //     (liveness/heartbeat/tick data) while the per-spec schedule fields stay;
 //   - monitors stays a LINK to the protected seed route; machinery stays OUT (OQ-2 unruled).
@@ -238,24 +240,37 @@ async function run() {
     noProject.status === 400 && noProject.body?.error?.code === "automation_project_ref_required",
     `${noProject.status}/${noProject.body?.error?.code}`);
 
-  // -- identity posture: probed HONESTLY, recorded not hidden -----------------
+  // -- identity gate (#237 finding CLOSED — next-legs III Leg 1): writes are identity-first ---
   const anonCreate = await jd("/v1/hypervisor/automations", {
     method: "POST",
     body: JSON.stringify({ project_ref: projectId, name: "anon-posture-probe", steps: [] }),
   }, false);
-  if (anonCreate.status === 401 || anonCreate.status === 403) {
-    ok("an unauthenticated spec mutation refuses TYPED (the family is identity-gated)",
-      !!(anonCreate.body?.error?.code || anonCreate.body?.code || anonCreate.body?.reason),
-      `${anonCreate.status}/${anonCreate.body?.error?.code || anonCreate.body?.code || anonCreate.body?.reason}`);
-  } else {
-    ok("current truth asserted: an unauthenticated spec mutation CROSSES (201, record admitted) under loopback dev posture — the family is ungated",
-      anonCreate.status === 201 && !!anonCreate.body?.automation?.automation_id,
-      `status ${anonCreate.status}`);
-    ok("FINDING(typed): automations writes cross with no identity envelope (loopback dev posture; W1.1/G-2 pull)", true,
-      "handle_automation_create/patch/delete resolve no principal; executor_identity defaults to operator; replies carry no admission receipt (the W2 lease-client pull)");
-    const probeId = anonCreate.body?.automation?.automation_id || "";
-    if (probeId) await jd(`/v1/hypervisor/automations/${encodeURIComponent(probeId)}`, { method: "DELETE" });
-  }
+  const listAfterAnon = await jd("/v1/hypervisor/automations");
+  ok("GATE: an anonymous direct daemon create refuses TYPED (401 request_principal_required) — never a silent success — and state is proven unchanged (no spec admitted)",
+    anonCreate.status === 401 && anonCreate.body?.code === "request_principal_required"
+      && (listAfterAnon.body?.automations || []).length === 0,
+    `${anonCreate.status}/${anonCreate.body?.code} · ${(listAfterAnon.body?.automations || []).length} specs`);
+  const anonNoProject = await jd("/v1/hypervisor/automations", {
+    method: "POST",
+    body: JSON.stringify({ name: "orphan-anon" }),
+  }, false);
+  ok("GATE rule E: identity is owed FIRST — an anonymous container-less create answers the 401, never the 400 project_ref field error (no field-shape probe exists for anonymous callers)",
+    anonNoProject.status === 401 && anonNoProject.body?.code === "request_principal_required",
+    `${anonNoProject.status}/${anonNoProject.body?.code}`);
+  const anonPatch = await jd("/v1/hypervisor/automations/auto_absent", { method: "PATCH", body: JSON.stringify({ enabled: false }) }, false);
+  const anonDelete = await jd("/v1/hypervisor/automations/auto_absent", { method: "DELETE" }, false);
+  const anonRotate = await jd("/v1/hypervisor/automations/auto_absent/webhook-rotate", { method: "POST" }, false);
+  const anonRun = await jd("/v1/hypervisor/automations/auto_absent/runs", { method: "POST", body: "{}" }, false);
+  const anonCancel = await jd("/v1/hypervisor/automation-executions/aex_absent/cancel", { method: "POST" }, false);
+  ok("GATE: every anonymous write verb refuses 401 request_principal_required BEFORE the record load (patch/delete/webhook-rotate/run-now/cancel) — the not-found reply is never an anonymous existence oracle",
+    [anonPatch, anonDelete, anonRotate, anonRun, anonCancel].every((r) => r.status === 401 && r.body?.code === "request_principal_required"),
+    JSON.stringify([anonPatch.status, anonDelete.status, anonRotate.status, anonRun.status, anonCancel.status]));
+  const who = await jd("/v1/hypervisor/auth/whoami");
+  const principalRef = who.body?.principal?.principal_ref
+    || (who.body?.principal?.principal_id ? `user://${who.body.principal.principal_id}` : "");
+  ok("the bootstrap session resolves a canonical principal ref (the binding subject for every INV-37 row below)",
+    who.body?.authenticated === true && principalRef.startsWith("user://"),
+    principalRef);
 
   // -- create through the served grammar (session-carried), round-trip readback
   const createRes = await seedPost("", {
@@ -287,6 +302,25 @@ async function run() {
   ok("spec mutations answer WITHOUT an admission receipt — the named W2 defect is current daemon truth (asserted, not styled around)",
     spec.ok === true && !JSON.stringify(spec).includes("receipt_ref") && !JSON.stringify(spec).includes("agentgres"),
     "");
+  ok("INV-37: the stored spec binds the RESOLVED creating principal — acting_principal_ref names the bootstrap principal and executor_identity defaults to it (never the operator literal)",
+    spec.automation?.acting_principal_ref === principalRef
+      && spec.automation?.executor_identity?.kind === "user"
+      && spec.automation?.executor_identity?.ref === principalRef,
+    JSON.stringify({ acting: spec.automation?.acting_principal_ref, executor: spec.automation?.executor_identity }));
+
+  // -- anonymous serve-lane action: the typed refusal SURFACES (no blind 302) --
+  const anonServeRun = await fetch(`${SERVE}${SEED_LANE}/${encodeURIComponent(automationId)}/run`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: "",
+    redirect: "manual",
+  }).then(async (r) => ({ status: r.status, text: await r.text() })).catch(() => ({ status: 0, text: "" }));
+  const runsAfterAnonServe = (await jd(`/v1/hypervisor/automations/${encodeURIComponent(automationId)}/runs`)).body?.runs || [];
+  ok("GATE: an anonymous serve-lane action (Run now with no session) surfaces the daemon's typed refusal — 401 with the machine-readable request_principal_required marker, and NO run was recorded",
+    anonServeRun.status === 401
+      && anonServeRun.text.includes('data-ioi-refusal-code="request_principal_required"')
+      && runsAfterAnonServe.length === 0,
+    `status ${anonServeRun.status} · ${runsAfterAnonServe.length} runs`);
 
   const listPage = await pageText(`/automations?project=${encodeURIComponent(projectId)}`);
   // The trigger pill keeps the SEED grammar's own precedence (the `trigger` object — which the
@@ -340,6 +374,9 @@ async function run() {
   ok("run-now crosses through the seed lane and run HISTORY records the execution: terminal `done`, 1 step done, a real environment_id",
     ran.status === 302 && exec.status === "done" && exec.counts?.done === 1 && String(exec.environment_id || "").length > 0,
     JSON.stringify({ status: exec.status, counts: exec.counts }));
+  ok("INV-37: the recorded execution binds the acting principal — the manual run's acting_principal_ref is the resolved session principal and executor_identity rides the spec's principal-bound identity (never the operator literal)",
+    exec.acting_principal_ref === principalRef && exec.executor_identity?.ref === principalRef,
+    JSON.stringify({ acting: exec.acting_principal_ref, executor: exec.executor_identity }));
   const execRead = await jd(`/v1/hypervisor/automation-executions/${encodeURIComponent(exec.execution_id || "")}`);
   ok("the execution readback route answers the same record (the run drawer's read)",
     execRead.body?.ok === true && execRead.body?.execution?.status === "done",

--- a/apps/hypervisor/surfaces/automations/index.mjs
+++ b/apps/hypervisor/surfaces/automations/index.mjs
@@ -311,7 +311,7 @@ function detailView(model, base) {
       else if(node==='authority'){body.authority_policy_ref=val('cv-authority')||null;body.default_runtime_policy_ref=val('cv-runtime')||null;}
       else if(node==='delivery'){var sk=val('cv-step-kind'),sb=(val('cv-step-body')||'').trim();body.steps=sb?[sk==='command'?{kind:'command',command:sb}:{kind:'agent',prompt:sb}]:[];}
       var msg=document.getElementById('msg-'+node);if(msg)msg.textContent='saving…';
-      fetch('${SEED_LANE}/${enc(id)}/patch',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)}).then(function(r){return r.json();}).then(function(d){if(d&&d.ok===false){if(msg)msg.textContent='⚠ '+((d.error&&d.error.message)||d.reason||'invalid');}else{location.reload();}}).catch(function(){if(msg)msg.textContent='save failed';});}
+      fetch('${SEED_LANE}/${enc(id)}/patch',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)}).then(function(r){return r.json();}).then(function(d){if(d&&d.ok===false){if(msg)msg.textContent='⚠ '+((d.error&&d.error.message)||d.message||d.reason||'invalid');}else{location.reload();}}).catch(function(){if(msg)msg.textContent='save failed';});}
   </script>`;
   return `${back}<h1>${esc(a.name || id)}<span class="pill ${enabled ? "ok" : "muted"}">${enabled ? "enabled" : "disabled"}</span></h1>
     <p class="sub">${esc(a.description || "")}</p>${pipeline}${actions}

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -260,6 +260,10 @@ pub(crate) struct DaemonState {
     // session_ref. Opening one exposes workspace bytes, so it is wallet-gated by
     // the execution authority (the `port_exposure` scope). Aborted/replaced on
     // re-execute; the tasks die with the daemon process.
+    // Per-boot internal dispatch token: authenticates the daemon's OWN loopback dispatches
+    // (scheduler tick, accepted-webhook fire) through the identity-gated automations run lane.
+    // Never persisted, never emitted in any response; dies with the process.
+    pub(crate) internal_dispatch_token: String,
     pub(crate) preview_servers: Mutex<HashMap<String, PreviewServer>>,
     // WS-4 — live cloud-hypervisor microVMs keyed by environment id. A running env on the
     // microvm substrate keeps its VM here so WorkRun/exec requests run IN-GUEST; stop/delete
@@ -586,6 +590,14 @@ async fn async_main() -> anyhow::Result<()> {
         token_expiry: Mutex::new(HashMap::new()),
         stream_frame_delay_ms,
         boot_id: format!("boot_{}", uuid::Uuid::new_v4()),
+        // Per-boot internal dispatch secret (identity-gated automations run lane): lives only in
+        // process memory, never emitted in any response, handed only to the daemon's own
+        // scheduler tick and the accepted-webhook fire.
+        internal_dispatch_token: format!(
+            "idisp_{}{}",
+            uuid::Uuid::new_v4().simple(),
+            uuid::Uuid::new_v4().simple()
+        ),
         vault_bound: Mutex::new(HashSet::new()),
         preview_servers: Mutex::new(HashMap::new()),
         model_route_lock: Mutex::new(()),
@@ -3853,6 +3865,7 @@ async fn async_main() -> anyhow::Result<()> {
     tokio::spawn(automation_scheduler(
         state.data_dir.clone(),
         state.base_url.clone(),
+        state.internal_dispatch_token.clone(),
     ));
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
@@ -4797,7 +4810,7 @@ fn load_record(data_dir: &str, kind: &str, id: &str) -> Option<Value> {
     serde_json::from_slice(&bytes).ok()
 }
 
-async fn automation_scheduler(data_dir: String, base_url: String) {
+async fn automation_scheduler(data_dir: String, base_url: String, dispatch_token: String) {
     // Let the HTTP listener come up before the first self-call.
     sleep(std::time::Duration::from_secs(5)).await;
     let client = reqwest::Client::new();
@@ -4805,7 +4818,15 @@ async fn automation_scheduler(data_dir: String, base_url: String) {
     let mut tick_seq: u64 = 0;
     loop {
         tick_seq += 1;
-        scheduler_tick(&data_dir, &base_url, &client, &booted_at, tick_seq).await;
+        scheduler_tick(
+            &data_dir,
+            &base_url,
+            &client,
+            &booted_at,
+            tick_seq,
+            &dispatch_token,
+        )
+        .await;
         sleep(std::time::Duration::from_secs(SCHED_TICK_SECS)).await;
     }
 }
@@ -4824,6 +4845,7 @@ async fn scheduler_tick(
     client: &reqwest::Client,
     booted_at: &str,
     tick_seq: u64,
+    dispatch_token: &str,
 ) {
     let now = iso_now();
     let Some(now_ts) = epoch_of(&now) else {
@@ -4911,9 +4933,13 @@ async fn scheduler_tick(
         let client = client.clone();
         let data_dir = data_dir.to_string();
         let id = id.to_string();
+        // The identity-gated manual-run lane admits the daemon's own tick through the per-boot
+        // internal dispatch token; the run executes as the spec's stored executor_identity.
+        let dispatch_token = dispatch_token.to_string();
         tokio::spawn(async move {
             let ok = match client
                 .post(&url)
+                .header("x-ioi-internal-dispatch", dispatch_token)
                 .json(&json!({ "trigger": "schedule" }))
                 .send()
                 .await

--- a/crates/node/src/bin/hypervisor_daemon_routes/orchestration_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/orchestration_routes.rs
@@ -64,6 +64,10 @@ const FORWARDED_AUTH_HEADERS: &[&str] = &[
     "x-forwarded-host",
     "x-forwarded-for",
     "x-ioi-forwarded",
+    // The per-boot internal dispatch token (scheduler tick / accepted-webhook fire). Loopback
+    // self-calls only; a caller-supplied value forwards inert — it can never match the per-boot
+    // secret, which is never emitted in any response.
+    "x-ioi-internal-dispatch",
 ];
 
 async fn call(
@@ -147,13 +151,66 @@ fn link_project_automation(data_dir: &str, project_id: &str, automation_id: &str
     let _ = persist_record(data_dir, "projects", project_id, &project);
 }
 
+/// Typed identity/scope refusal for the automations family (the ODK ontology precedent, #236):
+/// the status is derived from the refusal kind, the body carries the machine-readable code.
+fn automation_scope_refusal(
+    error: super::substrate_store::RequestScopeRefusal,
+) -> (StatusCode, Json<Value>) {
+    use super::substrate_store::RequestScopeRefusal;
+    let status = match error {
+        RequestScopeRefusal::AuthenticationRequired
+        | RequestScopeRefusal::PrincipalIdentityInvalid => StatusCode::UNAUTHORIZED,
+        RequestScopeRefusal::TenantAuthorityRequired
+        | RequestScopeRefusal::ResourceScopeRequired
+        | RequestScopeRefusal::ResourceOwnerMismatch => StatusCode::FORBIDDEN,
+        RequestScopeRefusal::SubstrateUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+    };
+    (
+        status,
+        Json(json!({ "ok": false, "code": error.code(), "message": error.message() })),
+    )
+}
+
+/// True when the request carries THIS boot's internal dispatch token — the daemon's own
+/// scheduler tick and the accepted-webhook fire, which cross the manual-run route over loopback.
+/// The token is minted per boot, lives only in process memory, and is never emitted in any
+/// response, so a valid presentation can only originate from this daemon process. Internal
+/// dispatch is NOT a session: the run executes as the spec's stored `executor_identity`
+/// (the delegated durable authority), never as an ambient operator.
+fn internal_dispatch_authorized(st: &DaemonState, headers: &HeaderMap) -> bool {
+    headers
+        .get("x-ioi-internal-dispatch")
+        .and_then(|v| v.to_str().ok())
+        .map(|presented| {
+            // Constant-time-ish compare: same-length XOR fold (the token is per-boot random).
+            let expected = st.internal_dispatch_token.as_bytes();
+            let presented = presented.as_bytes();
+            presented.len() == expected.len()
+                && presented
+                    .iter()
+                    .zip(expected)
+                    .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+                    == 0
+        })
+        .unwrap_or(false)
+}
+
 /// POST /v1/hypervisor/automations — create a project-scoped AutomationWorkflow spec.
 /// `project_ref` (alias `project_id`) is REQUIRED: an automation is durable work that must hang off
 /// a project. Returns 400 if absent. On success the project's `automation_refs` is updated.
 pub(crate) async fn handle_automation_create(
     State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> (StatusCode, Json<Value>) {
+    // #237 finding closed — identity FIRST (rule E): an anonymous caller is owed the typed 401
+    // before any field validation runs (project_ref included), so no field-shape probe exists
+    // for unauthenticated callers. An automation spec is authored durable work, not an
+    // anonymous append.
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        Ok(identity) => identity,
+        Err(error) => return automation_scope_refusal(error),
+    };
     let project_id = body
         .get("project_ref")
         .and_then(|v| v.as_str())
@@ -205,7 +262,12 @@ pub(crate) async fn handle_automation_create(
         "steps": body.get("steps").cloned().unwrap_or_else(|| json!([])),
         "workflow_graph_ref": body.get("workflow_graph_ref").cloned().unwrap_or(Value::Null),
         "limits": body.get("limits").cloned().unwrap_or_else(|| json!({ "max_total": 100, "per_exec_seconds": 600, "budget": Value::Null })),
-        "executor_identity": body.get("executor_identity").cloned().unwrap_or_else(|| json!({ "kind": "user", "ref": "operator" })),
+        // INV-37: the execution identity defaults to the RESOLVED creating principal, never an
+        // ambient "operator" literal. A caller-supplied executor_identity (delegated execution
+        // config) still wins — it is spec surface, not attribution.
+        "executor_identity": body.get("executor_identity").cloned().unwrap_or_else(|| json!({ "kind": "user", "ref": identity.principal_ref })),
+        // Who performed this mutation (refreshed on PATCH) — resolved server-side, never client-set.
+        "acting_principal_ref": identity.principal_ref,
         "environment_class_id": body.get("environment_class_id").and_then(|v| v.as_str()).unwrap_or("local-workspace-v0"),
         "recipe_ref": body.get("recipe_ref").cloned().unwrap_or(Value::Null),
         // Agent/runtime config (the HypervisorAutomationSpec surface).
@@ -302,8 +364,16 @@ pub(crate) async fn handle_automation_execution_get(
 pub(crate) async fn handle_automation_patch(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
+    headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> (StatusCode, Json<Value>) {
+    // #237 finding closed — identity FIRST (rule E): the typed 401 is owed BEFORE the record
+    // load, so an unauthenticated caller can never use the not-found reply as an existence
+    // oracle (or probe field shapes through the schedule validator).
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        Ok(identity) => identity,
+        Err(error) => return automation_scope_refusal(error),
+    };
     let Some(mut a) = load(&st.data_dir, "automations", &id) else {
         return (
             StatusCode::OK,
@@ -355,6 +425,9 @@ pub(crate) async fn handle_automation_patch(
         a["next_run_at"] = Value::Null;
     }
     a["updated_at"] = json!(iso_now());
+    // INV-37: the spec records who performed the last mutation (resolved, never client-set —
+    // `acting_principal_ref` is deliberately absent from the patchable key list above).
+    a["acting_principal_ref"] = json!(identity.principal_ref);
     // W1.2 / MEF-GAP-008 — CRITICAL: a discarded `enabled:false` patch returns 200 "paused" while the
     // scheduler keeps firing the spec. Fail closed so pause is honest.
     if persist_record(&st.data_dir, "automations", &id, &a).is_err() {
@@ -374,7 +447,14 @@ pub(crate) async fn handle_automation_patch(
 pub(crate) async fn handle_automation_delete(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
-) -> Json<Value> {
+    headers: HeaderMap,
+) -> (StatusCode, Json<Value>) {
+    // #237 finding closed — identity FIRST (rule E): the typed 401 is owed BEFORE the record
+    // load, so an anonymous caller gets no existence oracle. All authenticated outcomes keep
+    // their 200 body shapes exactly (the ODK delete precedent, #236).
+    if let Err(error) = super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        return automation_scope_refusal(error);
+    }
     let project_id = load(&st.data_dir, "automations", &id).and_then(|a| {
         a.get("project_id")
             .and_then(|v| v.as_str())
@@ -384,7 +464,10 @@ pub(crate) async fn handle_automation_delete(
     if let Some(pid) = project_id {
         link_project_automation(&st.data_dir, &pid, &id, false);
     }
-    Json(json!({ "ok": removed, "removed": removed, "automation_id": id }))
+    (
+        StatusCode::OK,
+        Json(json!({ "ok": removed, "removed": removed, "automation_id": id })),
+    )
 }
 
 /// GET /v1/hypervisor/automations/:id/runs — the spec's run history (automation-execution records),
@@ -1191,7 +1274,14 @@ fn record_rotated_webhook_token(
 pub(crate) async fn handle_automation_webhook_rotate(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
+    headers: HeaderMap,
 ) -> (StatusCode, Json<Value>) {
+    // #237 finding closed — identity FIRST (rule E): minting/rotating the trigger secret is a
+    // write of trigger AUTHORITY; the typed 401 is owed BEFORE the record load. The inbound
+    // /webhook trigger itself stays on its own token lane (gate-exempt), untouched here.
+    if let Err(error) = super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        return automation_scope_refusal(error);
+    }
     let Some(a) = load(&st.data_dir, "automations", &id) else {
         // PRESERVED VERBATIM. This packet changes the durability contract, not the not-found
         // contract; the return type had to name a status, and naming OK keeps the existing wire
@@ -1360,8 +1450,15 @@ pub(crate) async fn handle_automation_webhook(
     let receipt = receipt_id.clone();
     // Opportunistic: on the webhook path there is no session to forward, so this
     // is a no-op there. It matters when the same executor runs for an
-    // authenticated caller.
-    let inbound = headers.clone();
+    // authenticated caller. The accepted fire additionally carries the per-boot
+    // internal dispatch token — the trigger token already authenticated this
+    // crossing (receipt above), and the identity-gated manual-run lane admits the
+    // daemon's own dispatch through that token, executing as the spec's stored
+    // executor_identity.
+    let mut inbound = headers.clone();
+    if let Ok(value) = axum::http::HeaderValue::from_str(&st.internal_dispatch_token) {
+        inbound.insert("x-ioi-internal-dispatch", value);
+    }
     tokio::spawn(async move {
         if let Ok(r) = call(
             &base,
@@ -1400,12 +1497,34 @@ pub(crate) async fn handle_automation_start(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
     inbound: axum::http::HeaderMap,
-) -> Result<Json<Value>, AppError> {
+) -> Result<(StatusCode, Json<Value>), AppError> {
+    // #237 finding closed — identity FIRST (rule E): a manual run is a write crossing; the typed
+    // 401 is owed BEFORE the record load. The daemon's OWN dispatches (scheduler tick, accepted
+    // webhook fire) cross with the per-boot internal dispatch token instead of a session — they
+    // are the daemon acting on the stored spec, and the run's acting identity is then the spec's
+    // own `executor_identity` (the delegated durable authority), never an ambient operator.
+    let acting_principal_ref =
+        match super::substrate_store::resolve_request_identity(&st.data_dir, &inbound) {
+            Ok(identity) => Some(identity.principal_ref),
+            Err(error) => {
+                if !internal_dispatch_authorized(&st, &inbound) {
+                    return Ok(automation_scope_refusal(error));
+                }
+                None // internal dispatch — resolved from the spec below, after the load
+            }
+        };
     let Some(automation) = load(&st.data_dir, "automations", &id) else {
-        return Ok(Json(
-            json!({ "ok": false, "reason": "automation not found" }),
+        return Ok((
+            StatusCode::OK,
+            Json(json!({ "ok": false, "reason": "automation not found" })),
         ));
     };
+    let acting_principal_ref = acting_principal_ref.unwrap_or_else(|| {
+        automation["executor_identity"]["ref"]
+            .as_str()
+            .unwrap_or("")
+            .to_string()
+    });
     let base = st.base_url.clone();
     let exec_id = format!("aex_{:x}", nanos());
     let steps = automation["steps"].as_array().cloned().unwrap_or_default();
@@ -1415,6 +1534,9 @@ pub(crate) async fn handle_automation_start(
         "schema_version": "ioi.hypervisor.automation-execution.v1",
         "execution_id": exec_id, "automation_id": id, "status": "running",
         "executor_identity": automation["executor_identity"], "environment_id": Value::Null,
+        // INV-37: who triggered this run — the resolved session principal on a manual run, the
+        // spec's delegated executor ref on an internal (scheduler/webhook) dispatch.
+        "acting_principal_ref": acting_principal_ref,
         "step_results": [], "counts": counts, "started_at": iso_now(), "finished_at": Value::Null
     });
     // W1.2 / MEF-GAP-008 — this running exec is the concurrency-gate input; a discarded write means
@@ -1457,8 +1579,9 @@ pub(crate) async fn handle_automation_start(
                 "automation_execution_persistence_failed: the failed-execution record did not commit".to_string(),
             ));
         }
-        return Ok(Json(
-            json!({ "ok": false, "reason": "env create failed", "execution": exec }),
+        return Ok((
+            StatusCode::OK,
+            Json(json!({ "ok": false, "reason": "env create failed", "execution": exec })),
         ));
     }
     let _ = call(
@@ -1655,14 +1778,23 @@ pub(crate) async fn handle_automation_start(
         &inbound,
     )
     .await;
-    Ok(Json(json!({ "ok": !failed, "execution": exec })))
+    Ok((
+        StatusCode::OK,
+        Json(json!({ "ok": !failed, "execution": exec })),
+    ))
 }
 
 /// POST /v1/hypervisor/automation-executions/:id/cancel — stop a running execution.
 pub(crate) async fn handle_automation_cancel(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
+    headers: HeaderMap,
 ) -> (StatusCode, Json<Value>) {
+    // #237 finding closed — identity FIRST (rule E): stopping a running execution is a write;
+    // the typed 401 is owed BEFORE the record load (no existence oracle for anonymous callers).
+    if let Err(error) = super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        return automation_scope_refusal(error);
+    }
     let Some(mut exec) = load(&st.data_dir, "automation-executions", &id) else {
         return (
             StatusCode::OK,

--- a/scripts/audit-admission-evidence-provenance.mjs
+++ b/scripts/audit-admission-evidence-provenance.mjs
@@ -365,11 +365,14 @@ const H_BASELINE = [
   "ontology_projection_routes.rs::handle_projection_patch",
   "ontology_projection_routes.rs::handle_projection_recheck",
   "ontology_projection_routes.rs::handle_projection_retire",
-  "orchestration_routes.rs::handle_automation_cancel",
-  "orchestration_routes.rs::handle_automation_create",
-  "orchestration_routes.rs::handle_automation_delete",
-  "orchestration_routes.rs::handle_automation_patch",
-  "orchestration_routes.rs::handle_automation_start",
+  // "orchestration_routes.rs::handle_automation_cancel" / "handle_automation_create" /
+  // "handle_automation_delete" / "handle_automation_patch" / "handle_automation_start" —
+  // LEFT the baseline 2026-08-10 (#237 finding closed, next-legs III Leg 1): the automations
+  // write verbs now resolve identity FIRST via substrate_store::resolve_request_identity
+  // (rule E — typed 401 before any record load) and bind acting_principal_ref into the
+  // spec/execution records; the vanishing entries are the ratchet improving, not stale pins.
+  // handle_automation_webhook stays pinned below: it authenticates by its own per-automation
+  // trigger token (the auth gate exempts */webhook), not by a resolved principal.
   "orchestration_routes.rs::handle_automation_webhook",
   "orchestration_routes.rs::handle_placement_resolve",
   "orchestration_routes.rs::handle_venue_policy_put",


### PR DESCRIPTION
## What

Closes the #237 automations identity-envelope finding (next-legs III Leg 1) by copying the ODK ontology precedent (#236) onto the daemon automations family.

### Daemon — every write verb is identity-first (rule E)

`handle_automation_create` / `patch` / `delete` / `start` (both `POST /:id/start` and `POST /:id/runs`) / `webhook_rotate` / `cancel` now resolve identity FIRST via `substrate_store::resolve_request_identity`, refusing through a new `automation_scope_refusal` helper — the typed 401 `request_principal_required` is owed BEFORE any record load or field validation, so anonymous callers get no existence oracle and no field-shape probe. Reads stay ungated (house norm); the inbound `/webhook` trigger keeps its own token lane (gate-exempt), untouched.

### INV-37 — principal-bound execution identity

- The spec's `executor_identity` defaults to the RESOLVED creating principal, never the `"operator"` literal (caller-supplied executor_identity still wins — spec surface, not attribution).
- The spec stamps `acting_principal_ref` at create and refreshes it on PATCH.
- Every execution record binds `acting_principal_ref`: the session principal on a manual run; the spec's delegated executor ref on internal dispatch.

### Internal dispatch — scheduler + webhook fires keep crossing

The scheduler tick and the accepted-webhook fire cross the manual-run route over loopback with NO session. A per-boot random token (`DaemonState.internal_dispatch_token`, process-memory only, never emitted in any response) authenticates the daemon's own dispatches through the gated lane. Both paths live-proven end-to-end: scheduled `every_seconds` fire and token-authenticated webhook accept both land terminal `done` with principal-bound identity.

### Serve — refusals surface instead of blind 302s

Every automations action lane already rides the ambient `daemonFetch` (DEF-IDENT-1 — the caller's cookie forwards; no bare daemon fetches existed). The change is refusal honesty: run/pause/resume/delete/create/webhook-rotate surface the daemon's 401/403 as a typed page (`data-ioi-refusal-code`) instead of a 302 that pretended the verb crossed; the canvas patch lane passes the refusal status + message through.

### Verifier — 44/44

The FINDING(typed) pass row is REPLACED by gate assertions: anonymous direct daemon create AND anonymous serve-lane run → typed 401 with state proven unchanged; rule E ordering (401 before the 400 `project_ref` error; all five write verbs refuse before the record load); the stored spec and recorded execution bind the bootstrap principal.

## Gates

- automations journey 44/44 · ontology 36/36 · projects-saga 11/11 · governance 20/20
- cargo build clean · `cargo fmt --all --check` · targeted tests green (webhook 5/5, identity 23/23; the `automation` filter matches 0 test names)
- `check:architecture-contracts` / `check:architecture-docs` / `check:mutation-foundation` (census UNMOVED: 67 occurrences / 25 files, registry matches) / `check:mutation-handlers` / `check:source-neutral` all green
- `check:admission-evidence`: the five automations handlers LEFT the H baseline per the checker's documented in-file procedure (H-census 177→172, dated justification comment — the ratchet improving); `handle_automation_webhook` stays pinned (own-token lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)