### PR TITLE
feat(hypervisor): /applications greenfield launcher — compiler+registry truth only, typed ineligibility, recall removes rows live; check:applications-journey (next-legs III Leg 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
           npm run check:studio-journey --workspace=@ioi/hypervisor-app
           npm run check:packages-journey --workspace=@ioi/hypervisor-app
           npm run check:automations-journey --workspace=@ioi/hypervisor-app
+          npm run check:applications-journey --workspace=@ioi/hypervisor-app
           npm run check:projects-saga --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -18,6 +18,7 @@
     "check:studio-journey": "node scripts/verify-hypervisor-studio-journey.mjs",
     "check:packages-journey": "node scripts/verify-hypervisor-packages-journey.mjs",
     "check:automations-journey": "node scripts/verify-hypervisor-automations-journey.mjs",
+    "check:applications-journey": "node scripts/verify-hypervisor-applications-journey.mjs",
     "check:projects-saga": "node scripts/verify-hypervisor-projects-saga.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -32,6 +32,7 @@ import * as missionsModule from "../surfaces/missions/index.mjs";
 import * as studioModule from "../surfaces/studio/index.mjs";
 import * as packagesModule from "../surfaces/packages/index.mjs";
 import * as automationsModule from "../surfaces/automations/index.mjs";
+import * as applicationsModule from "../surfaces/applications/index.mjs";
 
 // Capability model (operational wave): `capabilities` is the AUTHORITY-derived set of acts the
 // surface genuinely supports today (never inferred from pixel certification or daemon_wired);
@@ -83,6 +84,16 @@ export const SURFACES = [
   // module-served with truthful ownership markers). Evidence: the packages journey verifier.
   { slug: "packages", owner: "Packages", title: "Packages", icon: MARKETPLACE_APP_ICON_URI, route: "/__ioi/packages/registry", canonical_route: "/packages", verifier: "scripts/verify-hypervisor-packages-journey.mjs", certification: "n/a", capabilities: ["browse", "select", "inspect", "create", "transition"], operational_state: "act", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "packages-marketplace", owner: "Packages", title: "Packages / Marketplace", icon: MARKETPLACE_APP_ICON_URI, route: "/__ioi/packages/marketplace", canonical_route: "/packages/marketplace", verifier: "scripts/verify-hypervisor-packages-journey.mjs", certification: "n/a", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
+  // W2.1 next-legs III Leg 3: the Applications greenfield launcher — canonical /applications
+  // plus a FRESH legacy lane /__ioi/applications-launcher (the /__ioi/applications T2 readout
+  // keeps serving untouched until the W4 cutover). GREENFIELD, typed non-parity
+  // (seed-ux-provenance.v1.json: no provenance-qualified seed exists; the owner-authorized
+  // greenfield lane is the only open path — this row claims no seed preservation and no
+  // parity). The module is READ-ONLY BY CONTRACT: launch is navigation over the compiled
+  // product-surface projection joined live with the package registry; it declares zero
+  // actions because every admission-class verb belongs to its owner surface. Evidence: the
+  // applications journey verifier.
+  { slug: "applications", owner: "Applications", title: "Applications", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/applications-launcher", canonical_route: "/applications", verifier: "scripts/verify-hypervisor-applications-journey.mjs", certification: "n/a", capabilities: ["browse", "inspect"], operational_state: "read_only_by_contract", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "monitors", owner: "Automations", title: "Automate", icon: MON_APP_TILE_URI, route: "/__ioi/automations/monitors", verifier: "scripts/verify-hypervisor-app-parity-monitors.mjs", certification: "pixel-certifications/monitors.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   // W2.1 next-legs II Leg 4: the Automations surface packet — canonical /automations plus a
   // FRESH legacy lane /__ioi/automations-cockpit (deliberately NOT nested under
@@ -197,6 +208,7 @@ bindSurface("studio-home", studioModule);
 bindSurface("packages", packagesModule);
 bindSurface("packages-marketplace", packagesModule);
 bindSurface("automations", automationsModule);
+bindSurface("applications", applicationsModule);
 
 // Test-only fault surface (NEVER without the runtime-test flag): gives the action-runtime
 // verifier a module whose action THROWS (route isolation proof) and one that claims success

--- a/apps/hypervisor/scripts/v2-route-shell.mjs
+++ b/apps/hypervisor/scripts/v2-route-shell.mjs
@@ -85,9 +85,11 @@ export const V2_ROUTE_TABLE = [
     kind: "core workspace",
     rule: "one catalog/compiler projection",
     waves: "W0.2 · W1",
-    build_state: "compiler-fed (W0.2) — nav/catalog/palette/launch render the compiled product-surface projection (scripts/surface-compiler.mjs); the three hand-maintained catalogs are retired as authorities; the Wave 1 build lands the full workspace page (surfaces/applications.md §5)",
+    build_state: "W2.1 greenfield launcher landed (next-legs III Leg 3) — the bound surface module serves this canonical route: a READ-ONLY launcher over the one compiled product-surface projection joined live with the package registry (typed ineligibility verbatim, reserved registrations declared nonlaunchable, recall removes rows by derivation on every read). Greenfield-authorized non-parity lane (seed-ux-provenance.v1.json); the W0.2 compiled navigation band keeps feeding the shell pages",
     serving_today: [
-      { href: "/__ioi/applications", label: "Applications estate readout", note: "renders the compiled product-surface projection (W0.2)" },
+      { href: "/applications", label: "Applications launcher (canonical)", note: "bound surface module — compiler+registry truth only; launch is navigation, never a mutation" },
+      { href: "/__ioi/applications-launcher", label: "Applications launcher (legacy lane)", note: "same module on the fresh legacy lane; keeps serving until the W4 cutover" },
+      { href: "/__ioi/applications", label: "Applications estate readout", note: "renders the compiled product-surface projection (W0.2); keeps serving untouched until the W4 cutover" },
       { href: "/__ioi/home", label: "Estate launcher", note: "the owned launcher lanes — fed by the same compiled projection as of W0.2" },
     ],
   },

--- a/apps/hypervisor/scripts/verify-hypervisor-applications-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-applications-journey.mjs
@@ -1,0 +1,409 @@
+#!/usr/bin/env node
+// Applications launcher journey verifier (greenfield packet, next-legs III Leg 3).
+//
+// Proves, against an ISOLATED real daemon + serve lane, the SURF-applications acceptance for
+// the canonical /applications greenfield launcher (typed non-parity lane —
+// seed-ux-provenance.v1.json; the module claims no seed preservation and no parity):
+//
+//   - the launcher enumerates ONLY compiler-admitted applications: the 15 compiled
+//     registrations render as rows and NOTHING else does over an empty registry;
+//   - launchable rows link the projection's own resolved_launch_route and those routes
+//     resolve; unavailable rows state the exact typed reason verbatim;
+//   - launch and direct deep link preserve context: the ?org= scope rides every launch href,
+//     and following the launcher's href is byte-equivalent in destination to the directly
+//     constructed deep link;
+//   - the reserved Embodied Systems registration renders declared-nonlaunchable (typing read
+//     from the compiler-owned registration source, GET /v1/hypervisor/core-taxonomy) — never
+//     hidden, never a launch link;
+//   - folded owners never reappear as peers (Missions / Marketplace / Workbench / Agent
+//     Studio absent from the served launcher);
+//   - the cross-surface journey the commissioning names: install a registry package (ODK mesh
+//     → candidate → release → installation, the #235/#239 fixture recipe) → its row appears
+//     with typed ineligibility facts; RECALL the release → the row is GONE from /applications
+//     on the very next read (derived, no cleanup step) and STAYS gone across daemon restart;
+//   - a daemon outage never fabricates launchability: daemon down → typed unavailability page
+//     with ZERO rows; daemon back → truth returns;
+//   - 3-posture browser matrix (light/dark/narrow-reduced-motion).
+//
+// Exit: 0 pass · 1 fail · 2 blocked (daemon binary missing).
+//   IOI_HYPERVISOR_DAEMON_BINARY  default target/debug/hypervisor-daemon
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+  srv.on("error", reject);
+});
+
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try {
+  fs.accessSync(daemonBinary, fs.constants.X_OK);
+} catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-applications-journey-"));
+let daemon = null;
+let serve = null;
+let daemonPort = 0;
+let DAEMON = "";
+let SERVE = "";
+let SESSION = "";
+
+const PKG = "applications-journey-app";
+const INST = "primary";
+const SURFACE_REF = `surface://extensions/${PKG}`;
+const CANONICAL = "/applications";
+const LANE = "/__ioi/applications-launcher";
+// The compiled first-party registration set (crates hypervisor_surface_records.json — 15 rows:
+// 12 owners + 2 substrate + the reserved Embodied Systems registration).
+const COMPILED_NAMES = [
+  "Studio", "Automations", "Ontology", "Data", "Governance", "Provenance", "Evaluations",
+  "Improvement", "Foundry", "Packages", "Developer Workspace", "Developer Console",
+  "Environments", "Operations", "Embodied Systems",
+];
+const RETIRED_OWNER_NAMES = ["Missions", "Marketplace", "Workbench", "Agent Studio"];
+
+async function startDaemon() {
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${daemonPort}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1/v1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = "";
+  daemon.stdout.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  await waitFor(`${DAEMON}/healthz`, 30000);
+  return () => log;
+}
+
+// Daemon JSON with the operator session (the packages family is identity-first).
+const jd = (p, init) => fetch(`${DAEMON}${p}`, {
+  headers: {
+    "content-type": "application/json",
+    ...(SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+  },
+  ...init,
+}).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+  .catch(() => ({ status: 0, body: {} }));
+
+const pageText = (p, { authenticated = true } = {}) => fetch(`${SERVE}${p}`, {
+  headers: authenticated && SESSION ? { cookie: `ioi_session=${SESSION}` } : {},
+}).then(async (r) => ({ status: r.status, text: await r.text(), headers: r.headers }))
+  .catch(() => ({ status: 0, text: "", headers: new Headers() }));
+
+const entryNames = (text) => [...text.matchAll(/data-ioi-entry-name="([^"]*)"/gu)].map((m) => m[1]);
+const launchHrefs = (text) => [...text.matchAll(/data-ioi-launchable="true" href="([^"]*)"/gu)].map((m) => m[1]);
+
+async function run() {
+  daemonPort = await freePort();
+  DAEMON = `http://127.0.0.1:${daemonPort}`;
+  const daemonLogFn = await startDaemon();
+  const token = daemonLogFn().match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  if (token) {
+    const boot = await jd("/v1/hypervisor/auth/bootstrap", {
+      method: "POST",
+      body: JSON.stringify({ token, password: "applications-journey-bootstrap-v1", email: "applications-journey@ioi.local" }),
+    });
+    SESSION = boot.body?.session_token ?? "";
+  }
+  ok("operator bootstrap yields an authenticated session", SESSION.startsWith("ioi_sess_"), SESSION.slice(0, 12));
+  const who = (await jd("/v1/hypervisor/auth/whoami")).body || {};
+  const OWNER = (who.principal?.tenant_refs || []).find((t) => typeof t === "string" && t.startsWith("org://")) || "";
+  ok("the session authenticates a principal with an org:// owner tenant", !!OWNER, OWNER || "no owner tenant");
+
+  const servePort = await freePort();
+  const productUiPort = await freePort();
+  SERVE = `http://127.0.0.1:${servePort}`;
+  serve = spawn(process.execPath, [path.join(HERE, "serve-product-ui.mjs")], {
+    cwd: APP,
+    env: {
+      ...process.env,
+      PORT: String(servePort),
+      PRODUCT_UI_PORT: String(productUiPort),
+      IOI_PRODUCT_UI_PUBLIC: path.join(APP, "product-ui", "owned", "public"),
+      IOI_HYPERVISOR_DAEMON_URL: DAEMON,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await waitFor(`${SERVE}${CANONICAL}`, 30000);
+
+  // -- canonical + legacy mounts render with truthful ownership ---------------
+  const landing = await pageText(CANONICAL);
+  ok("canonical /applications 200s as the module's own mount (ownership headers + heading)",
+    landing.status === 200 && landing.headers.get("x-ioi-surface-route") === CANONICAL
+      && landing.headers.get("x-ioi-surface-owner") === "Applications"
+      && landing.text.includes("<h1>Applications</h1>"),
+    `status ${landing.status} route ${landing.headers.get("x-ioi-surface-route")}`);
+  const legacy = await pageText(LANE);
+  ok("the fresh legacy lane serves the same module with its own truthful marker",
+    legacy.status === 200 && legacy.headers.get("x-ioi-surface-route") === LANE
+      && legacy.headers.get("x-ioi-surface-owner") === "Applications",
+    `status ${legacy.status} route ${legacy.headers.get("x-ioi-surface-route")}`);
+  ok("the launcher names its greenfield provenance honestly (typed non-parity lane, no seed/parity claim)",
+    landing.text.includes("greenfield") && landing.text.includes("seed-ux-provenance.v1.json")
+      && landing.text.includes("no seed preservation and no parity"),
+    "");
+
+  // -- enumeration: ONLY compiler-admitted applications -----------------------
+  const names = entryNames(landing.text);
+  ok("the launcher enumerates EXACTLY the 15 compiled registrations over an empty registry — only compiler-admitted applications, nothing else",
+    names.length === COMPILED_NAMES.length && COMPILED_NAMES.every((n) => names.includes(n)),
+    `entries ${names.length}: ${names.join("|").slice(0, 160)}`);
+  const hrefs = launchHrefs(landing.text);
+  ok("exactly the 14 active registrations render launchable; the reserved registration is the one nonlaunchable compiled row",
+    hrefs.length === 14 && (landing.text.match(/data-ioi-launchable="false"/gu) || []).length === 1,
+    `launchable ${hrefs.length}`);
+  ok("launchable rows link the projection's own resolved routes (spot: /studio, /packages, /governance)",
+    ["/studio", "/packages", "/governance"].every((r) => hrefs.includes(r)),
+    hrefs.join("|").slice(0, 200));
+  const targets = await Promise.all(["/studio", "/packages", "/governance"].map((r) => pageText(r)));
+  ok("the spot-checked launch targets resolve 200 (module mounts /studio + /packages, the /governance owner page)",
+    targets.every((t) => t.status === 200)
+      && targets[0].headers.get("x-ioi-surface-route") === "/studio"
+      && targets[1].headers.get("x-ioi-surface-route") === "/packages",
+    targets.map((t) => t.status).join("/"));
+
+  // -- context preservation: ?org= rides the projection AND every launch href --
+  const scoped = await pageText(`${CANONICAL}?org=${encodeURIComponent(OWNER)}`);
+  const scopedHrefs = launchHrefs(scoped.text);
+  ok("the ?org= scope is live: the projection answers for that org and EVERY launch href carries the scope forward",
+    scoped.status === 200 && scoped.text.includes(`org ${OWNER}`)
+      && scopedHrefs.length === 14 && scopedHrefs.every((h) => h.includes("org=")),
+    scopedHrefs[0] || "");
+  const studioHref = (scoped.text.match(/data-ioi-entry-name="Studio" data-ioi-launchable="true" href="([^"]*)"/u) || [])[1] || "";
+  const clickNav = await pageText(studioHref);
+  const deepLink = await pageText(`/studio?org=${encodeURIComponent(OWNER)}`);
+  ok("deep link ≡ click-nav: following the launcher's Studio href and requesting the directly constructed deep link land on the same surface with the same context",
+    studioHref === `/studio?org=${encodeURIComponent(OWNER)}`
+      && clickNav.status === 200 && deepLink.status === 200
+      && clickNav.headers.get("x-ioi-surface-route") === deepLink.headers.get("x-ioi-surface-route")
+      && clickNav.text.includes("Studio") && deepLink.text.includes("Studio"),
+    studioHref);
+  const badOrg = await pageText(`${CANONICAL}?org=${encodeURIComponent("org://not-a-member")}`, { authenticated: true });
+  ok("an org scope the caller does not hold renders the daemon's typed membership refusal with ZERO rows — the module never re-adjudicates scope",
+    badOrg.status === 200 && badOrg.text.includes("hypervisor.organization_membership_required")
+      && entryNames(badOrg.text).length === 0,
+    "");
+
+  // -- the reserved Embodied Systems registration -----------------------------
+  ok("Embodied Systems renders as the reserved registration row: declared nonlaunchable, planned typing from the compiler-owned registration source, the projection's typed reason verbatim",
+    landing.text.includes('data-ioi-entry-name="Embodied Systems" data-ioi-launchable="false" data-ioi-reserved="planned"')
+      && landing.text.includes("declared nonlaunchable")
+      && landing.text.includes("no_eligible_release_installation_or_serving_binding"),
+    "");
+  ok("the reserved row is never a launch link and never hidden",
+    !landing.text.includes('<a class="card launch" data-ioi-entry-name="Embodied Systems"')
+      && entryNames(landing.text).includes("Embodied Systems"),
+    "");
+
+  // -- folded owners never reappear as peers ----------------------------------
+  ok("retired owner names are absent from the served launcher (Missions / Marketplace / Workbench / Agent Studio) and no retired-owner defect row fired",
+    RETIRED_OWNER_NAMES.every((n) => !landing.text.includes(n))
+      && !landing.text.includes("data-ioi-retired-owner-defect"),
+    RETIRED_OWNER_NAMES.filter((n) => landing.text.includes(n)).join("|") || "clean");
+
+  // -- registry fixture: ODK mesh → candidate → release → installation --------
+  const ont = await jd("/v1/hypervisor/odk/domain-ontologies", {
+    method: "POST",
+    body: JSON.stringify({ domain: "applications-journey", owner_ref: OWNER, idempotency_key: "applications-journey-ont-1" }),
+  });
+  const ontRef = ont.body?.ontology?.ref || "";
+  const sd = await jd("/v1/hypervisor/odk/surface-descriptors", {
+    method: "POST",
+    body: JSON.stringify({ name: "Applications journey surface", composition_pattern: "domain_app", ontology_ref: ontRef, owner_ref: OWNER, idempotency_key: "applications-journey-sd-1" }),
+  });
+  const sdRef = sd.body?.surface_descriptor?.ref || "";
+  const man = await jd("/v1/hypervisor/odk/manifests", {
+    method: "POST",
+    body: JSON.stringify({ name: "Applications journey manifest", ontology_refs: [ontRef], recipe_refs: [], surface_descriptor_refs: [sdRef], owner_ref: OWNER, idempotency_key: "applications-journey-man-1" }),
+  });
+  const manRef = man.body?.manifest?.ref || "";
+  const dapp = await jd("/v1/hypervisor/domain-apps", {
+    method: "POST",
+    body: JSON.stringify({ name: "Applications journey app", surface_descriptor_ref: sdRef, odk_manifest_ref: manRef, owner_ref: OWNER, idempotency_key: "applications-journey-dapp-1" }),
+  });
+  const dappRef = dapp.body?.domain_app?.domain_app_ref || "";
+  ok("the ODK source mesh admits (ontology → domain_app descriptor → manifest → draft DomainApp)",
+    ont.status === 201 && sd.status === 201 && man.status === 201 && dapp.status === 201 && !!dappRef,
+    dappRef || `statuses ${ont.status}/${sd.status}/${man.status}/${dapp.status}`);
+  const candidate = await jd("/v1/hypervisor/packages", {
+    method: "POST",
+    body: JSON.stringify({ package_id: PKG, owner_ref: OWNER, domain_app_ref: dappRef, idempotency_key: "applications-journey-candidate-1" }),
+  });
+  const candidateHead = candidate.body?.package?.agentgres?.head || "";
+  const release = await jd(`/v1/hypervisor/packages/${PKG}/releases`, {
+    method: "POST",
+    body: JSON.stringify({
+      idempotency_key: "applications-journey-release-1",
+      expected_package_head: candidateHead,
+      surface_distribution: "private_registry",
+      surface_capability_depth: "propose",
+      object_contract_refs: ["object-model://applications-journey"],
+      action_contract_refs: ["action://applications-journey/propose"],
+      evidence_refs: ["artifact://applications-journey/conformance"],
+    }),
+  });
+  const releaseDigest = String(release.body?.release?.record?.release_ref || "").split("/release/").at(-1) || "";
+  const releaseHead = release.body?.release?.agentgres?.head || "";
+  const install = await jd(`/v1/hypervisor/packages/${PKG}/releases/${encodeURIComponent(releaseDigest)}/installations`, {
+    method: "POST",
+    body: JSON.stringify({
+      idempotency_key: "applications-journey-install-1",
+      expected_release_head: releaseHead,
+      installation_id: INST,
+      visibility: "organization",
+      allowed_object_contract_refs: ["object-model://applications-journey"],
+      allowed_action_refs: ["action://applications-journey/propose"],
+    }),
+  });
+  ok("the registry package admits end to end (candidate → immutable release → installed binding, receipts throughout)",
+    candidate.status === 201 && release.status === 201 && install.status === 201
+      && String(install.body?.installation?.agentgres?.receipt_ref || "").startsWith("receipt://"),
+    `statuses ${candidate.status}/${release.status}/${install.status}`);
+
+  // -- the installed row APPEARS with its typed ineligibility -----------------
+  const withInstall = await pageText(CANONICAL);
+  const installNames = entryNames(withInstall.text);
+  ok("the installed registry surface appears in the launcher on the very next read — inventory presence, never a launch claim",
+    withInstall.status === 200 && installNames.length === COMPILED_NAMES.length + 1
+      && installNames.includes(PKG) && withInstall.text.includes(SURFACE_REF),
+    `entries ${installNames.length}`);
+  ok("the registry row states its exact typed ineligibility: registry source, both derived reasons verbatim, installation facts, no launch href",
+    withInstall.text.includes(`data-ioi-entry-name="${PKG}" data-ioi-launchable="false"`)
+      && withInstall.text.includes("package registry")
+      && withInstall.text.includes("extension_application_registration_absent")
+      && withInstall.text.includes("surface_serving_binding_absent")
+      && withInstall.text.includes(`install://${PKG}/${INST}`)
+      && !withInstall.text.includes(`<a class="card launch" data-ioi-entry-name="${PKG}"`),
+    "");
+
+  // -- RECALL removes the row from /applications immediately ------------------
+  const recall = await jd(`/v1/hypervisor/packages/${PKG}/releases/${encodeURIComponent(releaseDigest)}/recall`, {
+    method: "POST",
+    body: JSON.stringify({
+      idempotency_key: "applications-journey-recall-1",
+      expected_release_head: releaseHead,
+      reason: "applications-journey: recall must remove the launcher row on the next read",
+    }),
+  });
+  ok("the release recall admits (immutable disposition successor active → recalled, receipted)",
+    recall.status === 200 || recall.status === 201,
+    `status ${recall.status}`);
+  const afterRecall = await pageText(CANONICAL);
+  const afterNames = entryNames(afterRecall.text);
+  ok("after recall the surface is GONE from /applications on the very next read — no row, no residue, the compiled catalog unchanged (absence is derived, not cleaned up)",
+    afterRecall.status === 200 && afterNames.length === COMPILED_NAMES.length
+      && !afterNames.includes(PKG) && !afterRecall.text.includes(SURFACE_REF)
+      && COMPILED_NAMES.every((n) => afterNames.includes(n)),
+    `entries ${afterNames.length}`);
+
+  // -- daemon outage: typed unavailability, ZERO fabricated rows --------------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  const down = await pageText(CANONICAL);
+  ok("daemon down: the launcher renders the typed unavailability page — degradation code named, zero rows, zero launchable claims, the no-fabrication rule stated",
+    down.status === 200 && down.text.includes("data-ioi-degraded=")
+      && entryNames(down.text).length === 0
+      && !down.text.includes('data-ioi-launchable="true"')
+      && down.text.includes("never fabricates launchability"),
+    `status ${down.status}`);
+  ok("daemon down: no static inventory leaks into the catalog (no compiled names render as rows)",
+    !down.text.includes("data-ioi-entry-name="),
+    "");
+
+  // -- daemon back: truth returns, recall survives restart --------------------
+  await startDaemon();
+  let back = { status: 0, text: "" };
+  for (let attempt = 0; attempt < 5; attempt++) {
+    await new Promise((r) => setTimeout(r, 1200));
+    back = await pageText(CANONICAL);
+    if (back.status === 200 && entryNames(back.text).length === COMPILED_NAMES.length) break;
+  }
+  const backNames = entryNames(back.text);
+  ok("daemon restarted: compiled truth returns (15 rows, 14 launchable) and the recalled surface STAYS absent — the launcher-feed loss is derived from admitted truth, not process state",
+    back.status === 200 && backNames.length === COMPILED_NAMES.length
+      && launchHrefs(back.text).length === 14
+      && !backNames.includes(PKG) && !back.text.includes(SURFACE_REF),
+    `entries ${backNames.length}`);
+
+  // -- 3-posture matrix -------------------------------------------------------
+  let pw = null;
+  try { pw = await import("playwright"); } catch { pw = null; }
+  if (!pw) {
+    ok("posture matrix skipped — playwright unavailable", false, "install playwright to run the browser matrix");
+  } else {
+    const browser = await pw.chromium.launch();
+    for (const [name, opts] of [
+      ["light-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "light" }],
+      ["dark-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "dark" }],
+      ["narrow-reduced-motion", { viewport: { width: 390, height: 844 }, colorScheme: "light", reducedMotion: "reduce" }],
+    ]) {
+      const ctx = await browser.newContext(opts);
+      const page = await ctx.newPage();
+      const errors = [];
+      page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+      const resp = await page.goto(`${SERVE}${CANONICAL}`, { waitUntil: "networkidle", timeout: 45000 }).catch(() => null);
+      const body = resp ? await page.evaluate(() => document.body.innerText) : "";
+      await page.keyboard.press("Tab");
+      const focused = resp ? await page.evaluate(() => document.activeElement?.tagName ?? "") : "";
+      ok(`posture ${name}: renders, keyboard-focusable, zero console errors`,
+        resp && resp.status() === 200 && body.length > 0 && errors.length === 0 && focused !== "" && focused !== "BODY",
+        errors[0]?.slice(0, 100) ?? `focus ${focused}`);
+      await ctx.close();
+    }
+    await browser.close();
+  }
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  cleanup();
+  process.exit(1);
+});
+
+function cleanup() {
+  try { serve?.kill("SIGTERM"); } catch { /* gone */ }
+  try { daemon?.kill("SIGTERM"); } catch { /* gone */ }
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* keep */ }
+}

--- a/apps/hypervisor/surfaces/applications/index.mjs
+++ b/apps/hypervisor/surfaces/applications/index.mjs
@@ -1,0 +1,272 @@
+// Applications — the canonical /applications greenfield launcher (next-legs III Leg 3).
+//
+// GREENFIELD, TYPED NON-PARITY: no provenance-qualified seed exists for this surface — two
+// recovery passes promoted zero candidates — so this build rides the owner-authorized
+// greenfield-authorized-non-parity lane recorded in apps/hypervisor/seed-ux-provenance.v1.json.
+// It claims no seed preservation and no parity; it is canon-first over
+// docs/architecture/components/hypervisor/core-clients-surfaces.md ("one catalog/compiler
+// projection", § Product-Surface Compiler, § Hypervisor Applications).
+//
+// READ-ONLY BY CONTRACT: launch is NAVIGATION over a compiled projection, never a mutation.
+// The module declares zero actions; every admission-class verb (install / enable / recall /
+// mount / serve) is authority-crossing and lives with its owner (Packages, Governance) — this
+// surface renders their consequences, it never performs them.
+//
+// ONE truth source, two reads, both through the shared read client on the REQUEST-scoped
+// daemon capability (typed degradation, no caching, refusals verbatim):
+//
+//   1. POST /v1/hypervisor/product-surface-projections — THE compiler projection
+//      (lifecycle_routes.rs handle_product_surface_projection). Its application_entries are
+//      the launcher's ONLY membership authority: the compiled first-party registrations
+//      (registration → admitted+active release → installed+enabled installation for the
+//      request org → serving binding; `launchable` requires all three) JOINED live with the
+//      package-registry namespace (installed, non-uninstalled bindings on non-recalled
+//      releases, org-scoped, `entry_source: "hypervisor-package-registry"`). A recalled or
+//      uninstalled surface is ABSENT by derivation on every read — recall removes the row
+//      immediately, and after restart, because there is no row state to clean up. Registry
+//      unreadability is the daemon's typed 503 (hypervisor.package_registry_projection_
+//      unavailable) and renders verbatim — never a silently thinner catalog.
+//   2. GET /v1/hypervisor/core-taxonomy — the compiler-owned registration source. The
+//      projection entry deliberately carries no availability field, so the reserved/planned
+//      typing of a registration (Embodied Systems: `surface_availability: "planned"`) is read
+//      from the taxonomy's application_registrations and joined by surface_ref. That is stated
+//      on the page: the reservation TYPING comes from the registration source; the
+//      nonlaunchability itself is projection truth (no release exists, so `launchable: false`
+//      with the projection's own typed reason).
+//
+// HONESTY RULES this module holds:
+//   - Rows render EXACTLY the projection truth: launchable rows link the projection's own
+//     resolved_launch_route (with the caller's ?org= scope carried through — launch and deep
+//     link preserve context); ineligible rows are disabled with the exact
+//     disabled_reason_codes verbatim; reserved registrations render declared-nonlaunchable,
+//     never hidden, never a coming-soon tile.
+//   - Daemon outage → a typed unavailability page with ZERO rows. This launcher deliberately
+//     renders NO static fallback inventory: a launcher row implies launch adjudication and an
+//     outage never fabricates launchability (the W0.2 shell navigation band separately keeps
+//     its safe static NAV inventory — navigation is not launchability).
+//   - Folded owners never reappear as peers. The estate's retired owner names (Missions →
+//     Work; the storefront owner → the Packages optional mode; the old workbench and
+//     agent-studio owner names → Developer Workspace / Studio) are a refusal set: a projection
+//     entry carrying one would render as a typed defect refusal, never as a peer row.
+import { escHtml } from "../kit.mjs";
+
+const esc = escHtml;
+const LEGACY_ROUTE = "/__ioi/applications-launcher";
+const CANONICAL_ROUTE = "/applications";
+const PROJECTION_PATH = "/v1/hypervisor/product-surface-projections";
+const TAXONOMY_PATH = "/v1/hypervisor/core-taxonomy";
+const PROJECTION_SCHEMA = "ioi.hypervisor.product_surface_projection.v1";
+const TAXONOMY_SCHEMA = "ioi.runtime.hypervisor_core_taxonomy.v2";
+const REGISTRY_ENTRY_SOURCE = "hypervisor-package-registry";
+
+export const meta = {
+  slug: "applications",
+  route: LEGACY_ROUTE,
+  verifier: "scripts/verify-hypervisor-applications-journey.mjs",
+  certification: "n/a",
+};
+
+// The folded-owner refusal set. These names owned surfaces once and were folded into canonical
+// owners (taxonomy retired_routes; canon § Hypervisor Applications: Missions → Work,
+// Marketplace → the Packages optional mode, Workbench → Developer Workspace, Agent Studio →
+// Studio); they survive in the estate only as tool-surface EVIDENCE rows (surface-registry.mjs
+// `owner` strings), never as catalog peers. This module renders server-side, so these constants
+// never reach the served page: a retired name appears in launcher HTML only if the projection
+// emits one — and then only inside the typed defect refusal below, never as a peer row.
+const RETIRED_OWNER_NAMES = new Set(["Missions", "Marketplace", "Workbench", "Agent Studio"]);
+
+// ---------------------------------------------------------------------------------------------
+// load — both reads ride the caller's own identity envelope when the runtime supplies the
+// request-scoped capability; anonymous stays anonymous (the daemon adjudicates scope, the
+// module never re-implements policy). The ?org= query parameter IS the live scope selector:
+// it rides the projection request as org_ref, the daemon adjudicates membership (a caller
+// outside the org gets the typed hypervisor.organization_membership_required refusal,
+// rendered verbatim), and every launch href carries it forward so launch and direct deep
+// link preserve the same context.
+export async function load(ctx) {
+  const { createReadClient } = await import("../read-client.mjs");
+  const client = typeof ctx.daemonFetch === "function"
+    ? createReadClient({ daemon: "", fetchImpl: ctx.daemonFetch })
+    : createReadClient({ daemon: ctx.daemon });
+  const org = (ctx.url.searchParams.get("org") || "").trim();
+  const body = { context: { launcher: "applications" } };
+  if (org) body.org_ref = org;
+  const projection = await client.read(PROJECTION_PATH, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    expectSchema: PROJECTION_SCHEMA,
+  });
+  const taxonomy = await client.read(TAXONOMY_PATH, { expectSchema: TAXONOMY_SCHEMA });
+  return { projection, taxonomy, org };
+}
+
+// No actions, deliberately: launch is navigation. Admission-class verbs are authority-crossing
+// and belong to their owners; declaring one here would mint a second mutation path.
+export const actions = [];
+
+// ---------------------------------------------------------------------------------------------
+const pill = (cls, label) => `<span class="pill ${cls}">${esc(label)}</span>`;
+const reasonCodes = (codes) => (Array.isArray(codes) && codes.length
+  ? codes.map((c) => `<code>${esc(String(c))}</code>`).join(" ")
+  : "—");
+
+function withOrg(route, org) {
+  return org ? `${route}${route.includes("?") ? "&" : "?"}org=${encodeURIComponent(org)}` : route;
+}
+
+// Availability join over the compiler-owned registration source (see header note 2).
+function availabilityBySurfaceRef(taxonomy) {
+  if (!taxonomy?.ok) return null;
+  const rows = Array.isArray(taxonomy.payload?.application_registrations)
+    ? taxonomy.payload.application_registrations
+    : [];
+  const map = new Map();
+  for (const row of rows) {
+    if (typeof row?.surface_ref === "string") map.set(row.surface_ref, row);
+  }
+  return map;
+}
+
+// The typed zero-row outage page. `result` is the read client's degraded result for the
+// projection read — its code/message (and the daemon's own refusal body, when one exists)
+// render verbatim. Nothing else renders: no rows, no static inventory, no launch state.
+function unavailableView(result) {
+  const refusal = result?.refusal && typeof result.refusal === "object"
+    ? `<pre>${esc(JSON.stringify(result.refusal, null, 2))}</pre>`
+    : "";
+  return `<div class="empty" data-ioi-degraded="${esc(result?.code || "daemon_unavailable")}">
+      <b>The compiled projection is unavailable</b> — <code>${esc(result?.code || "daemon_unavailable")}</code>
+      <div style="margin-top:6px">${esc(result?.message || "the daemon did not answer")}</div>
+    </div>
+    ${refusal}
+    <p class="sub" style="margin-top:14px">Zero rows are rendered. A launcher row implies launch adjudication, and this surface never fabricates launchability: membership and launch state come only from <code>POST ${esc(PROJECTION_PATH)}</code>. The catalog returns when the compiler answers.</p>`;
+}
+
+function workspaceBand(entries, org) {
+  const links = (entries || []).map((w) => {
+    const route = typeof w.canonical_route === "string" ? w.canonical_route : "";
+    const label = w.display_name || route;
+    if (!route) return pill("muted", label);
+    return `<a class="pill muted" style="text-decoration:none" data-ioi-workspace-name="${esc(label)}" href="${esc(withOrg(route, org))}">${esc(label)}</a>`;
+  });
+  return `<div class="band" aria-label="Core workspaces">
+      <span class="bandlabel">Core workspaces</span>
+      <div class="pills">${links.join("")}</div>
+    </div>`;
+}
+
+// One catalog row, rendered with its exact projection truth. `registration` is the taxonomy
+// registration row for this surface_ref (or undefined), `taxonomyDegraded` names the
+// registration-source outage when the availability join could not be read.
+function entryRow(entry, { org, registration, taxonomyDegraded }) {
+  const name = String(entry.display_name || entry.identity_ref || "");
+  if (RETIRED_OWNER_NAMES.has(name)) {
+    // Folded owners never reappear as peers — a typed refusal row, never a launch link.
+    return `<div class="card defect" data-ioi-retired-owner-defect="${esc(name)}">
+        <div class="main"><div class="name">retired owner name refused</div>
+        <div class="meta">the projection emitted a folded owner name as a peer entry — this launcher refuses to render it as an application; the canonical owner carries this surface (defect: report against the compiler feed)</div></div>
+      </div>`;
+  }
+  const fromRegistry = entry.entry_source === REGISTRY_ENTRY_SOURCE;
+  const reserved = registration?.surface_availability === "planned";
+  const launchRoute = typeof entry.resolved_launch_route === "string" && entry.resolved_launch_route.startsWith("/")
+    ? entry.resolved_launch_route
+    : null;
+  const launchable = entry.launchable === true && launchRoute !== null;
+  const sourcePill = fromRegistry ? pill("muted", "package registry") : pill("muted", "compiled registration");
+  const identity = `<div class="meta"><code>${esc(String(entry.identity_ref || ""))}</code>${entry.canonical_route ? ` · <code>${esc(String(entry.canonical_route))}</code>` : ""}</div>`;
+  if (launchable) {
+    const href = withOrg(launchRoute, org);
+    return `<a class="card launch" data-ioi-entry-name="${esc(name)}" data-ioi-launchable="true" href="${esc(href)}">
+        <div class="main"><div class="name">${esc(name)}${sourcePill}</div>${identity}
+        <div class="meta">launch → <code>${esc(href)}</code>${entry.surface_capability_depth ? ` · depth ${esc(String(entry.surface_capability_depth))}` : ""}${entry.surface_operational_state ? ` · ${esc(String(entry.surface_operational_state))}` : ""}</div></div>
+        <span class="pill ok">launchable</span>
+      </a>`;
+  }
+  if (reserved) {
+    return `<div class="card" data-ioi-entry-name="${esc(name)}" data-ioi-launchable="false" data-ioi-reserved="planned">
+        <div class="main"><div class="name">${esc(name)}${sourcePill}${pill("warn", "reserved · planned")}</div>${identity}
+        <div class="meta">declared nonlaunchable — a reserved registration row, rendered so it is never hidden and never a coming-soon tile. The <code>surface_availability: "planned"</code> typing is read from the compiler-owned registration source (<code>GET ${esc(TAXONOMY_PATH)}</code> · application_registrations); the projection entry itself carries no availability field — its own truth is <code>launchable: false</code> with the typed reason below, because no release exists for this registration.</div>
+        <div class="meta">reasons: ${reasonCodes(entry.disabled_reason_codes)}</div></div>
+        <span class="pill warn">nonlaunchable</span>
+      </div>`;
+  }
+  // Ineligible row — the projection's exact typed reasons, verbatim. Registry-sourced entries
+  // additionally carry their eligibility facts (installation/release refs, enablement,
+  // disposition) so the row states WHY it is inventory without being launchable.
+  const registryFacts = fromRegistry
+    ? `<div class="meta">${pill("muted", `installation ${String(entry.surface_installation_state || "—")}`)}${pill("warn", String(entry.surface_enablement_state || "—"))}${entry.release_disposition ? pill(entry.release_disposition === "active" ? "ok" : "warn", `release ${String(entry.release_disposition)}`) : ""}</div>
+       <div class="meta"><code>${esc(String(entry.installation_ref || ""))}</code> · <code>${esc(String(entry.release_ref || ""))}</code></div>`
+    : "";
+  const typingNote = taxonomyDegraded && !fromRegistry
+    ? `<div class="meta">registration-source read unavailable (<code>${esc(taxonomyDegraded)}</code>) — reservation typing unknown for this render; the reasons above are projection truth</div>`
+    : "";
+  return `<div class="card" data-ioi-entry-name="${esc(name)}" data-ioi-launchable="false">
+      <div class="main"><div class="name">${esc(name)}${sourcePill}</div>${identity}
+      <div class="meta">reasons: ${reasonCodes(entry.disabled_reason_codes)}</div>${registryFacts}${typingNote}</div>
+      <span class="pill warn">not launchable</span>
+    </div>`;
+}
+
+// ---------------------------------------------------------------------------------------------
+export function render(model, ctx) {
+  const onLegacyMount = ctx.url.pathname.startsWith("/__ioi/");
+  const base = onLegacyMount ? LEGACY_ROUTE : CANONICAL_ROUTE;
+  const org = model.org || "";
+  const projection = model.projection;
+  let bodyHtml;
+  if (!projection?.ok) {
+    bodyHtml = unavailableView(projection);
+  } else {
+    const payload = projection.payload || {};
+    const availability = availabilityBySurfaceRef(model.taxonomy);
+    const taxonomyDegraded = availability === null ? (model.taxonomy?.code || "daemon_unavailable") : null;
+    const entries = Array.isArray(payload.application_entries) ? payload.application_entries : [];
+    const rows = entries.map((entry) => entryRow(entry, {
+      org,
+      registration: availability?.get(String(entry.identity_ref || "")),
+      taxonomyDegraded,
+    })).join("");
+    const scope = `<div class="band" aria-label="Scope">
+        <span class="bandlabel">Scope</span>
+        <div class="pills">${pill("muted", `org ${payload.org_ref || "—"}`)}${pill("muted", `principal ${payload.principal_ref || "—"}`)}${org ? `<a class="pill muted" style="text-decoration:none" href="${esc(base)}">clear org scope</a>` : ""}</div>
+      </div>`;
+    const catalog = entries.length
+      ? rows
+      : `<div class="empty">The compiled projection returned zero application entries — honest absence, nothing is substituted.</div>`;
+    bodyHtml = `${workspaceBand(payload.workspace_entries, org)}${scope}
+      <h2 id="catalog">Application catalog</h2>
+      ${catalog}
+      <div class="foot">Membership and launch state: <code>POST ${esc(PROJECTION_PATH)}</code> (projection <code>${esc(String(payload.projection_id || "—"))}</code>, read-model-only). Reservation typing: <code>GET ${esc(TAXONOMY_PATH)}</code>${taxonomyDegraded ? ` — unavailable this render (<code>${esc(taxonomyDegraded)}</code>)` : ""}. Registry-sourced rows are inventory truth, never launchability; a recalled or uninstalled surface is absent by derivation on every read.</div>`;
+  }
+  const head = `<h1>Applications</h1>
+    <p class="sub">The one catalog/compiler projection. Every row below is compiler truth for this exact request — launchable rows navigate to their surface (launch is navigation, never a mutation); ineligible rows state their exact typed reasons; reserved registrations render declared-nonlaunchable. This surface is a greenfield build on the typed non-parity lane (<code>seed-ux-provenance.v1.json</code>): it claims no seed preservation and no parity.</p>`;
+  const css = `:root{color-scheme:dark}
+  body{margin:0;background:#0c0d10;color:#e6e7ea;font:14px/1.55 -apple-system,Segoe UI,Roboto,sans-serif}
+  .wrap{max-width:980px;margin:0 auto;padding:32px 24px 80px}
+  a{color:#8ab4ff}
+  h1{font-size:26px;margin:0 0 6px;letter-spacing:-.02em}
+  .sub{color:#9a9da6;margin:0 0 22px;max-width:820px}
+  h2{font-size:13px;letter-spacing:.04em;text-transform:uppercase;color:#878a93;margin:26px 0 10px;font-weight:600}
+  .band{display:flex;align-items:baseline;gap:12px;margin:0 0 10px;flex-wrap:wrap}
+  .bandlabel{font-size:11.5px;letter-spacing:.04em;text-transform:uppercase;color:#6f7280;white-space:nowrap}
+  .pills{display:flex;flex-wrap:wrap;gap:6px}
+  .card{display:flex;align-items:center;gap:14px;padding:13px 16px;border:1px solid #24262d;border-radius:12px;background:#15171c;margin-bottom:8px;text-decoration:none;color:inherit}
+  a.card.launch:hover{border-color:#3a82f6;background:#191b21}
+  .card.defect{border-color:#5c2323;background:#221111}
+  .card .main{flex:1;min-width:0}
+  .card .name{font-weight:600;color:#fff}
+  .card .meta{color:#878a93;font-size:12.5px;margin-top:3px;overflow-wrap:anywhere}
+  .pill{display:inline-block;padding:2px 9px;border-radius:999px;font-size:11px;border:1px solid;white-space:nowrap;margin-left:6px}
+  .ok{color:#46c277;border-color:#235c3b;background:#11281b}
+  .warn{color:#d6a13a;border-color:#5c4a23;background:#28220f}
+  .muted{color:#9a9da6;border-color:#2a2c33}
+  .empty{color:#6f7280;padding:18px;border:1px dashed #24262d;border-radius:12px}
+  code{font-size:11.5px;color:#aab;background:#0e0f13;padding:1px 5px;border-radius:4px}
+  pre{background:#0e0f13;border:1px solid #24262d;border-radius:8px;padding:12px;overflow:auto;font:11.5px/1.5 ui-monospace,monospace;color:#cdd1d8;white-space:pre-wrap;word-break:break-all}
+  .foot{color:#6f7280;font-size:12.5px;margin-top:28px;border-top:1px solid #1b1d23;padding-top:14px}
+  @media(max-width:700px){.wrap{padding:24px 14px 56px}.card{align-items:flex-start}}`;
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Applications · Hypervisor</title><style>${css}</style></head>
+<body><div class="wrap">${head}${bodyHtml}</div></body></html>`;
+}

--- a/docs/architecture/_meta/shipped-products.v1.json
+++ b/docs/architecture/_meta/shipped-products.v1.json
@@ -59,6 +59,7 @@
         "inventory_version": 1,
         "routes": [
           "/",
+          "/__ioi/applications-launcher",
           "/__ioi/automations-cockpit",
           "/__ioi/automations/monitors",
           "/__ioi/data/sources",
@@ -107,8 +108,8 @@
           "/work/new-session",
           "/work/sessions"
         ],
-        "expected_count": 48,
-        "sha256": "a07ccd566c3f5e9bdd9d1a588d73518fb12ae8e866e183a492ed59b682ebb78a",
+        "expected_count": 49,
+        "sha256": "5eb52f183d4b702f55dd702a56bc4a1c0659f96742034f956301fd7ea1ba9c4e",
         "browser_verification_id": "served-surface-smoke"
       },
       "state_authority_mode": "daemon_authoritative_projection",
@@ -339,7 +340,7 @@
           {
             "path": "apps/hypervisor-web/src/site/WorkerTraining.jsx",
             "contains": [
-              "fixture result · not production"
+              "fixture result \u00b7 not production"
             ]
           }
         ]


### PR DESCRIPTION
The Applications greenfield packet (next-legs III Leg 3), STACKED on #239 (`w2.1/recall-launcher-join`) — the module consumes the launcher-feed join that PR lands.

**Greenfield, typed non-parity.** No provenance-qualified seed exists for this surface (two recovery passes promoted zero candidates); the build rides the owner-authorized `greenfield-authorized-non-parity` lane already typed in `apps/hypervisor/seed-ux-provenance.v1.json`. It claims no seed preservation and no parity — canon-first over `core-clients-surfaces.md` ("one catalog/compiler projection").

## What lands

- **`apps/hypervisor/surfaces/applications/index.mjs`** — canonical `/applications` + fresh legacy lane `/__ioi/applications-launcher` (the `/__ioi/applications` T2 readout keeps serving untouched until W4). **READ-ONLY BY CONTRACT**: launch is navigation; zero actions declared — admission-class verbs stay with their owners. Membership + launch state come ONLY from `POST /v1/hypervisor/product-surface-projections` (compiled registrations joined live with the package registry): launchable rows link the projection's own `resolved_launch_route` with the `?org=` scope carried through every href; ineligible rows render the exact `disabled_reason_codes` verbatim plus registry eligibility facts; registry-unreadability (typed 503) and org-membership refusals render verbatim with zero rows.
- **Reserved registrations**: the projection entry carries no availability field, so Embodied Systems' `surface_availability: "planned"` typing is joined from the compiler-owned registration source (`GET /v1/hypervisor/core-taxonomy` → `application_registrations`) and stated as such on the row — declared nonlaunchable, never hidden, never a launch link; nonlaunchability itself stays projection truth (`launchable: false`, typed reason — no release exists).
- **Folded owners never reappear**: retired owner names (Missions / Marketplace / Workbench / Agent Studio) are a server-side refusal set — a projection entry carrying one would render as a typed defect refusal, never a peer row; the verifier asserts the served launcher contains none.
- **Daemon outage never fabricates launchability**: typed unavailability page with ZERO rows — deliberately no static fallback inventory here (a launcher row implies launch adjudication); the W0.2 shell nav band keeps its safe static NAV inventory separately.
- **`check:applications-journey` (27/27)** wired into package.json + the CI first-surface-journeys step: exact 15-row compiled enumeration; 14 launchable + href resolution; deep link ≡ click-nav under a live org scope; reserved row; retired names; install → typed ineligible row → **recall → row GONE on the very next read** → daemon kill/restart (outage fabricates nothing; recall absence survives restart); 3-posture matrix.
- **`shipped-products.v1.json`**: fresh legacy lane joins the served browser-route inventory (48 → 49, digest recomputed — recipe verified against the prior checked-in digest). `/applications` was already a shipped v2 route, now module-served. `v2-route-shell.mjs` `/applications` row records the rehome.

## Verification (daemon built from the base branch)

- `check:applications-journey` **27/27**
- Regressions: packages **49/49**, studio **33/33**, automations **44/44**, governance **20/20**; `test:hypervisor-app-clients`, `test:hypervisor-route-shell` green; `check:source-neutral`, `check:seed-provenance`, `check:owned-product-ui`, `check:shell-parity` 6/6, `check:ported-seed` 413/413
- Product-surfaces browser smoke green on both new mounts × 3 visual contexts; the full-suite run stops at the vendored-SPA `/` `WatchEvents ERR_ABORTED` flake — pre-existing, recorded identically on the untouched #235/#237 checkouts (noted, not fenced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
