### PR TITLE
feat(hypervisor): /home partial pre-W3 cockpit slice — owner-backed counts, live deep-links, typed Operations gap; check:home-cockpit (next-legs IV Leg 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,7 @@ jobs:
           npm run check:applications-journey --workspace=@ioi/hypervisor-app
           npm run check:systems-journey --workspace=@ioi/hypervisor-app
           npm run check:work-cockpit --workspace=@ioi/hypervisor-app
+          npm run check:home-cockpit --workspace=@ioi/hypervisor-app
           npm run check:projects-saga --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -21,6 +21,7 @@
     "check:applications-journey": "node scripts/verify-hypervisor-applications-journey.mjs",
     "check:systems-journey": "node scripts/verify-hypervisor-systems-journey.mjs",
     "check:work-cockpit": "node scripts/verify-hypervisor-work-cockpit.mjs",
+    "check:home-cockpit": "node scripts/verify-hypervisor-home-cockpit.mjs",
     "check:projects-saga": "node scripts/verify-hypervisor-projects-saga.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -35,6 +35,7 @@ import * as automationsModule from "../surfaces/automations/index.mjs";
 import * as applicationsModule from "../surfaces/applications/index.mjs";
 import * as systemsModule from "../surfaces/systems/index.mjs";
 import * as workModule from "../surfaces/work/index.mjs";
+import * as homeModule from "../surfaces/home/index.mjs";
 
 // Capability model (operational wave): `capabilities` is the AUTHORITY-derived set of acts the
 // surface genuinely supports today (never inferred from pixel certification or daemon_wired);
@@ -134,6 +135,17 @@ export const SURFACES = [
   { slug: "work", owner: "Work", title: "Work", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/work-cockpit", canonical_route: "/work", verifier: "scripts/verify-hypervisor-work-cockpit.mjs", certification: "n/a", capabilities: ["browse", "inspect"], operational_state: "inspect", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "work-sessions", owner: "Work", title: "Work / Sessions", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/work-sessions", canonical_route: "/work/sessions", verifier: "scripts/verify-hypervisor-work-cockpit.mjs", certification: "n/a", capabilities: ["browse", "filter", "select", "inspect"], operational_state: "inspect", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "work-new-session", owner: "Work", title: "Work / New Session", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/work-new-session", canonical_route: "/work/new-session", verifier: "scripts/verify-hypervisor-work-cockpit.mjs", certification: "n/a", capabilities: ["browse", "create"], operational_state: "act", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
+  // W2.1 next-legs IV Leg 4: the Home PARTIAL PRE-W3 COCKPIT SLICE — canonical /home plus a
+  // FRESH legacy lane /__ioi/home-cockpit. NOT Home completion: SURF-home and W3.1 remain open;
+  // the home-cockpit projection route (GET /v1/hypervisor/home-cockpit) is a typed W3 absence,
+  // so the slice composes the same per-family reads the live /ai explorer composes — which
+  // keeps serving untouched as a CURRENT LIVE ENTRY, never a substitute seed. Greenfield
+  // canon-first on the typed non-parity lane (seed-ux-provenance.v1.json home record): no seed
+  // preservation, no parity claims. Read-only by contract: Home launches, owns no object and
+  // declares zero actions (New Session is Work's affordance advertised by navigation);
+  // parked/failed-run rows render real counts with their Operations deep-links a typed
+  // disabled-named-gap until the /operations mount lands. Evidence: check:home-cockpit.
+  { slug: "home", owner: "Home", title: "Home", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/home-cockpit", canonical_route: "/home", verifier: "scripts/verify-hypervisor-home-cockpit.mjs", certification: "n/a", capabilities: ["browse", "inspect"], operational_state: "inspect", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "changes", owner: "Improvement", title: "Upgrade Assistant", icon: CHG_APP_TILE_URI, route: "/__ioi/improvement/changes", verifier: "scripts/verify-hypervisor-app-parity-changes.mjs", certification: "pixel-certifications/changes.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "evalsuites", owner: "Evaluations", title: "AIP Evals", icon: EVL_APP_TILE_URI, route: "/__ioi/evaluations/evalsuites", verifier: "scripts/verify-hypervisor-app-parity-evalsuites.mjs", certification: "pixel-certifications/evalsuites.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
 ];
@@ -245,6 +257,8 @@ bindSurface("systems", systemsModule);
 bindSurface("work", workModule);
 bindSurface("work-sessions", workModule);
 bindSurface("work-new-session", workModule);
+// Home: one row, one module — the partial pre-W3 cockpit slice (read-only, zero actions).
+bindSurface("home", homeModule);
 
 // Test-only fault surface (NEVER without the runtime-test flag): gives the action-runtime
 // verifier a module whose action THROWS (route isolation proof) and one that claims success

--- a/apps/hypervisor/scripts/verify-hypervisor-home-cockpit.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-home-cockpit.mjs
@@ -1,0 +1,495 @@
+// verify-hypervisor-home-cockpit — the Home PARTIAL PRE-W3 COCKPIT SLICE verifier
+// (check:home-cockpit, next-legs IV Leg 4). Deliberately NOT a "-journey": the Home journey
+// (the manifest SURF-home acceptance — resumable/blocked/failed/approval-requiring/completed
+// work with full state survival) is SURF-home's to earn; SURF-home and W3.1 REMAIN OPEN and
+// nothing here claims Home completion.
+//
+// What this verifier proves, live against an isolated daemon + serve stack:
+//   - the home-cockpit projection pair is a TYPED W3 ABSENCE pinned mechanically at /v1
+//     (GET /v1/hypervisor/home-cockpit and /v1/hypervisor/session-operations are route-missing)
+//     and stated typed on the page — the metrics strip is never a fabricated rollup;
+//   - canonical /home renders every pane owner-backed from REAL routes only, HONEST-EMPTY on a
+//     fresh daemon BEFORE any seeding (zeros stated as absence, never invented rows);
+//   - seeded fixtures (an approval request, a project, a session) surface as REAL counts and
+//     rows, and every LIVE deep-link target answers 200 showing the linked record class
+//     (/governance/approvals, /work/sessions, /projects via the browser, /applications);
+//   - the Operations-targeted links are a typed disabled-named-gap with the exact reason —
+//     and the gap is REAL, pinned mechanically (/operations serves only the substrate shell,
+//     no Operations surface module binds it; the pin fails the day the mount lands);
+//   - the applications grid is compiler-projection truth ONLY: the page's entry set equals the
+//     projection's entry set, launchable tiles link the projection's own routes, and the
+//     folded-owner refusal set holds (no retired owner name renders anywhere);
+//   - the cross-surface New Session journey: /home advertises Work's affordance at
+//     /work/new-session, the create admits exactly ONE session (202 + provision receipt) on the
+//     identity-carrying action lane, subject-less per the typed W3 C-1 absence
+//     (subject_attachments EXACTLY []), and Home renders the admitted readback;
+//   - /ai keeps serving untouched (current live entry, never a substitute seed);
+//   - reload + daemon-restart survival of counts; daemon outage renders the typed
+//     unavailability page with ZERO fabricated counts (the canon fallback-fixture rule,
+//     api.md:167-169); the 3-posture browser matrix on /home.
+//
+// Exit: 0 pass · 1 fail · 2 blocked (daemon binary missing).
+//   IOI_HYPERVISOR_DAEMON_BINARY  default target/debug/hypervisor-daemon
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+  srv.on("error", reject);
+});
+
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try {
+  fs.accessSync(daemonBinary, fs.constants.X_OK);
+} catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-home-cockpit-"));
+let daemon = null;
+let serve = null;
+let daemonPort = 0;
+let DAEMON = "";
+let SERVE = "";
+let SESSION = "";
+
+const HOME = "/home";
+const FRESH_HOME = "/__ioi/home-cockpit";
+const LINK_APPROVALS = "/governance/approvals";
+const LINK_SESSIONS = "/work/sessions";
+const LINK_NEW_SESSION = "/work/new-session";
+const LINK_PROJECTS = "/projects";
+const LINK_APPLICATIONS = "/applications";
+const WORK_NEW_SESSION_ACTION_LANE = "/__ioi/work-new-session";
+const RETIRED_OWNER_NAMES = ["Missions", "Marketplace", "Workbench", "Agent Studio"];
+
+async function startDaemon() {
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${daemonPort}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1/v1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = "";
+  daemon.stdout.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  await waitFor(`${DAEMON}/healthz`, 30000);
+  return () => log;
+}
+
+const jd = (p, init, cookie = true) => fetch(`${DAEMON}${p}`, {
+  ...init,
+  headers: {
+    ...(init?.body ? { "content-type": "application/json" } : {}),
+    ...(cookie && SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+  },
+}).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+  .catch(() => ({ status: 0, body: {} }));
+
+const pageText = (p, { authenticated = true } = {}) => fetch(`${SERVE}${p}`, {
+  headers: authenticated && SESSION ? { cookie: `ioi_session=${SESSION}` } : {},
+}).then(async (r) => ({ status: r.status, text: await r.text(), headers: r.headers }))
+  .catch(() => ({ status: 0, text: "", headers: new Headers() }));
+
+// A module-action form POST (PRG 303) — the redirect query carries acted/receipt/record/result
+// or refused/reason; both are parsed, never followed blindly.
+async function act(lane, tail, fields) {
+  const r = await fetch(`${SERVE}${lane}${tail}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      ...(SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+    },
+    body: new URLSearchParams(fields).toString(),
+    redirect: "manual",
+  }).catch(() => null);
+  const location = r?.headers?.get("location") || "";
+  let q = new URLSearchParams();
+  try {
+    q = new URL(location, "http://x").searchParams;
+  } catch { /* keep empty */ }
+  return { status: r?.status ?? 0, location, q };
+}
+
+const entryNames = (html) => [...html.matchAll(/data-ioi-entry-name="([^"]*)"/gu)].map((m) => m[1]).sort();
+
+async function run() {
+  daemonPort = await freePort();
+  DAEMON = `http://127.0.0.1:${daemonPort}`;
+  const daemonLogFn = await startDaemon();
+  const token = daemonLogFn().match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  if (token) {
+    const boot = await jd("/v1/hypervisor/auth/bootstrap", {
+      method: "POST",
+      body: JSON.stringify({ token, password: "home-cockpit-bootstrap-v1", email: "home-cockpit@ioi.local" }),
+    });
+    SESSION = boot.body?.session_token ?? "";
+  }
+  ok("operator bootstrap yields an authenticated session", SESSION.startsWith("ioi_sess_"), SESSION.slice(0, 12));
+
+  // -- TYPED W3 ABSENCE (mechanical): the home-cockpit projection pair is route-missing -------
+  const index = await jd("/v1");
+  const idxStr = JSON.stringify(index.body);
+  ok("typed W3 absence pinned mechanically: GET /v1/hypervisor/home-cockpit (home_cockpit_projection.v1, api.md:132-169) and GET /v1/hypervisor/session-operations (api.md:171-181) are route-missing at the daemon — the W3 build list owns them; this slice may only compose per-family reads, never simulate the rollup",
+    !idxStr.includes("home-cockpit") && !idxStr.includes("home_cockpit") && !idxStr.includes("session-operations"),
+    "zero home-cockpit/session-operations hits at /v1");
+
+  // -- serve boot -----------------------------------------------------------------------------
+  const servePort = await freePort();
+  const productUiPort = await freePort();
+  SERVE = `http://127.0.0.1:${servePort}`;
+  serve = spawn(process.execPath, [path.join(HERE, "serve-product-ui.mjs")], {
+    cwd: APP,
+    env: {
+      ...process.env,
+      PORT: String(servePort),
+      PRODUCT_UI_PORT: String(productUiPort),
+      IOI_PRODUCT_UI_PUBLIC: path.join(APP, "product-ui", "owned", "public"),
+      IOI_HYPERVISOR_DAEMON_URL: DAEMON,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await waitFor(`${SERVE}${HOME}`, 30000);
+
+  // -- HONEST-EMPTY PASS on the fresh daemon, BEFORE any seeding ------------------------------
+  const empty = await pageText(HOME);
+  ok("canonical /home 200s as the module's own mount (ownership headers name the served route + owner)",
+    empty.status === 200
+      && empty.headers.get("x-ioi-surface-route") === HOME
+      && empty.headers.get("x-ioi-surface-owner") === "Home",
+    `route ${empty.headers.get("x-ioi-surface-route")} · owner ${empty.headers.get("x-ioi-surface-owner")}`);
+  ok("the page states its scope TYPED: partial pre-W3 cockpit slice, NOT Home completion (SURF-home and W3.1 remain open; the manifest SURF-home acceptance is the full bar)",
+    empty.text.includes('data-ioi-scope="partial-pre-w3-cockpit-slice"')
+      && empty.text.includes("NOT Home completion")
+      && empty.text.includes("SURF-home and W3.1 remain open"));
+  ok("every pane is present on the fresh render: approvals waiting · parked/failed runs · recent sessions · recent projects · applications grid · the New Session entry to Work's affordance",
+    empty.text.includes('id="home-approvals"')
+      && empty.text.includes('id="home-parked-failed"')
+      && empty.text.includes('id="home-recent-sessions"')
+      && empty.text.includes('id="home-recent-projects"')
+      && empty.text.includes('id="home-applications"')
+      && new RegExp(`<a[^>]*href="${LINK_NEW_SESSION}"[^>]*data-ioi-new-session-entry`, "u").test(empty.text));
+  ok("honest-empty everywhere BEFORE seeding: all five owner-backed panes state typed absence-of-rows (approvals, parked-runs, failed-runs, sessions, projects) and ZERO record rows render",
+    ["approvals", "parked-runs", "failed-runs", "sessions", "projects"].every((k) => empty.text.includes(`data-ioi-honest-empty="${k}"`))
+      && !empty.text.includes("data-ioi-approval-row")
+      && !empty.text.includes("data-ioi-session-row")
+      && !empty.text.includes("data-ioi-project-row")
+      && !empty.text.includes("data-ioi-parked-row")
+      && !empty.text.includes("data-ioi-failed-row"));
+  ok("the metrics-strip absence renders TYPED on the page (the home-cockpit projection is W3's, never a fabricated rollup)",
+    empty.text.includes('data-ioi-w3-absence="home_cockpit_projection"')
+      && empty.text.includes("route-missing"));
+  ok("Home declares itself read-only: New Session is Work's affordance advertised by navigation (Home mints nothing), and the module declares zero actions",
+    empty.text.includes("never mints the object itself") && empty.text.includes("Home owns no truth"));
+
+  const freshHome = await pageText(FRESH_HOME);
+  ok("the fresh legacy lane /__ioi/home-cockpit serves the same module with truthful per-lane markers",
+    freshHome.status === 200
+      && freshHome.headers.get("x-ioi-surface-route") === FRESH_HOME
+      && freshHome.text.includes('id="home-approvals"'),
+    `route ${freshHome.headers.get("x-ioi-surface-route")}`);
+
+  // -- the Operations gap: typed on the page, REAL at the estate ------------------------------
+  ok("the Operations-targeted links are a typed disabled-named-gap with the exact reason (counts real, links disabled until the Operations mount lands — never a dead link, never a fabricated destination)",
+    empty.text.includes('data-ioi-named-gap="operations-mount"')
+      && empty.text.includes("disabled-named-gap — the canonical Operations mount is not live")
+      && empty.text.includes("GET /v1/hypervisor/failover/runs · GET /v1/hypervisor/operations")
+      && empty.text.includes("never a dead link and never a fabricated destination"));
+  const opsServe = await pageText("/operations");
+  ok("the gap is REAL, pinned mechanically: /operations serves only the W0.1 substrate shell (owner marker 'substrate', no Operations surface module) — the day an Operations mount lands this pin fails and the gap must be re-ruled",
+    opsServe.status === 200 && opsServe.headers.get("x-ioi-surface-owner") === "substrate",
+    `owner ${opsServe.headers.get("x-ioi-surface-owner")}`);
+
+  // -- /ai: the current live entry keeps serving untouched ------------------------------------
+  const ai = await pageText("/ai", { authenticated: false });
+  ok("/ai still serves the explorer readout untouched — a CURRENT LIVE ENTRY (never a substitute seed; the greenfield lane claims no parity with it)",
+    ai.status === 200 && ai.text.length > 50000, `${ai.status} · ${ai.text.length}B`);
+
+  // -- retired owner names never render -------------------------------------------------------
+  ok("no retired owner name renders on the fresh /home (Missions · Marketplace · Workbench · Agent Studio — the folded-owner refusal set holds)",
+    RETIRED_OWNER_NAMES.every((name) => !empty.text.includes(name)));
+
+  // -- SEED real fixtures via the daemon ------------------------------------------------------
+  const apprSeed = await jd("/v1/hypervisor/governance/approval-requests", {
+    method: "POST",
+    body: JSON.stringify({
+      subject_ref: "canon://hypervisor/home-cockpit-slice",
+      request_kind: "home_cockpit_check",
+      reason: "home cockpit slice fixture — pending approval seed",
+    }),
+  });
+  const apprId = apprSeed.body?.approval_request?.id || "";
+  ok("fixture: an approval request seeds through the daemon and is pending",
+    (apprSeed.status === 200 || apprSeed.status === 201 || apprSeed.status === 202)
+      && !!apprId
+      && (apprSeed.body?.approval_request?.status ?? "pending") === "pending",
+    `${apprSeed.status} · ${apprId}`);
+
+  const PROJECT_NAME = "home-cockpit-fixture";
+  const projSeed = await fetch(`${SERVE}/api/ioi.v1.ProjectService/CreateProject`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(SESSION ? { cookie: `ioi_session=${SESSION}` } : {}) },
+    body: JSON.stringify({ name: PROJECT_NAME, initializer: { specs: [{ git: { remoteUri: "https://example.invalid/home/fixture.git" } }] } }),
+  }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) })).catch(() => ({ status: 0, body: {} }));
+  const projectId = projSeed.body?.project?.id || "";
+  ok("fixture: a project seeds through the identity-forwarding serve lane and is durable daemon truth",
+    projSeed.status === 200 && !!projectId
+      && (await jd(`/v1/hypervisor/projects/${encodeURIComponent(projectId)}`)).status === 200,
+    `${projSeed.status} · ${projectId}`);
+
+  const sessSeed = await jd("/v1/hypervisor/sessions", {
+    method: "POST",
+    body: JSON.stringify({ initial_input: "home cockpit slice fixture session" }),
+  });
+  const seedSessionRef = sessSeed.body?.session_ref || "";
+  ok("fixture: a session seeds via POST /v1/hypervisor/sessions under the operator identity (202 + provision receipt)",
+    sessSeed.status === 202 && seedSessionRef.startsWith("session:")
+      && String(sessSeed.body?.receipt_ref || "").startsWith("receipt://"),
+    `${sessSeed.status} · ${seedSessionRef.slice(0, 24)}`);
+
+  // -- the seeded counts and rows render owner-backed -----------------------------------------
+  const seeded = await pageText(HOME);
+  ok("approvals waiting reflects the seeded fixture: count 1, the request renders as a row (kind + subject), deep-linking /governance/approvals",
+    seeded.text.includes("1 waiting")
+      && seeded.text.includes("home_cockpit_check")
+      && seeded.text.includes("canon://hypervisor/home-cockpit-slice")
+      && seeded.text.includes("data-ioi-approval-row")
+      && seeded.text.includes(`href="${LINK_APPROVALS}"`));
+  ok("recent sessions reflects the seeded fixture: count 1, the session ref renders as a resume row deep-linking /work/sessions",
+    seeded.text.includes("1 session")
+      && seeded.text.includes(seedSessionRef)
+      && seeded.text.includes("data-ioi-session-row")
+      && seeded.text.includes(`href="${LINK_SESSIONS}?session=${encodeURIComponent(seedSessionRef)}"`));
+  ok("recent projects reflects the seeded fixture: count 1, the project renders as a row deep-linking /projects",
+    seeded.text.includes("1 project")
+      && seeded.text.includes(PROJECT_NAME)
+      && seeded.text.includes("data-ioi-project-row")
+      && seeded.text.includes(`href="${LINK_PROJECTS}"`));
+  ok("the parked/failed panes stay honest-empty (no failover/operations fixtures exist) — real zeros stated as absence, never invented rows",
+    seeded.text.includes('data-ioi-honest-empty="parked-runs"')
+      && seeded.text.includes('data-ioi-honest-empty="failed-runs"'));
+
+  // -- applications grid = compiler-projection truth ONLY -------------------------------------
+  const projection = await jd("/v1/hypervisor/product-surface-projections", {
+    method: "POST",
+    body: JSON.stringify({ context: { launcher: "home-cockpit-verifier" } }),
+  });
+  const projectionEntries = Array.isArray(projection.body?.application_entries) ? projection.body.application_entries : [];
+  const expectedNames = projectionEntries.map((e) => String(e.display_name || e.identity_ref || "")).sort();
+  const pageNames = entryNames(seeded.text);
+  ok("the applications grid renders EXACTLY the projection's entry set — nothing the projection wouldn't admit, nothing the projection admits hidden",
+    projection.status === 200 && expectedNames.length > 0 && JSON.stringify(pageNames) === JSON.stringify(expectedNames),
+    `page ${pageNames.length} entries vs projection ${expectedNames.length}`);
+  const launchables = projectionEntries.filter((e) => e.launchable === true && typeof e.resolved_launch_route === "string");
+  ok("launchable tiles link the projection's own resolved_launch_route; non-launchable entries render disabled with their typed reasons — launch state is projection truth, never invented",
+    launchables.length > 0
+      && launchables.every((e) => seeded.text.includes(`href="${e.resolved_launch_route}"`))
+      && projectionEntries.filter((e) => e.launchable !== true)
+        .every((e) => new RegExp(`data-ioi-entry-name="${String(e.display_name || e.identity_ref || "").replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}" data-ioi-launchable="false"`, "u").test(seeded.text)),
+    `${launchables.length} launchable`);
+  ok("no retired owner name renders on the seeded /home either (refusal set holds over live projection truth)",
+    RETIRED_OWNER_NAMES.every((name) => !pageNames.includes(name)));
+
+  // -- follow the actual hrefs: every LIVE deep-link target shows the linked record class -----
+  const apprPage = await pageText(LINK_APPROVALS);
+  ok("deep link /governance/approvals: 200 under the Governance owner and the seeded approval request renders (the linked record class, followed from Home's own href)",
+    apprPage.status === 200
+      && apprPage.headers.get("x-ioi-surface-owner") === "Governance"
+      && (apprPage.text.includes("home_cockpit_check") || apprPage.text.includes(apprId)),
+    `owner ${apprPage.headers.get("x-ioi-surface-owner")}`);
+  const sessHref = (seeded.text.match(new RegExp(`href="(${LINK_SESSIONS}\\?session=[^"]*)"`, "u")) || [])[1] || "";
+  const sessPage = await pageText(sessHref);
+  ok("deep link /work/sessions?session=…: 200 under the Work owner and the seeded session's facts render (followed from Home's own resume row href)",
+    !!sessHref && sessPage.status === 200
+      && sessPage.headers.get("x-ioi-surface-owner") === "Work"
+      && sessPage.text.includes(seedSessionRef)
+      && sessPage.text.includes("Session facts"),
+    sessHref.slice(0, 60));
+  const projPage = await pageText(LINK_PROJECTS);
+  ok("deep link /projects: the vendored Projects subtree serves 200 (its record class is asserted in the browser below — the page is client-rendered)",
+    projPage.status === 200 && projPage.text.length > 10000, `${projPage.status} · ${projPage.text.length}B`);
+  const appsPage = await pageText(LINK_APPLICATIONS);
+  ok("deep link /applications: 200 under the Applications owner with the full catalog (the grid's 'full launcher' href lands on the one compiled projection)",
+    appsPage.status === 200
+      && appsPage.headers.get("x-ioi-surface-owner") === "Applications"
+      && appsPage.text.includes("Application catalog"));
+  const firstLaunch = launchables[0];
+  const launchTarget = firstLaunch ? await pageText(firstLaunch.resolved_launch_route) : { status: 0 };
+  ok("following a launchable tile's href lands 200 — launch is navigation over an admitted projection row, never a mutation",
+    !!firstLaunch && launchTarget.status === 200,
+    firstLaunch ? `${firstLaunch.display_name} → ${firstLaunch.resolved_launch_route}` : "no launchable entries");
+
+  // -- the cross-surface New Session journey (subject-less, per the typed W3 C-1 absence) -----
+  const newSessionPage = await pageText(LINK_NEW_SESSION);
+  ok("the New Session entry advertises Work's affordance: /work/new-session 200s under the Work owner with NO subject input (the typed W3 C-1 absence stated on the form)",
+    newSessionPage.status === 200
+      && newSessionPage.headers.get("x-ioi-surface-owner") === "Work"
+      && !/name="subject/u.test(newSessionPage.text)
+      && newSessionPage.text.includes('data-ioi-w3-absence="subject_attachments"'));
+  const created = await act(WORK_NEW_SESSION_ACTION_LANE, "/actions/create-session", {
+    initial_input: "home cockpit cross-surface journey — admitted create",
+  });
+  const journeyRef = created.q.get("record") || "";
+  ok("the journey create admits exactly ONE session through the identity-carrying action lane (PRG 303, provision receipt, session record)",
+    created.status === 303
+      && created.q.get("acted") === "create-session"
+      && String(created.q.get("receipt") || "").startsWith("receipt://hypervisor/session-provision/")
+      && journeyRef.startsWith("session:")
+      && created.q.get("result") === "provisioned",
+    `record ${journeyRef.slice(0, 24)}`);
+  const journeyRecord = (await jd(`/v1/hypervisor/sessions/${encodeURIComponent(journeyRef)}`)).body?.session || null;
+  ok("admitted readback at the daemon: provisioned, owner daemon-resolved to the authenticated principal, and subject_attachments EXACTLY [] (subject-less — the typed W3 absence, never masqueraded)",
+    !!journeyRecord && journeyRecord.lifecycle_state === "provisioned"
+      && String(journeyRecord.owner_ref || "").startsWith("user://")
+      && journeyRecord.owner_ref !== "user://local-operator"
+      && Array.isArray(journeyRecord.subject_attachments) && journeyRecord.subject_attachments.length === 0,
+    `owner ${journeyRecord?.owner_ref}`);
+  const afterJourney = await pageText(HOME);
+  ok("Home renders the admitted readback: the journey session joins Recent sessions (2 sessions, both refs) — cross-surface create lands back on owner-backed truth",
+    afterJourney.text.includes("2 sessions")
+      && afterJourney.text.includes(seedSessionRef)
+      && afterJourney.text.includes(journeyRef));
+
+  // -- reload survival ------------------------------------------------------------------------
+  const reload = await pageText(HOME);
+  ok("reload: /home re-renders every seeded count and row from daemon truth (nothing was page-local state)",
+    reload.status === 200
+      && reload.text.includes("1 waiting")
+      && reload.text.includes("2 sessions")
+      && reload.text.includes(PROJECT_NAME)
+      && reload.text.includes(journeyRef));
+
+  // -- daemon-restart survival ----------------------------------------------------------------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  await startDaemon();
+  let survived = { status: 0, text: "" };
+  for (let attempt = 0; attempt < 3; attempt++) {
+    survived = await pageText(HOME);
+    if (survived.status === 200 && survived.text.includes(journeyRef)) break;
+    await new Promise((r) => setTimeout(r, 1200));
+  }
+  ok("daemon restart: the approval, the project and both sessions survive as durable records and /home re-renders the same counts",
+    survived.status === 200
+      && survived.text.includes("1 waiting")
+      && survived.text.includes("home_cockpit_check")
+      && survived.text.includes(PROJECT_NAME)
+      && survived.text.includes("2 sessions")
+      && survived.text.includes(seedSessionRef)
+      && survived.text.includes(journeyRef));
+
+  // -- daemon outage: the typed unavailability page, zero fabricated counts -------------------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  const down = await pageText(HOME);
+  ok("daemon down: /home renders the TYPED unavailability page — the canon fallback-fixture rule held verbatim (nothing is shown rather than fixtures)",
+    down.status === 200
+      && down.text.includes('data-ioi-daemon-unavailable="true"')
+      && down.text.includes("Daemon unreachable")
+      && down.text.includes("data-ioi-scope"),
+    `status ${down.status}`);
+  ok("zero fabricated counts on the outage page: no approval kind, no project name, no session refs, no count pills, no honest-empty markers pretending the daemon answered",
+    !down.text.includes("home_cockpit_check")
+      && !down.text.includes(PROJECT_NAME)
+      && !down.text.includes(seedSessionRef)
+      && !down.text.includes(journeyRef)
+      && !down.text.includes("waiting")
+      && !down.text.includes("data-ioi-honest-empty"));
+  await startDaemon();
+  await waitFor(`${DAEMON}/healthz`, 30000);
+
+  // -- 3-posture matrix on /home + the /projects record class in the browser ------------------
+  let pw = null;
+  try { pw = await import("playwright"); } catch { pw = null; }
+  if (!pw) {
+    ok("posture matrix skipped — playwright unavailable", false, "install playwright to run the browser matrix");
+  } else {
+    const browser = await pw.chromium.launch();
+    for (const [name, opts] of [
+      ["light-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "light" }],
+      ["dark-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "dark" }],
+      ["narrow-reduced-motion", { viewport: { width: 390, height: 844 }, colorScheme: "light", reducedMotion: "reduce" }],
+    ]) {
+      const ctx = await browser.newContext(opts);
+      const page = await ctx.newPage();
+      const errors = [];
+      page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+      const resp = await page.goto(`${SERVE}${HOME}`, { waitUntil: "networkidle", timeout: 45000 }).catch(() => null);
+      const body = resp ? await page.evaluate(() => document.body.innerText) : "";
+      await page.keyboard.press("Tab");
+      const focused = resp ? await page.evaluate(() => document.activeElement?.tagName ?? "") : "";
+      ok(`posture ${name}: /home renders, keyboard-focusable, zero console errors`,
+        resp && resp.status() === 200 && body.length > 0 && errors.length === 0 && focused !== "" && focused !== "BODY",
+        errors[0]?.slice(0, 100) ?? `focus ${focused}`);
+      await ctx.close();
+    }
+    // /projects is the vendored client-rendered subtree: its record class is asserted here,
+    // in the browser, following Home's own deep-link. (Pre-existing vendored console noise on
+    // that page is not this slice's regression and is not asserted either way.)
+    const ctx = await browser.newContext();
+    await ctx.addCookies([{ name: "ioi_session", value: SESSION, url: SERVE }]);
+    const page = await ctx.newPage();
+    await page.goto(`${SERVE}${LINK_PROJECTS}`, { waitUntil: "networkidle", timeout: 45000 }).catch(() => null);
+    let projectsBody = "";
+    for (let attempt = 0; attempt < 5; attempt++) {
+      await page.waitForTimeout(1500);
+      projectsBody = await page.evaluate(() => document.body.innerText).catch(() => "");
+      if (projectsBody.includes(PROJECT_NAME)) break;
+    }
+    ok("deep link /projects shows the linked record class in the browser: the seeded project renders on the vendored Projects subtree",
+      projectsBody.includes(PROJECT_NAME), `body ${projectsBody.length}B`);
+    await ctx.close();
+    await browser.close();
+  }
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  cleanup();
+  process.exit(1);
+});
+
+function cleanup() {
+  try { serve?.kill("SIGTERM"); } catch { /* gone */ }
+  try { daemon?.kill("SIGTERM"); } catch { /* gone */ }
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* keep */ }
+}

--- a/apps/hypervisor/surfaces/home/index.mjs
+++ b/apps/hypervisor/surfaces/home/index.mjs
@@ -1,0 +1,317 @@
+// Home — the canonical /home PARTIAL PRE-W3 COCKPIT SLICE (next-legs IV Leg 4).
+//
+// SCOPE RULING (bounds every claim in this file): this is NOT Home completion. SURF-home and
+// W3.1 REMAIN OPEN. The manifest SURF-home acceptance (owner-backed resumable/blocked/failed/
+// approval-requiring/completed work as counts and rows that deep-link correctly; full state
+// survival) is the FULL bar — this slice delivers the pre-W3 subset only. Evidence:
+// scripts/verify-hypervisor-home-cockpit.mjs (check:home-cockpit — deliberately NOT a
+// "-journey"; the Home journey is SURF-home's to earn).
+//
+// GREENFIELD, TYPED NON-PARITY: no provenance-qualified seed exists for Home — two recovery
+// passes promoted zero candidates — so this build rides the owner-authorized
+// greenfield-authorized-non-parity lane recorded in apps/hypervisor/seed-ux-provenance.v1.json
+// (home record). It claims no seed preservation and no parity; it is canon-first over
+// docs/architecture/components/hypervisor/core-clients-surfaces.md (§ Home: default command
+// and resume surface; Home may draft work but must NOT become the durable owner of anything).
+// The live /ai explorer readout is a CURRENT LIVE ENTRY, untouched — never a substitute seed.
+//
+// TYPED W3 ABSENCES stated, never simulated:
+//   - `GET /v1/hypervisor/home-cockpit` (ioi.hypervisor.home_cockpit_projection.v1,
+//     api.md:132-169) and `GET /v1/hypervisor/session-operations` (api.md:171-181) are
+//     route-missing at the daemon — the W3 build list owns them. This slice therefore composes
+//     the SAME per-family reads the live /ai explorer composes, server-side over the shared
+//     read client; the metrics strip that needs the projection stays a named absence, never a
+//     fabricated rollup.
+//   - The canonical /operations mount is NOT live on this estate: no surface row binds it.
+//     Parked-at-wallet-gate and failed-run rows render their REAL counts (failover/operations
+//     reads) but their owning-surface links are disabled-named-gap — named, never a dead link.
+//
+// READ-ONLY BY CONTRACT: Home launches; it owns no object and performs no mutation. New
+// Session is Work's affordance ADVERTISED here (navigation to /work/new-session — the
+// identity-carrying create lane lives with Work); the Applications grid renders the compiler
+// projection's truth and nothing the projection wouldn't admit (the #241 refusal-set approach
+// guards folded owner names). The canon fallback-fixture rule (api.md:167-169) is held
+// verbatim: a daemon outage renders a typed unavailability page with ZERO fabricated counts —
+// nothing is shown rather than fixtures.
+import { escHtml } from "../kit.mjs";
+
+const esc = escHtml;
+const enc = encodeURIComponent;
+
+const LEGACY_ROUTE = "/__ioi/home-cockpit";
+const CANONICAL_ROUTE = "/home";
+
+// LIVE deep-link targets on this estate (each one a bound canonical mount or served subtree).
+const LINK_APPROVALS = "/governance/approvals";
+const LINK_SESSIONS = "/work/sessions";
+const LINK_NEW_SESSION = "/work/new-session";
+const LINK_PROJECTS = "/projects";
+const LINK_APPLICATIONS = "/applications";
+const LINK_AI_ENTRY = "/ai";
+
+const SCOPE_MARKER = "partial-pre-w3-cockpit-slice";
+const SCOPE_NOTE = "Partial pre-W3 cockpit slice — NOT Home completion. SURF-home and W3.1 remain open; the manifest SURF-home acceptance is the full bar and this slice delivers the pre-W3 subset. The home-cockpit projection route is a typed W3 absence (stated below), and the /ai explorer readout keeps serving untouched as a current live entry.";
+
+const HOME_PROJECTION_ABSENCE = "typed W3 absence — GET /v1/hypervisor/home-cockpit (ioi.hypervisor.home_cockpit_projection.v1) and GET /v1/hypervisor/session-operations are route-missing at the daemon (the W3 build list owns them). This page composes the same per-family reads the live /ai explorer composes; the metrics strip that needs the projection stays a named absence, never a fabricated rollup.";
+const OPERATIONS_GAP_REASON = "disabled-named-gap — the canonical Operations mount is not live on this estate: no Operations surface module binds /operations (the route serves only the W0.1 substrate shell today). The parked/failed-run counts on this pane are REAL daemon truth (GET /v1/hypervisor/failover/runs · GET /v1/hypervisor/operations), but their owning-surface deep-links stay disabled until the Operations mount lands; a named gap, never a dead link and never a fabricated destination.";
+
+const PROJECTION_PATH = "/v1/hypervisor/product-surface-projections";
+const PROJECTION_SCHEMA = "ioi.hypervisor.product_surface_projection.v1";
+
+// The folded-owner refusal set (#241, the Applications launcher approach): these names owned
+// surfaces once and were folded into canonical owners. A projection entry carrying one renders
+// as a typed defect refusal, never as a peer tile. This module renders server-side, so the
+// names below reach the page only inside that refusal.
+const RETIRED_OWNER_NAMES = new Set(["Missions", "Marketplace", "Workbench", "Agent Studio"]);
+
+export const meta = {
+  slug: "home",
+  route: LEGACY_ROUTE,
+  verifier: "scripts/verify-hypervisor-home-cockpit.mjs",
+  certification: "n/a",
+};
+
+// ---------------------------------------------------------------------------------------------
+// load — every read through the shared read client on the request-scoped identity capability
+// (the caller's own envelope rides every read; the daemon owner-filters session truth before
+// this page ever sees it). Seven owner-backed reads, the same families the live explorer
+// composes — REAL routes only, no home-cockpit rollup exists to read (typed W3 absence).
+export async function load(ctx) {
+  const { createReadClient } = await import("../read-client.mjs");
+  const client = typeof ctx.daemonFetch === "function"
+    ? createReadClient({ daemon: "", fetchImpl: ctx.daemonFetch })
+    : createReadClient({ daemon: ctx.daemon });
+  const [whoami, approvals, failover, operations, sessions, projects, projection] = await Promise.all([
+    client.read("/v1/hypervisor/auth/whoami"),
+    client.read("/v1/hypervisor/governance/approval-requests"),
+    client.read("/v1/hypervisor/failover/runs"),
+    client.read("/v1/hypervisor/operations"),
+    client.read("/v1/hypervisor/sessions", { expectSchema: "ioi.hypervisor.sessions-list.v1" }),
+    client.read("/v1/hypervisor/projects"),
+    client.read(PROJECTION_PATH, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ context: { launcher: "home" } }),
+      expectSchema: PROJECTION_SCHEMA,
+    }),
+  ]);
+  return { whoami, approvals, failover, operations, sessions, projects, projection };
+}
+
+// No actions, deliberately: Home creates nothing. New Session is Work's affordance (canon
+// :1478-1482 — Home can ASK Core to create a New Session; the create lane lives at
+// /work/new-session), Activate Goal is GoalRun's (absent here — W2 scope). Declaring an
+// action here would make Home mint an object it must never own.
+export const actions = [];
+
+// ---------------------------------------------------------------------------------------------
+const pill = (text, cls) => `<span class="pill ${cls}">${esc(text)}</span>`;
+const scopeBanner = () => `<div class="scope" data-ioi-scope="${SCOPE_MARKER}">${esc(SCOPE_NOTE)}</div>`;
+const degraded = (result, plane) => `<div class="empty" data-ioi-degraded="${esc(result?.code || "daemon_unavailable")}" data-ioi-degraded-plane="${esc(plane)}">unavailable — <code>${esc(result?.code || "daemon_unavailable")}</code> (${esc(result?.message || "the plane did not answer")}). A down read renders its typed absence; zeros are never shown as truth.</div>`;
+const disabledGapLink = (label) => `<button class="act ghost" type="button" disabled data-ioi-named-gap="operations-mount" data-ioi-disabled-reason="${esc(OPERATIONS_GAP_REASON)}">${esc(label)}</button>`;
+
+const lifecyclePill = (state) => pill(state || "unknown", state === "provisioned" ? "ok" : state === "torn_down" ? "muted" : "warn");
+
+// ---- governed-work band ---------------------------------------------------------------------
+function approvalsPane(res) {
+  const head = `<h2 id="home-approvals">Approvals waiting</h2>`;
+  if (!res?.ok) return `${head}${degraded(res, "governance/approval-requests")}`;
+  const pending = (Array.isArray(res.payload?.approval_requests) ? res.payload.approval_requests : [])
+    .filter((a) => a.status === "pending");
+  if (!pending.length) {
+    return `${head}<div class="empty" data-ioi-honest-empty="approvals">No approvals waiting — all clear. This count reads real governance truth (<code>GET /v1/hypervisor/governance/approval-requests</code>); it never fabricates rows.</div>
+      <div class="row"><a class="act ghost" href="${LINK_APPROVALS}">Open Governance / Approvals →</a></div>`;
+  }
+  const rows = pending.slice(0, 5).map((a) => `<a class="card" data-ioi-approval-row href="${LINK_APPROVALS}">
+      <div class="main"><div class="name">${esc(a.request_kind || "approval")} ${pill("pending", "warn")}</div>
+      <div class="meta"><code>${esc(a.subject_ref || "")}</code>${a.requested_at ? ` · ${esc(a.requested_at)}` : ""}</div></div>
+      <span class="act ghost">review →</span></a>`).join("");
+  return `${head}<div class="row">${pill(`${pending.length} waiting`, "warn")}</div>${rows}
+    <div class="row"><a class="act ghost" href="${LINK_APPROVALS}">Open Governance / Approvals →</a></div>`;
+}
+
+function parkedAndFailedPane(failover, operations) {
+  const head = `<h2 id="home-parked-failed">Runs parked at the wallet gate · failed runs</h2>
+    <p class="sub">Counts are real daemon truth. Their owning surface is Operations, whose canonical mount is not live yet — the Operations links on this pane are a <b>disabled named gap</b>, never a dead link.</p>
+    <div class="row">${disabledGapLink("Open Operations →")}</div>`;
+  const parkedBody = (() => {
+    if (!failover?.ok) return degraded(failover, "failover/runs");
+    const parked = (Array.isArray(failover.payload?.runs) ? failover.payload.runs : [])
+      .filter((r) => String(r.status || "").startsWith("awaiting_authority"));
+    if (!parked.length) return `<div class="empty" data-ioi-honest-empty="parked-runs">No runs parked at a wallet gate (<code>GET /v1/hypervisor/failover/runs</code>, <code>awaiting_authority_*</code>) — all clear, never fabricated.</div>`;
+    return `<div class="row">${pill(`${parked.length} parked`, "warn")}</div>` + parked.slice(0, 5).map((r) => `<div class="card" data-ioi-parked-row>
+        <div class="main"><div class="name">parked — ${esc(String(r.status || "").replace("awaiting_authority_", ""))} ${pill("blocked", "warn")}</div>
+        <div class="meta">${esc(r.failure_condition || "run")}${r.environment_ref ? ` · <code>${esc(r.environment_ref)}</code>` : ""}</div></div>
+        ${disabledGapLink("Operations →")}</div>`).join("");
+  })();
+  const failedBody = (() => {
+    if (!operations?.ok) return degraded(operations, "operations");
+    const failures = Array.isArray(operations.payload?.runs?.failures) ? operations.payload.runs.failures : [];
+    if (!failures.length) return `<div class="empty" data-ioi-honest-empty="failed-runs">No failed runs (<code>GET /v1/hypervisor/operations</code>) — all clear, never fabricated.</div>`;
+    return `<div class="row">${pill(`${failures.length} failed`, "warn")}</div>` + failures.slice(0, 5).map((r) => `<div class="card" data-ioi-failed-row>
+        <div class="main"><div class="name">failed — ${esc(r.name || r.automation_id || r.execution_id || "run")} ${pill("failed", "warn")}</div>
+        <div class="meta">${esc(r.project_id || "—")}${r.finished_at ? ` · ${esc(r.finished_at)}` : ""}</div></div>
+        ${disabledGapLink("Operations →")}</div>`).join("");
+  })();
+  return `${head}${parkedBody}${failedBody}`;
+}
+
+// ---- resume band ----------------------------------------------------------------------------
+function sessionsPane(res) {
+  const head = `<h2 id="home-recent-sessions">Recent sessions</h2>`;
+  if (!res?.ok) return `${head}${degraded(res, "sessions")}`;
+  const sessions = Array.isArray(res.payload?.sessions) ? res.payload.sessions : [];
+  if (!sessions.length) {
+    return `${head}<div class="empty" data-ioi-honest-empty="sessions">No sessions for this principal yet — session truth is owner-filtered by the daemon before this page sees it. Start one from <a href="${LINK_NEW_SESSION}">New Session</a>.</div>
+      <div class="row"><a class="act ghost" href="${LINK_SESSIONS}">Open Work / Sessions →</a></div>`;
+  }
+  const rows = sessions.slice(0, 5).map((s) => `<a class="card" data-ioi-session-row href="${LINK_SESSIONS}?session=${enc(s.session_ref || "")}">
+      <div class="main"><div class="name"><code>${esc(s.session_ref || "")}</code> ${lifecyclePill(s.lifecycle_state)}</div>
+      <div class="meta">${s.project_ref ? `<code>${esc(String(s.project_ref))}</code> · ` : ""}${esc(s.created_at || "")}</div></div>
+      <span class="act ghost">resume →</span></a>`).join("");
+  return `${head}<div class="row">${pill(`${sessions.length} session${sessions.length === 1 ? "" : "s"}`, "muted")}</div>${rows}
+    <div class="row"><a class="act ghost" href="${LINK_SESSIONS}">Open Work / Sessions →</a></div>`;
+}
+
+function projectsPane(res) {
+  const head = `<h2 id="home-recent-projects">Recent projects</h2>`;
+  if (!res?.ok) return `${head}${degraded(res, "projects")}`;
+  const projects = Array.isArray(res.payload?.projects) ? res.payload.projects : [];
+  if (!projects.length) {
+    return `${head}<div class="empty" data-ioi-honest-empty="projects">No projects yet — honest absence (<code>GET /v1/hypervisor/projects</code>), nothing substituted.</div>
+      <div class="row"><a class="act ghost" href="${LINK_PROJECTS}">Open Projects →</a></div>`;
+  }
+  const rows = projects.slice(0, 5).map((p) => `<a class="card" data-ioi-project-row href="${LINK_PROJECTS}">
+      <div class="main"><div class="name">${esc(p.name || p.project_id || "project")}</div>
+      <div class="meta"><code>${esc(p.project_id || p.id || "")}</code>${p.created_at ? ` · ${esc(p.created_at)}` : ""}</div></div>
+      <span class="act ghost">open →</span></a>`).join("");
+  return `${head}<div class="row">${pill(`${projects.length} project${projects.length === 1 ? "" : "s"}`, "muted")}</div>${rows}
+    <div class="row"><a class="act ghost" href="${LINK_PROJECTS}">Open Projects →</a></div>`;
+}
+
+// ---- applications grid (projection truth only — the #241 refusal-set approach) --------------
+function applicationsPane(res) {
+  const head = `<h2 id="home-applications">Applications</h2>`;
+  if (!res?.ok) {
+    return `${head}${degraded(res, "product-surface-projections")}
+      <p class="sub">Zero tiles render on a failed projection read: a launcher tile implies launch adjudication, and this pane never fabricates launchability — membership comes only from <code>POST ${esc(PROJECTION_PATH)}</code>.</p>
+      <div class="row"><a class="act ghost" href="${LINK_APPLICATIONS}">Open Applications →</a></div>`;
+  }
+  const entries = Array.isArray(res.payload?.application_entries) ? res.payload.application_entries : [];
+  const tiles = entries.map((entry) => {
+    const name = String(entry.display_name || entry.identity_ref || "");
+    if (RETIRED_OWNER_NAMES.has(name)) {
+      // Folded owners never reappear as peers — a typed defect refusal, never a tile.
+      return `<div class="card defect" data-ioi-retired-owner-defect="${esc(name)}">
+          <div class="main"><div class="name">retired owner name refused</div>
+          <div class="meta">the projection emitted a folded owner name as a peer entry — this grid refuses to render it as an application; the canonical owner carries this surface (defect: report against the compiler feed)</div></div>
+        </div>`;
+    }
+    const launchRoute = typeof entry.resolved_launch_route === "string" && entry.resolved_launch_route.startsWith("/")
+      ? entry.resolved_launch_route
+      : null;
+    if (entry.launchable === true && launchRoute !== null) {
+      return `<a class="card launch" data-ioi-entry-name="${esc(name)}" data-ioi-launchable="true" href="${esc(launchRoute)}">
+          <div class="main"><div class="name">${esc(name)}</div>
+          <div class="meta">launch → <code>${esc(launchRoute)}</code></div></div>
+          <span class="pill ok">launchable</span></a>`;
+    }
+    const reasons = Array.isArray(entry.disabled_reason_codes) && entry.disabled_reason_codes.length
+      ? entry.disabled_reason_codes.map((c) => `<code>${esc(String(c))}</code>`).join(" ")
+      : "—";
+    return `<div class="card" data-ioi-entry-name="${esc(name)}" data-ioi-launchable="false">
+        <div class="main"><div class="name">${esc(name)}</div>
+        <div class="meta">not launchable — reasons: ${reasons}</div></div>
+        <span class="pill warn">not launchable</span></div>`;
+  }).join("");
+  const grid = entries.length
+    ? tiles
+    : `<div class="empty" data-ioi-honest-empty="applications">The compiled projection returned zero application entries — honest absence, nothing is substituted.</div>`;
+  return `${head}
+    <p class="sub">Compiler-projection truth only (<code>POST ${esc(PROJECTION_PATH)}</code>): launchable tiles navigate to their surface, ineligible tiles state their exact typed reasons, and nothing renders that the projection wouldn't admit (folded owner names are a refusal set). The <a href="${LINK_APPLICATIONS}">Applications launcher →</a> is the full catalog.</p>
+    ${grid}`;
+}
+
+// ---- full daemon outage: the canon fallback-fixture rule, held verbatim ---------------------
+const READ_KEYS = ["whoami", "approvals", "failover", "operations", "sessions", "projects", "projection"];
+function daemonUnreachable(model) {
+  return READ_KEYS.every((key) => {
+    const r = model[key];
+    return r && r.ok === false && (r.code === "daemon_unavailable" || r.code === "read_timeout" || r.status === 0);
+  });
+}
+
+function unavailableView(model) {
+  const first = model.whoami;
+  return `<div class="gapcard" data-ioi-daemon-unavailable="true">
+      <b>Daemon unreachable — governed-work status unavailable.</b>
+      <p class="sub" style="margin:6px 0 0;text-transform:none;letter-spacing:0">Every read failed typed (<code>${esc(first?.code || "daemon_unavailable")}</code>). Zero counts are fabricated and zero rows are shown rather than fixtures — the canon fallback-fixture rule (api.md:167-169): a fixture source must be visible and must never be presented as admitted runtime truth, so nothing is presented at all. The page returns when the daemon answers.</p>
+    </div>
+    <div class="row">
+      <a class="act ghost" href="${LINK_APPROVALS}">Governance / Approvals →</a>
+      <a class="act ghost" href="${LINK_SESSIONS}">Work / Sessions →</a>
+      <a class="act ghost" href="${LINK_PROJECTS}">Projects →</a>
+      <a class="act ghost" href="${LINK_APPLICATIONS}">Applications →</a>
+    </div>`;
+}
+
+// ---------------------------------------------------------------------------------------------
+export function render(model, ctx) {
+  const who = model.whoami?.ok
+    ? (model.whoami.payload?.principal?.name || model.whoami.payload?.principal?.principal_id || model.whoami.payload?.principal_ref || "")
+    : "";
+  const identityLine = model.whoami?.ok
+    ? `signed in as <code>${esc(String(who || "principal"))}</code>`
+    : `identity read unavailable — <code>${esc(model.whoami?.code || "daemon_unavailable")}</code> (typed absence, never a guessed name)`;
+  const getStarted = `<div class="row">
+      <a class="act" href="${LINK_NEW_SESSION}" data-ioi-new-session-entry>+ New Session</a>
+      <a class="act ghost" href="${LINK_APPLICATIONS}">Applications</a>
+      <a class="act ghost" href="${LINK_PROJECTS}">Projects</a>
+      <a class="act ghost" href="${LINK_AI_ENTRY}">Explorer readout (/ai)</a>
+    </div>
+    <p class="sub">New Session is Work's affordance advertised here — Home asks Core to create it at <code>${LINK_NEW_SESSION}</code> and never mints the object itself. Home owns no truth: every row routes to its owning surface.</p>`;
+  const projectionAbsence = `<div class="gapcard" data-ioi-w3-absence="home_cockpit_projection">
+      <b>Metrics strip absent — a typed W3 absence.</b>
+      <p class="sub" style="margin:6px 0 0;text-transform:none;letter-spacing:0">${esc(HOME_PROJECTION_ABSENCE)}</p>
+    </div>`;
+  const inner = daemonUnreachable(model)
+    ? `${scopeBanner()}${unavailableView(model)}${projectionAbsence}`
+    : `${scopeBanner()}${getStarted}${projectionAbsence}
+      ${approvalsPane(model.approvals)}
+      ${parkedAndFailedPane(model.failover, model.operations)}
+      ${sessionsPane(model.sessions)}
+      ${projectsPane(model.projects)}
+      ${applicationsPane(model.projection)}`;
+  const css = `:root{color-scheme:dark}
+  body{margin:0;background:#0c0d10;color:#e6e7ea;font:14px/1.55 -apple-system,Segoe UI,Roboto,sans-serif}
+  .wrap{max-width:920px;margin:0 auto;padding:40px 24px 80px}
+  a{color:#8ab4ff}
+  .brand{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#6f7280;margin-bottom:8px}
+  h1{font-size:26px;margin:0 0 6px;letter-spacing:-.02em}
+  .sub{color:#9a9da6;margin:0 0 22px;max-width:720px;overflow-wrap:anywhere}
+  .row{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin:0 0 22px}
+  .act{padding:8px 14px;border-radius:8px;border:0;background:#fff;color:#111;font:inherit;font-weight:600;text-decoration:none;cursor:pointer}
+  .act:hover{background:#eee}
+  .act.ghost{background:transparent;color:#cbd0da;border:1px solid #2a2c33}
+  .act.ghost:hover{color:#fff;border-color:#3a3d45}
+  .act[disabled]{opacity:.45;cursor:not-allowed}
+  h2{font-size:13px;letter-spacing:.04em;text-transform:uppercase;color:#878a93;margin:26px 0 10px;font-weight:600}
+  .card{display:flex;align-items:center;gap:14px;padding:14px 16px;border:1px solid #24262d;border-radius:12px;background:#15171c;margin-bottom:8px;text-decoration:none;color:inherit}
+  a.card.launch:hover{border-color:#3a82f6;background:#191b21}
+  .card.defect{border-color:#5c2323;background:#221111}
+  .card .main{flex:1;min-width:0}
+  .card .name{font-weight:600;color:#fff}
+  .card .meta{color:#878a93;font-size:12.5px;margin-top:3px;overflow-wrap:anywhere}
+  .pill{display:inline-block;padding:2px 9px;border-radius:999px;font-size:11px;border:1px solid;white-space:nowrap;margin-left:8px}
+  .ok{color:#46c277;border-color:#235c3b;background:#11281b}
+  .warn{color:#d6a13a;border-color:#5c4a23;background:#28220f}
+  .muted{color:#9a9da6;border-color:#2a2c33}
+  .empty{color:#6f7280;padding:18px;border:1px dashed #24262d;border-radius:12px;overflow-wrap:anywhere;margin-bottom:8px}
+  .gapcard{padding:14px 16px;border:1px dashed #5c4a23;border-radius:12px;background:#15130c;margin:0 0 18px;overflow-wrap:anywhere}
+  .scope{padding:10px 14px;border:1px solid #2a3a5c;border-radius:10px;background:#0e1420;color:#9db4d8;font-size:12.5px;margin:0 0 18px;overflow-wrap:anywhere}
+  code{font-size:11.5px;color:#aab;background:#0e0f13;padding:1px 5px;border-radius:4px}
+  @media(max-width:700px){.wrap{padding:24px 14px 56px}.card{align-items:flex-start}}`;
+  const head = `<h1 id="home-owner">Home</h1>
+    <p class="sub">The default command and resume surface — owner-backed counts and rows from real daemon routes, deep-linking into the owning surfaces. ${identityLine}.</p>`;
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Home · Hypervisor</title><style>${css}</style></head><body><div class="wrap"><div class="brand">IOI Hypervisor</div>${head}${inner}</div></body></html>`;
+}

--- a/docs/architecture/_meta/shipped-products.v1.json
+++ b/docs/architecture/_meta/shipped-products.v1.json
@@ -66,6 +66,7 @@
           "/__ioi/evaluations/evalsuites",
           "/__ioi/foundry/models",
           "/__ioi/governance/approvals",
+          "/__ioi/home-cockpit",
           "/__ioi/improvement/changes",
           "/__ioi/marketplace/listings",
           "/__ioi/missions",
@@ -112,8 +113,8 @@
           "/work/new-session",
           "/work/sessions"
         ],
-        "expected_count": 53,
-        "sha256": "e34a5d14f4472100b707ac07420a47acc14cfea308449b5e2ab142e88520b676",
+        "expected_count": 54,
+        "sha256": "7f3a790f853e578230fede3209a8d70f146ef846ff76a1e0836d47c24907f7c1",
         "browser_verification_id": "served-surface-smoke"
       },
       "state_authority_mode": "daemon_authoritative_projection",


### PR DESCRIPTION
## Home — partial pre-W3 cockpit slice (next-legs IV Leg 4)

**SCOPE RULING (bounds every claim below): this is NOT Home completion.** The manifest SURF-home acceptance (resumable/blocked/failed/approval-requiring/completed work with full state survival) is the FULL bar; **SURF-home and W3.1 REMAIN OPEN.** The verifier is `check:home-cockpit` — deliberately not a "-journey"; the Home journey is SURF-home's to earn. Greenfield canon-first on the typed non-parity lane: the seed-ux-provenance `home` record carries the owner-authorized greenfield authorization, and `verify-hypervisor-seed-provenance --surface home --require-ready` is **GREEN** via that record (asserted this run). No seed preservation, no parity claims; `/ai` (the live explorer readout) keeps serving untouched as a **current live entry, never a substitute seed** — asserted live.

STACKED on #246 (`w2.1/work-cockpit`): Home's deep-links and cross-surface create need the /work mounts.

### What lands

**One module, two lanes** (`apps/hypervisor/surfaces/home/index.mjs`; registry row `canonical_route: /home` + fresh non-colliding legacy lane `/__ioi/home-cockpit`):

- **Owner-backed counts + rows from REAL routes only** — approvals waiting (governance/approval-requests, deep-link `/governance/approvals`), runs parked at the wallet gate (`failover/runs`, `awaiting_authority_*`) + failed runs (`operations` runs.failures), recent sessions (owner-filtered, deep-link `/work/sessions?session=…`), recent projects (deep-link `/projects`), applications grid from `POST /v1/hypervisor/product-surface-projections` ONLY (deep-link `/applications`), New Session entry advertising Work's affordance at `/work/new-session`. Every read rides the shared read client on the request-scoped identity capability.
- **Home declares ZERO actions** — it launches and mints nothing (New Session is Work's; Activate Goal is GoalRun's and stays W2 scope, absent not simulated).
- **Honest-empty everywhere; typed degradation per plane** — a down read renders its typed absence (`data-ioi-degraded` + code), never zeros pretending to be truth; full daemon outage renders the typed unavailability page with ZERO fabricated counts (the canon fallback-fixture rule, api.md:167-169, held verbatim).

### Typed gaps and absences (stated, never simulated)

- **The home-cockpit projection pair is a typed W3 absence**, pinned mechanically at `/v1` (zero `home-cockpit`/`session-operations` route hits) and stated typed on the page — this slice composes the same seven per-family reads the live explorer composes; the metrics strip is never a fabricated rollup.
- **The Operations deep-links are `disabled-named-gap`** with the exact reason (counts real, links disabled): the canonical Operations mount is not live — pinned REAL mechanically (`/operations` serves owner `substrate`, the W0.1 shell; the pin fails the day an Operations mount lands, forcing the gap to be re-ruled). A pane-level "Open Operations" control carries the gap even when the panes are honestly empty.
- **Retired owner names never render** (#241 refusal set: Missions · Marketplace · Workbench · Agent Studio): a projection entry carrying one would render as a typed defect refusal, never a peer tile — and the page's entry set is asserted EXACTLY equal to the projection's entry set (nothing admitted hidden, nothing unadmitted shown).
- The **subject-less create** carries #246's typed W3 C-1 absence through the cross-surface journey: `subject_attachments` EXACTLY `[]` on the daemon record.

### Evidence

- **`check:home-cockpit` 40/40** (package.json + CI journeys step), proven IN ORDER: honest-empty pass on the fresh daemon BEFORE seeding → fixtures seeded via the daemon (pending approval request, project through the identity-forwarding serve lane, session via `POST /v1/hypervisor/sessions`) → counts reflect them → every LIVE deep-link followed from Home's own hrefs shows the linked record class (`/governance/approvals` under Governance, `/work/sessions?session=…` under Work, `/applications` catalog, `/projects` asserted **in the browser** — vendored client-rendered subtree) → cross-surface New Session journey (/home → /work/new-session → create → admitted readback lands back on Home: 2 sessions) → reload + daemon-restart survival → daemon-down typed unavailability (zero fixture strings leak) → 3-posture matrix on /home (zero console errors).
- Regressions vs this PR's daemon binary: work-cockpit 46/46 · governance-journey 20/20 · applications-journey 27/27 · projects-saga 11/11.
- Suites: app-clients 20/20 · route-shell 14/14 · app-events 12/12 · watchevents-fence 13/13 · source-neutral · seed-provenance (full + `--require-ready home` GREEN) · owned-product-ui · shell-parity 6/6 · ported-seed 413/413.
- Scoped product smoke on `/home` (`IOI_PRODUCT_SMOKE_PRODUCT=hypervisor-owned-served-ui IOI_PRODUCT_SMOKE_ROUTE=/home`): 3/3 route renders (light/dark/narrow); shipped-manifest `route_inventory` 53→54 with recomputed digest.

### Panes: live data vs typed gaps

| Pane | State |
|---|---|
| Approvals waiting | LIVE — real rows, deep-link `/governance/approvals` |
| Parked at wallet gate / failed runs | counts LIVE (real reads, honest-empty this estate) — links **typed disabled-named-gap** (Operations mount) |
| Recent sessions | LIVE — deep-link `/work/sessions` |
| Recent projects | LIVE — deep-link `/projects` |
| Applications grid | LIVE — projection truth only, deep-link `/applications` |
| New Session entry | LIVE navigation → `/work/new-session` |
| Metrics strip | **typed W3 absence** (home-cockpit projection route-missing) |

### Deviations / notes

- The Home applications grid renders the projection's own "Operations" tile as launchable → `/operations` (projection truth — the compiler admits it), while the parked/failed-run OWNING-SURFACE deep-links stay a typed gap per the scope ruling. Both are asserted; the tension resolves when the Operations mount lands and the mechanical pin flips.
- The parked/failed-run panes carry an always-rendered pane-level disabled-named-gap control in addition to per-row links, so the gap is asserted even on an honestly-empty estate (no failover/operations fixtures are fabricated to force rows).
- One merge unit, zero Rust: no daemon-side change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)