### PR TITLE
fix(hypervisor): seed-gate repairs — select-value state signatures + capture-time re-establishment + goto hardening; schema/sources re-derived (next-legs IV Leg 2)

### DIFF
--- a/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
+++ b/apps/hypervisor/scripts/capture-hypervisor-seed-route-graph.mjs
@@ -46,6 +46,13 @@ const SHOTS = process.env.IOI_SEED_SHOTS_DIR ?? path.join(repoRoot, ".artifacts"
 const SCHEMA = "ioi.hypervisor.seed-interaction-route-graph.v1";
 const MAX_NODES = Number(opt("--max-nodes", "400"));
 const MAX_CONTROLS_PER_NODE = Number(opt("--max-controls", "80"));
+// Warm-up hardening (seed-gate repairs, 2026-08-11): a cold serve under crawl
+// load can miss one navigation window entirely ("no response") while the same
+// route probes 200 out-of-band — that minted false unreachable-route blockers.
+// Timeouts are tool internals, parametrized here; a genuine HTTP error (>=400)
+// is a product fact and is never retried.
+const GOTO_TIMEOUT_MS = Number(opt("--goto-timeout", "45000"));
+const SETTLE_RETRY_MS = Number(opt("--settle-retry-ms", "3000"));
 
 const surface = opt("--surface");
 if (!surface) die(1, "--surface is required");
@@ -141,6 +148,18 @@ const neutralizeStrings = (value) => {
   return value;
 };
 
+// One settle-and-retry pass separates serve warm-up from a genuinely dead
+// route: retry ONLY when there was no response at all (timeout/connection),
+// never on an HTTP status, and never while a download is the real outcome.
+const makeGotoSettled = (pg, downloadPending) => async (url, timeout = GOTO_TIMEOUT_MS) => {
+  let resp = await pg.goto(url, { waitUntil: "domcontentloaded", timeout }).catch(() => null);
+  if (!resp && !downloadPending()) {
+    await pg.waitForTimeout(SETTLE_RETRY_MS);
+    resp = await pg.goto(url, { waitUntil: "domcontentloaded", timeout }).catch(() => null);
+  }
+  return resp;
+};
+
 async function reachable(url) {
   try {
     const res = await fetch(url, { method: "GET", redirect: "manual" });
@@ -225,7 +244,20 @@ async function stateSignature(page) {
       "|" + [...document.forms].map((f) => f.getAttribute("action") || "").sort().join("&");
     let hh = 0;
     for (let i = 0; i < hidden.length; i++) hh = ((hh << 5) - hh + hidden.charCodeAt(i)) | 0;
-    return `${location.pathname}${location.search}#open=${open}#fc=${formControls}#hf=${hh}|${texts.join("|")}`.slice(0, 800);
+    // Visible <select> and checked-radio VALUES are user-reachable state: a
+    // section select re-targets a sibling GET form without changing the URL,
+    // hidden fields, headings or control counts (schema n11 / sources n1
+    // residuals, 2026-08-10). Record them (bounded, sorted) so select-value
+    // state mints distinct nodes instead of silently contradictory edges.
+    const chosen = [...document.querySelectorAll("select")].filter(visible)
+      .map((el) => `s:${el.name || el.id}=${String(el.value).slice(0, 40)}`)
+      .concat([...document.querySelectorAll("input[type=radio]")]
+        .filter((el) => visible(el) && el.checked)
+        .map((el) => `r:${el.name || el.id}=${String(el.value).slice(0, 40)}`))
+      .sort().join("&");
+    let sv = 0;
+    for (let i = 0; i < chosen.length; i++) sv = ((sv << 5) - sv + chosen.charCodeAt(i)) | 0;
+    return `${location.pathname}${location.search}#open=${open}#fc=${formControls}#hf=${hh}#sv=${sv}|${texts.join("|")}`.slice(0, 800);
   });
 }
 
@@ -250,6 +282,45 @@ async function capture() {
   page.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text().slice(0, 200)); });
   let pendingDownload = null;
   page.on("download", (d) => { pendingDownload = d.suggestedFilename(); d.cancel().catch(() => {}); });
+  const gotoSettled = makeGotoSettled(page, () => pendingDownload !== null);
+  const nodeRecById = new Map(); // id -> node record (for capture-time establishment)
+
+  // A node under crawl must be LIVE before any of its controls is clicked: the
+  // crawl leaves the page wherever the previous node's processing ended, so
+  // without re-establishment the first click of a dequeued node fires against a
+  // stale DOM and mints misattributed edges (the schema n11 "Filter" and
+  // sources n1 select residuals, 2026-08-10). Route nodes goto their URL;
+  // state nodes replay their entry-edge chain — exactly the discipline
+  // interaction replay's establish() already enforces on the other side.
+  async function establishForCrawl(current) {
+    const rec = nodeRecById.get(current.nodeId);
+    if (rec && (await stateSignature(page)) === rec.signature) return true; // already live
+    if (!rec || rec.kind === "route") {
+      const resp = await gotoSettled(current.url);
+      if (!resp || resp.status() >= 400) return false;
+      await page.waitForTimeout(600);
+      return true;
+    }
+    const chain = [];
+    let cur = rec;
+    let guard = 0;
+    while (cur && cur.kind !== "route" && guard++ < 12) {
+      if (!cur.entry_edge?.control || !nodeRecById.has(cur.entry_edge.from)) return false;
+      chain.unshift(cur.entry_edge.control);
+      cur = nodeRecById.get(cur.entry_edge.from);
+    }
+    if (!cur || cur.kind !== "route") return false;
+    const resp = await gotoSettled(new URL(cur.url, SERVE).toString());
+    if (!resp || resp.status() >= 400) return false;
+    await page.waitForTimeout(900);
+    for (const control of chain) {
+      const clicked = await page.locator(CONTROL_SELECTOR).nth(control.index)
+        .click({ timeout: 4000 }).then(() => true).catch(() => false);
+      if (!clicked) return false;
+      await page.waitForTimeout(700);
+    }
+    return true;
+  }
 
   async function snapshotNode(kind, entryEdge) {
     const signature = await stateSignature(page);
@@ -270,11 +341,12 @@ async function capture() {
       screenshot: { sha256: digest, posture: "1440x900-light" },
       console_errors: consoleErrors.splice(0).slice(0, 10),
     });
+    nodeRecById.set(id, nodes.at(-1));
     return { id, fresh: true, census };
   }
 
-  const startResp = await page.goto(startUrl, { waitUntil: "domcontentloaded", timeout: 30000 })
-    .catch((e) => { die(2, `BLOCKED: cannot open ${startUrl}: ${e.message}`); });
+  const startResp = await gotoSettled(startUrl);
+  if (!startResp) die(2, `BLOCKED: cannot open ${startUrl}: no response (after settle retry)`);
   await page.waitForTimeout(2500);
   if (startResp && startResp.status() >= 400) {
     blockers.push({ kind: "start-route-error", node: "n0", reason: `HTTP ${startResp.status()} at ${ownedRoute}` });
@@ -286,6 +358,13 @@ async function capture() {
   while (frontier.length > 0 && nodes.length < MAX_NODES) {
     const current = frontier.shift();
     const census = current.census;
+    if (!(await establishForCrawl(current))) {
+      blockers.push({
+        kind: "state-reestablish-failed", node: current.nodeId,
+        reason: `cannot re-establish ${current.nodeId} (${current.url.replace(SERVE, "")}) before crawling its ${census.length} controls`,
+      });
+      continue;
+    }
     if (census.length > MAX_CONTROLS_PER_NODE) {
       blockers.push({
         kind: "control-census-overflow", node: current.nodeId,
@@ -315,11 +394,20 @@ async function capture() {
         }
         visitedUrls.add(target.toString());
         pendingDownload = null;
-        const resp = await page.goto(target.toString(), { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+        const resp = await gotoSettled(target.toString());
         await page.waitForTimeout(1200);
         if (pendingDownload) {
           edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "download", detail: pendingDownload });
           blockers.push({ kind: "download-instead-of-ux", node: current.nodeId, reason: `${target.pathname} starts a download (${pendingDownload})` });
+        } else if (!resp && page.url() === target.toString()) {
+          // Same-document navigation (fragment-only link): Playwright's goto
+          // returns no response object by design, but the document never left —
+          // the landed URL proves it. Record the real navigation instead of
+          // minting a false unreachable-route blocker (sources "View all"
+          // #sources-catalog, 2026-08-11).
+          const snap = await snapshotNode("route", { from: current.nodeId, control });
+          edges.push({ from: current.nodeId, to: snap.id, control, action: "goto", outcome: "navigated" });
+          if (snap.fresh) frontier.push({ nodeId: snap.id, url: page.url(), census: snap.census ?? (await censusOf(page)) });
         } else if (!resp || resp.status() >= 400) {
           edges.push({ from: current.nodeId, to: null, control, action: "goto", outcome: "error", detail: resp ? `HTTP ${resp.status()}` : "no response" });
           blockers.push({ kind: "unreachable-route", node: current.nodeId, reason: `${target.pathname}: ${resp ? `HTTP ${resp.status()}` : "no response"}` });
@@ -328,8 +416,7 @@ async function capture() {
           edges.push({ from: current.nodeId, to: snap.id, control, action: "goto", outcome: "navigated" });
           if (snap.fresh) frontier.push({ nodeId: snap.id, url: page.url(), census: snap.census ?? (await censusOf(page)) });
         }
-        await page.goto(current.url, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
-        await page.waitForTimeout(600);
+        await establishForCrawl(current);
         continue;
       }
       // Non-link control: click, classify the outcome, recover.
@@ -348,11 +435,13 @@ async function capture() {
       await page.waitForTimeout(900);
       if (!clicked) {
         edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "unclickable" });
+        await establishForCrawl(current); // the retry Escape may have closed a state node's overlay
         continue;
       }
       if (blockedWrites.length > writesBefore) {
         edges.push({ from: current.nodeId, to: null, control, action: "click", outcome: "blocked-write-attempt", detail: blockedWrites.at(-1) });
         await page.keyboard.press("Escape").catch(() => {});
+        await establishForCrawl(current);
         continue;
       }
       if (pendingDownload) {
@@ -374,17 +463,16 @@ async function capture() {
           frontier.push({ nodeId: snap.id, url: page.url(), census: snap.census ?? (await censusOf(page)) });
         }
       }
-      // Recover to the node under crawl: Escape for overlays, goto for navigation.
+      // Recover to the node under crawl: Escape for overlays, then full
+      // re-establishment (a same-URL DOM leak — e.g. a changed select — is
+      // invisible to a URL check but poisons every subsequent edge).
       await page.keyboard.press("Escape").catch(() => {});
-      if (!page.url().startsWith(current.url)) {
-        await page.goto(current.url, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
-        await page.waitForTimeout(600);
-      }
+      await establishForCrawl(current);
     }
     // Back-stack probe from this node.
     await page.goBack({ timeout: 8000 }).then(() => edges.push({ from: current.nodeId, to: "back-stack", control: null, action: "back", outcome: "navigated" })).catch(() =>
       edges.push({ from: current.nodeId, to: null, control: null, action: "back", outcome: "noop" }));
-    await page.goto(current.url, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+    await gotoSettled(current.url).catch(() => null);
   }
   if (frontier.length > 0) {
     blockers.push({ kind: "node-cap-reached", node: null, reason: `${frontier.length} unexplored nodes beyond --max-nodes ${MAX_NODES}` });
@@ -398,10 +486,11 @@ async function capture() {
     const pctx = await browser.newContext({ viewport: vp, colorScheme, reducedMotion });
     await installQuarantine(pctx, []);
     const ppage = await pctx.newPage();
+    const pGoto = makeGotoSettled(ppage, () => false);
     for (const node of nodes.filter((n) => n.kind === "route")) {
       const target = new URL(node.url, SERVE).toString();
-      const ok = await ppage.goto(target, { waitUntil: "domcontentloaded", timeout: 20000 }).then((r) => r && r.status() < 400).catch(() => false);
-      if (!ok) continue;
+      const resp = await pGoto(target);
+      if (!(resp && resp.status() < 400)) continue;
       await ppage.waitForTimeout(800);
       const png = await ppage.screenshot({ fullPage: false });
       const digest = sha(png);
@@ -462,6 +551,7 @@ async function replay() {
   const page = await context.newPage();
   let pendingDownload = null;
   page.on("download", (d) => { pendingDownload = d.suggestedFilename(); d.cancel().catch(() => {}); });
+  const gotoSettled = makeGotoSettled(page, () => pendingDownload !== null);
 
   const problems = [];
   const nodeById = new Map(graph.nodes.map((n) => [n.id, n]));
@@ -484,7 +574,7 @@ async function replay() {
   const establish = async (node) => {
     const p = pathTo(node);
     if (!p) return false;
-    const resp = await page.goto(new URL(p.route.url, SERVE).toString(), { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+    const resp = await gotoSettled(new URL(p.route.url, SERVE).toString());
     if (!resp || resp.status() >= 400) return false;
     await page.waitForTimeout(900);
     for (const control of p.chain) {
@@ -524,7 +614,7 @@ async function replay() {
       if (edge.action === "goto") {
         const target = edge.to ? nodeById.get(edge.to) : null;
         if (edge.outcome === "navigated" && target) {
-          const resp = await page.goto(new URL(target.url, SERVE).toString(), { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => null);
+          const resp = await gotoSettled(new URL(target.url, SERVE).toString());
           await page.waitForTimeout(800);
           if (!resp || resp.status() >= 400) {
             problems.push(`edge ${node.id}->${edge.to}: target ${target.url} unreachable (${resp ? `HTTP ${resp.status()}` : "no response"})`);

--- a/apps/hypervisor/seed-graphs/data/pipeline.v1.json
+++ b/apps/hypervisor/seed-graphs/data/pipeline.v1.json
@@ -5,18 +5,18 @@
   "owned_route": "/__ioi/pipeline",
   "capture_route": null,
   "runtime": {
-    "serve_url": "http://127.0.0.1:4173",
+    "serve_url": "http://127.0.0.1:40637",
     "capture_url": null
   },
-  "captured_at": "2026-08-10T01:21:19.780Z",
+  "captured_at": "2026-08-11T12:09:30.529Z",
   "quarantine": {
     "network_policy": "local-only",
     "corpus_mutation": "denied",
     "html_injection": "denied",
     "spa_fallback": "denied",
     "allowed_origins": [
-      "http://127.0.0.1:4173",
-      "http://localhost:4173",
+      "http://127.0.0.1:40637",
+      "http://localhost:40637",
       "http://127.0.0.1:9225",
       "http://localhost:9225"
     ],
@@ -26,24 +26,24 @@
     {
       "id": "n0",
       "kind": "route",
-      "signature": "/__ioi/pipeline#open=2|",
+      "signature": "/__ioi/pipeline#open=2#fc=1#hf=124#sv=0|",
       "url": "/__ioi/pipeline",
       "title": "Pipeline Builder",
       "entry_edge": null,
-      "controls": 60,
+      "controls": 52,
       "disabled_controls": 22,
       "screenshot": {
-        "sha256": "0f59490bd5b3e7d2e79e4dfb24713818fae7554f2b6bfb94c84f687b1c5e265b",
+        "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "0f59490bd5b3e7d2e79e4dfb24713818fae7554f2b6bfb94c84f687b1c5e265b",
+          "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "a64210bd760d57529af8619b6e7ba8346b8a96af357600e047b7d21bc508728e",
+          "sha256": "2d002128c13f3fc086bc4ed26bc19a93382f90029d48081313fb224686dff346",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -51,8 +51,8 @@
     {
       "id": "n1",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n0",
@@ -60,25 +60,25 @@
           "index": 5,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+          "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
           "disabled": false,
           "label": "Preview"
         }
       },
-      "controls": 68,
-      "disabled_controls": 31,
+      "controls": 52,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "3c965257aa0fb2387554233366a5343c79b110865986372097094f5560bcbb24",
+        "sha256": "a0122e119800647db7f27f759f8310896674e3dfa55b1ffd22a2fb4670253c89",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "3c965257aa0fb2387554233366a5343c79b110865986372097094f5560bcbb24",
+          "sha256": "a0122e119800647db7f27f759f8310896674e3dfa55b1ffd22a2fb4670253c89",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "04e8989c75f2ed1145a0f97813d540a0e935c8b9c35dfc98480849a6da40b595",
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -86,8 +86,8 @@
     {
       "id": "n2",
       "kind": "route",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+      "signature": "/__ioi/pipeline?panel=search#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n0",
@@ -95,25 +95,25 @@
           "index": 28,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+          "href": "/__ioi/pipeline?panel=search",
           "disabled": false,
           "label": "Search pipeline — the right panel becomes the real record search"
         }
       },
-      "controls": 58,
+      "controls": 50,
       "disabled_controls": 21,
       "screenshot": {
-        "sha256": "c3ef9b9bde08142ce23c1d843e9def1bc694cd648ef831ef7b75d0c613d2bbb7",
+        "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "c3ef9b9bde08142ce23c1d843e9def1bc694cd648ef831ef7b75d0c613d2bbb7",
+          "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "80c56be988f0a72d77a932f8b1c7ecaf8521b82ec4d6010a55053ba3be2cf48f",
+          "sha256": "a514b8da169f45d7c75a412d9e8e8271a9ca93438464939060b5d51a522acd3b",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -121,7 +121,7 @@
     {
       "id": "n3",
       "kind": "state",
-      "signature": "/__ioi/pipeline?legend=0#open=1|",
+      "signature": "/__ioi/pipeline?legend=0#open=1#fc=1#hf=124#sv=0|",
       "url": "/__ioi/pipeline?legend=0",
       "title": "Pipeline Builder",
       "entry_edge": {
@@ -135,54 +135,119 @@
           "label": "Toggle legend"
         }
       },
-      "controls": 55,
+      "controls": 47,
       "disabled_controls": 21,
       "screenshot": {
-        "sha256": "20f765b1f71914f1be7f7dfe0b4c473d7b452e310cfbc03612d7c22f8abbe1ef",
+        "sha256": "270ff12dc81fb08e1dd2571ab0a9eba04317b61b61d80e45f0c9836967645926",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
       "id": "n4",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=input#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n0",
         "control": {
-          "index": 40,
-          "tag": "a",
+          "index": 34,
+          "tag": "button",
           "role": null,
-          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+          "href": null,
           "disabled": false,
-          "label": "probe-reencode"
+          "label": "Hide this color"
         }
       },
-      "controls": 60,
+      "controls": 52,
       "disabled_controls": 22,
       "screenshot": {
-        "sha256": "0f59490bd5b3e7d2e79e4dfb24713818fae7554f2b6bfb94c84f687b1c5e265b",
+        "sha256": "fd80d8465df79c36a8cd327ab5fd2f6493d719704b13f7a84e70dbb021c3fdb1",
         "posture": "1440x900-light"
       },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "0f59490bd5b3e7d2e79e4dfb24713818fae7554f2b6bfb94c84f687b1c5e265b",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "a64210bd760d57529af8619b6e7ba8346b8a96af357600e047b7d21bc508728e",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
+      "console_errors": []
     },
     {
       "id": "n5",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=clean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=clean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "86bca95bf5c30f1a66700b263108ce1664b2bb12d8bf07b2a6706a0587154177",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n6",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=calc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=calc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "2d6c279e17cc12394884fb556a25fbb432b1608ce998664450c300c6ca51aa23",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n7",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=output#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=output",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n0",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "b217a87115da7fde8f16f074358def2cfeccdb054f73e4021694bdd84a49df3d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n8",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7#open=2|",
-      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+      "signature": "/__ioi/pipeline?tab=suggestions#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n0",
@@ -190,130 +255,25 @@
           "index": 41,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+          "href": "/__ioi/pipeline?tab=suggestions",
           "disabled": false,
-          "label": "Datasource"
+          "label": "Suggestions"
         }
       },
-      "controls": 74,
-      "disabled_controls": 32,
+      "controls": 50,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "bf48622bcd242d22377d53d803b2bed5de7646b2e39e16bcd61ea0673bcd1bc0",
+        "sha256": "d733a89e950a3b58aa0f8f0d0c9ef77189e726b3cdbb097d16e57189994b75a1",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "bf48622bcd242d22377d53d803b2bed5de7646b2e39e16bcd61ea0673bcd1bc0",
+          "sha256": "d733a89e950a3b58aa0f8f0d0c9ef77189e726b3cdbb097d16e57189994b75a1",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "6b4c77944af56832698480c4678b00eaf4d309c6d376bbeaeecda81b42a96f61",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n6",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7#open=2|",
-      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n0",
-        "control": {
-          "index": 42,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-          "disabled": false,
-          "label": "Object mapping"
-        }
-      },
-      "controls": 74,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "d90828302d6e7a8c6987424387c672fb23e44ff5205ac83dd64e8d91c126d4ce",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "d90828302d6e7a8c6987424387c672fb23e44ff5205ac83dd64e8d91c126d4ce",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "b10a19959f4889fd82ce17a28f1244e65a55a2dfab44e7570c965b2ccc79ddad",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n7",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7#open=2|",
-      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n0",
-        "control": {
-          "index": 43,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
-          "disabled": false,
-          "label": "Policy gate"
-        }
-      },
-      "controls": 74,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "e9492b9d4805e12a7c344f7eea815747c93bd74910940309bba02eb0a112efa1",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "e9492b9d4805e12a7c344f7eea815747c93bd74910940309bba02eb0a112efa1",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "008e67eb8580adacc362aae36c896b86f4069cbe05eaf91f42a0fc55f132250c",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n8",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7#open=2|",
-      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n0",
-        "control": {
-          "index": 44,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
-          "disabled": false,
-          "label": "Transform plan"
-        }
-      },
-      "controls": 74,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "d2fb4a001340cdaccaa262fd2d58d59ba745befd518a65a8046f178131c94786",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "d2fb4a001340cdaccaa262fd2d58d59ba745befd518a65a8046f178131c94786",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "cfffb44e7e9ad611357059fd063384b84bd9da6efbd95843f1308c505c058411",
+          "sha256": "24c5ee897a27beea4f7d4281f260facc1b14141f69e7f39e95fb240bffeec09b",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -321,34 +281,34 @@
     {
       "id": "n9",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7#open=2|",
-      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+      "signature": "/__ioi/pipeline?tab=warnings#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=warnings",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n0",
         "control": {
-          "index": 45,
+          "index": 42,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+          "href": "/__ioi/pipeline?tab=warnings",
           "disabled": false,
-          "label": "Read projection"
+          "label": "Pipeline warnings"
         }
       },
-      "controls": 74,
-      "disabled_controls": 32,
+      "controls": 56,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "6b6cd598a5350a3ff715a948ca5f7e3f3e9c52d72376172f3ce6ed738136f537",
+        "sha256": "6ffddaed6750b89dd169cb2edfd5950c606f20e2e8f066544405dec3191d5aa8",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "6b6cd598a5350a3ff715a948ca5f7e3f3e9c52d72376172f3ce6ed738136f537",
+          "sha256": "6ffddaed6750b89dd169cb2edfd5950c606f20e2e8f066544405dec3191d5aa8",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "a95a386f189dff8783e7e900b078527e1ba5eba8ef3214aea9c929f4a8325220",
+          "sha256": "74fb4782b377226f62934956ea050c0b7c3bb17d1a588e8fc6bc508cbed41b83",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -356,34 +316,34 @@
     {
       "id": "n10",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7#open=2|",
-      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+      "signature": "/__ioi/pipeline?panel=tree#open=2#fc=0#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=tree",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n0",
         "control": {
-          "index": 46,
+          "index": 51,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+          "href": "/__ioi/pipeline?panel=tree",
           "disabled": false,
-          "label": "Lease + session"
+          "label": "Pipeline file tree — the real ladder-record tree"
         }
       },
-      "controls": 74,
-      "disabled_controls": 32,
+      "controls": 50,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "d3e78102c5139602fac8200c04644540e23f92619084ee51418ea8ce3f01b9ae",
+        "sha256": "b51e646295b240fe26e6ea51cdeede0fad64019c924f8a085aecfa8bc5d62933",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "d3e78102c5139602fac8200c04644540e23f92619084ee51418ea8ce3f01b9ae",
+          "sha256": "b51e646295b240fe26e6ea51cdeede0fad64019c924f8a085aecfa8bc5d62933",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "c79aed01e54b4cc5267f378e40e30054ea4b7b688ee965f6c6c415b95feb711e",
+          "sha256": "5b7d7c9df9027584f9fb05011b33d9a89a196f403bb097daf9a04b57faac74b5",
           "posture": "390x844-light-reduced-motion"
         }
       ]
@@ -391,183 +351,8 @@
     {
       "id": "n11",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n0",
-        "control": {
-          "index": 47,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-          "disabled": false,
-          "label": "Materialized objects"
-        }
-      },
-      "controls": 74,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "ce98919f63165943823adb64a5b3b2f6aa9d16af8b3a4f2672d044bac400209f",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "ce98919f63165943823adb64a5b3b2f6aa9d16af8b3a4f2672d044bac400209f",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "e508b921602e8d2d049207523ee3035d2f42dc7339dcc2d722c68ac8e6e4772c",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n12",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n0",
-        "control": {
-          "index": 49,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
-          "disabled": false,
-          "label": "Suggestions"
-        }
-      },
-      "controls": 58,
-      "disabled_controls": 22,
-      "screenshot": {
-        "sha256": "7e791fdb527f71c0ee00232ddb021e33205d93b776a1d9b859f27a617c66778d",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "7e791fdb527f71c0ee00232ddb021e33205d93b776a1d9b859f27a617c66778d",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "a941e38f7d7bcba816c8b0093ae0bea408a7463f35cb827ede6b1c6cc477d565",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n13",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n0",
-        "control": {
-          "index": 50,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
-          "disabled": false,
-          "label": "Pipeline warnings"
-        }
-      },
-      "controls": 64,
-      "disabled_controls": 22,
-      "screenshot": {
-        "sha256": "bd73fba1c2e99f83a57e244320268b06a98f7c5395303e5d4a6c1b3965912493",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "bd73fba1c2e99f83a57e244320268b06a98f7c5395303e5d4a6c1b3965912493",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "8ce465fccd9f866187689c41551f100c2a024e0e6d54385e28f4eb060d73a5a5",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n14",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n0",
-        "control": {
-          "index": 59,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
-          "disabled": false,
-          "label": "Pipeline file tree — the real ladder-record tree"
-        }
-      },
-      "controls": 58,
-      "disabled_controls": 21,
-      "screenshot": {
-        "sha256": "1211ad5150f02936db6e4c222341fdd25e2c0eb1e3ec6b77f42fec43d496cddb",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "1211ad5150f02936db6e4c222341fdd25e2c0eb1e3ec6b77f42fec43d496cddb",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "59b556b42deac5bc9ea5a85bff6f0eea4e97693584665963b3897417bfc6e306",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n15",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n1",
-        "control": {
-          "index": 28,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview",
-          "disabled": false,
-          "label": "Search pipeline — the right panel becomes the real record search"
-        }
-      },
-      "controls": 66,
-      "disabled_controls": 30,
-      "screenshot": {
-        "sha256": "1bf82062b3dfdc6310162dc4e9a0aaa92a0e0dca8348a2bd97a1d7ae85667f66",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "1bf82062b3dfdc6310162dc4e9a0aaa92a0e0dca8348a2bd97a1d7ae85667f66",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "8710d0d8f2e5629921af4722d1cff3c018effa77199434d3d7a89ff4dec894c5",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n16",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&legend=0#open=1|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&legend=0#pb-preview",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&legend=0#pb-preview",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n1",
@@ -580,29 +365,29 @@
           "label": "Toggle legend"
         }
       },
-      "controls": 63,
-      "disabled_controls": 30,
+      "controls": 47,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "6e8c9c0941749a3ed3d2066bb36b262ec1c85ba48743eb632ed7df713374a2d9",
+        "sha256": "0e3de2a0ea575d511b578c645d59bb6f72c57498b6dc6d8b73c267f7b6c7d884",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "daca982fe96f4a2c415785fe1577ed232571ddcb3da5a263016c1af833534ee9",
+          "sha256": "6d0340dfe6c6655f92a3c7eaa39fa7e8f4ba8f7d18e1d5ec50da0a9dab0dbcf5",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "04e8989c75f2ed1145a0f97813d540a0e935c8b9c35dfc98480849a6da40b595",
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n17",
+      "id": "n12",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=input#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=input#pb-preview",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=input#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=input#pb-preview",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n1",
@@ -615,29 +400,29 @@
           "label": "Hide this color"
         }
       },
-      "controls": 67,
-      "disabled_controls": 31,
+      "controls": 52,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "5c478f387b5bfe995f3f4ca4943a3426e3ff70def2faab0ff6ce0f3c281d52d6",
+        "sha256": "f4989a422a83a517fbedbe8dc39225443ebef76e7faaa812e2e126f1abd046e7",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "5c478f387b5bfe995f3f4ca4943a3426e3ff70def2faab0ff6ce0f3c281d52d6",
+          "sha256": "f4989a422a83a517fbedbe8dc39225443ebef76e7faaa812e2e126f1abd046e7",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "04e8989c75f2ed1145a0f97813d540a0e935c8b9c35dfc98480849a6da40b595",
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n18",
+      "id": "n13",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=clean#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=clean#pb-preview",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=clean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=clean#pb-preview",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n1",
@@ -650,29 +435,29 @@
           "label": "Hide this color"
         }
       },
-      "controls": 66,
-      "disabled_controls": 31,
+      "controls": 52,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "77a4fcbd13f8e14f8df63cb1fca15b8308bbb8a94d24443cf79c22f9b534f497",
+        "sha256": "b4e2574f180fdc4376c2c861b49aca541a7ad32a28735801e804b286a36ce8b2",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "77a4fcbd13f8e14f8df63cb1fca15b8308bbb8a94d24443cf79c22f9b534f497",
+          "sha256": "b4e2574f180fdc4376c2c861b49aca541a7ad32a28735801e804b286a36ce8b2",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "04e8989c75f2ed1145a0f97813d540a0e935c8b9c35dfc98480849a6da40b595",
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n19",
+      "id": "n14",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=calc#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=calc#pb-preview",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=calc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=calc#pb-preview",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n1",
@@ -685,29 +470,29 @@
           "label": "Hide this color"
         }
       },
-      "controls": 65,
-      "disabled_controls": 31,
+      "controls": 52,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "7a5b8d93a8ddbe917a65f43454d72cad90898f1a1cb9194dc6b517c3f6ebc706",
+        "sha256": "72a24a98bd0a2b6134abe7b6aeb8cbb04dd156db8165dc0f45b03a36180d697c",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "7a5b8d93a8ddbe917a65f43454d72cad90898f1a1cb9194dc6b517c3f6ebc706",
+          "sha256": "72a24a98bd0a2b6134abe7b6aeb8cbb04dd156db8165dc0f45b03a36180d697c",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "4fda88767bd67dfd7baef455ee6fc33112737902eed1deb365ec1d9a127facc0",
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n20",
+      "id": "n15",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=output#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview&hide=output#pb-preview",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=output#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=output#pb-preview",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n1",
@@ -720,274 +505,64 @@
           "label": "Hide this color"
         }
       },
-      "controls": 67,
-      "disabled_controls": 31,
+      "controls": 52,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "c8a2ddf0d45d90ed584ac0395493252cb26a0bd745ba55ce115710bd65824e01",
+        "sha256": "ab518f84512d96b90731da33913e285a1001bfc597d2a8c05334c656fb0788c0",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "e1dd3585e2a761e36e64fd104e4e122801b23be6f8ee0ebdaf297bfaaa0d63f4",
+          "sha256": "7f7dc969e04795497266af2f736b97ea4f0343cc4886ed8d43719f4e136eac9c",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "b15ffc3d7bdb088c9c93605bcf9f06d31905d724e525807b91d5b04a3343d7ef",
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n21",
+      "id": "n16",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
-      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview",
+      "signature": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n1",
+        "from": "n2",
         "control": {
-          "index": 41,
+          "index": 5,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview",
+          "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
           "disabled": false,
-          "label": "Datasource"
+          "label": "Preview"
         }
       },
-      "controls": 68,
-      "disabled_controls": 31,
+      "controls": 50,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "6abcb20c040f503ab1dcb3b618de4441ea0e32564547b2647e4571297953e71e",
+        "sha256": "a39ce4836072deed4e0a5ec9d2cfd13c675031b8e93bcaab4eb9517fed574acf",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "6abcb20c040f503ab1dcb3b618de4441ea0e32564547b2647e4571297953e71e",
+          "sha256": "a39ce4836072deed4e0a5ec9d2cfd13c675031b8e93bcaab4eb9517fed574acf",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "8418ed733f449eba7b629ba8f0c7fe0cc28a39e977455eae9bfd772bed1cd60a",
+          "sha256": "410e65e355dcb19e091db50b9fac0d4a68500dfd32e28185a8cc8f1078b26e28",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n22",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
-      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n1",
-        "control": {
-          "index": 42,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview",
-          "disabled": false,
-          "label": "Object mapping"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "4f6f670e065803dbb4f2889629797fdb73c056f81c35d9d10a3c72b8408b6f4d",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "4f6f670e065803dbb4f2889629797fdb73c056f81c35d9d10a3c72b8408b6f4d",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "9e1c7c54762551f8b406101b9cb12f1f50eb1791610f80c519beca76d56c61b4",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n23",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
-      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n1",
-        "control": {
-          "index": 43,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview",
-          "disabled": false,
-          "label": "Policy gate"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "176c8201bada21ad1416351bb91035b47a726210739c7d1c7a3edc62661bb4c6",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "176c8201bada21ad1416351bb91035b47a726210739c7d1c7a3edc62661bb4c6",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "339e887432907d923a779f4c374b0c9c32fe8e991c5cb6cba09bedc31ae2310f",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n24",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
-      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n1",
-        "control": {
-          "index": 44,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview",
-          "disabled": false,
-          "label": "Transform plan"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "06cf13aab2a762786b40e54a33e88463d767bce1705b436a38514e788c442345",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "06cf13aab2a762786b40e54a33e88463d767bce1705b436a38514e788c442345",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "3fa049f63f42872ad9f9a80ffedf915bfdd0b85bb59027dca6695ac6abb7800f",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n25",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
-      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n1",
-        "control": {
-          "index": 45,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview",
-          "disabled": false,
-          "label": "Read projection"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "1e5de1aa327bb35d9c46bb9de0944e6bb4f53f5a5116f357eef9b8dc284d4e2f",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "1e5de1aa327bb35d9c46bb9de0944e6bb4f53f5a5116f357eef9b8dc284d4e2f",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "ab014727dd579bc420bd4c6f4329749984686539f85f0a503e4d1464a8e18e20",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n26",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview#open=2|",
-      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n1",
-        "control": {
-          "index": 46,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview",
-          "disabled": false,
-          "label": "Lease + session"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "b9d1cbf01865123ebebbf225a93128a68b86bc6b9cc4fb309ec8d3081d157cb1",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "b9d1cbf01865123ebebbf225a93128a68b86bc6b9cc4fb309ec8d3081d157cb1",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "3bb5f799ff6c18e700ec6d0b4d33d26a80bd9b4b25f93c4848818a830cf52095",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n27",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n1",
-        "control": {
-          "index": 59,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-          "disabled": false,
-          "label": "Suggestions"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "7990b0181a42e3886bb047006ac59e880180450c1dfd28db5f05cf6baa7168e0",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "7990b0181a42e3886bb047006ac59e880180450c1dfd28db5f05cf6baa7168e0",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "7c2d6cdbf3ed96132bbe2445542e317cabba1b12bb534882f0a2274d904aee63",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n28",
+      "id": "n17",
       "kind": "state",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&legend=0#open=1|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&legend=0",
+      "signature": "/__ioi/pipeline?panel=search&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&legend=0",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n2",
@@ -1000,362 +575,22 @@
           "label": "Toggle legend"
         }
       },
-      "controls": 53,
+      "controls": 45,
       "disabled_controls": 20,
       "screenshot": {
-        "sha256": "af57bcc9a4ede4f1b5656c4591b7dc8f89925c60605d85ae34bcd1d7b024c4e1",
+        "sha256": "0de88cf1c62cb9b0a11076d42e3493560563439b70bfd724780bf78c91cafc9f",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n29",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
-      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n2",
-        "control": {
-          "index": 41,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search",
-          "disabled": false,
-          "label": "Datasource"
-        }
-      },
-      "controls": 72,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "edce2db1a012a967a82d8a7da8439bb4365d27532c74dc76b70911b081a77148",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "edce2db1a012a967a82d8a7da8439bb4365d27532c74dc76b70911b081a77148",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "1d33aecb81e0395a82e613f6f98f6884c5f40a49bbb9caae310f700d7cdcc411",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n30",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
-      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n2",
-        "control": {
-          "index": 42,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search",
-          "disabled": false,
-          "label": "Object mapping"
-        }
-      },
-      "controls": 72,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "da74b5d62ea3ba5b199da41a85c9a3685c50f4af4bbba8b30263536c0ff5af9c",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "da74b5d62ea3ba5b199da41a85c9a3685c50f4af4bbba8b30263536c0ff5af9c",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "acf18a3a36dbef1c9c78329a481f6f25aa2bd59502d56ee27512b8fb9da40fb8",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n31",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
-      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n2",
-        "control": {
-          "index": 43,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search",
-          "disabled": false,
-          "label": "Policy gate"
-        }
-      },
-      "controls": 72,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "992f7248fa8c719c83810456a04c9a33bf0d1ee49c891de76fa83ab8b776f0b2",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "992f7248fa8c719c83810456a04c9a33bf0d1ee49c891de76fa83ab8b776f0b2",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "ab39f8c07f9f09fa1b79fcbdd186b02af77a421032016695b2c3c158ab13a345",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n32",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
-      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n2",
-        "control": {
-          "index": 44,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search",
-          "disabled": false,
-          "label": "Transform plan"
-        }
-      },
-      "controls": 72,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "7782cce648735ef4217d2529f13b71e0b22bff518e9ea97fa3f9ddbb78f17960",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "7782cce648735ef4217d2529f13b71e0b22bff518e9ea97fa3f9ddbb78f17960",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "d60d3f161c3d637c6176f50ec117eb441cf92294f74f18603bfa8707c2a81bde",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n33",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
-      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n2",
-        "control": {
-          "index": 45,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search",
-          "disabled": false,
-          "label": "Read projection"
-        }
-      },
-      "controls": 72,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "d09614412c970d31b3886bdaaf74fc36e3ec3391f1f589df62f2b739c935bed2",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "d09614412c970d31b3886bdaaf74fc36e3ec3391f1f589df62f2b739c935bed2",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "931331a87881b923d79f8c3646f105e9deae64c959a1141b07a11e0dac5f698f",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n34",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
-      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n2",
-        "control": {
-          "index": 46,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search",
-          "disabled": false,
-          "label": "Lease + session"
-        }
-      },
-      "controls": 72,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "15d61c19c0aee46679ad1e18568a2c2c91702592ad549896078738a0454647d6",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "15d61c19c0aee46679ad1e18568a2c2c91702592ad549896078738a0454647d6",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "2e6f392f785523cea6a42fb623f7d712bf9903c2a0ae02027ea0b2f8c6af825f",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n35",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n2",
-        "control": {
-          "index": 47,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search",
-          "disabled": false,
-          "label": "Materialized objects"
-        }
-      },
-      "controls": 72,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "8211743c48fb31427e5af7db7954cdda6b1c47158d95a91522ac8836dfaf0126",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "8211743c48fb31427e5af7db7954cdda6b1c47158d95a91522ac8836dfaf0126",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "e170af0297929f86c8573a8d140caea6e7bacddbab1863bcca27af28ec26f177",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n36",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=suggestions#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=suggestions",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n2",
-        "control": {
-          "index": 49,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=suggestions",
-          "disabled": false,
-          "label": "Suggestions"
-        }
-      },
-      "controls": 56,
-      "disabled_controls": 21,
-      "screenshot": {
-        "sha256": "d99750b00f7eb2aa8b41081ebc74847c30bf2ede376e6a82634806b1d7ed841d",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "d99750b00f7eb2aa8b41081ebc74847c30bf2ede376e6a82634806b1d7ed841d",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "4b40096e86a9ed2517896f36c190e59e3046f477a55a16ab8672413b7aa8dec4",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n37",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=warnings#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=warnings",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n2",
-        "control": {
-          "index": 50,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=warnings",
-          "disabled": false,
-          "label": "Pipeline warnings"
-        }
-      },
-      "controls": 62,
-      "disabled_controls": 21,
-      "screenshot": {
-        "sha256": "24bde16fd8e580b95de31e55aa41bd4e810ee9afa7c7d2454849c210cbaffc48",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "24bde16fd8e580b95de31e55aa41bd4e810ee9afa7c7d2454849c210cbaffc48",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "7597b1b370db73307d84bd2ed7f0b576f6ce3fdbd6cdf68b99e8053d3a0a8bb5",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n38",
+      "id": "n18",
       "kind": "state",
-      "signature": "/__ioi/pipeline?legend=0&node=lease&ontology=ont_18ca2757d28a20f7#open=1|",
-      "url": "/__ioi/pipeline?legend=0&node=lease&ontology=ont_18ca2757d28a20f7",
+      "signature": "/__ioi/pipeline?panel=search&hide=input#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=input",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n3",
-        "control": {
-          "index": 46,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Toggle bottom bar"
-        }
-      },
-      "controls": 69,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "a2725446b86ef3098234729ffa5b7149a08e1db7fd3f65f7dd58dd8e822bf7cb",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n39",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n4",
+        "from": "n2",
         "control": {
           "index": 34,
           "tag": "button",
@@ -1365,19 +600,189 @@
           "label": "Hide this color"
         }
       },
-      "controls": 59,
-      "disabled_controls": 22,
+      "controls": 50,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "8ea283134416f881fac7b21c6f305814541a81d5e5bc122efd9c97571de98cd9",
+        "sha256": "98f983bf11e3fd207778bbff440bdd97bd96010a14f147ed1a71ac9fc64081c8",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n40",
+      "id": "n19",
       "kind": "state",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "signature": "/__ioi/pipeline?panel=search&hide=clean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=clean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "ea33f284ea3a14bc464e4e87f307d4cca38714439bb49a71ba5713a43dc63f1e",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n20",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=calc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=calc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "8dcdeafac08849a463487e4f4b6c95c13413b303bd0063572a43b052657e84b0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n21",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=output#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=output",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "9d4be81562682cf9e8bad8c5edaf6c90d2c23e37aac78ec73fffa9cd9b769f5a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n22",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?panel=search&tab=suggestions#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 41,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+          "disabled": false,
+          "label": "Suggestions"
+        }
+      },
+      "controls": 48,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "8e14bf2df6ffa445193e2c4914607327007e2e6ad38a9d9fd6e2da3d160e2712",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "8e14bf2df6ffa445193e2c4914607327007e2e6ad38a9d9fd6e2da3d160e2712",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "4377d7e9cc39a5212b24271d16333af0b674495a98254a5ca8c62f4aea16b7e7",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n23",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?panel=search&tab=warnings#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=warnings",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 42,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?panel=search&tab=warnings",
+          "disabled": false,
+          "label": "Pipeline warnings"
+        }
+      },
+      "controls": 54,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "2639308813ae54e687b87e013395e1c02d79f3b4ff08497163560372f557af68",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "2639308813ae54e687b87e013395e1c02d79f3b4ff08497163560372f557af68",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "cdca97bc842ce64e55bcbdcadd194dfb5d6fa49c15dae0969c1b6f196febe082",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n24",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=input&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n4",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 47,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "32d453ce08c878f16c82e131d9b52a468dc935a8dbbf9e7fee2d89ddcfbe5a09",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n25",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=input%2Cclean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input%2Cclean",
       "title": "Pipeline Builder",
       "entry_edge": {
         "from": "n4",
@@ -1390,10 +795,395 @@
           "label": "Hide this color"
         }
       },
-      "controls": 57,
+      "controls": 52,
       "disabled_controls": 22,
       "screenshot": {
-        "sha256": "a11f57d93b7a861b3eb2c61b428a1b29263af727f55b5a9e3f06033af293424e",
+        "sha256": "fee4de8e31944753c72bd674561e0eeb62e0f8979711c35e4120f117e8834159",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n26",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=input%2Ccalc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n4",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "529e55b8f5ff3bc85643e843b81b3ce0eb1f9b50742166f52f9be1fbd193e3a7",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n27",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=input%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n4",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "32cc5721f6a0d1ee6387c5bb11a4188efc149b8f2ec46ab02d0183e16c60d606",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n28",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=clean&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=clean&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 47,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "270ff12dc81fb08e1dd2571ab0a9eba04317b61b61d80e45f0c9836967645926",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n29",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=clean%2Ccalc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=clean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "a383f5ba17eefb9198ad62b21131908c8798acb804f5ceb00941df03aab71bb0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n30",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=clean%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=clean%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n5",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "0f5a3d78ffbf4880f90a7ee1914a9ee0ea9efc518e3b04bbca025e6d643db4a4",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n31",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=calc&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=calc&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 47,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "32d453ce08c878f16c82e131d9b52a468dc935a8dbbf9e7fee2d89ddcfbe5a09",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n32",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=calc%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=calc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n6",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "17093d0b8025fc12ed0b7ca865654e231336cee1ea31f1e2dd7287b6e758536d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n33",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=output&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=output&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n7",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 47,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "270ff12dc81fb08e1dd2571ab0a9eba04317b61b61d80e45f0c9836967645926",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n34",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "e8feba6e5663374d341d829a13319d603db9b621bbb5ccddb2016d5dca2bb6b0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n35",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=input#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "27f36b30ce07ad8098aedc2ccad818ef2b315563ee6bd2879c48e408d8621afd",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n36",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=clean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=clean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "340225e8af7e502acbd3df954a21df8af1412dccb2939d06fcdef47f62f73b64",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n37",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=calc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=calc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "862c04a388d1a9517139ba2096e30ba32501a9ff38075d1147fb6a8f465cb501",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n38",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=output#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=output",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "5a08455ed4af34b31276bc4b5e841c1ac17bd2b0a3f54b445a25407b62aa184d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n39",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?panel=tree&tab=suggestions#open=2#fc=0#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=tree&tab=suggestions",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n8",
+        "control": {
+          "index": 49,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?panel=tree&tab=suggestions",
+          "disabled": false,
+          "label": "Pipeline file tree — the real ladder-record tree"
+        }
+      },
+      "controls": 48,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "6d0520c9a04531729d1356c65738ebf979ee5fc768d10f417b216ced50bd79d7",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "6d0520c9a04531729d1356c65738ebf979ee5fc768d10f417b216ced50bd79d7",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "320e36745354eb3996ff932e2339de964cf5e51907e288374a32f181746ca310",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n40",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=warnings&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=warnings&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 51,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "1059f50c4b5782ded243b39f330b3de43c1aed3a947a77ca768ce8bafb0ff5ea",
         "posture": "1440x900-light"
       },
       "console_errors": []
@@ -1401,11 +1191,1526 @@
     {
       "id": "n41",
       "kind": "state",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "signature": "/__ioi/pipeline?tab=warnings&hide=input#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=warnings&hide=input",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n4",
+        "from": "n9",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 56,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "9f2858182cf078afceba3cc7098ace3189234d9b752b9e79fd43d24da3ca06ae",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n42",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=warnings&hide=clean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=warnings&hide=clean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 56,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "55b05380b5acd440ba298e39d77dfaa4b827306946cb6064697e8ea26f001f0a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n43",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=warnings&hide=calc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=warnings&hide=calc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 56,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "a667a0584af210f14542180b1287fa91902cc9378e345835612e7671e79252ec",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n44",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=warnings&hide=output#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=warnings&hide=output",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 56,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "e3d7c97ad74a500770b7daea80bf50fa822b3f53713cb2c4065f8db39bde75c0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n45",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=datasource#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=datasource",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 44,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=datasource",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "2d002128c13f3fc086bc4ed26bc19a93382f90029d48081313fb224686dff346",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n46",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=mapping#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=mapping",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 45,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=mapping",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "2d002128c13f3fc086bc4ed26bc19a93382f90029d48081313fb224686dff346",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n47",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=policy#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=policy",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 46,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=policy",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "2d002128c13f3fc086bc4ed26bc19a93382f90029d48081313fb224686dff346",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n48",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=transform#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=transform",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 47,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=transform",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "2d002128c13f3fc086bc4ed26bc19a93382f90029d48081313fb224686dff346",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n49",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=projection#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=projection",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 48,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=projection",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "2d002128c13f3fc086bc4ed26bc19a93382f90029d48081313fb224686dff346",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n50",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=lease#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=lease",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 49,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=lease",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "2d002128c13f3fc086bc4ed26bc19a93382f90029d48081313fb224686dff346",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n51",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 50,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=materialized",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "42eb6e64cdef014bf61a8e3a54e992cf9f76b4f6fc660bedc3662913ee806305",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "2d002128c13f3fc086bc4ed26bc19a93382f90029d48081313fb224686dff346",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n52",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?panel=tree&tab=warnings#open=2#fc=0#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=tree&tab=warnings",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n9",
+        "control": {
+          "index": 55,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?panel=tree&tab=warnings",
+          "disabled": false,
+          "label": "Pipeline file tree — the real ladder-record tree"
+        }
+      },
+      "controls": 54,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "934f47509bd0575d1cad88b72b02575554910e693a4d1858bcb2db211c05e4ca",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "934f47509bd0575d1cad88b72b02575554910e693a4d1858bcb2db211c05e4ca",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "5193787fe7aa7a4440b71bd4323f59928c2b7e203ea0b155bc2fe2bf8e658352",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n53",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&panel=tree&tab=preview#open=2#fc=0#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&panel=tree&tab=preview#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 5,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=materialized&panel=tree&tab=preview#pb-preview",
+          "disabled": false,
+          "label": "Preview"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "2d03aaed2307ebf8103e8fe7b324f231b8171acf6fa89928fa02414c0db726c1",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "2d03aaed2307ebf8103e8fe7b324f231b8171acf6fa89928fa02414c0db726c1",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "41f410a952a50d481654bd762219c780d7a86c262baeb47560e90c4c61559799",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n54",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=tree&legend=0#open=1#fc=0#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=tree&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 20,
+      "screenshot": {
+        "sha256": "fd8cfb923ba191782fad921a556affa0c648ea27b300caee89a095a1aca311b5",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n55",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=tree&hide=input#open=2#fc=0#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=tree&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "8775efcb3143e226ecb49596aecb028b987f0f0f9624c5ca6b1fd7a1a38e55ac",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n56",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=tree&hide=clean#open=2#fc=0#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=tree&hide=clean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "fe526d1d686b7443b1b5ade063abf78335667797d6c7a897c250852456433166",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n57",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=tree&hide=calc#open=2#fc=0#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=tree&hide=calc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "f7e5da6ae50973eec2130c61637c7ecc66e66f59be32687ae4b13a3fcf966285",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n58",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=tree&hide=output#open=2#fc=0#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=tree&hide=output",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n10",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "b354aa0fa93ff26ca197e736efbdfad087a30e9b940b2b340f410b757be6294a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n59",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=input&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=input&legend=0#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n12",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 47,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "0e3de2a0ea575d511b578c645d59bb6f72c57498b6dc6d8b73c267f7b6c7d884",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "6d0340dfe6c6655f92a3c7eaa39fa7e8f4ba8f7d18e1d5ec50da0a9dab0dbcf5",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n60",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=input%2Cclean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=input%2Cclean#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n12",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "cf64c4112947dc0827c6ccc9c561ed07781040f99363e94f2e2bff0c9af7e0ce",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "cf64c4112947dc0827c6ccc9c561ed07781040f99363e94f2e2bff0c9af7e0ce",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n61",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=input%2Ccalc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=input%2Ccalc#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n12",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "a7dd5708016a8f0c87aed6e5054daa4f97a0cf8ad4ecda937c440b02a87b87ab",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "a7dd5708016a8f0c87aed6e5054daa4f97a0cf8ad4ecda937c440b02a87b87ab",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n62",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=input%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=input%2Coutput#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n12",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "205511188936142addb33286e03dc81f30d9a7b4bb574187e6abfeb309f69f58",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "29d6a9203991d08a38b5d18a628475ce3589238daff387d336a3ccdd8669d8ce",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n63",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=clean&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=clean&legend=0#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n13",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 47,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "0e3de2a0ea575d511b578c645d59bb6f72c57498b6dc6d8b73c267f7b6c7d884",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "6d0340dfe6c6655f92a3c7eaa39fa7e8f4ba8f7d18e1d5ec50da0a9dab0dbcf5",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n64",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=clean%2Ccalc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=clean%2Ccalc#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n13",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "f4f836122e16de86d3a2ede072785e76be513393eb1dfc78def2f617ffb5df29",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "f4f836122e16de86d3a2ede072785e76be513393eb1dfc78def2f617ffb5df29",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n65",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=clean%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=clean%2Coutput#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n13",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "499aff00c52ba6023e659812ec475bdbd0553687471b17d13e772dab30e3a3db",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "9eb16891a738dacac48d8f664232bff85591ec2fab239025b23dc008918a9a67",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n66",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=calc&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=calc&legend=0#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n14",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 47,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "0e3de2a0ea575d511b578c645d59bb6f72c57498b6dc6d8b73c267f7b6c7d884",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "6d0340dfe6c6655f92a3c7eaa39fa7e8f4ba8f7d18e1d5ec50da0a9dab0dbcf5",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n67",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=calc%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=calc%2Coutput#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n14",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 52,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "2952ef9923854dc3440eeb467cd3ef201ad8b1cec8e321995fdcfbd352827d96",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "096995c17f16fc3ccb51aa40e991e4583e18cde69d238635af75e22d9646db35",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n68",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&tab=preview&hide=output&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&tab=preview&hide=output&legend=0#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n15",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 47,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "0e3de2a0ea575d511b578c645d59bb6f72c57498b6dc6d8b73c267f7b6c7d884",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "6d0340dfe6c6655f92a3c7eaa39fa7e8f4ba8f7d18e1d5ec50da0a9dab0dbcf5",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "9b90c527d82ae94574317d01c29e99f651e96480d55defa2da9381c02bfa1313",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n69",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&legend=0#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n16",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 20,
+      "screenshot": {
+        "sha256": "db7515f2a5d8f9f75e2f47b62a00b00ddb40195bf7819011dddb8384375e19ca",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "b8b44232aa5d34c6af05701e2d0388dd10d415a08ae4fcc49326dc86715b371a",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "410e65e355dcb19e091db50b9fac0d4a68500dfd32e28185a8cc8f1078b26e28",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n70",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&hide=input#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&hide=input#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n16",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "eb6e1bbc0f73809373b31d5691978f99a19c0b85af777886813d751a7d8f858a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "eb6e1bbc0f73809373b31d5691978f99a19c0b85af777886813d751a7d8f858a",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "410e65e355dcb19e091db50b9fac0d4a68500dfd32e28185a8cc8f1078b26e28",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n71",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&hide=clean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&hide=clean#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n16",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "2431ef9d05bc1c8d3c12675d86566c6bd756c2640faafb7b42ecd4a4978f8639",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "2431ef9d05bc1c8d3c12675d86566c6bd756c2640faafb7b42ecd4a4978f8639",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "410e65e355dcb19e091db50b9fac0d4a68500dfd32e28185a8cc8f1078b26e28",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n72",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&hide=calc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&hide=calc#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n16",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "8c449e3d87ea909b4982a31c29dd9d9fa0959ae2605dea994306eb7aced0bc39",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "8c449e3d87ea909b4982a31c29dd9d9fa0959ae2605dea994306eb7aced0bc39",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "410e65e355dcb19e091db50b9fac0d4a68500dfd32e28185a8cc8f1078b26e28",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n73",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&hide=output#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&panel=search&tab=preview&hide=output#pb-preview",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n16",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "224c9fc9fdf8aae97356a11733fa0479270fa54c37a24737eab4a04637c2a597",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "224c9fc9fdf8aae97356a11733fa0479270fa54c37a24737eab4a04637c2a597",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "410e65e355dcb19e091db50b9fac0d4a68500dfd32e28185a8cc8f1078b26e28",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n74",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=input&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=input&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n18",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 20,
+      "screenshot": {
+        "sha256": "8e0ccaf126ad59913c10da61e75d8e7150d38e79ebd4949eba5bfa71544c0862",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n75",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=input%2Cclean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n18",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "9157f7a4456cd41ef61e327288d7bde3f1f0a1c552ec8ca48d2a04b7aa12c875",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n76",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=input%2Ccalc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=input%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n18",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "c1dfd63b25bc793422aa9a0c088b565772773d3b4939b0a1d4faad542469d7ab",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n77",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=input%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=input%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n18",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "6648406f9ccc82c58afffd0ee87369b6750d47c2d3577e98c7682f2d314d9635",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n78",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=clean&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=clean&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n19",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 20,
+      "screenshot": {
+        "sha256": "0de88cf1c62cb9b0a11076d42e3493560563439b70bfd724780bf78c91cafc9f",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n79",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=clean%2Ccalc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=clean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n19",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "bb43d4ab55e50e398dce30598a0da77f50a45436268c38ed8b35142e858e7f1a",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n80",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=clean%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=clean%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n19",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "ea4634d670e59529d52afa5323477166ac2bfab25e4c15567c9ac0be9155e1f8",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n81",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=calc&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=calc&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n20",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 20,
+      "screenshot": {
+        "sha256": "8e0ccaf126ad59913c10da61e75d8e7150d38e79ebd4949eba5bfa71544c0862",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n82",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=calc%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=calc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n20",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "836ba74e0ac8f4d3c32cfc7185810efb96aeaeb28ee6925fe9f814b2abae5650",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n83",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&hide=output&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&hide=output&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n21",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 20,
+      "screenshot": {
+        "sha256": "0de88cf1c62cb9b0a11076d42e3493560563439b70bfd724780bf78c91cafc9f",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n84",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&tab=suggestions&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=suggestions&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n22",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 43,
+      "disabled_controls": 20,
+      "screenshot": {
+        "sha256": "1584fa1513ccd44e698650052e132269970f5c9f88da826f21809e3bfa77d2d2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n85",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&tab=suggestions&hide=input#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=suggestions&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n22",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 48,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "a19b4ad2e062a03829fa08a8c41338b90eec9711c6b568da9edc58f94e14ccf3",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n86",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&tab=suggestions&hide=clean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=suggestions&hide=clean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n22",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 48,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "d87d2f5322463178f187f160f0d28c6817b87c70607470b07a2aa2f73c31800f",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n87",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&tab=suggestions&hide=calc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=suggestions&hide=calc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n22",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 48,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "7dcbf29456186060b6f44d66099fb3eeabbe8732530452a2cc2ba397a5f3b29b",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n88",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&tab=suggestions&hide=output#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=suggestions&hide=output",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n22",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 48,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "280d97ad0e74bd58743b79176e4bd62be82f8009c556798e8330f3a1a94ff94d",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n89",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&tab=warnings&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=warnings&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n23",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 49,
+      "disabled_controls": 20,
+      "screenshot": {
+        "sha256": "be8641afb1cdfcaf3fe5514233e5acb4acdca5f3d9863b3f97ef8c5726c21e92",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n90",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&tab=warnings&hide=input#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=warnings&hide=input",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n23",
+        "control": {
+          "index": 34,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 54,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "bd533a0d37f853212275814d24a43acaf4526e010e5ee2cfed8a13c62c1cd705",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n91",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&tab=warnings&hide=clean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=warnings&hide=clean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n23",
+        "control": {
+          "index": 35,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 54,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "944883467362fa8e5bdc2b31bf9c0b7b23b68961812b721a402ff21e5603e173",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n92",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?panel=search&tab=warnings&hide=calc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=warnings&hide=calc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n23",
         "control": {
           "index": 36,
           "tag": "button",
@@ -1416,156 +2721,21 @@
         }
       },
       "controls": 54,
-      "disabled_controls": 22,
-      "screenshot": {
-        "sha256": "97ace4be5a3f56e2f8f62c9d959935175d44f5f5bdb9c89a2036aa2923244b30",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n42",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n4",
-        "control": {
-          "index": 37,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 53,
-      "disabled_controls": 22,
-      "screenshot": {
-        "sha256": "9ea1814d95817949d3ef0fa8c167abbdcaaf660833015cd60ab5379b8672335f",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n43",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
-      "url": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&legend=0",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n5",
-        "control": {
-          "index": 33,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Toggle legend"
-        }
-      },
-      "controls": 55,
       "disabled_controls": 21,
       "screenshot": {
-        "sha256": "20f765b1f71914f1be7f7dfe0b4c473d7b452e310cfbc03612d7c22f8abbe1ef",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "8a4b6b82fe2342910f7af13e72b0832a243db2472b44fab7602afa8a9b1e4930",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "1438ce792c930536c234940d53d0a7743b33a90f8391ef104c136b39115621d1",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n44",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
-      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n5",
-        "control": {
-          "index": 34,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 73,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "d4791db7a08071b41592221c8ab3a99a1a20c1f1c9af1f7aa7dd30aab8a2e8d8",
+        "sha256": "d8e76eaf13f108dcb078ec2ef876c88261876550e9c16f12d841f3c5da4cf5ea",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n45",
+      "id": "n93",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
-      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "signature": "/__ioi/pipeline?panel=search&tab=warnings&hide=output#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?panel=search&tab=warnings&hide=output",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n5",
-        "control": {
-          "index": 35,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 71,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "59ad89ca2460c1cd7bf5cf72ae0e615e755016638554a3dd24b745d5267246d3",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n46",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
-      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n5",
-        "control": {
-          "index": 36,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "86ea5cc5a7943052591d86aa48191f46ce5ffe362db5f53a73973c3a7e91ddb3",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n47",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
-      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n5",
+        "from": "n23",
         "control": {
           "index": 37,
           "tag": "button",
@@ -1575,57 +2745,267 @@
           "label": "Hide this color"
         }
       },
-      "controls": 67,
-      "disabled_controls": 32,
+      "controls": 54,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "f434d31027a9f34f15b79444797a6ae120d83bcb996e52a9cbbc035681261111",
+        "sha256": "7ab2c9fa5c2db75ca44cafdd3d6cb4ac36df7da68f0b99191f85474550c97b5f",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n48",
+      "id": "n94",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
-      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "signature": "/__ioi/pipeline?node=datasource&panel=search#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=datasource&panel=search",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n5",
+        "from": "n23",
         "control": {
-          "index": 59,
+          "index": 44,
           "tag": "a",
           "role": null,
-          "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+          "href": "/__ioi/pipeline?node=datasource&panel=search",
           "disabled": false,
-          "label": "Suggestions"
+          "label": "Go to node"
         }
       },
-      "controls": 68,
-      "disabled_controls": 31,
+      "controls": 50,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "1a7de17f0d4aa65dd2c8e90acf29bc59957be7ba38508fbae81f5e97c1f37a73",
+        "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
         "posture": "1440x900-light"
       },
       "console_errors": [],
       "posture_matrix": [
         {
-          "sha256": "1a7de17f0d4aa65dd2c8e90acf29bc59957be7ba38508fbae81f5e97c1f37a73",
+          "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
           "posture": "1440x900-dark"
         },
         {
-          "sha256": "a04aaf19dc9707de0ffb1a0cd5e96608f8582edc21837a43449eedfab314734b",
+          "sha256": "a514b8da169f45d7c75a412d9e8e8271a9ca93438464939060b5d51a522acd3b",
           "posture": "390x844-light-reduced-motion"
         }
       ]
     },
     {
-      "id": "n49",
+      "id": "n95",
       "kind": "route",
-      "signature": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
-      "url": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&legend=0",
+      "signature": "/__ioi/pipeline?node=mapping&panel=search#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=mapping&panel=search",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n6",
+        "from": "n23",
+        "control": {
+          "index": 45,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=mapping&panel=search",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a514b8da169f45d7c75a412d9e8e8271a9ca93438464939060b5d51a522acd3b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n96",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=policy&panel=search#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=policy&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n23",
+        "control": {
+          "index": 46,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=policy&panel=search",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a514b8da169f45d7c75a412d9e8e8271a9ca93438464939060b5d51a522acd3b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n97",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=transform&panel=search#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=transform&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n23",
+        "control": {
+          "index": 47,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=transform&panel=search",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a514b8da169f45d7c75a412d9e8e8271a9ca93438464939060b5d51a522acd3b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n98",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=projection&panel=search#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=projection&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n23",
+        "control": {
+          "index": 48,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=projection&panel=search",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a514b8da169f45d7c75a412d9e8e8271a9ca93438464939060b5d51a522acd3b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n99",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=lease&panel=search#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=lease&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n23",
+        "control": {
+          "index": 49,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=lease&panel=search",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a514b8da169f45d7c75a412d9e8e8271a9ca93438464939060b5d51a522acd3b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n100",
+      "kind": "route",
+      "signature": "/__ioi/pipeline?node=materialized&panel=search#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?node=materialized&panel=search",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n23",
+        "control": {
+          "index": 50,
+          "tag": "a",
+          "role": null,
+          "href": "/__ioi/pipeline?node=materialized&panel=search",
+          "disabled": false,
+          "label": "Go to node"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "08bbc9998beeb595dddf9ee662ebc36a4c7081501e229ca66698ab1a18a4e1b2",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "a514b8da169f45d7c75a412d9e8e8271a9ca93438464939060b5d51a522acd3b",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n101",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=input%2Cclean&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input%2Cclean&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n25",
         "control": {
           "index": 33,
           "tag": "button",
@@ -1635,82 +3015,22 @@
           "label": "Toggle legend"
         }
       },
-      "controls": 69,
-      "disabled_controls": 31,
+      "controls": 47,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "51e38c77d02fcbf337acdb1f1a2fa6fb08f996e340106c43eff20e3f5a637894",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "1e69f59a91672873c6cfed8e16d17a9abf7cc8e695e76019b50ca046e16eab2c",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "89206977091b0b60cbbcdbd948775d7643f3bce1dc9d71c18abfb4ae86a9d498",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n50",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
-      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n6",
-        "control": {
-          "index": 34,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 73,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "2b17e782aa0cc0b772a1753ab752c979720222a1a395e91ca6f8268bf7eda488",
+        "sha256": "270ff12dc81fb08e1dd2571ab0a9eba04317b61b61d80e45f0c9836967645926",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n51",
+      "id": "n102",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
-      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "signature": "/__ioi/pipeline?hide=input%2Cclean%2Ccalc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input%2Cclean%2Ccalc",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n6",
-        "control": {
-          "index": 35,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 71,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "eb67f9277f45be0b605be5f332264e312077427e1b68e176ed45c21e5b87b581",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n52",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
-      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n6",
+        "from": "n25",
         "control": {
           "index": 36,
           "tag": "button",
@@ -1720,22 +3040,22 @@
           "label": "Hide this color"
         }
       },
-      "controls": 68,
-      "disabled_controls": 32,
+      "controls": 52,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "dd2edf2d59af64b4bae86367d261516c27c24db18c885d0468c5d78090c94117",
+        "sha256": "838a760674ce19634b689bf7ad5bf232fa68945d4cfc8e18eb92125f20c5f319",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n53",
+      "id": "n103",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
-      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "signature": "/__ioi/pipeline?hide=input%2Cclean%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input%2Cclean%2Coutput",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n6",
+        "from": "n25",
         "control": {
           "index": 37,
           "tag": "button",
@@ -1745,57 +3065,22 @@
           "label": "Hide this color"
         }
       },
-      "controls": 67,
-      "disabled_controls": 32,
+      "controls": 52,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "0571bb3972ea4d47f5edfcf289ae5e49314ec4f3535bb4be25f1c5b74acd264d",
+        "sha256": "d78600bc5fc1efedbc7bfac772be8081b1929e7e3ee963cbb91a9e05a0dcec25",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n54",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
-      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "id": "n104",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=input%2Ccalc&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input%2Ccalc&legend=0",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n6",
-        "control": {
-          "index": 59,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-          "disabled": false,
-          "label": "Suggestions"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "cc7e9f92421d656d13ec9fba8445aa176561f5949032493ece188a81bee602f1",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "cc7e9f92421d656d13ec9fba8445aa176561f5949032493ece188a81bee602f1",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "bd6e5385163cbcf2a3ab84eb39a892ad6b40699405144d080b8c894a167c8bfe",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n55",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
-      "url": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&legend=0",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n7",
+        "from": "n26",
         "control": {
           "index": 33,
           "tag": "button",
@@ -1805,107 +3090,22 @@
           "label": "Toggle legend"
         }
       },
-      "controls": 69,
-      "disabled_controls": 31,
+      "controls": 47,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "e8edf38d555bbcbced2c9594e8426fbf442990c708b93c95b5dc8332cafb0d19",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "3bcaeea5a0c7537e4e773f3d26a3d35f46c55369adc4bcf299ad87b053ac2817",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "10982cec16da1194b2e91a0530b2cc4ea70630b9c1d746b3b82255afbaae8e51",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n56",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
-      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n7",
-        "control": {
-          "index": 34,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 73,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "aa790712b9430844e1794824fb9b8f6400cb75a99f15dd3cf3eb229dbcc2f62e",
+        "sha256": "32d453ce08c878f16c82e131d9b52a468dc935a8dbbf9e7fee2d89ddcfbe5a09",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n57",
+      "id": "n105",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
-      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "signature": "/__ioi/pipeline?hide=input%2Ccalc%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input%2Ccalc%2Coutput",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n7",
-        "control": {
-          "index": 35,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 71,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "d209edab011b7966bf8ebec5737f3bc61bd0e8f7f5bf4297f264e21c9739151c",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n58",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
-      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n7",
-        "control": {
-          "index": 36,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "c6c59a3c9ccda38b1eaaeb841be0c6fa00ffdecdf89c99f6a37bf27ec64fd6f2",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n59",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
-      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n7",
+        "from": "n26",
         "control": {
           "index": 37,
           "tag": "button",
@@ -1915,57 +3115,22 @@
           "label": "Hide this color"
         }
       },
-      "controls": 67,
-      "disabled_controls": 32,
+      "controls": 52,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "d3a1b2bfcbc8f9b2844247c2ed00e7f1f71741cecc3ebb47b62112ac621719a0",
+        "sha256": "2a30618dd3b26611009d67d1f4ce7aa7e260ffa0fa63f41b9c39a64110858905",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n60",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
-      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "id": "n106",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=input%2Coutput&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=input%2Coutput&legend=0",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n7",
-        "control": {
-          "index": 59,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-          "disabled": false,
-          "label": "Suggestions"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "20a461b75fb447dc043fc51257cb041c45ee4697e6d067fb2a596d1e1f2b9fe9",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "20a461b75fb447dc043fc51257cb041c45ee4697e6d067fb2a596d1e1f2b9fe9",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "d1ddef4f2c1a8c2aff14e5f50b02ee958cbb3c8ee28f1eebd8e24af0fac66880",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n61",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
-      "url": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&legend=0",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n8",
+        "from": "n27",
         "control": {
           "index": 33,
           "tag": "button",
@@ -1975,167 +3140,22 @@
           "label": "Toggle legend"
         }
       },
-      "controls": 69,
-      "disabled_controls": 31,
+      "controls": 47,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "fa9068f2ed47a5ca8673262172ed2aa9ae6c0b58a6ab10ea454df6efafd7a6cd",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "5498cf68ce37b87c8df9f0cc88a1530196594ddd2edc2e59c204cc3feffd8bb7",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "8b62fd7771f73ca28b6f09c046a9e40fbb3b9d5c72df6cd7f43f61b41a85eb2e",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n62",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
-      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n8",
-        "control": {
-          "index": 34,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 73,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "d30b4376d3ae983f1ac9c362b236e559844e1087e75972010718f0f45b66bf40",
+        "sha256": "270ff12dc81fb08e1dd2571ab0a9eba04317b61b61d80e45f0c9836967645926",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n63",
+      "id": "n107",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
-      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "signature": "/__ioi/pipeline?hide=clean%2Ccalc&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=clean%2Ccalc&legend=0",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n8",
-        "control": {
-          "index": 35,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 71,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "a0568cdac858efc51fab940707d2aabac9b3fb7a92b81997326c33ef5d3610e4",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n64",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
-      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n8",
-        "control": {
-          "index": 36,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "3ca99d90923ad7c4130dbe43e814c0dee5cbdbcdf60f2269dae13543db1fe0aa",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n65",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
-      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n8",
-        "control": {
-          "index": 37,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 67,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "df1ed29c7022a857933c957aeb80cd9666fdaa26e1e223463b9c9882bf1e70a0",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n66",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
-      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n8",
-        "control": {
-          "index": 59,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-          "disabled": false,
-          "label": "Suggestions"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "8b92473be56aae39bd0f803f2fb1abca4c2a288f4db597505b9998de65aad923",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "8b92473be56aae39bd0f803f2fb1abca4c2a288f4db597505b9998de65aad923",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "535b371168a36a28d5fe15cffefd51cc3d8841720556ed6eb51446a336dab36a",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n67",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
-      "url": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&legend=0",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n9",
+        "from": "n29",
         "control": {
           "index": 33,
           "tag": "button",
@@ -2145,107 +3165,22 @@
           "label": "Toggle legend"
         }
       },
-      "controls": 69,
-      "disabled_controls": 31,
+      "controls": 47,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "1b1d9ac2105beb21e0f2f2a0bc9c5f687d9ee2d38205a5da8a1c96cc33238779",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "89b8f3df9077cc1c7c019e4b5ab0faa742bbf720dbbb778532c64855a59fb98e",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "8450e8ee3b05061388a2d85eaacc28bc88031c9f3ab294c38651175329872f6c",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n68",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
-      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n9",
-        "control": {
-          "index": 34,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 73,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "36d565f87a16bdff29fa4bccf8460995fc048b7eb379a6ebcfc3b93d45a6437f",
+        "sha256": "32d453ce08c878f16c82e131d9b52a468dc935a8dbbf9e7fee2d89ddcfbe5a09",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n69",
+      "id": "n108",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
-      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "signature": "/__ioi/pipeline?hide=clean%2Ccalc%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=clean%2Ccalc%2Coutput",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n9",
-        "control": {
-          "index": 35,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 71,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "cebbcbb800e40fca8abd394f12e70b2ad1b7a8564487ba2c9c3298b606ad040e",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n70",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
-      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n9",
-        "control": {
-          "index": 36,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "2e4eff55feb1fb1b30e93cb5f1b73797aa6420feab7a03f67d082a0ddf9bbf3f",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n71",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
-      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n9",
+        "from": "n29",
         "control": {
           "index": 37,
           "tag": "button",
@@ -2255,57 +3190,22 @@
           "label": "Hide this color"
         }
       },
-      "controls": 67,
-      "disabled_controls": 32,
+      "controls": 52,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "673d9a7b7d8d30e72100a4ec602f63325e166206a9d266e70679eb568bd7c3a0",
+        "sha256": "a353e16a863968a67c50e3775cff398a16657432e4e7da5e5f4003f671261f51",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n72",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
-      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+      "id": "n109",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?hide=clean%2Coutput&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=clean%2Coutput&legend=0",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n9",
-        "control": {
-          "index": 59,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-          "disabled": false,
-          "label": "Suggestions"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "c791964e5376a490a5af70846325e7dd9304704eae002fab1ad8dc9bf4036538",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "c791964e5376a490a5af70846325e7dd9304704eae002fab1ad8dc9bf4036538",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "c13db80cc17482f4a9b063ef63a48c6e2ea86cf2ca3ddbf4057f7d58a8bd01ec",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n73",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
-      "url": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&legend=0",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n10",
+        "from": "n30",
         "control": {
           "index": 33,
           "tag": "button",
@@ -2315,167 +3215,22 @@
           "label": "Toggle legend"
         }
       },
-      "controls": 69,
-      "disabled_controls": 31,
+      "controls": 47,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "4f82913002fc21d9fbc92b44792ac2c55f532d81e69d9cfc15dec74fb6d81b72",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "6a0549c3bad8a00785ce2ecef9c01ca9fd945c5b0a0d36931efdd1df8493522d",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "b0361a3be1d589a14e54418a947c1b93907b1fea9f76a7e7a20cb135b5413eb2",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n74",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
-      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n10",
-        "control": {
-          "index": 34,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 73,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "740edf255e2ae7ff30a0e1cd7ac14eb2cae89d3339948c8ba3adc1aed14cdad3",
+        "sha256": "270ff12dc81fb08e1dd2571ab0a9eba04317b61b61d80e45f0c9836967645926",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n75",
+      "id": "n110",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
-      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "signature": "/__ioi/pipeline?hide=calc%2Coutput&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?hide=calc%2Coutput&legend=0",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n10",
-        "control": {
-          "index": 35,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 71,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "49c8c10e3cd98696c3f53e42627b977bdf6138f9f083c20895383cf0194ddf2b",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n76",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
-      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n10",
-        "control": {
-          "index": 36,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "0fdbbed4e8deeef7754aaf018ca21788576327fccce3c56a73d0489aaed2ad76",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n77",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
-      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n10",
-        "control": {
-          "index": 37,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 67,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "0101d150fe4833ae7b832acb6c988b0add51a450cd6391153805b1c6ec58be33",
-        "posture": "1440x900-light"
-      },
-      "console_errors": []
-    },
-    {
-      "id": "n78",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=suggestions#open=2|",
-      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n10",
-        "control": {
-          "index": 59,
-          "tag": "a",
-          "role": null,
-          "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-          "disabled": false,
-          "label": "Suggestions"
-        }
-      },
-      "controls": 68,
-      "disabled_controls": 31,
-      "screenshot": {
-        "sha256": "a2cc9a7afbe18824d71d78b36ae70df4b7e0c68bd1be80af8b5e5bb00b9343f6",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "a2cc9a7afbe18824d71d78b36ae70df4b7e0c68bd1be80af8b5e5bb00b9343f6",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "d569a147122f2aa227c00ffd9856eb47cde86c507c38e7fad2109c843319f17c",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n79",
-      "kind": "route",
-      "signature": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&legend=0#open=1|",
-      "url": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&legend=0",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n11",
+        "from": "n32",
         "control": {
           "index": 33,
           "tag": "button",
@@ -2485,57 +3240,47 @@
           "label": "Toggle legend"
         }
       },
-      "controls": 69,
-      "disabled_controls": 31,
+      "controls": 47,
+      "disabled_controls": 21,
       "screenshot": {
-        "sha256": "267a7107be56d4888fedf0427901c542325f83758348af4084f09846624a84ff",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "a2725446b86ef3098234729ffa5b7149a08e1db7fd3f65f7dd58dd8e822bf7cb",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "477287e6bfa59554d0a64f0ce355681d31563d3c7620ed4c449266ff03b69453",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
-      "id": "n80",
-      "kind": "state",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input",
-      "title": "Pipeline Builder",
-      "entry_edge": {
-        "from": "n11",
-        "control": {
-          "index": 34,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Hide this color"
-        }
-      },
-      "controls": 73,
-      "disabled_controls": 32,
-      "screenshot": {
-        "sha256": "c0d056c760aa73ae8598013e6d224aca8fc915e004d161df1d6b8f5573ecfdab",
+        "sha256": "270ff12dc81fb08e1dd2571ab0a9eba04317b61b61d80e45f0c9836967645926",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n81",
+      "id": "n111",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=input&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=input&legend=0",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n11",
+        "from": "n35",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "9cc8a309ea8ea73b8389d6f69793f96cbd3c4826d470ac5195c420e47cd90193",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n112",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=input%2Cclean#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=input%2Cclean",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n35",
         "control": {
           "index": 35,
           "tag": "button",
@@ -2545,22 +3290,22 @@
           "label": "Hide this color"
         }
       },
-      "controls": 71,
-      "disabled_controls": 32,
+      "controls": 50,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "371c074ff5ee130805ec402f73d1b769b7bf6744c35521b6dfa1e7a36459796e",
+        "sha256": "2dd43f73a3de319dbe22dc298021b2c6321a3ee7592423170ae4f45995707822",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n82",
+      "id": "n113",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=input%2Ccalc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=input%2Ccalc",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n11",
+        "from": "n35",
         "control": {
           "index": 36,
           "tag": "button",
@@ -2570,22 +3315,22 @@
           "label": "Hide this color"
         }
       },
-      "controls": 68,
-      "disabled_controls": 32,
+      "controls": 50,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "3ecaf9ab98155e4f816e432d670dfc6533f30a4962f5719609f66734026363b4",
+        "sha256": "fd29ba0604d95290274b236b53ae766d4650dab052a4bc03878b4f6b0ad39c1d",
         "posture": "1440x900-light"
       },
       "console_errors": []
     },
     {
-      "id": "n83",
+      "id": "n114",
       "kind": "state",
-      "signature": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput#open=2|",
-      "url": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&hide=input%2Cclean%2Ccalc%2Coutput",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=input%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=input%2Coutput",
       "title": "Pipeline Builder",
       "entry_edge": {
-        "from": "n11",
+        "from": "n35",
         "control": {
           "index": 37,
           "tag": "button",
@@ -2595,10 +3340,135 @@
           "label": "Hide this color"
         }
       },
-      "controls": 67,
-      "disabled_controls": 32,
+      "controls": 50,
+      "disabled_controls": 22,
       "screenshot": {
-        "sha256": "bc04e93222403b96a5599a994c4e1f1050786ca8b1e48a222fa884d35ab8e110",
+        "sha256": "0eec04d8a408c77bd7d3dbf9b5ca57071fe7d114a748cff3a86049ac5844b7b5",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n115",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=clean&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=clean&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n36",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "e8feba6e5663374d341d829a13319d603db9b621bbb5ccddb2016d5dca2bb6b0",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n116",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=clean%2Ccalc#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=clean%2Ccalc",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n36",
+        "control": {
+          "index": 36,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "a52a7a8e5f9f01bc9859652903d73832754a9cb967d203b3e96c1d1099bb7985",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n117",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=clean%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=clean%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n36",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "5cc7aaef87a710098720f0b657e5dafaf90074e483be6ea75a9b0fac954e5f3f",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n118",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=calc&legend=0#open=1#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=calc&legend=0",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n37",
+        "control": {
+          "index": 33,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Toggle legend"
+        }
+      },
+      "controls": 45,
+      "disabled_controls": 21,
+      "screenshot": {
+        "sha256": "9cc8a309ea8ea73b8389d6f69793f96cbd3c4826d470ac5195c420e47cd90193",
+        "posture": "1440x900-light"
+      },
+      "console_errors": []
+    },
+    {
+      "id": "n119",
+      "kind": "state",
+      "signature": "/__ioi/pipeline?tab=suggestions&hide=calc%2Coutput#open=2#fc=1#hf=124#sv=0|",
+      "url": "/__ioi/pipeline?tab=suggestions&hide=calc%2Coutput",
+      "title": "Pipeline Builder",
+      "entry_edge": {
+        "from": "n37",
+        "control": {
+          "index": 37,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Hide this color"
+        }
+      },
+      "controls": 50,
+      "disabled_controls": 22,
+      "screenshot": {
+        "sha256": "afa061321c629eedcae3efa0787721505310c2c20bf14fce40193ba26cd9f556",
         "posture": "1440x900-light"
       },
       "console_errors": []
@@ -2682,7 +3552,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
         "disabled": false,
         "label": "Preview"
       },
@@ -2724,7 +3594,7 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/lineage?ontology=",
         "disabled": false,
         "label": "Lineage"
       },
@@ -2738,7 +3608,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
         "label": "Ontology Manager"
       },
@@ -2850,7 +3720,7 @@
         "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Add data"
       },
@@ -3004,7 +3874,7 @@
         "index": 28,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — the right panel becomes the real record search"
       },
@@ -3083,7 +3953,7 @@
     },
     {
       "from": "n0",
-      "to": null,
+      "to": "n4",
       "control": {
         "index": 34,
         "tag": "button",
@@ -3093,11 +3963,11 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "unclickable"
+      "outcome": "state-change"
     },
     {
       "from": "n0",
-      "to": null,
+      "to": "n5",
       "control": {
         "index": 35,
         "tag": "button",
@@ -3107,11 +3977,11 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "unclickable"
+      "outcome": "state-change"
     },
     {
       "from": "n0",
-      "to": null,
+      "to": "n6",
       "control": {
         "index": 36,
         "tag": "button",
@@ -3121,11 +3991,11 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "unclickable"
+      "outcome": "state-change"
     },
     {
       "from": "n0",
-      "to": null,
+      "to": "n7",
       "control": {
         "index": 37,
         "tag": "button",
@@ -3135,7 +4005,7 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "unclickable"
+      "outcome": "state-change"
     },
     {
       "from": "n0",
@@ -3153,84 +4023,42 @@
     },
     {
       "from": "n0",
-      "to": "n0",
+      "to": null,
       "control": {
         "index": 39,
-        "tag": "summary",
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
+        "label": "Create an ontology →"
       },
-      "action": "click",
-      "outcome": "noop"
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n0",
-      "to": "n4",
+      "to": "visited",
       "control": {
         "index": 40,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline",
         "disabled": false,
-        "label": "probe-reencode"
+        "label": "Selection preview"
       },
       "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n0",
-      "to": "n5",
-      "control": {
-        "index": 41,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Datasource"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n0",
-      "to": "n6",
-      "control": {
-        "index": 42,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Object mapping"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n0",
-      "to": "n7",
-      "control": {
-        "index": 43,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Policy gate"
-      },
-      "action": "goto",
-      "outcome": "navigated"
+      "outcome": "revisit"
     },
     {
       "from": "n0",
       "to": "n8",
       "control": {
-        "index": 44,
+        "index": 41,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?tab=suggestions",
         "disabled": false,
-        "label": "Transform plan"
+        "label": "Suggestions"
       },
       "action": "goto",
       "outcome": "navigated"
@@ -3239,727 +4067,657 @@
       "from": "n0",
       "to": "n9",
       "control": {
-        "index": 45,
+        "index": 42,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?tab=warnings",
         "disabled": false,
-        "label": "Read projection"
+        "label": "Pipeline warnings"
       },
       "action": "goto",
       "outcome": "navigated"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n0",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n0",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
     },
     {
       "from": "n0",
       "to": "n10",
       "control": {
-        "index": 46,
+        "index": 51,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?panel=tree",
         "disabled": false,
-        "label": "Lease + session"
+        "label": "Pipeline file tree — the real ladder-record tree"
       },
       "action": "goto",
       "outcome": "navigated"
     },
     {
       "from": "n0",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n1",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
+      "to": "n1",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n1",
       "to": "n11",
       "control": {
-        "index": 47,
-        "tag": "a",
+        "index": 33,
+        "tag": "button",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "href": null,
         "disabled": false,
-        "label": "Materialized objects"
+        "label": "Toggle legend"
       },
-      "action": "goto",
+      "action": "click",
       "outcome": "navigated"
     },
     {
-      "from": "n0",
-      "to": "visited",
-      "control": {
-        "index": 48,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Selection preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n0",
+      "from": "n1",
       "to": "n12",
       "control": {
-        "index": 49,
-        "tag": "a",
+        "index": 34,
+        "tag": "button",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "href": null,
         "disabled": false,
-        "label": "Suggestions"
+        "label": "Hide this color"
       },
-      "action": "goto",
+      "action": "click",
       "outcome": "navigated"
     },
     {
-      "from": "n0",
+      "from": "n1",
       "to": "n13",
       "control": {
-        "index": 50,
-        "tag": "a",
+        "index": 35,
+        "tag": "button",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
+        "href": null,
         "disabled": false,
-        "label": "Pipeline warnings"
+        "label": "Hide this color"
       },
-      "action": "goto",
+      "action": "click",
       "outcome": "navigated"
     },
     {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Toggle bottom bar"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 52,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 53,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "ODK substrate"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 54,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/pipeline",
-        "disabled": false,
-        "label": "Pipeline Builder capture ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 55,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Add"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n0",
-      "to": null,
-      "control": {
-        "index": 56,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Edit output settings"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n0",
-      "to": "visited",
-      "control": {
-        "index": 57,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Pipeline outputs"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n0",
-      "to": "visited",
-      "control": {
-        "index": 58,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Search pipeline — real record search"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n0",
+      "from": "n1",
       "to": "n14",
       "control": {
-        "index": 59,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
-        "disabled": false,
-        "label": "Pipeline file tree — the real ladder-record tree"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n0",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n1",
-      "to": "visited",
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline",
-        "disabled": false,
-        "label": "Pipeline Builder"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 4,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Build"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
-        "disabled": false,
-        "label": "Preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 6,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Schedule"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 7,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Deploy"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Lineage"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n1",
-      "to": "n1",
-      "control": {
-        "index": 10,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Panning mode — drag pans the canvas (live)"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 11,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 12,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "multi-select has no consumer (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 13,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 14,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 15,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "no freeform node placement, so nothing snaps (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "canvas annotations have no persistence plane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 17,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Add data"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 18,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Reusables"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "join authoring — named gap (no authoring authority)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 21,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "union authoring — named gap"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "split authoring — named gap"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "model application — named gap (model routes live in the Model Catalog)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 24,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP logo icon"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 25,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP generation is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 26,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP explanation is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 27,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "transform editing — named gap (no authoring authority)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": "n15",
-      "control": {
-        "index": 28,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview",
-        "disabled": false,
-        "label": "Search pipeline — the right panel becomes the real record search"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 29,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "color grouping is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": "n1",
-      "control": {
-        "index": 30,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom in"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n1",
-      "to": "n1",
-      "control": {
-        "index": 31,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom out"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n1",
-      "to": "n1",
-      "control": {
-        "index": 32,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom to fit"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n1",
-      "to": "n16",
-      "control": {
-        "index": 33,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Toggle legend"
-      },
-      "action": "click",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n1",
-      "to": "n17",
-      "control": {
-        "index": 34,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Hide this color"
-      },
-      "action": "click",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n1",
-      "to": "n18",
-      "control": {
-        "index": 35,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Hide this color"
-      },
-      "action": "click",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n1",
-      "to": "n19",
-      "control": {
         "index": 36,
         "tag": "button",
         "role": null,
@@ -3972,7 +4730,7 @@
     },
     {
       "from": "n1",
-      "to": "n20",
+      "to": "n15",
       "control": {
         "index": 37,
         "tag": "button",
@@ -4000,17 +4758,17 @@
     },
     {
       "from": "n1",
-      "to": "n1",
+      "to": null,
       "control": {
         "index": 39,
-        "tag": "summary",
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
+        "label": "Create an ontology →"
       },
-      "action": "click",
-      "outcome": "noop"
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n1",
@@ -4019,228 +4777,102 @@
         "index": 40,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline",
         "disabled": false,
-        "label": "probe-reencode"
+        "label": "Selection preview"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
       "from": "n1",
-      "to": "n21",
+      "to": "visited",
       "control": {
         "index": 41,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__ioi/pipeline?tab=suggestions",
         "disabled": false,
-        "label": "Datasource"
+        "label": "Suggestions"
       },
       "action": "goto",
-      "outcome": "navigated"
+      "outcome": "revisit"
     },
     {
       "from": "n1",
-      "to": "n22",
+      "to": "visited",
       "control": {
         "index": 42,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__ioi/pipeline?tab=warnings",
         "disabled": false,
-        "label": "Object mapping"
+        "label": "Pipeline warnings"
       },
       "action": "goto",
-      "outcome": "navigated"
+      "outcome": "revisit"
     },
     {
       "from": "n1",
-      "to": "n23",
+      "to": null,
       "control": {
         "index": 43,
-        "tag": "a",
+        "tag": "button",
         "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": null,
         "disabled": false,
-        "label": "Policy gate"
+        "label": "Toggle bottom bar"
       },
-      "action": "goto",
-      "outcome": "navigated"
+      "action": "click",
+      "outcome": "unclickable"
     },
     {
       "from": "n1",
-      "to": "n24",
+      "to": null,
       "control": {
         "index": 44,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
-        "label": "Transform plan"
+        "label": "Ontology Manager"
       },
       "action": "goto",
-      "outcome": "navigated"
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n1",
-      "to": "n25",
+      "to": null,
       "control": {
         "index": 45,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
-        "label": "Read projection"
+        "label": "ODK substrate"
       },
       "action": "goto",
-      "outcome": "navigated"
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n1",
-      "to": "n26",
+      "to": null,
       "control": {
         "index": 46,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__apps/pipeline",
         "disabled": false,
-        "label": "Lease + session"
+        "label": "Pipeline Builder capture ↗"
       },
       "action": "goto",
-      "outcome": "navigated"
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n1",
-      "to": "n1",
+      "to": null,
       "control": {
         "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 48,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Snapshot"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 49,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Transform"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 50,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Split"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Join"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 52,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Union"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 53,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Use LLM"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 54,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Generate"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 55,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Explain"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n1",
-      "to": null,
-      "control": {
-        "index": 56,
         "tag": "button",
         "role": null,
         "href": null,
@@ -4252,1594 +4884,12 @@
     },
     {
       "from": "n1",
-      "to": "visited",
-      "control": {
-        "index": 57,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Selection preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n1",
-      "to": "visited",
-      "control": {
-        "index": 58,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview",
-        "disabled": false,
-        "label": "Preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n1",
-      "to": "n27",
-      "control": {
-        "index": 59,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-        "disabled": false,
-        "label": "Suggestions"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n1",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": "visited",
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline",
-        "disabled": false,
-        "label": "Pipeline Builder"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 4,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Build"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": "n15",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search&tab=preview#pb-preview",
-        "disabled": false,
-        "label": "Preview"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 6,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Schedule"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 7,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Deploy"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Lineage"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": "n2",
-      "control": {
-        "index": 10,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Panning mode — drag pans the canvas (live)"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 11,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 12,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "multi-select has no consumer (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 13,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 14,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 15,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "no freeform node placement, so nothing snaps (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "canvas annotations have no persistence plane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 17,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Add data"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 18,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Reusables"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "join authoring — named gap (no authoring authority)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 21,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "union authoring — named gap"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "split authoring — named gap"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "model application — named gap (model routes live in the Model Catalog)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 24,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP logo icon"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 25,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP generation is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 26,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP explanation is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 27,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "transform editing — named gap (no authoring authority)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": "visited",
-      "control": {
-        "index": 28,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Search pipeline — the right panel becomes the real record search"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 29,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "color grouping is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": "n2",
-      "control": {
-        "index": 30,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom in"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n2",
-      "to": "n2",
-      "control": {
-        "index": 31,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom out"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n2",
-      "to": "n2",
-      "control": {
-        "index": 32,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom to fit"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n2",
-      "to": "n28",
-      "control": {
-        "index": 33,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Toggle legend"
-      },
-      "action": "click",
-      "outcome": "state-change"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 34,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Hide this color"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 35,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Hide this color"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 36,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Hide this color"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 37,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Hide this color"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 38,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Add color"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n2",
-      "to": "n2",
-      "control": {
-        "index": 39,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n2",
-      "to": "visited",
-      "control": {
-        "index": 40,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n2",
-      "to": "n29",
-      "control": {
-        "index": 41,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Datasource"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": "n30",
-      "control": {
-        "index": 42,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Object mapping"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": "n31",
-      "control": {
-        "index": 43,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Policy gate"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": "n32",
-      "control": {
-        "index": 44,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Transform plan"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": "n33",
-      "control": {
-        "index": 45,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Read projection"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": "n34",
-      "control": {
-        "index": 46,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Lease + session"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": "n35",
-      "control": {
-        "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": "visited",
-      "control": {
-        "index": 48,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Selection preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n2",
-      "to": "n36",
-      "control": {
-        "index": 49,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=suggestions",
-        "disabled": false,
-        "label": "Suggestions"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": "n37",
-      "control": {
-        "index": 50,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search&tab=warnings",
-        "disabled": false,
-        "label": "Pipeline warnings"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Toggle bottom bar"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 52,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 53,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "ODK substrate"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 54,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/pipeline",
-        "disabled": false,
-        "label": "Pipeline Builder capture ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": "visited",
-      "control": {
-        "index": 55,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Pipeline outputs"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n2",
-      "to": "visited",
-      "control": {
-        "index": 56,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Search pipeline — real record search"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n2",
-      "to": "visited",
-      "control": {
-        "index": 57,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
-        "disabled": false,
-        "label": "Pipeline file tree — the real ladder-record tree"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n2",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline",
-        "disabled": false,
-        "label": "Pipeline Builder"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 4,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Build"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
-        "disabled": false,
-        "label": "Preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 6,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Schedule"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 7,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Deploy"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Lineage"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": "n3",
-      "control": {
-        "index": 10,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Panning mode — drag pans the canvas (live)"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 11,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 12,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "multi-select has no consumer (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 13,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 14,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 15,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "no freeform node placement, so nothing snaps (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "canvas annotations have no persistence plane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 17,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Add data"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 18,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Reusables"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "join authoring — named gap (no authoring authority)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 21,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "union authoring — named gap"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "split authoring — named gap"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "model application — named gap (model routes live in the Model Catalog)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 24,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP logo icon"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 25,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP generation is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 26,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP explanation is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 27,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "transform editing — named gap (no authoring authority)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 28,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Search pipeline — the right panel becomes the real record search"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 29,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "color grouping is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": "n3",
-      "control": {
-        "index": 30,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom in"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n3",
-      "to": "n3",
-      "control": {
-        "index": 31,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom out"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n3",
-      "to": "n3",
-      "control": {
-        "index": 32,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom to fit"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n3",
-      "to": "n28",
-      "control": {
-        "index": 33,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Toggle legend"
-      },
-      "action": "click",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 34,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
-      },
-      "action": "click",
-      "outcome": "unclickable"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 35,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 36,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Datasource"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 37,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Object mapping"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 38,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Policy gate"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 39,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Transform plan"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 40,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Read projection"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 41,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Lease + session"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 42,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 43,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Selection preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 44,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
-        "disabled": false,
-        "label": "Suggestions"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 45,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
-        "disabled": false,
-        "label": "Pipeline warnings"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "n38",
-      "control": {
-        "index": 46,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Toggle bottom bar"
-      },
-      "action": "click",
-      "outcome": "state-change"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
       "to": null,
       "control": {
         "index": 48,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "ODK substrate"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 49,
-        "tag": "a",
-        "role": null,
-        "href": "/__apps/pipeline",
-        "disabled": false,
-        "label": "Pipeline Builder capture ↗"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 50,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Add"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Edit output settings"
       },
@@ -5847,13 +4897,13 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n3",
+      "from": "n1",
       "to": "visited",
       "control": {
-        "index": 52,
+        "index": 49,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline",
         "disabled": false,
         "label": "Pipeline outputs"
       },
@@ -5861,13 +4911,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n3",
+      "from": "n1",
       "to": "visited",
       "control": {
-        "index": 53,
+        "index": 50,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — real record search"
       },
@@ -5875,13 +4925,13 @@
       "outcome": "revisit"
     },
     {
-      "from": "n3",
+      "from": "n1",
       "to": "visited",
       "control": {
-        "index": 54,
+        "index": 51,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
+        "href": "/__ioi/pipeline?panel=tree",
         "disabled": false,
         "label": "Pipeline file tree — the real ladder-record tree"
       },
@@ -5889,14 +4939,14 @@
       "outcome": "revisit"
     },
     {
-      "from": "n3",
+      "from": "n1",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 0,
@@ -5910,7 +4960,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 1,
@@ -5924,7 +4974,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 2,
@@ -5938,7 +4988,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": "visited",
       "control": {
         "index": 3,
@@ -5952,7 +5002,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 4,
@@ -5966,21 +5016,21 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
-      "to": "visited",
+      "from": "n2",
+      "to": "n16",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
         "disabled": false,
         "label": "Preview"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "navigated"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 6,
@@ -5994,7 +5044,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 7,
@@ -6008,13 +5058,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/lineage?ontology=",
         "disabled": false,
         "label": "Lineage"
       },
@@ -6022,13 +5072,13 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
         "label": "Ontology Manager"
       },
@@ -6036,8 +5086,8 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
-      "to": "n4",
+      "from": "n2",
+      "to": "n2",
       "control": {
         "index": 10,
         "tag": "button",
@@ -6050,7 +5100,7 @@
       "outcome": "noop"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 11,
@@ -6064,7 +5114,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 12,
@@ -6078,7 +5128,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 13,
@@ -6092,7 +5142,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 14,
@@ -6106,7 +5156,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 15,
@@ -6120,7 +5170,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 16,
@@ -6134,13 +5184,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Add data"
       },
@@ -6148,7 +5198,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 18,
@@ -6162,7 +5212,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 19,
@@ -6176,7 +5226,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 20,
@@ -6190,7 +5240,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 21,
@@ -6204,7 +5254,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 22,
@@ -6218,7 +5268,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 23,
@@ -6232,7 +5282,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 24,
@@ -6246,7 +5296,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 25,
@@ -6260,7 +5310,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 26,
@@ -6274,7 +5324,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 27,
@@ -6288,13 +5338,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": "visited",
       "control": {
         "index": 28,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — the right panel becomes the real record search"
       },
@@ -6302,7 +5352,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 29,
@@ -6316,8 +5366,8 @@
       "outcome": "disabled"
     },
     {
-      "from": "n4",
-      "to": "n4",
+      "from": "n2",
+      "to": "n2",
       "control": {
         "index": 30,
         "tag": "button",
@@ -6330,8 +5380,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n4",
-      "to": "n4",
+      "from": "n2",
+      "to": "n2",
       "control": {
         "index": 31,
         "tag": "button",
@@ -6344,8 +5394,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n4",
-      "to": "n4",
+      "from": "n2",
+      "to": "n2",
       "control": {
         "index": 32,
         "tag": "button",
@@ -6358,7 +5408,714 @@
       "outcome": "noop"
     },
     {
-      "from": "n4",
+      "from": "n2",
+      "to": "n17",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n2",
+      "to": "n18",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n2",
+      "to": "n19",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n2",
+      "to": "n20",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n2",
+      "to": "n21",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "n22",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": "n23",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n2",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "n3",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": "n3",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n3",
+      "to": "n3",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n3",
+      "to": "n3",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n3",
       "to": "n0",
       "control": {
         "index": 33,
@@ -6372,22 +6129,687 @@
       "outcome": "navigated"
     },
     {
-      "from": "n4",
-      "to": "n39",
+      "from": "n3",
+      "to": null,
       "control": {
         "index": 34,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 38,
         "tag": "button",
         "role": null,
         "href": null,
         "disabled": false,
-        "label": "Hide this color"
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 42,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n3",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n3",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n4",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": "n4",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n4",
+      "to": "n24",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
       },
       "action": "click",
       "outcome": "state-change"
     },
     {
       "from": "n4",
-      "to": "n40",
+      "to": "n0",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n4",
+      "to": "n25",
       "control": {
         "index": 35,
         "tag": "button",
@@ -6401,7 +6823,7 @@
     },
     {
       "from": "n4",
-      "to": "n41",
+      "to": "n26",
       "control": {
         "index": 36,
         "tag": "button",
@@ -6415,7 +6837,7 @@
     },
     {
       "from": "n4",
-      "to": "n42",
+      "to": "n27",
       "control": {
         "index": 37,
         "tag": "button",
@@ -6443,17 +6865,17 @@
     },
     {
       "from": "n4",
-      "to": "n4",
+      "to": null,
       "control": {
         "index": 39,
-        "tag": "summary",
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
+        "label": "Create an ontology →"
       },
-      "action": "click",
-      "outcome": "noop"
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
     },
     {
       "from": "n4",
@@ -6462,9 +6884,9 @@
         "index": 40,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline",
         "disabled": false,
-        "label": "probe-reencode"
+        "label": "Selection preview"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -6476,9 +6898,9 @@
         "index": 41,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?tab=suggestions",
         "disabled": false,
-        "label": "Datasource"
+        "label": "Suggestions"
       },
       "action": "goto",
       "outcome": "revisit"
@@ -6490,119 +6912,7 @@
         "index": 42,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Object mapping"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 43,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Policy gate"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 44,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Transform plan"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 45,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Read projection"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 46,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Lease + session"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 48,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Selection preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 49,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=suggestions",
-        "disabled": false,
-        "label": "Suggestions"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n4",
-      "to": "visited",
-      "control": {
-        "index": 50,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&tab=warnings",
+        "href": "/__ioi/pipeline?tab=warnings",
         "disabled": false,
         "label": "Pipeline warnings"
       },
@@ -6613,7 +6923,7 @@
       "from": "n4",
       "to": null,
       "control": {
-        "index": 51,
+        "index": 43,
         "tag": "button",
         "role": null,
         "href": null,
@@ -6627,10 +6937,10 @@
       "from": "n4",
       "to": null,
       "control": {
-        "index": 52,
+        "index": 44,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
         "label": "Ontology Manager"
       },
@@ -6641,10 +6951,10 @@
       "from": "n4",
       "to": null,
       "control": {
-        "index": 53,
+        "index": 45,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "ODK substrate"
       },
@@ -6655,7 +6965,7 @@
       "from": "n4",
       "to": null,
       "control": {
-        "index": 54,
+        "index": 46,
         "tag": "a",
         "role": null,
         "href": "/__apps/pipeline",
@@ -6669,7 +6979,7 @@
       "from": "n4",
       "to": null,
       "control": {
-        "index": 55,
+        "index": 47,
         "tag": "button",
         "role": null,
         "href": null,
@@ -6683,10 +6993,10 @@
       "from": "n4",
       "to": null,
       "control": {
-        "index": 56,
+        "index": 48,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Edit output settings"
       },
@@ -6697,10 +7007,10 @@
       "from": "n4",
       "to": "visited",
       "control": {
-        "index": 57,
+        "index": 49,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline",
         "disabled": false,
         "label": "Pipeline outputs"
       },
@@ -6711,10 +7021,10 @@
       "from": "n4",
       "to": "visited",
       "control": {
-        "index": 58,
+        "index": 50,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — real record search"
       },
@@ -6725,10 +7035,10 @@
       "from": "n4",
       "to": "visited",
       "control": {
-        "index": 59,
+        "index": 51,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7&panel=tree",
+        "href": "/__ioi/pipeline?panel=tree",
         "disabled": false,
         "label": "Pipeline file tree — the real ladder-record tree"
       },
@@ -6819,7 +7129,7 @@
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
         "disabled": false,
         "label": "Preview"
       },
@@ -6861,7 +7171,7 @@
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/lineage?ontology=",
         "disabled": false,
         "label": "Lineage"
       },
@@ -6875,7 +7185,7 @@
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
         "label": "Ontology Manager"
       },
@@ -6987,7 +7297,7 @@
         "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Add data"
       },
@@ -7141,7 +7451,7 @@
         "index": 28,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — the right panel becomes the real record search"
       },
@@ -7206,23 +7516,2977 @@
     },
     {
       "from": "n5",
+      "to": "n28",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n5",
+      "to": "n25",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": "n0",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n5",
+      "to": "n29",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n5",
+      "to": "n30",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n5",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n5",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": "n6",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n6",
+      "to": "n31",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n6",
+      "to": "n26",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": "n29",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": "n0",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n6",
+      "to": "n32",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n6",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n6",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": "n7",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n7",
+      "to": "n33",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n7",
+      "to": "n27",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": "n30",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": "n32",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": "n0",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n7",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n7",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": "n8",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n8",
+      "to": "n34",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n8",
+      "to": "n35",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n8",
+      "to": "n36",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n8",
+      "to": "n37",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n8",
+      "to": "n38",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "Agent Studio"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n8",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n8",
+      "to": "n39",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree&tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n8",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": "n9",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n9",
+      "to": "n40",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n9",
+      "to": "n41",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n9",
+      "to": "n42",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n9",
       "to": "n43",
       "control": {
-        "index": 33,
+        "index": 36,
         "tag": "button",
         "role": null,
         "href": null,
         "disabled": false,
-        "label": "Toggle legend"
+        "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "navigated"
+      "outcome": "state-change"
     },
     {
-      "from": "n5",
+      "from": "n9",
       "to": "n44",
       "control": {
-        "index": 34,
+        "index": 37,
         "tag": "button",
         "role": null,
         "href": null,
@@ -7233,1295 +10497,350 @@
       "outcome": "state-change"
     },
     {
-      "from": "n5",
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n9",
       "to": "n45",
       "control": {
-        "index": 35,
-        "tag": "button",
+        "index": 44,
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/pipeline?node=datasource",
         "disabled": false,
-        "label": "Hide this color"
+        "label": "Go to node"
       },
-      "action": "click",
-      "outcome": "state-change"
+      "action": "goto",
+      "outcome": "navigated"
     },
     {
-      "from": "n5",
+      "from": "n9",
       "to": "n46",
       "control": {
-        "index": 36,
-        "tag": "button",
+        "index": 45,
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/pipeline?node=mapping",
         "disabled": false,
-        "label": "Hide this color"
+        "label": "Go to node"
       },
-      "action": "click",
-      "outcome": "state-change"
+      "action": "goto",
+      "outcome": "navigated"
     },
     {
-      "from": "n5",
+      "from": "n9",
       "to": "n47",
       "control": {
-        "index": 37,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Hide this color"
-      },
-      "action": "click",
-      "outcome": "state-change"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 38,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Add color"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": "n5",
-      "control": {
-        "index": 39,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 40,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 41,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Datasource"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 42,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Object mapping"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 43,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Policy gate"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 44,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Transform plan"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 45,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Read projection"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
         "index": 46,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?node=policy",
         "disabled": false,
-        "label": "Lease + session"
+        "label": "Go to node"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "navigated"
     },
     {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 48,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Snapshot"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 49,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Transform"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 50,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Split"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Join"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 52,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Union"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 53,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Use LLM"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 54,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Generate"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 55,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Explain"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": null,
-      "control": {
-        "index": 56,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Add"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 57,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Selection preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
-      "to": "visited",
-      "control": {
-        "index": 58,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=preview",
-        "disabled": false,
-        "label": "Preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n5",
+      "from": "n9",
       "to": "n48",
       "control": {
-        "index": 59,
+        "index": 47,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "href": "/__ioi/pipeline?node=transform",
         "disabled": false,
-        "label": "Suggestions"
+        "label": "Go to node"
       },
       "action": "goto",
       "outcome": "navigated"
     },
     {
-      "from": "n5",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline",
-        "disabled": false,
-        "label": "Pipeline Builder"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 4,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Build"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
-        "disabled": false,
-        "label": "Preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 6,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Schedule"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 7,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Deploy"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Lineage"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n6",
-      "to": "n6",
-      "control": {
-        "index": 10,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Panning mode — drag pans the canvas (live)"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 11,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 12,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "multi-select has no consumer (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 13,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 14,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 15,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "no freeform node placement, so nothing snaps (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "canvas annotations have no persistence plane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 17,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Add data"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 18,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Reusables"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 19,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 20,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "join authoring — named gap (no authoring authority)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 21,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "union authoring — named gap"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 22,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "split authoring — named gap"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 23,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "model application — named gap (model routes live in the Model Catalog)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 24,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP logo icon"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 25,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP generation is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 26,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "AIP explanation is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 27,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "transform editing — named gap (no authoring authority)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 28,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&panel=search",
-        "disabled": false,
-        "label": "Search pipeline — the right panel becomes the real record search"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 29,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "color grouping is a reference-only lane (named gap)"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": "n6",
-      "control": {
-        "index": 30,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom in"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n6",
-      "to": "n6",
-      "control": {
-        "index": 31,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom out"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n6",
-      "to": "n6",
-      "control": {
-        "index": 32,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Zoom to fit"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n6",
+      "from": "n9",
       "to": "n49",
       "control": {
-        "index": 33,
-        "tag": "button",
+        "index": 48,
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/pipeline?node=projection",
         "disabled": false,
-        "label": "Toggle legend"
+        "label": "Go to node"
       },
-      "action": "click",
+      "action": "goto",
       "outcome": "navigated"
     },
     {
-      "from": "n6",
+      "from": "n9",
       "to": "n50",
       "control": {
-        "index": 34,
-        "tag": "button",
+        "index": 49,
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/pipeline?node=lease",
         "disabled": false,
-        "label": "Hide this color"
+        "label": "Go to node"
       },
-      "action": "click",
-      "outcome": "state-change"
+      "action": "goto",
+      "outcome": "navigated"
     },
     {
-      "from": "n6",
+      "from": "n9",
       "to": "n51",
       "control": {
-        "index": 35,
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized",
+        "disabled": false,
+        "label": "Go to node"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 51,
         "tag": "button",
         "role": null,
         "href": null,
-        "disabled": false,
-        "label": "Hide this color"
+        "disabled": true,
+        "label": "Add"
       },
-      "action": "click",
-      "outcome": "state-change"
+      "action": "none",
+      "outcome": "disabled"
     },
     {
-      "from": "n6",
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 52,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 53,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
+      "to": "visited",
+      "control": {
+        "index": 54,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n9",
       "to": "n52",
       "control": {
-        "index": 36,
+        "index": 55,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n9",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 4,
         "tag": "button",
         "role": null,
         "href": null,
-        "disabled": false,
-        "label": "Hide this color"
+        "disabled": true,
+        "label": "Build"
       },
-      "action": "click",
-      "outcome": "state-change"
+      "action": "none",
+      "outcome": "disabled"
     },
     {
-      "from": "n6",
+      "from": "n10",
       "to": "n53",
       "control": {
-        "index": 37,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Hide this color"
-      },
-      "action": "click",
-      "outcome": "state-change"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 38,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Add color"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": "n6",
-      "control": {
-        "index": 39,
-        "tag": "summary",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
-      },
-      "action": "click",
-      "outcome": "noop"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 40,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 41,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Datasource"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 42,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Object mapping"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 43,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Policy gate"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 44,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Transform plan"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 45,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Read projection"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 46,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Lease + session"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 48,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Snapshot"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 49,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Transform"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 50,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Split"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Join"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 52,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Union"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 53,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Use LLM"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 54,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Generate"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 55,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Explain"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": null,
-      "control": {
-        "index": 56,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Add"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 57,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Selection preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": "visited",
-      "control": {
-        "index": 58,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=preview",
-        "disabled": false,
-        "label": "Preview"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n6",
-      "to": "n54",
-      "control": {
-        "index": 59,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7&tab=suggestions",
-        "disabled": false,
-        "label": "Suggestions"
-      },
-      "action": "goto",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n6",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline",
-        "disabled": false,
-        "label": "Pipeline Builder"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 4,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Build"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "href": "/__ioi/pipeline?node=materialized&panel=tree&tab=preview#pb-preview",
         "disabled": false,
         "label": "Preview"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "navigated"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 6,
@@ -8535,7 +10854,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 7,
@@ -8549,13 +10868,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/lineage?ontology=",
         "disabled": false,
         "label": "Lineage"
       },
@@ -8563,13 +10882,13 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
         "label": "Ontology Manager"
       },
@@ -8577,8 +10896,8 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
-      "to": "n7",
+      "from": "n10",
+      "to": "n10",
       "control": {
         "index": 10,
         "tag": "button",
@@ -8591,7 +10910,7 @@
       "outcome": "noop"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 11,
@@ -8605,7 +10924,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 12,
@@ -8619,7 +10938,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 13,
@@ -8633,7 +10952,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 14,
@@ -8647,7 +10966,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 15,
@@ -8661,7 +10980,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 16,
@@ -8675,13 +10994,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Add data"
       },
@@ -8689,7 +11008,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 18,
@@ -8703,7 +11022,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 19,
@@ -8717,7 +11036,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 20,
@@ -8731,7 +11050,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 21,
@@ -8745,7 +11064,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 22,
@@ -8759,7 +11078,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 23,
@@ -8773,7 +11092,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 24,
@@ -8787,7 +11106,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 25,
@@ -8801,7 +11120,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 26,
@@ -8815,7 +11134,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 27,
@@ -8829,13 +11148,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 28,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — the right panel becomes the real record search"
       },
@@ -8843,7 +11162,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 29,
@@ -8857,8 +11176,8 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
-      "to": "n7",
+      "from": "n10",
+      "to": "n10",
       "control": {
         "index": 30,
         "tag": "button",
@@ -8871,8 +11190,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n7",
-      "to": "n7",
+      "from": "n10",
+      "to": "n10",
       "control": {
         "index": 31,
         "tag": "button",
@@ -8885,8 +11204,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n7",
-      "to": "n7",
+      "from": "n10",
+      "to": "n10",
       "control": {
         "index": 32,
         "tag": "button",
@@ -8899,8 +11218,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n7",
-      "to": "n55",
+      "from": "n10",
+      "to": "n54",
       "control": {
         "index": 33,
         "tag": "button",
@@ -8910,11 +11229,11 @@
         "label": "Toggle legend"
       },
       "action": "click",
-      "outcome": "navigated"
+      "outcome": "state-change"
     },
     {
-      "from": "n7",
-      "to": "n56",
+      "from": "n10",
+      "to": "n55",
       "control": {
         "index": 34,
         "tag": "button",
@@ -8927,8 +11246,8 @@
       "outcome": "state-change"
     },
     {
-      "from": "n7",
-      "to": "n57",
+      "from": "n10",
+      "to": "n56",
       "control": {
         "index": 35,
         "tag": "button",
@@ -8941,8 +11260,8 @@
       "outcome": "state-change"
     },
     {
-      "from": "n7",
-      "to": "n58",
+      "from": "n10",
+      "to": "n57",
       "control": {
         "index": 36,
         "tag": "button",
@@ -8955,8 +11274,8 @@
       "outcome": "state-change"
     },
     {
-      "from": "n7",
-      "to": "n59",
+      "from": "n10",
+      "to": "n58",
       "control": {
         "index": 37,
         "tag": "button",
@@ -8969,7 +11288,7 @@
       "outcome": "state-change"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": null,
       "control": {
         "index": 38,
@@ -8983,265 +11302,27 @@
       "outcome": "disabled"
     },
     {
-      "from": "n7",
-      "to": "n7",
+      "from": "n10",
+      "to": null,
       "control": {
         "index": 39,
-        "tag": "summary",
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
+        "label": "Create an ontology →"
       },
-      "action": "click",
-      "outcome": "noop"
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": "visited",
       "control": {
         "index": 40,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 41,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Datasource"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 42,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Object mapping"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 43,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Policy gate"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 44,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Transform plan"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 45,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Read projection"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 46,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Lease + session"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 48,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Snapshot"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 49,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Transform"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 50,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Split"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Join"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 52,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Union"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 53,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Use LLM"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 54,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Generate"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 55,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Explain"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": null,
-      "control": {
-        "index": 56,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Add"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n7",
-      "to": "visited",
-      "control": {
-        "index": 57,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?panel=tree",
         "disabled": false,
         "label": "Selection preview"
       },
@@ -9249,42 +11330,140 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n10",
       "to": "visited",
       "control": {
-        "index": 58,
+        "index": 41,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__ioi/pipeline?panel=tree&tab=suggestions",
         "disabled": false,
-        "label": "Preview"
+        "label": "Suggestions"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n7",
-      "to": "n60",
+      "from": "n10",
+      "to": "visited",
       "control": {
-        "index": 59,
+        "index": 42,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "href": "/__ioi/pipeline?panel=tree&tab=warnings",
         "disabled": false,
-        "label": "Suggestions"
+        "label": "Pipeline warnings"
       },
       "action": "goto",
-      "outcome": "navigated"
+      "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 0,
@@ -9298,7 +11477,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 1,
@@ -9312,7 +11491,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 2,
@@ -9326,7 +11505,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 3,
@@ -9340,7 +11519,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 4,
@@ -9354,13 +11533,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
         "disabled": false,
         "label": "Preview"
       },
@@ -9368,7 +11547,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 6,
@@ -9382,7 +11561,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 7,
@@ -9396,13 +11575,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/lineage?ontology=",
         "disabled": false,
         "label": "Lineage"
       },
@@ -9410,13 +11589,13 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
         "label": "Ontology Manager"
       },
@@ -9424,8 +11603,8 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
-      "to": "n8",
+      "from": "n11",
+      "to": "n11",
       "control": {
         "index": 10,
         "tag": "button",
@@ -9438,7 +11617,7 @@
       "outcome": "noop"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 11,
@@ -9452,7 +11631,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 12,
@@ -9466,7 +11645,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 13,
@@ -9480,7 +11659,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 14,
@@ -9494,7 +11673,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 15,
@@ -9508,7 +11687,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 16,
@@ -9522,13 +11701,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Add data"
       },
@@ -9536,7 +11715,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 18,
@@ -9550,7 +11729,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 19,
@@ -9564,7 +11743,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 20,
@@ -9578,7 +11757,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 21,
@@ -9592,7 +11771,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 22,
@@ -9606,7 +11785,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 23,
@@ -9620,7 +11799,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 24,
@@ -9634,7 +11813,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 25,
@@ -9648,7 +11827,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 26,
@@ -9662,7 +11841,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 27,
@@ -9676,13 +11855,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": "visited",
       "control": {
         "index": 28,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — the right panel becomes the real record search"
       },
@@ -9690,7 +11869,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n11",
       "to": null,
       "control": {
         "index": 29,
@@ -9704,8 +11883,8 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
-      "to": "n8",
+      "from": "n11",
+      "to": "n11",
       "control": {
         "index": 30,
         "tag": "button",
@@ -9718,8 +11897,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n8",
-      "to": "n8",
+      "from": "n11",
+      "to": "n11",
       "control": {
         "index": 31,
         "tag": "button",
@@ -9732,8 +11911,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n8",
-      "to": "n8",
+      "from": "n11",
+      "to": "n11",
       "control": {
         "index": 32,
         "tag": "button",
@@ -9746,8 +11925,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n8",
-      "to": "n61",
+      "from": "n11",
+      "to": "n1",
       "control": {
         "index": 33,
         "tag": "button",
@@ -9760,22 +11939,687 @@
       "outcome": "navigated"
     },
     {
-      "from": "n8",
-      "to": "n62",
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 42,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n11",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n11",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "n12",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": "n12",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n12",
+      "to": "n12",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n12",
+      "to": "n12",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n12",
+      "to": "n59",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n12",
+      "to": "n1",
       "control": {
         "index": 34,
         "tag": "button",
         "role": null,
         "href": null,
         "disabled": false,
-        "label": "Hide this color"
+        "label": "Show this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n8",
-      "to": "n63",
+      "from": "n12",
+      "to": "n60",
       "control": {
         "index": 35,
         "tag": "button",
@@ -9785,10 +12629,745 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n8",
+      "from": "n12",
+      "to": "n61",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n12",
+      "to": "n62",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n12",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n12",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": "n13",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n13",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n13",
+      "to": "n13",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n13",
+      "to": "n13",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n13",
+      "to": "n13",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n13",
+      "to": "n63",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n13",
+      "to": "n60",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n13",
+      "to": "n1",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n13",
       "to": "n64",
       "control": {
         "index": 36,
@@ -9799,10 +13378,10 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n8",
+      "from": "n13",
       "to": "n65",
       "control": {
         "index": 37,
@@ -9813,10 +13392,10 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n8",
+      "from": "n13",
       "to": null,
       "control": {
         "index": 38,
@@ -9830,248 +13409,122 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
-      "to": "n8",
+      "from": "n13",
+      "to": null,
       "control": {
         "index": 39,
-        "tag": "summary",
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
+        "label": "Create an ontology →"
       },
-      "action": "click",
-      "outcome": "noop"
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n13",
       "to": "visited",
       "control": {
         "index": 40,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline",
         "disabled": false,
-        "label": "probe-reencode"
+        "label": "Selection preview"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n13",
       "to": "visited",
       "control": {
         "index": 41,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?tab=suggestions",
         "disabled": false,
-        "label": "Datasource"
+        "label": "Suggestions"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n13",
       "to": "visited",
       "control": {
         "index": 42,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?tab=warnings",
         "disabled": false,
-        "label": "Object mapping"
+        "label": "Pipeline warnings"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n8",
-      "to": "visited",
+      "from": "n13",
+      "to": null,
       "control": {
         "index": 43,
-        "tag": "a",
+        "tag": "button",
         "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "href": null,
         "disabled": false,
-        "label": "Policy gate"
+        "label": "Toggle bottom bar"
       },
-      "action": "goto",
-      "outcome": "revisit"
+      "action": "click",
+      "outcome": "unclickable"
     },
     {
-      "from": "n8",
-      "to": "visited",
+      "from": "n13",
+      "to": null,
       "control": {
         "index": 44,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
-        "label": "Transform plan"
+        "label": "Ontology Manager"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
-      "to": "visited",
+      "from": "n13",
+      "to": null,
       "control": {
         "index": 45,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
-        "label": "Read projection"
+        "label": "ODK substrate"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
-      "to": "visited",
+      "from": "n13",
+      "to": null,
       "control": {
         "index": 46,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "href": "/__apps/pipeline",
         "disabled": false,
-        "label": "Lease + session"
+        "label": "Pipeline Builder capture ↗"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
-      "to": "visited",
+      "from": "n13",
+      "to": null,
       "control": {
         "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 48,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Snapshot"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 49,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Transform"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 50,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Split"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Join"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 52,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Union"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 53,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Use LLM"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 54,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Generate"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 55,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Explain"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n8",
-      "to": null,
-      "control": {
-        "index": 56,
         "tag": "button",
         "role": null,
         "href": null,
@@ -10082,56 +13535,70 @@
       "outcome": "disabled"
     },
     {
-      "from": "n8",
-      "to": "visited",
+      "from": "n13",
+      "to": null,
       "control": {
-        "index": 57,
+        "index": 48,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
-        "label": "Selection preview"
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n13",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n13",
       "to": "visited",
       "control": {
-        "index": 58,
+        "index": 50,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
-        "label": "Preview"
+        "label": "Search pipeline — real record search"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n8",
-      "to": "n66",
+      "from": "n13",
+      "to": "visited",
       "control": {
-        "index": 59,
+        "index": 51,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "href": "/__ioi/pipeline?panel=tree",
         "disabled": false,
-        "label": "Suggestions"
+        "label": "Pipeline file tree — the real ladder-record tree"
       },
       "action": "goto",
-      "outcome": "navigated"
+      "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n13",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 0,
@@ -10145,7 +13612,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 1,
@@ -10159,7 +13626,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 2,
@@ -10173,7 +13640,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": "visited",
       "control": {
         "index": 3,
@@ -10187,7 +13654,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 4,
@@ -10201,13 +13668,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
         "disabled": false,
         "label": "Preview"
       },
@@ -10215,7 +13682,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 6,
@@ -10229,7 +13696,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 7,
@@ -10243,13 +13710,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/lineage?ontology=",
         "disabled": false,
         "label": "Lineage"
       },
@@ -10257,13 +13724,13 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
         "label": "Ontology Manager"
       },
@@ -10271,8 +13738,8 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
-      "to": "n9",
+      "from": "n14",
+      "to": "n14",
       "control": {
         "index": 10,
         "tag": "button",
@@ -10285,7 +13752,7 @@
       "outcome": "noop"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 11,
@@ -10299,7 +13766,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 12,
@@ -10313,7 +13780,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 13,
@@ -10327,7 +13794,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 14,
@@ -10341,7 +13808,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 15,
@@ -10355,7 +13822,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 16,
@@ -10369,13 +13836,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Add data"
       },
@@ -10383,7 +13850,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 18,
@@ -10397,7 +13864,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 19,
@@ -10411,7 +13878,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 20,
@@ -10425,7 +13892,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 21,
@@ -10439,7 +13906,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 22,
@@ -10453,7 +13920,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 23,
@@ -10467,7 +13934,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 24,
@@ -10481,7 +13948,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 25,
@@ -10495,7 +13962,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 26,
@@ -10509,7 +13976,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 27,
@@ -10523,13 +13990,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": "visited",
       "control": {
         "index": 28,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — the right panel becomes the real record search"
       },
@@ -10537,7 +14004,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 29,
@@ -10551,8 +14018,8 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
-      "to": "n9",
+      "from": "n14",
+      "to": "n14",
       "control": {
         "index": 30,
         "tag": "button",
@@ -10565,8 +14032,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n9",
-      "to": "n9",
+      "from": "n14",
+      "to": "n14",
       "control": {
         "index": 31,
         "tag": "button",
@@ -10579,8 +14046,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n9",
-      "to": "n9",
+      "from": "n14",
+      "to": "n14",
       "control": {
         "index": 32,
         "tag": "button",
@@ -10593,8 +14060,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n9",
-      "to": "n67",
+      "from": "n14",
+      "to": "n66",
       "control": {
         "index": 33,
         "tag": "button",
@@ -10607,8 +14074,8 @@
       "outcome": "navigated"
     },
     {
-      "from": "n9",
-      "to": "n68",
+      "from": "n14",
+      "to": "n61",
       "control": {
         "index": 34,
         "tag": "button",
@@ -10618,11 +14085,11 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n9",
-      "to": "n69",
+      "from": "n14",
+      "to": "n64",
       "control": {
         "index": 35,
         "tag": "button",
@@ -10632,25 +14099,25 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n9",
-      "to": "n70",
+      "from": "n14",
+      "to": "n1",
       "control": {
         "index": 36,
         "tag": "button",
         "role": null,
         "href": null,
         "disabled": false,
-        "label": "Hide this color"
+        "label": "Show this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n9",
-      "to": "n71",
+      "from": "n14",
+      "to": "n67",
       "control": {
         "index": 37,
         "tag": "button",
@@ -10660,10 +14127,10 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": null,
       "control": {
         "index": 38,
@@ -10677,248 +14144,122 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
-      "to": "n9",
+      "from": "n14",
+      "to": null,
       "control": {
         "index": 39,
-        "tag": "summary",
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
+        "label": "Create an ontology →"
       },
-      "action": "click",
-      "outcome": "noop"
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": "visited",
       "control": {
         "index": 40,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline",
         "disabled": false,
-        "label": "probe-reencode"
+        "label": "Selection preview"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": "visited",
       "control": {
         "index": 41,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?tab=suggestions",
         "disabled": false,
-        "label": "Datasource"
+        "label": "Suggestions"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": "visited",
       "control": {
         "index": 42,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?tab=warnings",
         "disabled": false,
-        "label": "Object mapping"
+        "label": "Pipeline warnings"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n9",
-      "to": "visited",
+      "from": "n14",
+      "to": null,
       "control": {
         "index": 43,
-        "tag": "a",
+        "tag": "button",
         "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "href": null,
         "disabled": false,
-        "label": "Policy gate"
+        "label": "Toggle bottom bar"
       },
-      "action": "goto",
-      "outcome": "revisit"
+      "action": "click",
+      "outcome": "unclickable"
     },
     {
-      "from": "n9",
-      "to": "visited",
+      "from": "n14",
+      "to": null,
       "control": {
         "index": 44,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
-        "label": "Transform plan"
+        "label": "Ontology Manager"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
-      "to": "visited",
+      "from": "n14",
+      "to": null,
       "control": {
         "index": 45,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
-        "label": "Read projection"
+        "label": "ODK substrate"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
-      "to": "visited",
+      "from": "n14",
+      "to": null,
       "control": {
         "index": 46,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "href": "/__apps/pipeline",
         "disabled": false,
-        "label": "Lease + session"
+        "label": "Pipeline Builder capture ↗"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
-      "to": "visited",
+      "from": "n14",
+      "to": null,
       "control": {
         "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 48,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Snapshot"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 49,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Transform"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 50,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Split"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Join"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 52,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Union"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 53,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Use LLM"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 54,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Generate"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 55,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Explain"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n9",
-      "to": null,
-      "control": {
-        "index": 56,
         "tag": "button",
         "role": null,
         "href": null,
@@ -10929,56 +14270,70 @@
       "outcome": "disabled"
     },
     {
-      "from": "n9",
-      "to": "visited",
+      "from": "n14",
+      "to": null,
       "control": {
-        "index": 57,
+        "index": 48,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
-        "label": "Selection preview"
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n14",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": "visited",
       "control": {
-        "index": 58,
+        "index": 50,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
-        "label": "Preview"
+        "label": "Search pipeline — real record search"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n9",
-      "to": "n72",
+      "from": "n14",
+      "to": "visited",
       "control": {
-        "index": 59,
+        "index": 51,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "href": "/__ioi/pipeline?panel=tree",
         "disabled": false,
-        "label": "Suggestions"
+        "label": "Pipeline file tree — the real ladder-record tree"
       },
       "action": "goto",
-      "outcome": "navigated"
+      "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n14",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 0,
@@ -10992,7 +14347,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 1,
@@ -11006,7 +14361,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 2,
@@ -11020,7 +14375,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": "visited",
       "control": {
         "index": 3,
@@ -11034,7 +14389,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 4,
@@ -11048,13 +14403,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
         "disabled": false,
         "label": "Preview"
       },
@@ -11062,7 +14417,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 6,
@@ -11076,7 +14431,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 7,
@@ -11090,13 +14445,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/lineage?ontology=",
         "disabled": false,
         "label": "Lineage"
       },
@@ -11104,13 +14459,13 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
         "label": "Ontology Manager"
       },
@@ -11118,8 +14473,8 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
-      "to": "n10",
+      "from": "n15",
+      "to": "n15",
       "control": {
         "index": 10,
         "tag": "button",
@@ -11132,7 +14487,7 @@
       "outcome": "noop"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 11,
@@ -11146,7 +14501,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 12,
@@ -11160,7 +14515,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 13,
@@ -11174,7 +14529,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 14,
@@ -11188,7 +14543,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 15,
@@ -11202,7 +14557,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 16,
@@ -11216,13 +14571,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Add data"
       },
@@ -11230,7 +14585,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 18,
@@ -11244,7 +14599,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 19,
@@ -11258,7 +14613,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 20,
@@ -11272,7 +14627,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 21,
@@ -11286,7 +14641,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 22,
@@ -11300,7 +14655,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 23,
@@ -11314,7 +14669,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 24,
@@ -11328,7 +14683,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 25,
@@ -11342,7 +14697,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 26,
@@ -11356,7 +14711,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 27,
@@ -11370,13 +14725,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": "visited",
       "control": {
         "index": 28,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — the right panel becomes the real record search"
       },
@@ -11384,7 +14739,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n15",
       "to": null,
       "control": {
         "index": 29,
@@ -11398,8 +14753,8 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
-      "to": "n10",
+      "from": "n15",
+      "to": "n15",
       "control": {
         "index": 30,
         "tag": "button",
@@ -11412,8 +14767,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n10",
-      "to": "n10",
+      "from": "n15",
+      "to": "n15",
       "control": {
         "index": 31,
         "tag": "button",
@@ -11426,8 +14781,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n10",
-      "to": "n10",
+      "from": "n15",
+      "to": "n15",
       "control": {
         "index": 32,
         "tag": "button",
@@ -11440,8 +14795,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n10",
-      "to": "n73",
+      "from": "n15",
+      "to": "n68",
       "control": {
         "index": 33,
         "tag": "button",
@@ -11454,8 +14809,8 @@
       "outcome": "navigated"
     },
     {
-      "from": "n10",
-      "to": "n74",
+      "from": "n15",
+      "to": "n62",
       "control": {
         "index": 34,
         "tag": "button",
@@ -11465,10 +14820,2089 @@
         "label": "Hide this color"
       },
       "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n15",
+      "to": "n65",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n15",
+      "to": "n67",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n15",
+      "to": "n1",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n15",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n15",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": "n16",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": "n16",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n16",
+      "to": "n16",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n16",
+      "to": "n16",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n16",
+      "to": "n69",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n16",
+      "to": "n70",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n16",
+      "to": "n71",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n16",
+      "to": "n72",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n16",
+      "to": "n73",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n16",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": "n17",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n17",
+      "to": "n17",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n17",
+      "to": "n17",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n17",
+      "to": "n17",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n17",
+      "to": "n2",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n17",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": "n18",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n18",
+      "to": "n18",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n18",
+      "to": "n18",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n18",
+      "to": "n18",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n18",
+      "to": "n74",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
       "outcome": "state-change"
     },
     {
-      "from": "n10",
+      "from": "n18",
+      "to": "n2",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n18",
       "to": "n75",
       "control": {
         "index": 35,
@@ -11482,7 +16916,7 @@
       "outcome": "state-change"
     },
     {
-      "from": "n10",
+      "from": "n18",
       "to": "n76",
       "control": {
         "index": 36,
@@ -11496,7 +16930,7 @@
       "outcome": "state-change"
     },
     {
-      "from": "n10",
+      "from": "n18",
       "to": "n77",
       "control": {
         "index": 37,
@@ -11510,7 +16944,7 @@
       "outcome": "state-change"
     },
     {
-      "from": "n10",
+      "from": "n18",
       "to": null,
       "control": {
         "index": 38,
@@ -11524,265 +16958,27 @@
       "outcome": "disabled"
     },
     {
-      "from": "n10",
-      "to": "n10",
+      "from": "n18",
+      "to": null,
       "control": {
         "index": 39,
-        "tag": "summary",
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
+        "label": "Create an ontology →"
       },
-      "action": "click",
-      "outcome": "noop"
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n18",
       "to": "visited",
       "control": {
         "index": 40,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "probe-reencode"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 41,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Datasource"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 42,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Object mapping"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 43,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Policy gate"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 44,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Transform plan"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 45,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Read projection"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 46,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Lease + session"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 47,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
-        "disabled": false,
-        "label": "Materialized objects"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 48,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Snapshot"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 49,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Transform"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 50,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Split"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 51,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Join"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 52,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Union"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 53,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Use LLM"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 54,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Generate"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 55,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Explain"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n10",
-      "to": null,
-      "control": {
-        "index": 56,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Add"
-      },
-      "action": "none",
-      "outcome": "disabled"
-    },
-    {
-      "from": "n10",
-      "to": "visited",
-      "control": {
-        "index": 57,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Selection preview"
       },
@@ -11790,42 +16986,140 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n18",
       "to": "visited",
       "control": {
-        "index": 58,
+        "index": 41,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
         "disabled": false,
-        "label": "Preview"
+        "label": "Suggestions"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n10",
-      "to": "n78",
+      "from": "n18",
+      "to": "visited",
       "control": {
-        "index": 59,
+        "index": 42,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
         "disabled": false,
-        "label": "Suggestions"
+        "label": "Pipeline warnings"
       },
       "action": "goto",
-      "outcome": "navigated"
+      "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n18",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 0,
@@ -11839,7 +17133,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 1,
@@ -11853,7 +17147,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 2,
@@ -11867,7 +17161,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": "visited",
       "control": {
         "index": 3,
@@ -11881,7 +17175,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 4,
@@ -11895,13 +17189,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": "visited",
       "control": {
         "index": 5,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview",
+        "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
         "disabled": false,
         "label": "Preview"
       },
@@ -11909,7 +17203,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 6,
@@ -11923,7 +17217,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 7,
@@ -11937,13 +17231,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/lineage?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/lineage?ontology=",
         "disabled": false,
         "label": "Lineage"
       },
@@ -11951,13 +17245,13 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 9,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/ontology/manager?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
         "label": "Ontology Manager"
       },
@@ -11965,8 +17259,8 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
-      "to": "n11",
+      "from": "n19",
+      "to": "n19",
       "control": {
         "index": 10,
         "tag": "button",
@@ -11979,7 +17273,7 @@
       "outcome": "noop"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 11,
@@ -11993,7 +17287,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 12,
@@ -12007,7 +17301,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 13,
@@ -12021,7 +17315,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 14,
@@ -12035,7 +17329,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 15,
@@ -12049,7 +17343,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 16,
@@ -12063,13 +17357,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 17,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/odk?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
         "label": "Add data"
       },
@@ -12077,7 +17371,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 18,
@@ -12091,7 +17385,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 19,
@@ -12105,7 +17399,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 20,
@@ -12119,7 +17413,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 21,
@@ -12133,7 +17427,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 22,
@@ -12147,7 +17441,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 23,
@@ -12161,7 +17455,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 24,
@@ -12175,7 +17469,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 25,
@@ -12189,7 +17483,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 26,
@@ -12203,7 +17497,7 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 27,
@@ -12217,13 +17511,13 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": "visited",
       "control": {
         "index": 28,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&panel=search",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
         "label": "Search pipeline — the right panel becomes the real record search"
       },
@@ -12231,7 +17525,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 29,
@@ -12245,8 +17539,8 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
-      "to": "n11",
+      "from": "n19",
+      "to": "n19",
       "control": {
         "index": 30,
         "tag": "button",
@@ -12259,8 +17553,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n11",
-      "to": "n11",
+      "from": "n19",
+      "to": "n19",
       "control": {
         "index": 31,
         "tag": "button",
@@ -12273,8 +17567,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n11",
-      "to": "n11",
+      "from": "n19",
+      "to": "n19",
       "control": {
         "index": 32,
         "tag": "button",
@@ -12287,8 +17581,8 @@
       "outcome": "noop"
     },
     {
-      "from": "n11",
-      "to": "n79",
+      "from": "n19",
+      "to": "n78",
       "control": {
         "index": 33,
         "tag": "button",
@@ -12298,11 +17592,11 @@
         "label": "Toggle legend"
       },
       "action": "click",
-      "outcome": "navigated"
+      "outcome": "state-change"
     },
     {
-      "from": "n11",
-      "to": "n80",
+      "from": "n19",
+      "to": "n75",
       "control": {
         "index": 34,
         "tag": "button",
@@ -12312,25 +17606,25 @@
         "label": "Hide this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n11",
-      "to": "n81",
+      "from": "n19",
+      "to": "n2",
       "control": {
         "index": 35,
         "tag": "button",
         "role": null,
         "href": null,
         "disabled": false,
-        "label": "Hide this color"
+        "label": "Show this color"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "navigated"
     },
     {
-      "from": "n11",
-      "to": "n82",
+      "from": "n19",
+      "to": "n79",
       "control": {
         "index": 36,
         "tag": "button",
@@ -12343,8 +17637,8 @@
       "outcome": "state-change"
     },
     {
-      "from": "n11",
-      "to": "n83",
+      "from": "n19",
+      "to": "n80",
       "control": {
         "index": 37,
         "tag": "button",
@@ -12357,7 +17651,7 @@
       "outcome": "state-change"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": null,
       "control": {
         "index": 38,
@@ -12371,248 +17665,3615 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
-      "to": "n11",
+      "from": "n19",
+      "to": null,
       "control": {
         "index": 39,
-        "tag": "summary",
+        "tag": "a",
         "role": null,
-        "href": null,
+        "href": "/__ioi/odk/ontologies/new",
         "disabled": false,
-        "label": "Pipeline: probe-reencode ▾"
+        "label": "Create an ontology →"
       },
-      "action": "click",
-      "outcome": "noop"
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": "visited",
       "control": {
         "index": 40,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?panel=search",
         "disabled": false,
-        "label": "probe-reencode"
+        "label": "Selection preview"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": "visited",
       "control": {
         "index": 41,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=datasource&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
         "disabled": false,
-        "label": "Datasource"
+        "label": "Suggestions"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": "visited",
       "control": {
         "index": 42,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=mapping&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
         "disabled": false,
-        "label": "Object mapping"
+        "label": "Pipeline warnings"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n11",
-      "to": "visited",
+      "from": "n19",
+      "to": null,
       "control": {
         "index": 43,
-        "tag": "a",
+        "tag": "button",
         "role": null,
-        "href": "/__ioi/pipeline?node=policy&ontology=ont_18ca2757d28a20f7",
+        "href": null,
         "disabled": false,
-        "label": "Policy gate"
+        "label": "Toggle bottom bar"
       },
-      "action": "goto",
-      "outcome": "revisit"
+      "action": "click",
+      "outcome": "unclickable"
     },
     {
-      "from": "n11",
-      "to": "visited",
+      "from": "n19",
+      "to": null,
       "control": {
         "index": 44,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=transform&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/ontology/manager",
         "disabled": false,
-        "label": "Transform plan"
+        "label": "Ontology Manager"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
-      "to": "visited",
+      "from": "n19",
+      "to": null,
       "control": {
         "index": 45,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=projection&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
-        "label": "Read projection"
+        "label": "ODK substrate"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
-      "to": "visited",
+      "from": "n19",
+      "to": null,
       "control": {
         "index": 46,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=lease&ontology=ont_18ca2757d28a20f7",
+        "href": "/__apps/pipeline",
         "disabled": false,
-        "label": "Lease + session"
+        "label": "Pipeline Builder capture ↗"
       },
       "action": "goto",
-      "outcome": "revisit"
+      "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n11",
+      "from": "n19",
       "to": "visited",
       "control": {
         "index": 47,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/pipeline",
         "disabled": false,
-        "label": "Materialized objects"
+        "label": "Pipeline outputs"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n11",
-      "to": null,
+      "from": "n19",
+      "to": "visited",
       "control": {
         "index": 48,
-        "tag": "button",
+        "tag": "a",
         "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Snapshot"
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
       },
-      "action": "none",
-      "outcome": "disabled"
+      "action": "goto",
+      "outcome": "revisit"
     },
     {
-      "from": "n11",
-      "to": null,
+      "from": "n19",
+      "to": "visited",
       "control": {
         "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n19",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 4,
         "tag": "button",
         "role": null,
         "href": null,
         "disabled": true,
-        "label": "Transform"
+        "label": "Build"
       },
       "action": "none",
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
       "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": "n20",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": "n20",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n20",
+      "to": "n20",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n20",
+      "to": "n20",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n20",
+      "to": "n81",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n20",
+      "to": "n76",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n20",
+      "to": "n79",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n20",
+      "to": "n2",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n20",
+      "to": "n82",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n20",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": "n21",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": "n21",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n21",
+      "to": "n21",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n21",
+      "to": "n21",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n21",
+      "to": "n83",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n21",
+      "to": "n77",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n21",
+      "to": "n80",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n21",
+      "to": "n82",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n21",
+      "to": "n2",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n21",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": "n22",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": "n22",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n22",
+      "to": "n22",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n22",
+      "to": "n22",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n22",
+      "to": "n84",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n22",
+      "to": "n85",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n22",
+      "to": "n86",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n22",
+      "to": "n87",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n22",
+      "to": "n88",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n22",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "Agent Studio"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree&tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n22",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&panel=search&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": "n23",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": "n23",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n23",
+      "to": "n23",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n23",
+      "to": "n23",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n23",
+      "to": "n89",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n23",
+      "to": "n90",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n23",
+      "to": "n91",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n23",
+      "to": "n92",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n23",
+      "to": "n93",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n23",
+      "to": "n94",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=datasource&panel=search",
+        "disabled": false,
+        "label": "Go to node"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n23",
+      "to": "n95",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=mapping&panel=search",
+        "disabled": false,
+        "label": "Go to node"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n23",
+      "to": "n96",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=policy&panel=search",
+        "disabled": false,
+        "label": "Go to node"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n23",
+      "to": "n97",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=transform&panel=search",
+        "disabled": false,
+        "label": "Go to node"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n23",
+      "to": "n98",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=projection&panel=search",
+        "disabled": false,
+        "label": "Go to node"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n23",
+      "to": "n99",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=lease&panel=search",
+        "disabled": false,
+        "label": "Go to node"
+      },
+      "action": "goto",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n23",
+      "to": "n100",
       "control": {
         "index": 50,
-        "tag": "button",
+        "tag": "a",
         "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Split"
+        "href": "/__ioi/pipeline?node=materialized&panel=search",
+        "disabled": false,
+        "label": "Go to node"
       },
-      "action": "none",
-      "outcome": "disabled"
+      "action": "goto",
+      "outcome": "navigated"
     },
     {
-      "from": "n11",
-      "to": null,
+      "from": "n23",
+      "to": "visited",
       "control": {
         "index": 51,
-        "tag": "button",
+        "tag": "a",
         "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Join"
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline outputs"
       },
-      "action": "none",
-      "outcome": "disabled"
+      "action": "goto",
+      "outcome": "revisit"
     },
     {
-      "from": "n11",
-      "to": null,
+      "from": "n23",
+      "to": "visited",
       "control": {
         "index": 52,
-        "tag": "button",
+        "tag": "a",
         "role": null,
-        "href": null,
-        "disabled": true,
-        "label": "Union"
+        "href": "/__ioi/pipeline?panel=search&tab=warnings",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
       },
-      "action": "none",
-      "outcome": "disabled"
+      "action": "goto",
+      "outcome": "revisit"
     },
     {
-      "from": "n11",
-      "to": null,
+      "from": "n23",
+      "to": "visited",
       "control": {
         "index": 53,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree&tab=warnings",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n23",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 4,
         "tag": "button",
         "role": null,
         "href": null,
         "disabled": true,
-        "label": "Use LLM"
+        "label": "Build"
       },
       "action": "none",
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n24",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n24",
       "to": null,
       "control": {
-        "index": 54,
+        "index": 6,
         "tag": "button",
         "role": null,
         "href": null,
         "disabled": true,
-        "label": "Generate"
+        "label": "Schedule"
       },
       "action": "none",
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n24",
       "to": null,
       "control": {
-        "index": 55,
+        "index": 7,
         "tag": "button",
         "role": null,
         "href": null,
         "disabled": true,
-        "label": "Explain"
+        "label": "Deploy"
       },
       "action": "none",
       "outcome": "disabled"
     },
     {
-      "from": "n11",
+      "from": "n24",
       "to": null,
       "control": {
-        "index": 56,
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": "n24",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n24",
+      "to": "n24",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n24",
+      "to": "n24",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n24",
+      "to": "n24",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n24",
+      "to": "n4",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": "visited",
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n24",
+      "to": "visited",
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n24",
+      "to": "visited",
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": null,
+      "control": {
+        "index": 42,
         "tag": "button",
         "role": null,
         "href": null,
@@ -12623,27 +21284,146 @@
       "outcome": "disabled"
     },
     {
-      "from": "n11",
-      "to": "visited",
+      "from": "n24",
+      "to": null,
       "control": {
-        "index": 57,
+        "index": 43,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7",
+        "href": "/__ioi/odk?ontology=",
         "disabled": false,
-        "label": "Selection preview"
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n24",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
       },
       "action": "goto",
       "outcome": "revisit"
     },
     {
-      "from": "n11",
+      "from": "n24",
       "to": "visited",
       "control": {
-        "index": 58,
+        "index": 45,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview",
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n24",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n24",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
         "disabled": false,
         "label": "Preview"
       },
@@ -12651,13 +21431,503 @@
       "outcome": "revisit"
     },
     {
-      "from": "n11",
-      "to": "visited",
+      "from": "n25",
+      "to": null,
       "control": {
-        "index": 59,
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 8,
         "tag": "a",
         "role": null,
-        "href": "/__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=suggestions",
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": "n25",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": "n25",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n25",
+      "to": "n25",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n25",
+      "to": "n25",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n25",
+      "to": "n101",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n25",
+      "to": "n5",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n25",
+      "to": "n4",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n25",
+      "to": "n102",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n25",
+      "to": "n103",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n25",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
         "disabled": false,
         "label": "Suggestions"
       },
@@ -12665,7 +21935,8575 @@
       "outcome": "revisit"
     },
     {
-      "from": "n11",
+      "from": "n25",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n25",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n25",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n25",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n25",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n25",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": "n26",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": "n26",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n26",
+      "to": "n26",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n26",
+      "to": "n26",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n26",
+      "to": "n104",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n26",
+      "to": "n6",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n26",
+      "to": "n102",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n26",
+      "to": "n4",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n26",
+      "to": "n105",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n26",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n26",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n26",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n26",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n26",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n26",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n26",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": "n27",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": "n27",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n27",
+      "to": "n27",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n27",
+      "to": "n27",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n27",
+      "to": "n106",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n27",
+      "to": "n7",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n27",
+      "to": "n103",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n27",
+      "to": "n105",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n27",
+      "to": "n4",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n27",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n27",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n27",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n27",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n27",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n27",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n27",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": "n28",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": "n28",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n28",
+      "to": "n28",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n28",
+      "to": "n28",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n28",
+      "to": "n5",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": "visited",
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n28",
+      "to": "visited",
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n28",
+      "to": "visited",
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 42,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n28",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n28",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n28",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n28",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n28",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": "n29",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": "n29",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n29",
+      "to": "n29",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n29",
+      "to": "n29",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n29",
+      "to": "n107",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n29",
+      "to": "n102",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n29",
+      "to": "n6",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n29",
+      "to": "n5",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n29",
+      "to": "n108",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n29",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n29",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n29",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n29",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n29",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n29",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n29",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": "n30",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": "n30",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n30",
+      "to": "n30",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n30",
+      "to": "n30",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n30",
+      "to": "n109",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n30",
+      "to": "n103",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n30",
+      "to": "n7",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n30",
+      "to": "n108",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n30",
+      "to": "n5",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n30",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n30",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n30",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n30",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n30",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n30",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n30",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": "n31",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": "n31",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n31",
+      "to": "n31",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n31",
+      "to": "n31",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n31",
+      "to": "n6",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": "visited",
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n31",
+      "to": "visited",
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n31",
+      "to": "visited",
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 42,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n31",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n31",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n31",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n31",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n31",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": "n32",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": "n32",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n32",
+      "to": "n32",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n32",
+      "to": "n32",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n32",
+      "to": "n110",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n32",
+      "to": "n105",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n32",
+      "to": "n108",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n32",
+      "to": "n7",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n32",
+      "to": "n6",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n32",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n32",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 47,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n32",
+      "to": null,
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n32",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n32",
+      "to": "visited",
+      "control": {
+        "index": 50,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n32",
+      "to": "visited",
+      "control": {
+        "index": 51,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n32",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": "n33",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": "n33",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n33",
+      "to": "n33",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n33",
+      "to": "n33",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n33",
+      "to": "n7",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": "visited",
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n33",
+      "to": "visited",
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n33",
+      "to": "visited",
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "ODK substrate"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__apps/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder capture ↗"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 42,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n33",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n33",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n33",
+      "to": "visited",
+      "control": {
+        "index": 45,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n33",
+      "to": "visited",
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n33",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n34",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n34",
+      "to": "n34",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": "n34",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n34",
+      "to": "n34",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n34",
+      "to": "n34",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n34",
+      "to": "n8",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 34,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n34",
+      "to": "visited",
+      "control": {
+        "index": 35,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n34",
+      "to": "visited",
+      "control": {
+        "index": 36,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n34",
+      "to": "visited",
+      "control": {
+        "index": 37,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "Agent Studio"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 40,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n34",
+      "to": null,
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n34",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n34",
+      "to": "visited",
+      "control": {
+        "index": 43,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n34",
+      "to": "visited",
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree&tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n34",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n35",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n35",
+      "to": "n35",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": "n35",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n35",
+      "to": "n35",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n35",
+      "to": "n35",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n35",
+      "to": "n111",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n35",
+      "to": "n8",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n35",
+      "to": "n112",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n35",
+      "to": "n113",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n35",
+      "to": "n114",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n35",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n35",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n35",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "Agent Studio"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n35",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n35",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n35",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n35",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree&tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n35",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n36",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n36",
+      "to": "n36",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": "n36",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n36",
+      "to": "n36",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n36",
+      "to": "n36",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n36",
+      "to": "n115",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n36",
+      "to": "n112",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n36",
+      "to": "n8",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n36",
+      "to": "n116",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n36",
+      "to": "n117",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n36",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n36",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n36",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "Agent Studio"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n36",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n36",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n36",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n36",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree&tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n36",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n37",
+      "to": "visited",
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Pipeline Builder"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 4,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Build"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?node=materialized&tab=preview#pb-preview",
+        "disabled": false,
+        "label": "Preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 6,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Schedule"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 7,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Deploy"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/lineage?ontology=",
+        "disabled": false,
+        "label": "Lineage"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n37",
+      "to": "n37",
+      "control": {
+        "index": 10,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Panning mode — drag pans the canvas (live)"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 11,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer — selection is single-node URL state (?node=); a ma"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 12,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "multi-select has no consumer (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 13,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "graph authoring is a named gap — ladder records are authored in the Ontology Man"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 14,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "the ladder layout is fixed by the ODK contract order — freeform layout is a name"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 15,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "no freeform node placement, so nothing snaps (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "canvas annotations have no persistence plane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Add data"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 18,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Reusables"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 19,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform authoring requires a TransformationRun authoring authority — a named g"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 20,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "join authoring — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 21,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "union authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 22,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "split authoring — named gap"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 23,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "model application — named gap (model routes live in the Model Catalog)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 24,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP logo icon"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 25,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP generation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 26,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "AIP explanation is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 27,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "transform editing — named gap (no authoring authority)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": "visited",
+      "control": {
+        "index": 28,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — the right panel becomes the real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 29,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "color grouping is a reference-only lane (named gap)"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": "n37",
+      "control": {
+        "index": 30,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom in"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n37",
+      "to": "n37",
+      "control": {
+        "index": 31,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom out"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n37",
+      "to": "n37",
+      "control": {
+        "index": 32,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Zoom to fit"
+      },
+      "action": "click",
+      "outcome": "noop"
+    },
+    {
+      "from": "n37",
+      "to": "n118",
+      "control": {
+        "index": 33,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle legend"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n37",
+      "to": "n113",
+      "control": {
+        "index": 34,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n37",
+      "to": "n116",
+      "control": {
+        "index": 35,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n37",
+      "to": "n8",
+      "control": {
+        "index": 36,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Show this color"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n37",
+      "to": "n119",
+      "control": {
+        "index": 37,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Hide this color"
+      },
+      "action": "click",
+      "outcome": "state-change"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 38,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add color"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 39,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n37",
+      "to": "visited",
+      "control": {
+        "index": 40,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline",
+        "disabled": false,
+        "label": "Selection preview"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n37",
+      "to": "visited",
+      "control": {
+        "index": 41,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Suggestions"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n37",
+      "to": "visited",
+      "control": {
+        "index": 42,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=warnings",
+        "disabled": false,
+        "label": "Pipeline warnings"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 43,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Toggle bottom bar"
+      },
+      "action": "click",
+      "outcome": "unclickable"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 44,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/agent-studio#improvement-proposals",
+        "disabled": false,
+        "label": "Agent Studio"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 45,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": true,
+        "label": "Add"
+      },
+      "action": "none",
+      "outcome": "disabled"
+    },
+    {
+      "from": "n37",
+      "to": null,
+      "control": {
+        "index": 46,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk?ontology=",
+        "disabled": false,
+        "label": "Edit output settings"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n37",
+      "to": "visited",
+      "control": {
+        "index": 47,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline outputs"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n37",
+      "to": "visited",
+      "control": {
+        "index": 48,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=search&tab=suggestions",
+        "disabled": false,
+        "label": "Search pipeline — real record search"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n37",
+      "to": "visited",
+      "control": {
+        "index": 49,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/pipeline?panel=tree&tab=suggestions",
+        "disabled": false,
+        "label": "Pipeline file tree — the real ladder-record tree"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n37",
       "to": "back-stack",
       "control": null,
       "action": "back",
@@ -12674,75 +30512,60 @@
   ],
   "blockers": [
     {
-      "kind": "control-census-overflow",
-      "node": "n1",
-      "reason": "68 controls > cap 60; raise --max-controls and recapture"
-    },
-    {
-      "kind": "control-census-overflow",
-      "node": "n5",
-      "reason": "74 controls > cap 60; raise --max-controls and recapture"
-    },
-    {
-      "kind": "control-census-overflow",
-      "node": "n6",
-      "reason": "74 controls > cap 60; raise --max-controls and recapture"
-    },
-    {
-      "kind": "control-census-overflow",
-      "node": "n7",
-      "reason": "74 controls > cap 60; raise --max-controls and recapture"
-    },
-    {
-      "kind": "control-census-overflow",
-      "node": "n8",
-      "reason": "74 controls > cap 60; raise --max-controls and recapture"
-    },
-    {
-      "kind": "control-census-overflow",
-      "node": "n9",
-      "reason": "74 controls > cap 60; raise --max-controls and recapture"
-    },
-    {
-      "kind": "control-census-overflow",
-      "node": "n10",
-      "reason": "74 controls > cap 60; raise --max-controls and recapture"
-    },
-    {
-      "kind": "control-census-overflow",
-      "node": "n11",
-      "reason": "74 controls > cap 60; raise --max-controls and recapture"
-    },
-    {
       "kind": "node-cap-reached",
       "node": null,
-      "reason": "67 unexplored nodes beyond --max-nodes 80"
+      "reason": "81 unexplored nodes beyond --max-nodes 120"
     }
   ],
   "replay": {
     "mode": "interaction",
     "walked_all_edges": false,
-    "edges_total": 725,
-    "edges_executed": 146,
-    "edges_skip_classified": 567,
+    "edges_total": 1950,
+    "edges_executed": 335,
+    "edges_skip_classified": 1577,
     "problems": [
-      "edge n0/\"Hide this color\": recorded unclickable but clicks now — recapture this source",
-      "edge n0/\"Hide this color\": recorded unclickable but clicks now — recapture this source",
-      "edge n0/\"Hide this color\": recorded unclickable but clicks now — recapture this source",
-      "edge n0/\"Hide this color\": recorded unclickable but clicks now — recapture this source",
       "edge n0/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
-      "edge n1->n1: target /__ioi/pipeline?node=materialized&ontology=ont_18ca2757d28a20f7&tab=preview#pb-preview unreachable (no response)",
-      "edge n2/\"Hide this color\": recorded unclickable but clicks now — recapture this source",
-      "edge n2/\"Hide this color\": recorded unclickable but clicks now — recapture this source",
-      "edge n2/\"Hide this color\": recorded unclickable but clicks now — recapture this source",
-      "edge n2/\"Hide this color\": recorded unclickable but clicks now — recapture this source",
+      "edge n1/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
       "edge n2/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
-      "edge n3/\"Pipeline: probe-reencode ▾\": control unresolved (unclickable at capture and at replay)",
-      "edge n4/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)"
+      "edge n3/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n4/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n5/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n6/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n7/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n8/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n9/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n10/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n11/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n12/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n13/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n14/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n15/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n16/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n17/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n18/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n19/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n20/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n21/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n22/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n23/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n24/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n25/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n26/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n27/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n28/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n29/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n30/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n31/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n32/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n33/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n34/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n35/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n36/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)",
+      "edge n37/\"Toggle bottom bar\": control unresolved (unclickable at capture and at replay)"
     ],
-    "walked_at": "2026-08-10T01:26:28.277Z"
+    "walked_at": "2026-08-11T12:28:50.836Z"
   },
   "complete_interaction_route_graph": false,
   "shots_dir": ".artifacts/seed-graph-shots/data/pipeline",
-  "content_address": "60d34da15fd3c761648f868d3c1294f1e5f681d67ee79dce440e6c3cfc310eee"
+  "content_address": "b8580550fdbb5e4177b6e9e0793682fab6c1cf27b66a54bf4397385dbbc0db2d"
 }

--- a/apps/hypervisor/seed-graphs/data/sources.v1.json
+++ b/apps/hypervisor/seed-graphs/data/sources.v1.json
@@ -5,18 +5,18 @@
   "owned_route": "/__ioi/data/sources",
   "capture_route": null,
   "runtime": {
-    "serve_url": "http://127.0.0.1:4641",
+    "serve_url": "http://127.0.0.1:37769",
     "capture_url": null
   },
-  "captured_at": "2026-08-10T01:51:29.151Z",
+  "captured_at": "2026-08-11T10:49:54.789Z",
   "quarantine": {
     "network_policy": "local-only",
     "corpus_mutation": "denied",
     "html_injection": "denied",
     "spa_fallback": "denied",
     "allowed_origins": [
-      "http://127.0.0.1:4641",
-      "http://localhost:4641",
+      "http://127.0.0.1:37769",
+      "http://localhost:37769",
       "http://127.0.0.1:9225",
       "http://localhost:9225"
     ],
@@ -26,7 +26,7 @@
     {
       "id": "n0",
       "kind": "route",
-      "signature": "/__ioi/data/sources#open=0#fc=0|H1:Data Connection|H3:Data Connection|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
+      "signature": "/__ioi/data/sources#open=0#fc=0#hf=124#sv=0|H1:Data Connection|H3:Data Connection|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
       "url": "/__ioi/data/sources",
       "title": "Data Connection",
       "entry_edge": null,
@@ -51,7 +51,7 @@
     {
       "id": "n1",
       "kind": "route",
-      "signature": "/__ioi/data/sources?declare=1#open=0#fc=5|H1:Data Connection|H3:Data Connection|H2:Declare a new data source a validated, receipted registry re|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
+      "signature": "/__ioi/data/sources?declare=1#open=0#fc=5#hf=2105184127#sv=-1043901281|H1:Data Connection|H3:Data Connection|H2:Declare a new data source a validated, receipted registry re|H2:Declared source catalog 0 the real DataSource registry — new|H3:By kind|H3:By credential posture|H3:Sync activity (real)",
       "url": "/__ioi/data/sources?declare=1",
       "title": "Data Connection",
       "entry_edge": {
@@ -199,7 +199,7 @@
     },
     {
       "from": "n0",
-      "to": null,
+      "to": "n0",
       "control": {
         "index": 8,
         "tag": "a",
@@ -209,8 +209,7 @@
         "label": "View all"
       },
       "action": "goto",
-      "outcome": "error",
-      "detail": "no response"
+      "outcome": "navigated"
     },
     {
       "from": "n0",
@@ -427,7 +426,7 @@
         "label": "postgres — endpoint requiredmysql — endpoint requiredrest_api — endpoint require"
       },
       "action": "click",
-      "outcome": "state-change"
+      "outcome": "noop"
     },
     {
       "from": "n1",
@@ -487,7 +486,7 @@
     },
     {
       "from": "n1",
-      "to": null,
+      "to": "n1",
       "control": {
         "index": 12,
         "tag": "a",
@@ -497,8 +496,7 @@
         "label": "View all"
       },
       "action": "goto",
-      "outcome": "error",
-      "detail": "no response"
+      "outcome": "navigated"
     },
     {
       "from": "n1",
@@ -606,30 +604,17 @@
       "outcome": "navigated"
     }
   ],
-  "blockers": [
-    {
-      "kind": "unreachable-route",
-      "node": "n0",
-      "reason": "/__ioi/data/sources: no response"
-    },
-    {
-      "kind": "unreachable-route",
-      "node": "n1",
-      "reason": "/__ioi/data/sources: no response"
-    }
-  ],
+  "blockers": [],
   "replay": {
     "mode": "interaction",
-    "walked_all_edges": false,
+    "walked_all_edges": true,
     "edges_total": 38,
-    "edges_executed": 4,
-    "edges_skip_classified": 34,
-    "problems": [
-      "edge n1/\"postgres — endpoint requiredmysql — endpoint requiredrest_api — endpoint require\": recorded state-change, observed noop"
-    ],
-    "walked_at": "2026-08-10T01:51:40.592Z"
+    "edges_executed": 6,
+    "edges_skip_classified": 32,
+    "problems": [],
+    "walked_at": "2026-08-11T10:50:07.923Z"
   },
-  "complete_interaction_route_graph": false,
+  "complete_interaction_route_graph": true,
   "shots_dir": ".artifacts/seed-graph-shots/data/sources",
-  "content_address": "0c2e9ecfe40ff76da323913c0cb52c982962b0eab5543b4e94c78b7ecc3fade5"
+  "content_address": "be9a5a68ed0de7b8b882ade0ef9f881c80e92e6b82fcfd7be04b270205cb5745"
 }

--- a/apps/hypervisor/seed-graphs/governance/approvals.v1.json
+++ b/apps/hypervisor/seed-graphs/governance/approvals.v1.json
@@ -906,9 +906,9 @@
     "edges_executed": 5,
     "edges_skip_classified": 52,
     "problems": [],
-    "walked_at": "2026-08-09T23:42:35.820Z"
+    "walked_at": "2026-08-11T10:42:43.510Z"
   },
   "complete_interaction_route_graph": true,
   "shots_dir": ".artifacts/seed-graph-shots/governance/approvals",
-  "content_address": "502655ede6dd097a34ed96b69b8cfd70257444aa9985c051513289d60f71b92b"
+  "content_address": "9243b7aaab9a994d3d999d599d83a3e4f00815402b368af521ab55d2c3e539a0"
 }

--- a/apps/hypervisor/seed-graphs/ontology/schema.v1.json
+++ b/apps/hypervisor/seed-graphs/ontology/schema.v1.json
@@ -5,18 +5,18 @@
   "owned_route": "/__ioi/ontology/manager",
   "capture_route": null,
   "runtime": {
-    "serve_url": "http://127.0.0.1:4647",
+    "serve_url": "http://127.0.0.1:34213",
     "capture_url": null
   },
-  "captured_at": "2026-08-10T02:02:51.790Z",
+  "captured_at": "2026-08-11T10:45:45.300Z",
   "quarantine": {
     "network_policy": "local-only",
     "corpus_mutation": "denied",
     "html_injection": "denied",
     "spa_fallback": "denied",
     "allowed_origins": [
-      "http://127.0.0.1:4647",
-      "http://localhost:4647",
+      "http://127.0.0.1:34213",
+      "http://localhost:34213",
       "http://127.0.0.1:9225",
       "http://localhost:9225"
     ],
@@ -26,7 +26,7 @@
     {
       "id": "n0",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager#open=0#fc=1#hf=124|",
+      "signature": "/__ioi/ontology/manager#open=0#fc=1#hf=124#sv=0|",
       "url": "/__ioi/ontology/manager",
       "title": "Ontology Manager",
       "entry_edge": null,
@@ -51,7 +51,7 @@
     {
       "id": "n1",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=create#open=0#fc=5#hf=1634794649|",
+      "signature": "/__ioi/ontology/manager?section=create#open=0#fc=5#hf=1634794649#sv=0|",
       "url": "/__ioi/ontology/manager?section=create",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -86,7 +86,7 @@
     {
       "id": "n2",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=discover#open=0#fc=2#hf=-337893819|",
+      "signature": "/__ioi/ontology/manager?section=discover#open=0#fc=2#hf=-337893819#sv=0|",
       "url": "/__ioi/ontology/manager?section=discover",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -121,7 +121,7 @@
     {
       "id": "n3",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=configuration#open=0#fc=2#hf=-1970407374|",
+      "signature": "/__ioi/ontology/manager?section=configuration#open=0#fc=2#hf=-1970407374#sv=0|",
       "url": "/__ioi/ontology/manager?section=configuration",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -156,7 +156,7 @@
     {
       "id": "n4",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=object-types#open=0#fc=2#hf=-186047289|",
+      "signature": "/__ioi/ontology/manager?section=object-types#open=0#fc=2#hf=-186047289#sv=0|",
       "url": "/__ioi/ontology/manager?section=object-types",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -191,7 +191,7 @@
     {
       "id": "n5",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=properties#open=0#fc=2#hf=306510223|",
+      "signature": "/__ioi/ontology/manager?section=properties#open=0#fc=2#hf=306510223#sv=0|",
       "url": "/__ioi/ontology/manager?section=properties",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -226,7 +226,7 @@
     {
       "id": "n6",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=link-types#open=0#fc=2#hf=849017922|",
+      "signature": "/__ioi/ontology/manager?section=link-types#open=0#fc=2#hf=849017922#sv=0|",
       "url": "/__ioi/ontology/manager?section=link-types",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -261,7 +261,7 @@
     {
       "id": "n7",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=action-types#open=0#fc=2#hf=1069004158|",
+      "signature": "/__ioi/ontology/manager?section=action-types#open=0#fc=2#hf=1069004158#sv=0|",
       "url": "/__ioi/ontology/manager?section=action-types",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -296,7 +296,7 @@
     {
       "id": "n8",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=value-types#open=0#fc=2#hf=-203055271|",
+      "signature": "/__ioi/ontology/manager?section=value-types#open=0#fc=2#hf=-203055271#sv=0|",
       "url": "/__ioi/ontology/manager?section=value-types",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -331,7 +331,7 @@
     {
       "id": "n9",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=functions#open=0#fc=2#hf=1204822999|",
+      "signature": "/__ioi/ontology/manager?section=functions#open=0#fc=2#hf=1204822999#sv=0|",
       "url": "/__ioi/ontology/manager?section=functions",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -366,7 +366,7 @@
     {
       "id": "n10",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?section=health#open=0#fc=2#hf=-2072917064|",
+      "signature": "/__ioi/ontology/manager?section=health#open=0#fc=2#hf=-2072917064#sv=0|",
       "url": "/__ioi/ontology/manager?section=health",
       "title": "Ontology Manager",
       "entry_edge": {
@@ -401,11 +401,11 @@
     {
       "id": "n11",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=create&q=#open=0#fc=5#hf=1634794649|",
+      "signature": "/__ioi/ontology/manager?ontology=&section=create&q=#open=0#fc=5#hf=1634794649#sv=0|",
       "url": "/__ioi/ontology/manager?ontology=&section=create&q=",
       "title": "Ontology Manager",
       "entry_edge": {
-        "from": "n2",
+        "from": "n1",
         "control": {
           "index": 16,
           "tag": "button",
@@ -436,8 +436,43 @@
     {
       "id": "n12",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=discover&q=#open=0#fc=2#hf=-337893819|",
+      "signature": "/__ioi/ontology/manager?ontology=&section=discover&q=#open=0#fc=2#hf=-337893819#sv=0|",
       "url": "/__ioi/ontology/manager?ontology=&section=discover&q=",
+      "title": "Ontology Manager",
+      "entry_edge": {
+        "from": "n2",
+        "control": {
+          "index": 16,
+          "tag": "button",
+          "role": null,
+          "href": null,
+          "disabled": false,
+          "label": "Filter"
+        }
+      },
+      "controls": 18,
+      "disabled_controls": 0,
+      "screenshot": {
+        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
+        "posture": "1440x900-light"
+      },
+      "console_errors": [],
+      "posture_matrix": [
+        {
+          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
+          "posture": "1440x900-dark"
+        },
+        {
+          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
+          "posture": "390x844-light-reduced-motion"
+        }
+      ]
+    },
+    {
+      "id": "n13",
+      "kind": "route",
+      "signature": "/__ioi/ontology/manager?ontology=&section=configuration&q=#open=0#fc=2#hf=-1970407374#sv=0|",
+      "url": "/__ioi/ontology/manager?ontology=&section=configuration&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n3",
@@ -469,10 +504,10 @@
       ]
     },
     {
-      "id": "n13",
+      "id": "n14",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=configuration&q=#open=0#fc=2#hf=-1970407374|",
-      "url": "/__ioi/ontology/manager?ontology=&section=configuration&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=object-types&q=#open=0#fc=2#hf=-186047289#sv=0|",
+      "url": "/__ioi/ontology/manager?ontology=&section=object-types&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n4",
@@ -504,10 +539,10 @@
       ]
     },
     {
-      "id": "n14",
+      "id": "n15",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=object-types&q=#open=0#fc=2#hf=-186047289|",
-      "url": "/__ioi/ontology/manager?ontology=&section=object-types&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=properties&q=#open=0#fc=2#hf=306510223#sv=0|",
+      "url": "/__ioi/ontology/manager?ontology=&section=properties&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n5",
@@ -539,10 +574,10 @@
       ]
     },
     {
-      "id": "n15",
+      "id": "n16",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=properties&q=#open=0#fc=2#hf=306510223|",
-      "url": "/__ioi/ontology/manager?ontology=&section=properties&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=link-types&q=#open=0#fc=2#hf=849017922#sv=0|",
+      "url": "/__ioi/ontology/manager?ontology=&section=link-types&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n6",
@@ -574,10 +609,10 @@
       ]
     },
     {
-      "id": "n16",
+      "id": "n17",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=link-types&q=#open=0#fc=2#hf=849017922|",
-      "url": "/__ioi/ontology/manager?ontology=&section=link-types&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=action-types&q=#open=0#fc=2#hf=1069004158#sv=0|",
+      "url": "/__ioi/ontology/manager?ontology=&section=action-types&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n7",
@@ -609,10 +644,10 @@
       ]
     },
     {
-      "id": "n17",
+      "id": "n18",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=action-types&q=#open=0#fc=2#hf=1069004158|",
-      "url": "/__ioi/ontology/manager?ontology=&section=action-types&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=value-types&q=#open=0#fc=2#hf=-203055271#sv=0|",
+      "url": "/__ioi/ontology/manager?ontology=&section=value-types&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n8",
@@ -644,10 +679,10 @@
       ]
     },
     {
-      "id": "n18",
+      "id": "n19",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=value-types&q=#open=0#fc=2#hf=-203055271|",
-      "url": "/__ioi/ontology/manager?ontology=&section=value-types&q=",
+      "signature": "/__ioi/ontology/manager?ontology=&section=functions&q=#open=0#fc=2#hf=1204822999#sv=0|",
+      "url": "/__ioi/ontology/manager?ontology=&section=functions&q=",
       "title": "Ontology Manager",
       "entry_edge": {
         "from": "n9",
@@ -679,48 +714,13 @@
       ]
     },
     {
-      "id": "n19",
-      "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=functions&q=#open=0#fc=2#hf=1204822999|",
-      "url": "/__ioi/ontology/manager?ontology=&section=functions&q=",
-      "title": "Ontology Manager",
-      "entry_edge": {
-        "from": "n10",
-        "control": {
-          "index": 16,
-          "tag": "button",
-          "role": null,
-          "href": null,
-          "disabled": false,
-          "label": "Filter"
-        }
-      },
-      "controls": 18,
-      "disabled_controls": 0,
-      "screenshot": {
-        "sha256": "0ed5550759877c58c0f58a21a586a3df1567f29abde5dd85097f5013977e856c",
-        "posture": "1440x900-light"
-      },
-      "console_errors": [],
-      "posture_matrix": [
-        {
-          "sha256": "1ad022cd8425296db79ef1bbbe179007f2c65cd4124fb6c1c2db29d4237fe248",
-          "posture": "1440x900-dark"
-        },
-        {
-          "sha256": "aa6737b856385b6e42efab7cd194469fc64985c887367a4a1dd1ca783651254e",
-          "posture": "390x844-light-reduced-motion"
-        }
-      ]
-    },
-    {
       "id": "n20",
       "kind": "route",
-      "signature": "/__ioi/ontology/manager?ontology=&section=health&q=#open=0#fc=2#hf=-2072917064|",
+      "signature": "/__ioi/ontology/manager?ontology=&section=health&q=#open=0#fc=2#hf=-2072917064#sv=0|",
       "url": "/__ioi/ontology/manager?ontology=&section=health&q=",
       "title": "Ontology Manager",
       "entry_edge": {
-        "from": "n11",
+        "from": "n10",
         "control": {
           "index": 16,
           "tag": "button",
@@ -1221,7 +1221,7 @@
     },
     {
       "from": "n1",
-      "to": null,
+      "to": "n11",
       "control": {
         "index": 16,
         "tag": "button",
@@ -1231,7 +1231,7 @@
         "label": "Filter"
       },
       "action": "click",
-      "outcome": "boundary-off-allowlist"
+      "outcome": "navigated"
     },
     {
       "from": "n1",
@@ -1494,265 +1494,6 @@
     },
     {
       "from": "n2",
-      "to": "n11",
-      "control": {
-        "index": 16,
-        "tag": "button",
-        "role": null,
-        "href": null,
-        "disabled": false,
-        "label": "Filter"
-      },
-      "action": "click",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n2",
-      "to": null,
-      "control": {
-        "index": 17,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk/ontologies/new",
-        "disabled": false,
-        "label": "Create an ontology →"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n2",
-      "to": "back-stack",
-      "control": null,
-      "action": "back",
-      "outcome": "navigated"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 0,
-        "tag": "a",
-        "role": null,
-        "href": "/ai",
-        "disabled": false,
-        "label": "Home"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 1,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/odk",
-        "disabled": false,
-        "label": "Ontology"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 2,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "Applications"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": null,
-      "control": {
-        "index": 3,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/home",
-        "disabled": false,
-        "label": "View all"
-      },
-      "action": "goto",
-      "outcome": "boundary-off-allowlist"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 4,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager",
-        "disabled": false,
-        "label": "Ontology Manager"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 5,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=create",
-        "disabled": false,
-        "label": "New"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 6,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=discover",
-        "disabled": false,
-        "label": "Discover"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 7,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=configuration",
-        "disabled": false,
-        "label": "History"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 8,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=object-types",
-        "disabled": false,
-        "label": "Object types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 9,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=properties",
-        "disabled": false,
-        "label": "Properties0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 10,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=link-types",
-        "disabled": false,
-        "label": "Link types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 11,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=action-types",
-        "disabled": false,
-        "label": "Action types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 12,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=value-types",
-        "disabled": false,
-        "label": "Value types0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 13,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=functions",
-        "disabled": false,
-        "label": "Functions0"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 14,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=health",
-        "disabled": false,
-        "label": "Health issues"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
-      "to": "visited",
-      "control": {
-        "index": 15,
-        "tag": "a",
-        "role": null,
-        "href": "/__ioi/ontology/manager?section=configuration",
-        "disabled": false,
-        "label": "Ontology configuration"
-      },
-      "action": "goto",
-      "outcome": "revisit"
-    },
-    {
-      "from": "n3",
       "to": "n12",
       "control": {
         "index": 16,
@@ -1766,7 +1507,7 @@
       "outcome": "navigated"
     },
     {
-      "from": "n3",
+      "from": "n2",
       "to": null,
       "control": {
         "index": 17,
@@ -1780,14 +1521,14 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n3",
+      "from": "n2",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": null,
       "control": {
         "index": 0,
@@ -1801,7 +1542,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": null,
       "control": {
         "index": 1,
@@ -1815,7 +1556,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": null,
       "control": {
         "index": 2,
@@ -1829,7 +1570,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": null,
       "control": {
         "index": 3,
@@ -1843,7 +1584,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 4,
@@ -1857,7 +1598,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 5,
@@ -1871,7 +1612,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 6,
@@ -1885,7 +1626,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 7,
@@ -1899,7 +1640,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 8,
@@ -1913,7 +1654,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 9,
@@ -1927,7 +1668,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 10,
@@ -1941,7 +1682,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 11,
@@ -1955,7 +1696,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 12,
@@ -1969,7 +1710,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 13,
@@ -1983,7 +1724,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 14,
@@ -1997,7 +1738,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "visited",
       "control": {
         "index": 15,
@@ -2011,7 +1752,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "n13",
       "control": {
         "index": 16,
@@ -2025,7 +1766,7 @@
       "outcome": "navigated"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": null,
       "control": {
         "index": 17,
@@ -2039,14 +1780,14 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n4",
+      "from": "n3",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": null,
       "control": {
         "index": 0,
@@ -2060,7 +1801,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": null,
       "control": {
         "index": 1,
@@ -2074,7 +1815,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": null,
       "control": {
         "index": 2,
@@ -2088,7 +1829,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": null,
       "control": {
         "index": 3,
@@ -2102,7 +1843,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 4,
@@ -2116,7 +1857,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 5,
@@ -2130,7 +1871,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 6,
@@ -2144,7 +1885,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 7,
@@ -2158,7 +1899,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 8,
@@ -2172,7 +1913,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 9,
@@ -2186,7 +1927,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 10,
@@ -2200,7 +1941,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 11,
@@ -2214,7 +1955,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 12,
@@ -2228,7 +1969,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 13,
@@ -2242,7 +1983,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 14,
@@ -2256,7 +1997,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "visited",
       "control": {
         "index": 15,
@@ -2270,7 +2011,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "n14",
       "control": {
         "index": 16,
@@ -2284,7 +2025,7 @@
       "outcome": "navigated"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": null,
       "control": {
         "index": 17,
@@ -2298,14 +2039,14 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n5",
+      "from": "n4",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": null,
       "control": {
         "index": 0,
@@ -2319,7 +2060,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": null,
       "control": {
         "index": 1,
@@ -2333,7 +2074,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": null,
       "control": {
         "index": 2,
@@ -2347,7 +2088,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": null,
       "control": {
         "index": 3,
@@ -2361,7 +2102,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 4,
@@ -2375,7 +2116,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 5,
@@ -2389,7 +2130,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 6,
@@ -2403,7 +2144,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 7,
@@ -2417,7 +2158,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 8,
@@ -2431,7 +2172,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 9,
@@ -2445,7 +2186,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 10,
@@ -2459,7 +2200,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 11,
@@ -2473,7 +2214,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 12,
@@ -2487,7 +2228,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 13,
@@ -2501,7 +2242,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 14,
@@ -2515,7 +2256,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "visited",
       "control": {
         "index": 15,
@@ -2529,7 +2270,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "n15",
       "control": {
         "index": 16,
@@ -2543,7 +2284,7 @@
       "outcome": "navigated"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": null,
       "control": {
         "index": 17,
@@ -2557,14 +2298,14 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n6",
+      "from": "n5",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": null,
       "control": {
         "index": 0,
@@ -2578,7 +2319,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": null,
       "control": {
         "index": 1,
@@ -2592,7 +2333,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": null,
       "control": {
         "index": 2,
@@ -2606,7 +2347,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": null,
       "control": {
         "index": 3,
@@ -2620,7 +2361,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 4,
@@ -2634,7 +2375,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 5,
@@ -2648,7 +2389,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 6,
@@ -2662,7 +2403,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 7,
@@ -2676,7 +2417,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 8,
@@ -2690,7 +2431,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 9,
@@ -2704,7 +2445,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 10,
@@ -2718,7 +2459,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 11,
@@ -2732,7 +2473,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 12,
@@ -2746,7 +2487,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 13,
@@ -2760,7 +2501,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 14,
@@ -2774,7 +2515,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "visited",
       "control": {
         "index": 15,
@@ -2788,7 +2529,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "n16",
       "control": {
         "index": 16,
@@ -2802,7 +2543,7 @@
       "outcome": "navigated"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": null,
       "control": {
         "index": 17,
@@ -2816,14 +2557,14 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n7",
+      "from": "n6",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": null,
       "control": {
         "index": 0,
@@ -2837,7 +2578,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": null,
       "control": {
         "index": 1,
@@ -2851,7 +2592,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": null,
       "control": {
         "index": 2,
@@ -2865,7 +2606,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": null,
       "control": {
         "index": 3,
@@ -2879,7 +2620,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 4,
@@ -2893,7 +2634,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 5,
@@ -2907,7 +2648,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 6,
@@ -2921,7 +2662,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 7,
@@ -2935,7 +2676,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 8,
@@ -2949,7 +2690,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 9,
@@ -2963,7 +2704,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 10,
@@ -2977,7 +2718,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 11,
@@ -2991,7 +2732,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 12,
@@ -3005,7 +2746,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 13,
@@ -3019,7 +2760,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 14,
@@ -3033,7 +2774,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "visited",
       "control": {
         "index": 15,
@@ -3047,7 +2788,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "n17",
       "control": {
         "index": 16,
@@ -3061,7 +2802,7 @@
       "outcome": "navigated"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": null,
       "control": {
         "index": 17,
@@ -3075,14 +2816,14 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n8",
+      "from": "n7",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": null,
       "control": {
         "index": 0,
@@ -3096,7 +2837,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": null,
       "control": {
         "index": 1,
@@ -3110,7 +2851,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": null,
       "control": {
         "index": 2,
@@ -3124,7 +2865,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": null,
       "control": {
         "index": 3,
@@ -3138,7 +2879,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 4,
@@ -3152,7 +2893,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 5,
@@ -3166,7 +2907,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 6,
@@ -3180,7 +2921,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 7,
@@ -3194,7 +2935,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 8,
@@ -3208,7 +2949,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 9,
@@ -3222,7 +2963,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 10,
@@ -3236,7 +2977,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 11,
@@ -3250,7 +2991,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 12,
@@ -3264,7 +3005,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 13,
@@ -3278,7 +3019,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 14,
@@ -3292,7 +3033,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "visited",
       "control": {
         "index": 15,
@@ -3306,7 +3047,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "n18",
       "control": {
         "index": 16,
@@ -3320,7 +3061,7 @@
       "outcome": "navigated"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": null,
       "control": {
         "index": 17,
@@ -3334,14 +3075,14 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n9",
+      "from": "n8",
       "to": "back-stack",
       "control": null,
       "action": "back",
       "outcome": "navigated"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": null,
       "control": {
         "index": 0,
@@ -3355,7 +3096,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": null,
       "control": {
         "index": 1,
@@ -3369,7 +3110,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": null,
       "control": {
         "index": 2,
@@ -3383,7 +3124,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": null,
       "control": {
         "index": 3,
@@ -3397,7 +3138,7 @@
       "outcome": "boundary-off-allowlist"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 4,
@@ -3411,7 +3152,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 5,
@@ -3425,7 +3166,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 6,
@@ -3439,7 +3180,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 7,
@@ -3453,7 +3194,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 8,
@@ -3467,7 +3208,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 9,
@@ -3481,7 +3222,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 10,
@@ -3495,7 +3236,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 11,
@@ -3509,7 +3250,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 12,
@@ -3523,7 +3264,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 13,
@@ -3537,7 +3278,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 14,
@@ -3551,7 +3292,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "visited",
       "control": {
         "index": 15,
@@ -3565,7 +3306,7 @@
       "outcome": "revisit"
     },
     {
-      "from": "n10",
+      "from": "n9",
       "to": "n19",
       "control": {
         "index": 16,
@@ -3579,6 +3320,265 @@
       "outcome": "navigated"
     },
     {
+      "from": "n9",
+      "to": null,
+      "control": {
+        "index": 17,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk/ontologies/new",
+        "disabled": false,
+        "label": "Create an ontology →"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n9",
+      "to": "back-stack",
+      "control": null,
+      "action": "back",
+      "outcome": "navigated"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 0,
+        "tag": "a",
+        "role": null,
+        "href": "/ai",
+        "disabled": false,
+        "label": "Home"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 1,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/odk",
+        "disabled": false,
+        "label": "Ontology"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 2,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "Applications"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": null,
+      "control": {
+        "index": 3,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/home",
+        "disabled": false,
+        "label": "View all"
+      },
+      "action": "goto",
+      "outcome": "boundary-off-allowlist"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 4,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager",
+        "disabled": false,
+        "label": "Ontology Manager"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 5,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=create",
+        "disabled": false,
+        "label": "New"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 6,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=discover",
+        "disabled": false,
+        "label": "Discover"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 7,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "History"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 8,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=object-types",
+        "disabled": false,
+        "label": "Object types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 9,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=properties",
+        "disabled": false,
+        "label": "Properties0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 10,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=link-types",
+        "disabled": false,
+        "label": "Link types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 11,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=action-types",
+        "disabled": false,
+        "label": "Action types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 12,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=value-types",
+        "disabled": false,
+        "label": "Value types0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 13,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=functions",
+        "disabled": false,
+        "label": "Functions0"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 14,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=health",
+        "disabled": false,
+        "label": "Health issues"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "visited",
+      "control": {
+        "index": 15,
+        "tag": "a",
+        "role": null,
+        "href": "/__ioi/ontology/manager?section=configuration",
+        "disabled": false,
+        "label": "Ontology configuration"
+      },
+      "action": "goto",
+      "outcome": "revisit"
+    },
+    {
+      "from": "n10",
+      "to": "n20",
+      "control": {
+        "index": 16,
+        "tag": "button",
+        "role": null,
+        "href": null,
+        "disabled": false,
+        "label": "Filter"
+      },
+      "action": "click",
+      "outcome": "navigated"
+    },
+    {
       "from": "n10",
       "to": null,
       "control": {
@@ -3825,7 +3825,7 @@
     },
     {
       "from": "n11",
-      "to": "n20",
+      "to": "n11",
       "control": {
         "index": 16,
         "tag": "button",
@@ -3835,7 +3835,7 @@
         "label": "Filter"
       },
       "action": "click",
-      "outcome": "navigated"
+      "outcome": "noop"
     },
     {
       "from": "n11",
@@ -6207,16 +6207,14 @@
   "blockers": [],
   "replay": {
     "mode": "interaction",
-    "walked_all_edges": false,
+    "walked_all_edges": true,
     "edges_total": 400,
-    "edges_executed": 31,
-    "edges_skip_classified": 369,
-    "problems": [
-      "edge n11/\"Filter\": recorded navigated, observed noop"
-    ],
-    "walked_at": "2026-08-10T02:04:43.262Z"
+    "edges_executed": 32,
+    "edges_skip_classified": 368,
+    "problems": [],
+    "walked_at": "2026-08-11T10:47:39.422Z"
   },
-  "complete_interaction_route_graph": false,
+  "complete_interaction_route_graph": true,
   "shots_dir": ".artifacts/seed-graph-shots/ontology/schema",
-  "content_address": "2b5f8be12de4d69fa956cb3a7e91d5d7e8d2962891d95ba9140c60c93ade4d40"
+  "content_address": "11ab19a07673059ea3169b5371bf3533494504af921fb2e973c9a271ce417bba"
 }

--- a/apps/hypervisor/seed-ux-provenance.v1.json
+++ b/apps/hypervisor/seed-ux-provenance.v1.json
@@ -413,8 +413,8 @@
       "owner": "Ontology",
       "canonical_route": "/ontology",
       "baseline_status": "provenance-qualified-executable-seed-present",
-      "graph_mapping_status": "blocked-explored-control-graph-not-complete",
-      "seed_graph_ready_for_rehome": false,
+      "graph_mapping_status": "baseline-graphs-complete-corroborating-typed",
+      "seed_graph_ready_for_rehome": true,
       "greenfield_authorization": null,
       "graph_recovery_status": "required-for-every-summary-only-source",
       "sources": [
@@ -426,12 +426,12 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
           "graph_file": "seed-graphs/ontology/schema.v1.json",
           "class": "daemon_wired",
-          "replay_problem_count": 1,
+          "graph_capture_note": "2026-08-09 residual (edge n11/Filter recorded navigated, observed noop) was a capture-tool defect, not a product fact: the crawl clicked a dequeued node's controls against the previous node's still-live DOM, so n11's GET Filter fired from ?section=health. Fixed by capture-time state re-establishment plus select/radio values in the state signature; recaptured+interaction-replayed complete 2026-08-11 (0 problems, 0 blockers).",
           "seed_role": "baseline"
         },
         {
@@ -537,12 +537,12 @@
           "provenance_source": "apps/hypervisor/ported-seed-preservation.v1.json",
           "visual_evidence_status": "selected-provenance-qualified-protected-matrix-present",
           "graph": {
-            "evidence_level": "explored_control_graph",
-            "complete_interaction_route_graph": false
+            "evidence_level": "complete_interaction_route_graph",
+            "complete_interaction_route_graph": true
           },
           "graph_file": "seed-graphs/data/sources.v1.json",
           "class": "daemon_wired",
-          "replay_problem_count": 1,
+          "graph_capture_note": "2026-08-09/10 residuals were capture-tool defects, not product facts: (1) the recorded n1 select state-change was a click fired against the previous node's still-live DOM (stale dequeue); (2) both unreachable-route blockers were fragment-only 'View all' (#sources-catalog) links, whose same-document navigations return no response object by design. Fixed by capture-time state re-establishment and same-document-navigation typing; recaptured+interaction-replayed complete 2026-08-11 (0 problems, 0 blockers).",
           "seed_role": "baseline"
         },
         {
@@ -558,7 +558,8 @@
           },
           "graph_file": "seed-graphs/data/pipeline.v1.json",
           "class": "daemon_wired",
-          "replay_problem_count": 13,
+          "replay_problem_count": 38,
+          "graph_capture_note": "recaptured+interaction-replayed 2026-08-11 under the hardened tool (120 nodes, 1950 edges): every 2026-08-10 residual class is gone (census overflows, stale-dequeue click flakes, unreachable/download edges all zero). Two typed residuals remain and both are exact: (1) PRODUCT FACT - the 'Toggle bottom bar' control is censused visible on all 38 route nodes but is deterministically unclickable at capture AND at replay (obscured hit target in the seed render); (2) TOOL LIMIT - node-cap-reached, 81 unexplored nodes beyond --max-nodes 120; the surface's parameterized state space (node/ontology/tab/panel permutations) still grows past 350 nodes at the default 400 cap, so a complete crawl is not reachable at any practical budget. Baseline stays incomplete; the data seed gate stays closed on these two typed findings.",
           "seed_role": "baseline"
         },
         {


### PR DESCRIPTION
## What this is

Next-legs IV Leg 2: repair the three seed-graph residuals blocking the ontology and data seed gates, by fixing the capture tool where the tool was wrong and typing exactly what remains where the product or a hard tool limit is the truth.

## Root cause (differs from the 2026-08-09 diagnosis, same family)

The recorded residuals were **capture-tool defects, not product facts**:

1. **Stale-page-on-dequeue** (the real n11 mechanism): the crawl clicked a dequeued node's controls against the *previous* node's still-live DOM. Schema n11's "Filter" fired from `?section=health` (n10 was the previously processed node); sources n1's "select state-change" was actually a click landing on n0's link at the same census index. The diagnosed "visible select value" state distinction is real, but the misattribution came first.
2. **Fragment-only links typed as unreachable**: `#sources-catalog` same-document navigations return no response object in Playwright by design — both sources `unreachable-route: no response` blockers were this, not warm-up.

## Tool hardening (no weakened semantics)

- **Capture-time state re-establishment**: on dequeue and after every state-changing edge, route nodes re-goto their URL and state nodes replay their entry-edge chain — the same discipline replay's `establish()` already enforced on the other side; failure mints a typed `state-reestablish-failed` blocker.
- **`stateSignature` extended** with visible `<select>` and checked-radio VALUES (bounded 40 chars, sorted, hashed `#sv=`) so select-value state mints distinct nodes.
- **Same-document navigations** that verifiably land (`page.url()` equals target) are recorded as the navigation they are, never as `unreachable-route`.
- **Goto warm-up hardening**: `--goto-timeout` (default 45s) + one settle-and-retry pass on no-response only; HTTP errors are never retried.

## Per-graph outcomes (isolated daemon+serve pair per run; capture + interaction replay)

| graph | result | detail |
|---|---|---|
| `ontology/schema.v1.json` | **COMPLETE** | 21 nodes, 400 edges, 32 executed / 368 skip-classified, 0 problems, 0 blockers |
| `data/sources.v1.json` | **COMPLETE** | 2 nodes, 38 edges, 6 executed / 32 skip-classified, 0 problems, 0 blockers |
| `data/pipeline.v1.json` | honest incomplete | 120 nodes, 1950 edges, 335 executed / 1577 skip-classified; ALL old residual classes gone (census overflows 0, stale-dequeue flakes 0, unreachable 0, downloads 0); residuals typed below |

**Pipeline residual classification** (all in `graph_capture_note`):
- **PRODUCT FACT** — "Toggle bottom bar" is censused visible on all 38 route nodes and deterministically unclickable at capture AND replay (obscured hit target in the seed render). 38/38 replay problems are this one control.
- **TOOL LIMIT** — `node-cap-reached`: 81 unexplored nodes beyond `--max-nodes 120`; the parameterized state space (node/ontology/tab/panel) still grows past 350 nodes at the default 400 cap (that run was externally killed after ~2.2h), so a complete crawl is not reachable at a practical budget.

## Prior-complete-graph regression proof

`governance/approvals.v1.json` replayed under the NEW tool against a fresh isolated pair:

```
seed-route-graph replay(interaction): 5 edges executed, 52 skip-classified, 0 problems, 0 standing blockers -> complete_interaction_route_graph=true
```

Stored graphs are unaffected by the signature change (replay compares live-vs-live signatures; addresses bind no tool internals).

## require-ready proofs (verbatim)

`node apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs --require-ready --surface ontology` — **GREEN (exit 0)**:

```
seed-provenance: surface ontology corroborating context — 4 corroborating source(s) not interaction-complete (schema, explorer, objectview, objecteditor); typed states preserved, never gate inputs.
seed-provenance OK (require-ready ontology) — 20 surfaces, 58 sources (16 protected, 39 retained, 3 dormant), fail-closed graph gate armed.
```

`node apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs --require-ready --surface data` — **RED (exit 1), expected and typed**:

```
seed-provenance: surface data corroborating context — 5 corroborating source(s) not interaction-complete (ingest, sources, pipeline, dataset, inference); typed states preserved, never gate inputs.
seed-provenance: surface data: seed gate CLOSED — not ready for rehome; incomplete baseline sources: pipeline (typed capture note). A block record never opens work.

seed-provenance FAIL (require-ready data) — 1 failures
```

## Gates

- `check:seed-provenance` (full tracked gate): **GREEN** — `seed-provenance OK (full tracked gate) — 20 surfaces, 58 sources (16 protected, 39 retained, 3 dormant), fail-closed graph gate armed.`
- `check:source-neutral`: **GREEN** (brand + framing lines clean; graph evidence neutralized at record time)
- `check:governance-journey` (private rebuilt binary): **20/20 GREEN**

## Manifest derivation (strict, per verifier vocabulary)

- ontology: `seed_graph_ready_for_rehome` true derives from baseline {schema, explorer} both interaction-complete; status `baseline-graphs-complete-corroborating-typed` (4 corroborating sources stay typed, never gate inputs).
- data: ready stays false (pipeline baseline incomplete); status stays `blocked-explored-control-graph-not-complete`; sources + pipeline both carry exact `graph_capture_note` findings.

Do NOT merge without review — the coordinator rules the pipeline node-cap posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)