### PR TITLE
test(hypervisor): WatchEvents typed fence — full-tuple allowance, retained near-miss predicate test, DEF-SPA-WATCHEVENTS-1 (next-legs IV Leg 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
           npm run test:hypervisor-domain-app-runtime
           npm run test:hypervisor-app-harness
           npm run test:vite-production-authority-scan
+          npm run test:smoke-fence
           npm run test:product-shell-auth --workspace=@ioi/hypervisor-app
 
       - name: Test marketplace authority, lifecycle, and recovery contracts

--- a/docs/architecture/_meta/canon-to-code-delta.md
+++ b/docs/architecture/_meta/canon-to-code-delta.md
@@ -306,6 +306,16 @@ has now cost a CI cycle beyond its three recorded local reproductions — it
 deserves an owner decision (documented single-endpoint allowance in the smoke,
 or an SPA teardown fix), not further reruns.
 
+### Typed defect fences (2026-08-11, next-legs IV Leg 1)
+
+The previous block's standing operational note on the WatchEvents smoke flake is
+now EXECUTED by owner decision — the documented single-endpoint allowance, typed
+and fenced, with the SPA teardown repair filed as the removal path:
+
+| Delta | Evidence | Disposition |
+|---|---|---|
+| **DEF-SPA-WATCHEVENTS-1 — vendored-SPA event-stream teardown race kills the product smoke.** Navigating the served UI's `/` route (final route `/projects`, a `vendor_spa` row in the canonical route table) intermittently records `POST /api/gitpod.v1.EventService/WatchEvents (net::ERR_ABORTED)` as a browser request failure; the product browser smoke treats every request failure as fatal, so one teardown race kills otherwise-green runs. | Four recorded reproductions on untouched master: PR #235, PR #237 (twice), PR #241 — plus one full CI cycle lost (run 31444686784). | **fenced-with-filed-fix.** The vendored SPA's event-stream teardown owns the repair (out of scope for the fence cut). Until it lands, `scripts/smoke-product-surfaces.mjs` admits EXACTLY the recorded tuple via the exported pure predicate `isFencedWatchEventsAbort` (`scripts/lib/watchevents-fence.mjs`): hypervisor served-UI lane + `vendor_spa` final-route disposition (the smoke's own `V2_ROUTE_TABLE` classification) + same served origin + exact pathname + `POST` + exactly `net::ERR_ABORTED`; anything failing ANY element still fails the smoke, and fenced events are reported per route (`fenced_request_failures`), never silent. The near-miss boundary is CI-pinned by the retained `test:smoke-fence` suite (`scripts/lib/watchevents-fence.test.mjs`). **REMOVAL CONDITION: the PR that lands the SPA event-stream teardown fix deletes the allowance, this row's fence, and the predicate module in the same cut, and flips the retained test to assert the WatchEvents abort no longer occurs.** |
+
 ## Related Canon
 
 - [`implementation-matrix.md`](./implementation-matrix.md) — per-concept durable-form index (the wider matrix).

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "smoke:implementation-daemon": "node scripts/smoke-implementation-daemon.mjs",
     "smoke:package-registry": "node scripts/smoke-package-registry.mjs",
     "smoke:product-surfaces": "node scripts/smoke-product-surfaces.mjs",
+    "test:smoke-fence": "node --test scripts/lib/watchevents-fence.test.mjs",
     "test:system-genesis-compiler": "cargo test --locked -p ioi-types system_genesis",
     "dev:web": "npm run dev --workspace=@ioi/hypervisor-app",
     "dev:benchmarks": "npm run dev --workspace=apps/benchmarks",

--- a/scripts/lib/watchevents-fence.mjs
+++ b/scripts/lib/watchevents-fence.mjs
@@ -1,0 +1,73 @@
+// DEF-SPA-WATCHEVENTS-1 — the typed WatchEvents fence (next-legs IV Leg 1).
+//
+// THE DEFECT: the vendored SPA served on the Hypervisor product lane tears down its
+// event stream nondeterministically during navigation, and the browser records
+//   POST http://<served-origin>/api/gitpod.v1.EventService/WatchEvents (net::ERR_ABORTED)
+// as a request failure. The product browser smoke treats every request failure as
+// fatal, so this single teardown race intermittently kills otherwise-green runs.
+//
+// RECORDED REPRODUCTIONS (all on untouched master): PR #235, PR #237 (twice),
+// PR #241 — four local reproductions — plus one full CI cycle lost
+// (run 31444686784). Filed as DEF-SPA-WATCHEVENTS-1 in
+// docs/architecture/_meta/canon-to-code-delta.md.
+//
+// THE FENCE: this predicate admits EXACTLY the recorded failure tuple and nothing
+// else. Every element must match:
+//   1. product lane  — the Hypervisor served-UI target ("hypervisor-owned-served-ui");
+//   2. route class   — the FINAL route (after any redirect) is a vendored-SPA route,
+//                      classified by the smoke's own route authority: the
+//                      V2_ROUTE_TABLE row disposition === "vendor_spa"
+//                      (apps/hypervisor/scripts/v2-route-shell.mjs);
+//   3. same origin   — the failed request targets the served origin itself;
+//   4. exact pathname — /api/gitpod.v1.EventService/WatchEvents;
+//   5. method        — POST;
+//   6. failure class — exactly "net::ERR_ABORTED".
+// A failure missing ANY element still fails the smoke. The fence is an allowance
+// for ONE known teardown race, never a blanket request-failure waiver.
+//
+// REMOVAL CONDITION: the real repair is the vendored SPA's event-stream teardown
+// (out of scope here). The PR that lands that teardown fix MUST, in the same cut:
+// delete this module and the smoke's use of it, flip the retained predicate test
+// (scripts/lib/watchevents-fence.test.mjs) to assert the WatchEvents abort no
+// longer occurs, and delete the DEF-SPA-WATCHEVENTS-1 ledger row.
+
+/** The one product lane the fence applies to — the Hypervisor served-UI target. */
+export const FENCED_PRODUCT_LANE = "hypervisor-owned-served-ui";
+
+/** The exact pathname of the fenced endpoint. */
+export const FENCED_WATCHEVENTS_PATHNAME =
+  "/api/gitpod.v1.EventService/WatchEvents";
+
+/** The exact browser failure class the fence admits. */
+export const FENCED_FAILURE_TEXT = "net::ERR_ABORTED";
+
+/**
+ * Full-tuple allowance for DEF-SPA-WATCHEVENTS-1. Pure — no I/O, no ambient state.
+ *
+ * @param {{ url?: string, method?: string, error_text?: string }} failure
+ *   One collected browser request failure: the request URL, its HTTP method, and
+ *   the Playwright failure errorText.
+ * @param {{ product_lane?: string, final_route_disposition?: string, served_origin?: string }} routeContext
+ *   The smoke's own classification of the inspected route: the target lane name,
+ *   the V2_ROUTE_TABLE disposition of the FINAL route the page landed on, and the
+ *   origin the target is served from.
+ * @returns {boolean} true ONLY when every tuple element matches the recorded defect.
+ */
+export function isFencedWatchEventsAbort(failure, routeContext) {
+  if (!failure || !routeContext) return false;
+  if (routeContext.product_lane !== FENCED_PRODUCT_LANE) return false;
+  if (routeContext.final_route_disposition !== "vendor_spa") return false;
+  if (typeof routeContext.served_origin !== "string") return false;
+  if (failure.method !== "POST") return false;
+  if (failure.error_text !== FENCED_FAILURE_TEXT) return false;
+  if (typeof failure.url !== "string") return false;
+  let requestUrl;
+  try {
+    requestUrl = new URL(failure.url);
+  } catch {
+    return false;
+  }
+  if (requestUrl.origin !== routeContext.served_origin) return false;
+  if (requestUrl.pathname !== FENCED_WATCHEVENTS_PATHNAME) return false;
+  return true;
+}

--- a/scripts/lib/watchevents-fence.test.mjs
+++ b/scripts/lib/watchevents-fence.test.mjs
@@ -1,0 +1,129 @@
+// DEF-SPA-WATCHEVENTS-1 near-miss boundary test — RETAINED while the fence stands.
+// The full-tuple allowance in scripts/lib/watchevents-fence.mjs admits exactly ONE
+// recorded browser failure (the vendored SPA's WatchEvents teardown race:
+// reproductions #235, #237 ×2, #241 + CI run 31444686784); every near-miss below
+// proves a failure missing ANY tuple element still fails the product smoke.
+// Run: npm run test:smoke-fence
+// REMOVAL CONDITION: the PR that lands the vendored SPA event-stream teardown fix
+// deletes the fence and FLIPS this file to assert the WatchEvents abort no longer
+// occurs in the smoke.
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  FENCED_FAILURE_TEXT,
+  FENCED_PRODUCT_LANE,
+  FENCED_WATCHEVENTS_PATHNAME,
+  isFencedWatchEventsAbort,
+} from "./watchevents-fence.mjs";
+import { V2_ROUTE_TABLE } from "../../apps/hypervisor/scripts/v2-route-shell.mjs";
+
+const SERVED_ORIGIN = "http://127.0.0.1:44173";
+
+const recordedFailure = () => ({
+  url: `${SERVED_ORIGIN}${FENCED_WATCHEVENTS_PATHNAME}`,
+  method: "POST",
+  error_text: FENCED_FAILURE_TEXT,
+});
+
+const recordedContext = () => ({
+  product_lane: FENCED_PRODUCT_LANE,
+  final_route_disposition: "vendor_spa",
+  served_origin: SERVED_ORIGIN,
+});
+
+// ------------------------------ the recorded tuple ------------------------------
+
+test("the exact recorded tuple PASSES the fence", () => {
+  assert.equal(isFencedWatchEventsAbort(recordedFailure(), recordedContext()), true);
+});
+
+// ------------------------------ near misses: the request ------------------------------
+
+test("wrong endpoint pathname FAILS (a different EventService verb)", () => {
+  const failure = recordedFailure();
+  failure.url = `${SERVED_ORIGIN}/api/gitpod.v1.EventService/ListEvents`;
+  assert.equal(isFencedWatchEventsAbort(failure, recordedContext()), false);
+});
+
+test("a pathname EXTENDING the fenced endpoint FAILS (exact match, not prefix)", () => {
+  const failure = recordedFailure();
+  failure.url = `${SERVED_ORIGIN}${FENCED_WATCHEVENTS_PATHNAME}/extra`;
+  assert.equal(isFencedWatchEventsAbort(failure, recordedContext()), false);
+});
+
+test("wrong method FAILS (GET to the same endpoint)", () => {
+  const failure = recordedFailure();
+  failure.method = "GET";
+  assert.equal(isFencedWatchEventsAbort(failure, recordedContext()), false);
+});
+
+test("wrong failure class FAILS (net::ERR_CONNECTION_REFUSED is a real outage, never fenced)", () => {
+  const failure = recordedFailure();
+  failure.error_text = "net::ERR_CONNECTION_REFUSED";
+  assert.equal(isFencedWatchEventsAbort(failure, recordedContext()), false);
+});
+
+test("a different origin FAILS (cross-origin WatchEvents is not the recorded defect)", () => {
+  const failure = recordedFailure();
+  failure.url = `http://127.0.0.1:9999${FENCED_WATCHEVENTS_PATHNAME}`;
+  assert.equal(isFencedWatchEventsAbort(failure, recordedContext()), false);
+});
+
+test("a host-spelling origin mismatch FAILS (localhost is not the served 127.0.0.1 origin)", () => {
+  const failure = recordedFailure();
+  failure.url = `http://localhost:44173${FENCED_WATCHEVENTS_PATHNAME}`;
+  assert.equal(isFencedWatchEventsAbort(failure, recordedContext()), false);
+});
+
+test("an unparseable request URL FAILS closed", () => {
+  const failure = recordedFailure();
+  failure.url = "not a url";
+  assert.equal(isFencedWatchEventsAbort(failure, recordedContext()), false);
+});
+
+// ------------------------------ near misses: the route context ------------------------------
+
+test("an owned-surface (non-vendor) final route FAILS — shell disposition", () => {
+  const context = recordedContext();
+  context.final_route_disposition = "shell";
+  assert.equal(isFencedWatchEventsAbort(recordedFailure(), context), false);
+});
+
+test("an unclassified final route FAILS closed (null disposition)", () => {
+  const context = recordedContext();
+  context.final_route_disposition = null;
+  assert.equal(isFencedWatchEventsAbort(recordedFailure(), context), false);
+});
+
+test("a different product lane FAILS (only the Hypervisor served UI is fenced)", () => {
+  const context = recordedContext();
+  context.product_lane = "aiagent-xyz";
+  assert.equal(isFencedWatchEventsAbort(recordedFailure(), context), false);
+});
+
+test("a missing served origin FAILS closed", () => {
+  const context = recordedContext();
+  delete context.served_origin;
+  assert.equal(isFencedWatchEventsAbort(recordedFailure(), context), false);
+});
+
+// ------------------------------ the classification source ------------------------------
+
+test("the fence's route classification is the smoke's own: V2_ROUTE_TABLE dispositions", () => {
+  const dispositionByRoute = Object.fromEntries(
+    V2_ROUTE_TABLE.map((surface) => [
+      surface.route,
+      surface.disposition ?? "shell",
+    ]),
+  );
+  assert.equal(
+    dispositionByRoute["/projects"],
+    "vendor_spa",
+    "the '/' route's declared final path /projects must be a vendor_spa row — the recorded defect's route class",
+  );
+  assert.equal(
+    dispositionByRoute["/governance"],
+    "shell",
+    "an owned surface row stays outside the fence",
+  );
+});

--- a/scripts/smoke-product-surfaces.mjs
+++ b/scripts/smoke-product-surfaces.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
 import { SURFACES } from "../apps/hypervisor/scripts/surface-registry.mjs";
 import { V2_ROUTE_TABLE } from "../apps/hypervisor/scripts/v2-route-shell.mjs";
+import { isFencedWatchEventsAbort } from "./lib/watchevents-fence.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const shippedProductsManifestPath = path.join(
@@ -1033,6 +1034,16 @@ try {
   hypervisorTarget.routePatternByRoute = Object.fromEntries(
     hypervisorRoutes.map((route) => [route, route]),
   );
+  // DEF-SPA-WATCHEVENTS-1: the smoke's own route classification, verbatim from the
+  // canonical route table — a FINAL route is a vendored-SPA route exactly when its
+  // V2_ROUTE_TABLE row declares disposition "vendor_spa" (e.g. "/" lands on
+  // /projects, a vendor_spa row). Consumed by the typed WatchEvents fence below.
+  hypervisorTarget.routeDispositionByRoute = Object.fromEntries(
+    V2_ROUTE_TABLE.map((surface) => [
+      surface.route,
+      surface.disposition ?? "shell",
+    ]),
+  );
   assertManifestRoutes(hypervisorTarget, hypervisorRoutes);
   const expectedVisualRows =
     contexts.length *
@@ -1073,9 +1084,14 @@ try {
       }
     });
     page.on("requestfailed", (request) => {
-      requestFailures.push(
-        `${request.url()} (${request.failure()?.errorText ?? "failed"})`,
-      );
+      // Collected structured so the DEF-SPA-WATCHEVENTS-1 fence can match the full
+      // tuple (url, method, failure class) at the error gate below; every failure
+      // outside that one tuple still fails the smoke with the original message.
+      requestFailures.push({
+        url: request.url(),
+        method: request.method(),
+        error_text: request.failure()?.errorText ?? "failed",
+      });
     });
     page.on("response", (response) => {
       if (response.status() >= 400) {
@@ -1242,17 +1258,37 @@ try {
     const unexpectedResponseFailures = responseFailures.filter(
       (failure) => !target.namedGaps?.has(failure.key),
     );
+    // DEF-SPA-WATCHEVENTS-1 typed fence: the vendored SPA's event-stream teardown
+    // race (POST /api/gitpod.v1.EventService/WatchEvents → net::ERR_ABORTED on the
+    // served origin, hypervisor lane, vendor_spa final route) is admitted by the
+    // full-tuple predicate and reported, never fatal. Reproductions: #235, #237 ×2,
+    // #241 + CI run 31444686784. REMOVAL: deleted in the same PR that lands the SPA
+    // event-stream teardown fix (see scripts/lib/watchevents-fence.mjs).
+    const fenceRouteContext = {
+      product_lane: target.name,
+      final_route_disposition:
+        target.routeDispositionByRoute?.[finalPath] ?? null,
+      served_origin: new URL(url).origin,
+    };
+    const fencedRequestFailures = requestFailures.filter((failure) =>
+      isFencedWatchEventsAbort(failure, fenceRouteContext),
+    );
+    const unexpectedRequestFailures = requestFailures.filter(
+      (failure) => !isFencedWatchEventsAbort(failure, fenceRouteContext),
+    );
     if (
       pageErrors.length > 0 ||
       consoleErrors.length > 0 ||
-      requestFailures.length > 0 ||
+      unexpectedRequestFailures.length > 0 ||
       unexpectedResponseFailures.length > 0
     ) {
       throw new Error(
         `${contextSpec.name} ${url} emitted browser errors: ${[
           ...pageErrors,
           ...consoleErrors,
-          ...requestFailures,
+          ...unexpectedRequestFailures.map(
+            (failure) => `${failure.url} (${failure.error_text})`,
+          ),
           ...unexpectedResponseFailures.map((failure) => failure.message),
         ].join("; ")}`,
       );
@@ -1279,6 +1315,10 @@ try {
       named_gaps: responseFailures
         .filter((failure) => target.namedGaps?.has(failure.key))
         .map((failure) => failure.key),
+      fenced_request_failures: fencedRequestFailures.map(
+        (failure) =>
+          `${failure.method} ${failure.url} (${failure.error_text}) [DEF-SPA-WATCHEVENTS-1]`,
+      ),
       semantic_assertions: semanticAssertions,
       owner_contract: ownerContract || null,
       final_path: finalPath,


### PR DESCRIPTION
## What

The vendored SPA's event-stream teardown race — `POST /api/gitpod.v1.EventService/WatchEvents (net::ERR_ABORTED)` on the served origin while the smoke inspects a vendored-SPA route — has killed four otherwise-green runs on untouched master (#235, #237 twice, #241) and one full CI cycle (run 31444686784). The real repair is the SPA's event-stream teardown and stays out of scope; until it lands, this cut fences EXACTLY the recorded failure tuple, typed and CI-pinned (next-legs IV Leg 1, owner-authorized; executes the standing operational note filed by the Journey verification III block).

## The fence (full tuple, nothing wider)

`isFencedWatchEventsAbort(failure, routeContext)` — an exported pure predicate in `scripts/lib/watchevents-fence.mjs` — admits a browser request failure only when ALL of:

1. product lane is the Hypervisor served UI (`hypervisor-owned-served-ui`);
2. the FINAL route (after redirect, e.g. `/` → `/projects`) is a vendored-SPA route by the smoke's own classification — the `V2_ROUTE_TABLE` row `disposition === "vendor_spa"` (`apps/hypervisor/scripts/v2-route-shell.mjs`), carried onto the target as `routeDispositionByRoute`;
3. the failed request is same-origin with the served origin;
4. pathname is exactly `/api/gitpod.v1.EventService/WatchEvents`;
5. method is `POST`;
6. failure text is exactly `net::ERR_ABORTED`.

A failure missing ANY element still fails the smoke. Request failures are now collected structured (url, method, errorText); fenced events are recorded per route in the report as `fenced_request_failures` — reported, never silent. Unfenced failures keep the original error-message format.

## Retained near-miss boundary test

`scripts/lib/watchevents-fence.test.mjs` (13 tests, `npm run test:smoke-fence`, wired into the CI "Verify product client contracts" step of the browser-smoke job): the exact tuple passes; wrong endpoint, extended pathname, wrong method, wrong failure class (`ERR_CONNECTION_REFUSED`), different origin, host-spelling origin mismatch, unparseable URL, owned-surface (shell) route, unclassified route, wrong product lane, and missing served origin all FAIL; plus a grounding test pinning the classification source (`/projects` is `vendor_spa`; `/governance` is not).

## Ledger

`docs/architecture/_meta/canon-to-code-delta.md` — new typed-defect-fences block with row **DEF-SPA-WATCHEVENTS-1**, disposition **fenced-with-filed-fix**. REMOVAL CONDITION (stated in the row, the predicate module, and the test): the PR that lands the SPA event-stream teardown fix deletes the allowance, the fence row, and the predicate module in the same cut, and flips the retained test to assert the abort no longer occurs.

## Proof

- `npm run test:smoke-fence` — 13/13 green.
- `npm run smoke:product-surfaces` — full local run green: 323 route renders passed, AND the flake reproduced live during the run — three fenced WatchEvents aborts (`light /`, `light /projects`, `narrow /`, all final path `/projects`) admitted by the tuple and recorded in `fenced_request_failures`, while every other failure class stayed fatal. The fence is live-proven, not just unit-proven.
- `node scripts/check-architecture-docs.mjs` — green (177 files, 8 rules; work-item records OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
