### PR TITLE
feat(hypervisor): /operations partial pre-W3 cockpit slice — canonical mount, read-first runtime/failover truth, Home links flipped live; check:operations-cockpit (next-legs V Leg 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,7 @@ jobs:
           npm run check:systems-journey --workspace=@ioi/hypervisor-app
           npm run check:work-cockpit --workspace=@ioi/hypervisor-app
           npm run check:home-cockpit --workspace=@ioi/hypervisor-app
+          npm run check:operations-cockpit --workspace=@ioi/hypervisor-app
           npm run check:projects-saga --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -22,6 +22,7 @@
     "check:systems-journey": "node scripts/verify-hypervisor-systems-journey.mjs",
     "check:work-cockpit": "node scripts/verify-hypervisor-work-cockpit.mjs",
     "check:home-cockpit": "node scripts/verify-hypervisor-home-cockpit.mjs",
+    "check:operations-cockpit": "node scripts/verify-hypervisor-operations-cockpit.mjs",
     "check:projects-saga": "node scripts/verify-hypervisor-projects-saga.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -36,6 +36,7 @@ import * as applicationsModule from "../surfaces/applications/index.mjs";
 import * as systemsModule from "../surfaces/systems/index.mjs";
 import * as workModule from "../surfaces/work/index.mjs";
 import * as homeModule from "../surfaces/home/index.mjs";
+import * as operationsModule from "../surfaces/operations/index.mjs";
 
 // Capability model (operational wave): `capabilities` is the AUTHORITY-derived set of acts the
 // surface genuinely supports today (never inferred from pixel certification or daemon_wired);
@@ -143,9 +144,23 @@ export const SURFACES = [
   // canon-first on the typed non-parity lane (seed-ux-provenance.v1.json home record): no seed
   // preservation, no parity claims. Read-only by contract: Home launches, owns no object and
   // declares zero actions (New Session is Work's affordance advertised by navigation);
-  // parked/failed-run rows render real counts with their Operations deep-links a typed
-  // disabled-named-gap until the /operations mount lands. Evidence: check:home-cockpit.
+  // parked/failed-run rows render real counts with LIVE Operations deep-links (the
+  // operations-mount named gap was re-ruled the day /operations landed). Evidence:
+  // check:home-cockpit.
   { slug: "home", owner: "Home", title: "Home", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/home-cockpit", canonical_route: "/home", verifier: "scripts/verify-hypervisor-home-cockpit.mjs", certification: "n/a", capabilities: ["browse", "inspect"], operational_state: "inspect", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
+  // W2.1 next-legs V Leg 4: the Operations PARTIAL PRE-W3 COCKPIT SLICE — canonical /operations
+  // plus a FRESH legacy lane /__ioi/operations-cockpit. NOT Operations completion:
+  // SURF-operations remains open — its full acceptance (injected-fault detection, typed
+  // incident open, remediation/failover execution, restart/rollback/support export) is
+  // W3.2/W3.3-owned, and its seed gate carries the typed-blocked scheduler residual (a block
+  // record never opens work). Read-first by contract: eleven per-family daemon reads that
+  // exist TODAY (scheduler health, execution health, failover runs/plans, environment
+  // incidents/recovery, providers, spend reconciliation, storage backends/incidents,
+  // substrate status); every W3.2/W3.3-owned verb is a typed disabled-named-gap naming its
+  // owning unit; the W3 rollup projections (infrastructure-jobs, RPO/RTO, capacity overview)
+  // are typed route-missing absences, never simulated. The T2 readout /__ioi/operations is
+  // the rehome source and keeps serving untouched. Evidence: check:operations-cockpit.
+  { slug: "operations", owner: "Operations", title: "Operations", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/operations-cockpit", canonical_route: "/operations", verifier: "scripts/verify-hypervisor-operations-cockpit.mjs", certification: "n/a", capabilities: ["browse", "inspect"], operational_state: "inspect", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "changes", owner: "Improvement", title: "Upgrade Assistant", icon: CHG_APP_TILE_URI, route: "/__ioi/improvement/changes", verifier: "scripts/verify-hypervisor-app-parity-changes.mjs", certification: "pixel-certifications/changes.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "evalsuites", owner: "Evaluations", title: "AIP Evals", icon: EVL_APP_TILE_URI, route: "/__ioi/evaluations/evalsuites", verifier: "scripts/verify-hypervisor-app-parity-evalsuites.mjs", certification: "pixel-certifications/evalsuites.json", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
 ];
@@ -259,6 +274,8 @@ bindSurface("work-sessions", workModule);
 bindSurface("work-new-session", workModule);
 // Home: one row, one module — the partial pre-W3 cockpit slice (read-only, zero actions).
 bindSurface("home", homeModule);
+// Operations: one row, one module — the partial pre-W3 cockpit slice (read-first, zero actions).
+bindSurface("operations", operationsModule);
 
 // Test-only fault surface (NEVER without the runtime-test flag): gives the action-runtime
 // verifier a module whose action THROWS (route isolation proof) and one that claims success

--- a/apps/hypervisor/scripts/v2-route-shell.mjs
+++ b/apps/hypervisor/scripts/v2-route-shell.mjs
@@ -334,9 +334,11 @@ export const V2_ROUTE_TABLE = [
     kind: "substrate",
     rule: "—",
     waves: "W1 · W2",
-    build_state: "shell-only (W0.1) — Wave 1 read-first build (surfaces/operations.md §5); unified infrastructure-jobs projection is a Wave 3 backend build",
+    build_state: "W2.1 partial pre-W3 cockpit slice landed (next-legs V Leg 4) — the bound Operations surface module serves this canonical route: a read-first cockpit over the existing runtime/failover truth (scheduler health, execution health, cross-provider failover posture, environment incidents/recovery, provider health + customer-borne spend, storage custody, substrate status). NOT Operations completion: SURF-operations stays open — full acceptance needs the W3.2/W3.3 fault-injection/remediation matrix and the scheduler seed residual; the unified infrastructure-jobs projection, RPO/RTO rollup, and capacity overview stay Wave 3 backend builds (typed route-missing absences on the page)",
     serving_today: [
-      { href: "/__ioi/operations", label: "Operations readout", note: "runs / failures / failover posture over daemon truth" },
+      { href: "/operations", label: "Operations cockpit (canonical)", note: "bound Operations surface module — partial pre-W3 cockpit slice; read-first over eleven daemon read families, typed W3.2/W3.3 gaps" },
+      { href: "/__ioi/operations-cockpit", label: "Operations cockpit (legacy lane)", note: "same module on the fresh legacy lane; keeps serving until the W4 cutover" },
+      { href: "/__ioi/operations", label: "Operations readout", note: "protected T2 rehome source — runs / failures / failover posture over daemon truth; keeps serving untouched" },
     ],
   },
   {

--- a/apps/hypervisor/scripts/verify-hypervisor-home-cockpit.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-home-cockpit.mjs
@@ -13,9 +13,10 @@
 //   - seeded fixtures (an approval request, a project, a session) surface as REAL counts and
 //     rows, and every LIVE deep-link target answers 200 showing the linked record class
 //     (/governance/approvals, /work/sessions, /projects via the browser, /applications);
-//   - the Operations-targeted links are a typed disabled-named-gap with the exact reason —
-//     and the gap is REAL, pinned mechanically (/operations serves only the substrate shell,
-//     no Operations surface module binds it; the pin fails the day the mount lands);
+//   - the Operations-targeted links are LIVE deep-links (re-ruled, next-legs V Leg 4: the
+//     bound Operations surface module serves the canonical /operations mount — the former
+//     operations-mount disabled-named-gap is closed, and the mount is pinned mechanically:
+//     /operations answers under the Operations owner, never the bare substrate shell);
 //   - the applications grid is compiler-projection truth ONLY: the page's entry set equals the
 //     projection's entry set, launchable tiles link the projection's own routes, and the
 //     folded-owner refusal set holds (no retired owner name renders anywhere);
@@ -222,15 +223,22 @@ async function run() {
       && freshHome.text.includes('id="home-approvals"'),
     `route ${freshHome.headers.get("x-ioi-surface-route")}`);
 
-  // -- the Operations gap: typed on the page, REAL at the estate ------------------------------
-  ok("the Operations-targeted links are a typed disabled-named-gap with the exact reason (counts real, links disabled until the Operations mount lands — never a dead link, never a fabricated destination)",
-    empty.text.includes('data-ioi-named-gap="operations-mount"')
-      && empty.text.includes("disabled-named-gap — the canonical Operations mount is not live")
+  // -- the Operations links: LIVE deep-links, mount pinned REAL at the estate (re-ruled) ------
+  // Next-legs V Leg 4 re-ruling: the former operations-mount disabled-named-gap is CLOSED —
+  // the bound Operations surface module serves the canonical /operations mount, so Home's
+  // Operations-targeted links flipped live in the same cut that landed the mount.
+  ok("the Operations-targeted links are LIVE deep-links (counts real, the owning surface named and reachable) — the former operations-mount disabled-named-gap is closed and renders nowhere",
+    empty.text.includes('href="/operations" data-ioi-operations-link')
       && empty.text.includes("GET /v1/hypervisor/failover/runs · GET /v1/hypervisor/operations")
-      && empty.text.includes("never a dead link and never a fabricated destination"));
+      && empty.text.includes("the canonical Operations mount serves the partial pre-W3 cockpit slice at /operations")
+      && !empty.text.includes('data-ioi-named-gap="operations-mount"')
+      && !empty.text.includes("disabled-named-gap — the canonical Operations mount is not live"));
   const opsServe = await pageText("/operations");
-  ok("the gap is REAL, pinned mechanically: /operations serves only the W0.1 substrate shell (owner marker 'substrate', no Operations surface module) — the day an Operations mount lands this pin fails and the gap must be re-ruled",
-    opsServe.status === 200 && opsServe.headers.get("x-ioi-surface-owner") === "substrate",
+  ok("the mount is REAL, pinned mechanically: /operations answers 200 under the Operations owner at the canonical route (the bound surface module, never the bare substrate shell) — Home's flipped links resolve",
+    opsServe.status === 200
+      && opsServe.headers.get("x-ioi-surface-owner") === "Operations"
+      && opsServe.headers.get("x-ioi-surface-route") === "/operations"
+      && opsServe.text.includes('data-ioi-scope="partial-pre-w3-cockpit-slice"'),
     `owner ${opsServe.headers.get("x-ioi-surface-owner")}`);
 
   // -- /ai: the current live entry keeps serving untouched ------------------------------------

--- a/apps/hypervisor/scripts/verify-hypervisor-operations-cockpit.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-operations-cockpit.mjs
@@ -1,0 +1,461 @@
+// verify-hypervisor-operations-cockpit — the Operations PARTIAL PRE-W3 COCKPIT SLICE verifier
+// (check:operations-cockpit, next-legs V Leg 4). Deliberately NOT a "-journey": the Operations
+// journey (the manifest SURF-operations acceptance — injected-fault detection, typed incident
+// open, authority preview, remediation/failover execution, receipts/events, owner-app
+// readback, restart/rollback/support export) is W3.2/W3.3's to earn; SURF-operations REMAINS
+// OPEN (its seed gate also carries the typed-blocked scheduler residual) and nothing here
+// claims Operations completion.
+//
+// What this verifier proves, live against an isolated daemon + serve stack:
+//   - the read families this slice composes all EXIST at /v1 (compose only what exists), and
+//     the W3 rollup projections are TYPED ABSENCES pinned mechanically (no infrastructure-jobs
+//     projection family, no RPO/RTO rollup family, no capacity-overview family at /v1) and
+//     stated typed on the page — never a simulated rollup;
+//   - canonical /operations renders every pane owner-backed from REAL routes only,
+//     HONEST-EMPTY on a fresh daemon BEFORE any seeding (zeros stated as absence, never
+//     invented rows); the fresh legacy lane /__ioi/operations-cockpit serves the same module;
+//     the protected T2 seed /__ioi/operations keeps serving untouched;
+//   - every W3.2/W3.3-owned action (typed incident open, infrastructure remediation, failover
+//     run/arm/disarm/evaluate, archive export/verify/restore/repair) is a typed
+//     disabled-named-gap carrying its exact reason AND its owning unit; automation-run
+//     remediation renders as a LIVE delegation link to the Automations-owned mount;
+//   - the scheduler split holds: scheduler HEALTH renders here from the daemon's own
+//     scheduler-status read (value equality pinned), scheduler OBJECT truth deep-links the
+//     live /automations mount, and the seed residual stays typed on the page;
+//   - seeded fixtures (a scheduled automation, a failover plan, a fail-closed REFUSED failover
+//     run, a storage backend) surface as REAL rows — including the refusal reason rendered
+//     verbatim as fail-closed evidence, never hidden;
+//   - Home's flipped Operations links resolve: /home renders live /operations deep-links (the
+//     former operations-mount disabled-named-gap renders nowhere) and following them lands on
+//     this mount;
+//   - reload + daemon-restart survival of the read plane; daemon outage renders the typed
+//     unavailability page with ZERO fabricated counts (the canon fallback-fixture rule,
+//     api.md:167-169); the 3-posture browser matrix on /operations.
+//
+// Exit: 0 pass · 1 fail · 2 blocked (daemon binary missing).
+//   IOI_HYPERVISOR_DAEMON_BINARY  default target/debug/hypervisor-daemon
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+  srv.on("error", reject);
+});
+
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try {
+  fs.accessSync(daemonBinary, fs.constants.X_OK);
+} catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-operations-cockpit-"));
+let daemon = null;
+let serve = null;
+let daemonPort = 0;
+let DAEMON = "";
+let SERVE = "";
+let SESSION = "";
+
+const OPS = "/operations";
+const FRESH_OPS = "/__ioi/operations-cockpit";
+const SEED_READOUT = "/__ioi/operations";
+const HOME = "/home";
+const LINK_AUTOMATIONS = "/automations";
+
+// The eleven per-family reads the slice composes — every one must exist at /v1.
+const COMPOSED_FAMILY_ROUTES = [
+  "/v1/hypervisor/scheduler/status",
+  "/v1/hypervisor/operations",
+  "/v1/hypervisor/failover/runs",
+  "/v1/hypervisor/failover/plans",
+  "/v1/hypervisor/incidents",
+  "/v1/hypervisor/recovery-attempts",
+  "/v1/hypervisor/providers",
+  "/v1/hypervisor/provider-spend/reconciliation",
+  "/v1/hypervisor/storage-backends",
+  "/v1/hypervisor/storage-incidents",
+  "/v1/hypervisor/substrate/status",
+];
+
+async function startDaemon() {
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${daemonPort}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1/v1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = "";
+  daemon.stdout.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  await waitFor(`${DAEMON}/healthz`, 30000);
+  return () => log;
+}
+
+const jd = (p, init, cookie = true) => fetch(`${DAEMON}${p}`, {
+  ...init,
+  headers: {
+    ...(init?.body ? { "content-type": "application/json" } : {}),
+    ...(cookie && SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+  },
+}).then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+  .catch(() => ({ status: 0, body: {} }));
+
+const pageText = (p, { authenticated = true } = {}) => fetch(`${SERVE}${p}`, {
+  headers: authenticated && SESSION ? { cookie: `ioi_session=${SESSION}` } : {},
+}).then(async (r) => ({ status: r.status, text: await r.text(), headers: r.headers }))
+  .catch(() => ({ status: 0, text: "", headers: new Headers() }));
+
+async function run() {
+  daemonPort = await freePort();
+  DAEMON = `http://127.0.0.1:${daemonPort}`;
+  const daemonLogFn = await startDaemon();
+  const token = daemonLogFn().match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  if (token) {
+    const boot = await jd("/v1/hypervisor/auth/bootstrap", {
+      method: "POST",
+      body: JSON.stringify({ token, password: "operations-cockpit-bootstrap-v1", email: "operations-cockpit@ioi.local" }),
+    });
+    SESSION = boot.body?.session_token ?? "";
+  }
+  ok("operator bootstrap yields an authenticated session", SESSION.startsWith("ioi_sess_"), SESSION.slice(0, 12));
+
+  // -- COMPOSE ONLY WHAT EXISTS: the eleven read families are real at /v1 ---------------------
+  const index = await jd("/v1");
+  const idxStr = JSON.stringify(index.body);
+  ok("every composed read family EXISTS at the daemon /v1 index (the slice composes per-family reads that exist — surfaces/operations.md §2)",
+    COMPOSED_FAMILY_ROUTES.every((route) => idxStr.includes(`"${route}"`)),
+    `${COMPOSED_FAMILY_ROUTES.length} families pinned`);
+  ok("typed W3 absences pinned mechanically at /v1: no unified infrastructure-jobs projection family, no RPO/RTO + degraded/partition rollup family, no capacity/utilization overview family, and no /v1/hypervisor/operations subroute rollup — the W3 build list owns them; this slice may only compose per-family reads, never simulate a rollup",
+    !idxStr.includes("infrastructure-jobs")
+      && !idxStr.includes("infrastructure_jobs")
+      && !idxStr.includes("/v1/hypervisor/operations/")
+      && !idxStr.includes("rpo-rto") && !idxStr.includes("rpo_rto")
+      && !idxStr.includes("capacity-overview") && !idxStr.includes("capacity_utilization")
+      && !idxStr.includes("operations-rollup"),
+    "zero rollup-family hits at /v1");
+
+  // -- serve boot -----------------------------------------------------------------------------
+  const servePort = await freePort();
+  const productUiPort = await freePort();
+  SERVE = `http://127.0.0.1:${servePort}`;
+  serve = spawn(process.execPath, [path.join(HERE, "serve-product-ui.mjs")], {
+    cwd: APP,
+    env: {
+      ...process.env,
+      PORT: String(servePort),
+      PRODUCT_UI_PORT: String(productUiPort),
+      IOI_PRODUCT_UI_PUBLIC: path.join(APP, "product-ui", "owned", "public"),
+      IOI_HYPERVISOR_DAEMON_URL: DAEMON,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await waitFor(`${SERVE}${OPS}`, 30000);
+
+  // -- HONEST-EMPTY PASS on the fresh daemon, BEFORE any seeding ------------------------------
+  const empty = await pageText(OPS);
+  ok("canonical /operations 200s as the module's own mount (ownership headers name the served route + owner — the serve marker names the mount that served)",
+    empty.status === 200
+      && empty.headers.get("x-ioi-surface-route") === OPS
+      && empty.headers.get("x-ioi-surface-owner") === "Operations",
+    `route ${empty.headers.get("x-ioi-surface-route")} · owner ${empty.headers.get("x-ioi-surface-owner")}`);
+  ok("the page states its scope TYPED: partial pre-W3 cockpit slice, NOT Operations completion (SURF-operations remains open; W3.2/W3.3 own the full acceptance)",
+    empty.text.includes('data-ioi-scope="partial-pre-w3-cockpit-slice"')
+      && empty.text.includes("NOT Operations completion")
+      && empty.text.includes("SURF-operations remains open")
+      && empty.text.includes("W3.2/W3.3"));
+  ok("every pane is present on the fresh render: scheduler health · execution health · cross-provider failover · environment incidents & recovery · provider health · spend reconciliation · storage custody · substrate status",
+    empty.text.includes('id="ops-scheduler"')
+      && empty.text.includes('id="ops-execution"')
+      && empty.text.includes('id="ops-failover"')
+      && empty.text.includes('id="ops-incidents"')
+      && empty.text.includes('id="ops-providers"')
+      && empty.text.includes('id="ops-spend"')
+      && empty.text.includes('id="ops-storage"')
+      && empty.text.includes('id="ops-substrate"'));
+  ok("honest-empty everywhere BEFORE seeding: scheduled-specs, runs, failover-runs, failover-plans, incidents, recovery-attempts, storage-backends, storage-incidents all state typed absence-of-rows and ZERO record rows render",
+    ["scheduled-specs", "runs", "failover-runs", "failover-plans", "incidents", "recovery-attempts", "storage-backends", "storage-incidents"]
+      .every((k) => empty.text.includes(`data-ioi-honest-empty="${k}"`))
+      && !empty.text.includes("data-ioi-scheduled-spec-row")
+      && !empty.text.includes("data-ioi-failed-run-row")
+      && !empty.text.includes("data-ioi-failover-run-row")
+      && !empty.text.includes("data-ioi-failover-plan-row")
+      && !empty.text.includes("data-ioi-incident-row")
+      && !empty.text.includes("data-ioi-storage-backend-row"));
+  ok("the three W3 rollup absences render TYPED on the page (route-missing, never simulated): infrastructure-jobs projection · RPO/RTO + degraded/partition rollup · capacity/utilization overview",
+    empty.text.includes('data-ioi-w3-absence="infrastructure_jobs_projection"')
+      && empty.text.includes('data-ioi-w3-absence="rpo_rto_rollup"')
+      && empty.text.includes('data-ioi-w3-absence="capacity_utilization_overview"')
+      && empty.text.includes("route-missing"));
+
+  // -- typed disabled-named-gaps: every W3.2/W3.3-owned verb, with its owning unit ------------
+  ok("fault/remediation verbs are a typed disabled-named-gap owned by W3.2: typed incident open + infrastructure remediation render disabled with the exact reason and the owning unit",
+    empty.text.includes('data-ioi-named-gap="w3-fault-remediation"')
+      && /data-ioi-named-gap="w3-fault-remediation" data-ioi-owning-unit="W3\.2"/u.test(empty.text)
+      && empty.text.includes("owning unit W3.2"));
+  ok("failover execution is a typed disabled-named-gap owned by W3.2 (run · arm · disarm · evaluate) naming the exact daemon routes that exist and the never-automatic-authority contract",
+    empty.text.includes('data-ioi-named-gap="w3-failover-execution"')
+      && /data-ioi-named-gap="w3-failover-execution" data-ioi-owning-unit="W3\.2"/u.test(empty.text)
+      && empty.text.includes("POST /v1/hypervisor/failover/run")
+      && empty.text.includes("never automatic authority"));
+  ok("archive/custody ops are a typed disabled-named-gap owned by W3.3 (export · verify · restore · repair) naming POST /v1/hypervisor/storage-archive-ops and the sealed-before-write crossing",
+    empty.text.includes('data-ioi-named-gap="w3-archive-custody-ops"')
+      && /data-ioi-named-gap="w3-archive-custody-ops" data-ioi-owning-unit="W3\.3"/u.test(empty.text)
+      && empty.text.includes("POST /v1/hypervisor/storage-archive-ops"));
+  ok("automation-run remediation is a LIVE delegation, never a gap: the execution-health pane deep-links the Automations-owned mount (Operations mints no automation authority)",
+    empty.text.includes(`href="${LINK_AUTOMATIONS}" data-ioi-remediation-delegation`)
+      && empty.text.includes("Automations-owned authority"));
+
+  // -- the scheduler split + seed residual ----------------------------------------------------
+  ok("the scheduler split renders: scheduler HEALTH is Operations-owned (this pane), scheduler OBJECT truth is Automations-owned with a live deep-link, and the typed-blocked seed residual is stated (a block record never opens work)",
+    empty.text.includes(`href="${LINK_AUTOMATIONS}" data-ioi-scheduler-object-link`)
+      && empty.text.includes('data-ioi-seed-blocked="scheduler"')
+      && empty.text.includes("typed-blocked")
+      && empty.text.includes("seed-ux-provenance.v1.json"));
+  const schedBefore = await jd("/v1/hypervisor/scheduler/status");
+  const schedPage = await pageText(OPS);
+  const schedAfter = await jd("/v1/hypervisor/scheduler/status");
+  const pageLiveness = (schedPage.text.match(/data-ioi-scheduler-liveness="([^"]*)"/u) || [])[1] || "";
+  ok("scheduler health renders the daemon's OWN liveness value (GET /v1/hypervisor/scheduler/status — heartbeat-derived, value equality pinned against reads bracketing the render)",
+    !!pageLiveness
+      && (pageLiveness === String(schedBefore.body?.liveness || "") || pageLiveness === String(schedAfter.body?.liveness || "")),
+    `page ${pageLiveness} vs daemon ${schedBefore.body?.liveness}/${schedAfter.body?.liveness}`);
+
+  // -- provider health + spend rule are real reads --------------------------------------------
+  const providers = await jd("/v1/hypervisor/providers");
+  const firstProvider = (Array.isArray(providers.body?.providers) ? providers.body.providers : [])[0];
+  ok("provider health renders the daemon's real provider registry rows (first provider_ref present on the page) and states the customer-borne spend rule verbatim",
+    !!firstProvider
+      && empty.text.includes(String(firstProvider.provider_ref || ""))
+      && empty.text.includes("data-ioi-spend-rule")
+      && empty.text.includes("customer-borne"),
+    `first ${firstProvider?.provider_ref}`);
+  ok("spend reconciliation renders the real read (headroom · actual spent · reserved estimates · open exposures · teardown finalized · unsettled) — reserved estimates never presented as spend",
+    empty.text.includes("headroom")
+      && empty.text.includes("actual spent")
+      && empty.text.includes("reserved (open estimates)")
+      && empty.text.includes("never presented as spend"));
+
+  // -- lanes: fresh legacy lane + the protected T2 seed ---------------------------------------
+  const freshOps = await pageText(FRESH_OPS);
+  ok("the fresh legacy lane /__ioi/operations-cockpit serves the same module with truthful per-lane markers",
+    freshOps.status === 200
+      && freshOps.headers.get("x-ioi-surface-route") === FRESH_OPS
+      && freshOps.text.includes('id="ops-scheduler"'),
+    `route ${freshOps.headers.get("x-ioi-surface-route")}`);
+  const seedReadout = await pageText(SEED_READOUT);
+  ok("the protected T2 seed /__ioi/operations keeps serving untouched (rehome source; seed-preservation invariant — never redirected, never replaced)",
+    seedReadout.status === 200 && seedReadout.text.length > 10000,
+    `${seedReadout.status} · ${seedReadout.text.length}B`);
+
+  // -- SEED real fixtures via the daemon ------------------------------------------------------
+  const autoSeed = await jd("/v1/hypervisor/automations", {
+    method: "POST",
+    body: JSON.stringify({
+      name: "ops-cockpit-fixture-schedule",
+      project_ref: "project:ops-cockpit-fixture",
+      trigger_kind: "time",
+      schedule_spec: { cron: "0 3 * * *", timezone: "UTC" },
+    }),
+  });
+  const autoId = autoSeed.body?.automation?.automation_id || "";
+  ok("fixture: a scheduled automation seeds through the daemon under the operator identity (201; schedule_spec validated; INV-37 acting principal resolved)",
+    autoSeed.status === 201 && autoId.startsWith("auto_")
+      && String(autoSeed.body?.automation?.acting_principal_ref || "").length > 0,
+    `${autoSeed.status} · ${autoId}`);
+
+  const planSeed = await jd("/v1/hypervisor/failover/plans", {
+    method: "POST",
+    body: JSON.stringify({ environment_ref: "env-ops-cockpit-fixture" }),
+  });
+  const planRef = planSeed.body?.plan?.plan_ref || "";
+  ok("fixture: a failover plan seeds (200, fpl_*) with readiness no_restore_material — preparation evidence, honest about the missing material",
+    planSeed.status === 200 && planRef.startsWith("failover-plan://fpl_")
+      && planSeed.body?.plan?.readiness === "no_restore_material",
+    `${planSeed.status} · ${planRef}`);
+
+  const runSeed = await jd("/v1/hypervisor/failover/run", {
+    method: "POST",
+    body: JSON.stringify({ failure_condition: "provider_outage", plan_ref: planRef }),
+  });
+  const runRef = runSeed.body?.run?.run_ref || "";
+  ok("fixture: a failover run over the material-less plan REFUSES FAIL-CLOSED (409, failover_refused_no_restore_material) and the refused run persists as durable evidence",
+    runSeed.status === 409
+      && runSeed.body?.reason === "failover_refused_no_restore_material"
+      && runRef.startsWith("failover-run://for_")
+      && runSeed.body?.run?.status === "refused",
+    `${runSeed.status} · ${runRef}`);
+
+  const backendSeed = await jd("/v1/hypervisor/storage-backends", {
+    method: "POST",
+    body: JSON.stringify({ kind: "local_disk", display_name: "ops-cockpit-fixture-backend" }),
+  });
+  const backendRef = backendSeed.body?.backend?.account_ref || "";
+  ok("fixture: a storage backend seeds (201, sba_*, status unverified — health truth, never fabricated availability)",
+    backendSeed.status === 201 && backendRef.startsWith("storage-backend://sba_")
+      && backendSeed.body?.backend?.status === "unverified",
+    `${backendSeed.status} · ${backendRef}`);
+
+  // -- the seeded rows render owner-backed ----------------------------------------------------
+  const seeded = await pageText(OPS);
+  ok("scheduler health reflects the seeded fixture: the scheduled spec renders as a real row (name + cron) with its Automations object-truth link",
+    seeded.text.includes("data-ioi-scheduled-spec-row")
+      && seeded.text.includes("ops-cockpit-fixture-schedule")
+      && seeded.text.includes("0 3 * * *")
+      && seeded.text.includes("1 scheduled"));
+  ok("cross-provider failover reflects the seeded fixtures: the REFUSED run renders with its refusal reason verbatim (fail-closed evidence, never hidden) and the plan renders its readiness posture",
+    seeded.text.includes("data-ioi-failover-run-row")
+      && seeded.text.includes(runRef)
+      && seeded.text.includes("failover_refused_no_restore_material")
+      && seeded.text.includes("data-ioi-failover-plan-row")
+      && seeded.text.includes(planRef)
+      && seeded.text.includes("no_restore_material"));
+  ok("storage custody reflects the seeded fixture: the backend renders with its honest unverified health state",
+    seeded.text.includes("data-ioi-storage-backend-row")
+      && seeded.text.includes("ops-cockpit-fixture-backend")
+      && seeded.text.includes("unverified"));
+  ok("environment incidents stay honest-empty (no incident fixtures exist) — real zeros stated as absence, never invented rows",
+    seeded.text.includes('data-ioi-honest-empty="incidents"')
+      && seeded.text.includes('data-ioi-honest-empty="recovery-attempts"'));
+
+  // -- deep-link targets resolve live ---------------------------------------------------------
+  const autosPage = await pageText(LINK_AUTOMATIONS);
+  ok("the scheduler object-truth / remediation delegation link resolves: /automations 200s under the Automations owner (live canonical mount, not a gap)",
+    autosPage.status === 200 && autosPage.headers.get("x-ioi-surface-owner") === "Automations",
+    `owner ${autosPage.headers.get("x-ioi-surface-owner")}`);
+
+  // -- HOME RE-RULING: the flipped links are live and resolve to this mount -------------------
+  const homePage = await pageText(HOME);
+  ok("Home's Operations links are FLIPPED LIVE: /home renders href=\"/operations\" deep-links (data-ioi-operations-link) and the former operations-mount disabled-named-gap renders nowhere",
+    homePage.status === 200
+      && homePage.text.includes('href="/operations" data-ioi-operations-link')
+      && !homePage.text.includes('data-ioi-named-gap="operations-mount"'));
+  ok("following Home's own flipped link lands on the live Operations mount (200, Operations owner, the cockpit's panes)",
+    empty.status === 200
+      && empty.headers.get("x-ioi-surface-owner") === "Operations"
+      && empty.text.includes('id="ops-failover"'));
+
+  // -- reload survival ------------------------------------------------------------------------
+  const reload = await pageText(OPS);
+  ok("reload: /operations re-renders every seeded row from daemon truth (nothing was page-local state)",
+    reload.status === 200
+      && reload.text.includes("ops-cockpit-fixture-schedule")
+      && reload.text.includes(runRef)
+      && reload.text.includes("ops-cockpit-fixture-backend"));
+
+  // -- daemon-restart survival of the read plane ----------------------------------------------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  await startDaemon();
+  let survived = { status: 0, text: "" };
+  for (let attempt = 0; attempt < 3; attempt++) {
+    survived = await pageText(OPS);
+    if (survived.status === 200 && survived.text.includes(runRef)) break;
+    await new Promise((r) => setTimeout(r, 1200));
+  }
+  ok("daemon restart: the scheduled automation, the failover plan, the refused run and the storage backend survive as durable records and /operations re-renders the same rows (read-plane restart survival)",
+    survived.status === 200
+      && survived.text.includes("ops-cockpit-fixture-schedule")
+      && survived.text.includes(planRef)
+      && survived.text.includes(runRef)
+      && survived.text.includes("ops-cockpit-fixture-backend"));
+
+  // -- daemon outage: the typed unavailability page, zero fabricated counts -------------------
+  daemon.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 1200));
+  const down = await pageText(OPS);
+  ok("daemon down: /operations renders the TYPED unavailability page — the canon fallback-fixture rule held verbatim (nothing is shown rather than fixtures)",
+    down.status === 200
+      && down.text.includes('data-ioi-daemon-unavailable="true"')
+      && down.text.includes("Daemon unreachable")
+      && down.text.includes("data-ioi-scope"),
+    `status ${down.status}`);
+  ok("zero fabricated counts on the outage page: no fixture names, no run/plan/backend refs, no scheduled pills, no honest-empty markers pretending the daemon answered",
+    !down.text.includes("ops-cockpit-fixture-schedule")
+      && !down.text.includes(runRef)
+      && !down.text.includes(planRef)
+      && !down.text.includes("ops-cockpit-fixture-backend")
+      && !down.text.includes("scheduled")
+      && !down.text.includes("data-ioi-honest-empty"));
+  await startDaemon();
+  await waitFor(`${DAEMON}/healthz`, 30000);
+
+  // -- 3-posture browser matrix on /operations ------------------------------------------------
+  let pw = null;
+  try { pw = await import("playwright"); } catch { pw = null; }
+  if (!pw) {
+    ok("posture matrix skipped — playwright unavailable", false, "install playwright to run the browser matrix");
+  } else {
+    const browser = await pw.chromium.launch();
+    for (const [name, opts] of [
+      ["light-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "light" }],
+      ["dark-desktop", { viewport: { width: 1440, height: 900 }, colorScheme: "dark" }],
+      ["narrow-reduced-motion", { viewport: { width: 390, height: 844 }, colorScheme: "light", reducedMotion: "reduce" }],
+    ]) {
+      const ctx = await browser.newContext(opts);
+      const page = await ctx.newPage();
+      const errors = [];
+      page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+      const resp = await page.goto(`${SERVE}${OPS}`, { waitUntil: "networkidle", timeout: 45000 }).catch(() => null);
+      const body = resp ? await page.evaluate(() => document.body.innerText) : "";
+      await page.keyboard.press("Tab");
+      const focused = resp ? await page.evaluate(() => document.activeElement?.tagName ?? "") : "";
+      ok(`posture ${name}: /operations renders, keyboard-focusable, zero console errors`,
+        resp && resp.status() === 200 && body.length > 0 && errors.length === 0 && focused !== "" && focused !== "BODY",
+        errors[0]?.slice(0, 100) ?? `focus ${focused}`);
+      await ctx.close();
+    }
+    await browser.close();
+  }
+}
+
+run().then(() => {
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}).catch((e) => {
+  console.error("verifier crashed:", e);
+  cleanup();
+  process.exit(1);
+});
+
+function cleanup() {
+  try { serve?.kill("SIGTERM"); } catch { /* gone */ }
+  try { daemon?.kill("SIGTERM"); } catch { /* gone */ }
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* keep */ }
+}

--- a/apps/hypervisor/surfaces/home/index.mjs
+++ b/apps/hypervisor/surfaces/home/index.mjs
@@ -22,9 +22,11 @@
 //     the SAME per-family reads the live /ai explorer composes, server-side over the shared
 //     read client; the metrics strip that needs the projection stays a named absence, never a
 //     fabricated rollup.
-//   - The canonical /operations mount is NOT live on this estate: no surface row binds it.
-//     Parked-at-wallet-gate and failed-run rows render their REAL counts (failover/operations
-//     reads) but their owning-surface links are disabled-named-gap — named, never a dead link.
+//   - RE-RULED (next-legs V Leg 4): the canonical /operations mount is LIVE — the bound
+//     Operations surface module serves it (partial pre-W3 cockpit slice). Parked-at-wallet-gate
+//     and failed-run rows render their REAL counts (failover/operations reads) and their
+//     owning-surface links now deep-link /operations live; the former operations-mount
+//     disabled-named-gap is closed exactly as its own reason text promised.
 //
 // READ-ONLY BY CONTRACT: Home launches; it owns no object and performs no mutation. New
 // Session is Work's affordance ADVERTISED here (navigation to /work/new-session — the
@@ -48,12 +50,16 @@ const LINK_NEW_SESSION = "/work/new-session";
 const LINK_PROJECTS = "/projects";
 const LINK_APPLICATIONS = "/applications";
 const LINK_AI_ENTRY = "/ai";
+const LINK_OPERATIONS = "/operations";
 
 const SCOPE_MARKER = "partial-pre-w3-cockpit-slice";
 const SCOPE_NOTE = "Partial pre-W3 cockpit slice — NOT Home completion. SURF-home and W3.1 remain open; the manifest SURF-home acceptance is the full bar and this slice delivers the pre-W3 subset. The home-cockpit projection route is a typed W3 absence (stated below), and the /ai explorer readout keeps serving untouched as a current live entry.";
 
 const HOME_PROJECTION_ABSENCE = "typed W3 absence — GET /v1/hypervisor/home-cockpit (ioi.hypervisor.home_cockpit_projection.v1) and GET /v1/hypervisor/session-operations are route-missing at the daemon (the W3 build list owns them). This page composes the same per-family reads the live /ai explorer composes; the metrics strip that needs the projection stays a named absence, never a fabricated rollup.";
-const OPERATIONS_GAP_REASON = "disabled-named-gap — the canonical Operations mount is not live on this estate: no Operations surface module binds /operations (the route serves only the W0.1 substrate shell today). The parked/failed-run counts on this pane are REAL daemon truth (GET /v1/hypervisor/failover/runs · GET /v1/hypervisor/operations), but their owning-surface deep-links stay disabled until the Operations mount lands; a named gap, never a dead link and never a fabricated destination.";
+// Re-ruled (next-legs V Leg 4): the operations-mount disabled-named-gap is CLOSED — the bound
+// Operations surface module serves /operations (partial pre-W3 cockpit slice), so the
+// parked/failed rows' owning-surface links are live deep-links now.
+const OPERATIONS_LINKS_NOTE = "The parked/failed-run counts on this pane are REAL daemon truth (GET /v1/hypervisor/failover/runs · GET /v1/hypervisor/operations), and their owning surface is live: the canonical Operations mount serves the partial pre-W3 cockpit slice at /operations.";
 
 const PROJECTION_PATH = "/v1/hypervisor/product-surface-projections";
 const PROJECTION_SCHEMA = "ioi.hypervisor.product_surface_projection.v1";
@@ -108,7 +114,7 @@ export const actions = [];
 const pill = (text, cls) => `<span class="pill ${cls}">${esc(text)}</span>`;
 const scopeBanner = () => `<div class="scope" data-ioi-scope="${SCOPE_MARKER}">${esc(SCOPE_NOTE)}</div>`;
 const degraded = (result, plane) => `<div class="empty" data-ioi-degraded="${esc(result?.code || "daemon_unavailable")}" data-ioi-degraded-plane="${esc(plane)}">unavailable — <code>${esc(result?.code || "daemon_unavailable")}</code> (${esc(result?.message || "the plane did not answer")}). A down read renders its typed absence; zeros are never shown as truth.</div>`;
-const disabledGapLink = (label) => `<button class="act ghost" type="button" disabled data-ioi-named-gap="operations-mount" data-ioi-disabled-reason="${esc(OPERATIONS_GAP_REASON)}">${esc(label)}</button>`;
+const operationsLink = (label, anchor = "") => `<a class="act ghost" href="${LINK_OPERATIONS}${anchor}" data-ioi-operations-link>${esc(label)}</a>`;
 
 const lifecyclePill = (state) => pill(state || "unknown", state === "provisioned" ? "ok" : state === "torn_down" ? "muted" : "warn");
 
@@ -132,8 +138,8 @@ function approvalsPane(res) {
 
 function parkedAndFailedPane(failover, operations) {
   const head = `<h2 id="home-parked-failed">Runs parked at the wallet gate · failed runs</h2>
-    <p class="sub">Counts are real daemon truth. Their owning surface is Operations, whose canonical mount is not live yet — the Operations links on this pane are a <b>disabled named gap</b>, never a dead link.</p>
-    <div class="row">${disabledGapLink("Open Operations →")}</div>`;
+    <p class="sub">${esc(OPERATIONS_LINKS_NOTE)}</p>
+    <div class="row">${operationsLink("Open Operations →")}</div>`;
   const parkedBody = (() => {
     if (!failover?.ok) return degraded(failover, "failover/runs");
     const parked = (Array.isArray(failover.payload?.runs) ? failover.payload.runs : [])
@@ -142,7 +148,7 @@ function parkedAndFailedPane(failover, operations) {
     return `<div class="row">${pill(`${parked.length} parked`, "warn")}</div>` + parked.slice(0, 5).map((r) => `<div class="card" data-ioi-parked-row>
         <div class="main"><div class="name">parked — ${esc(String(r.status || "").replace("awaiting_authority_", ""))} ${pill("blocked", "warn")}</div>
         <div class="meta">${esc(r.failure_condition || "run")}${r.environment_ref ? ` · <code>${esc(r.environment_ref)}</code>` : ""}</div></div>
-        ${disabledGapLink("Operations →")}</div>`).join("");
+        ${operationsLink("Operations →", "#ops-failover")}</div>`).join("");
   })();
   const failedBody = (() => {
     if (!operations?.ok) return degraded(operations, "operations");
@@ -151,7 +157,7 @@ function parkedAndFailedPane(failover, operations) {
     return `<div class="row">${pill(`${failures.length} failed`, "warn")}</div>` + failures.slice(0, 5).map((r) => `<div class="card" data-ioi-failed-row>
         <div class="main"><div class="name">failed — ${esc(r.name || r.automation_id || r.execution_id || "run")} ${pill("failed", "warn")}</div>
         <div class="meta">${esc(r.project_id || "—")}${r.finished_at ? ` · ${esc(r.finished_at)}` : ""}</div></div>
-        ${disabledGapLink("Operations →")}</div>`).join("");
+        ${operationsLink("Operations →", "#ops-execution")}</div>`).join("");
   })();
   return `${head}${parkedBody}${failedBody}`;
 }
@@ -252,6 +258,7 @@ function unavailableView(model) {
       <a class="act ghost" href="${LINK_SESSIONS}">Work / Sessions →</a>
       <a class="act ghost" href="${LINK_PROJECTS}">Projects →</a>
       <a class="act ghost" href="${LINK_APPLICATIONS}">Applications →</a>
+      <a class="act ghost" href="${LINK_OPERATIONS}">Operations →</a>
     </div>`;
 }
 

--- a/apps/hypervisor/surfaces/operations/index.mjs
+++ b/apps/hypervisor/surfaces/operations/index.mjs
@@ -1,0 +1,411 @@
+// Operations — the canonical /operations PARTIAL PRE-W3 COCKPIT SLICE (next-legs V Leg 4).
+//
+// SCOPE RULING (bounds every claim in this file): this is NOT Operations completion.
+// SURF-operations REMAINS OPEN — its manifest acceptance (detect an injected runtime/provider/
+// storage fault, open a typed incident, preview authority, execute remediation/failover, emit
+// receipts/events, verify owner-app readback, rehearse restart/rollback/support export) needs
+// the W3.2 fault matrix and the W3.3 snapshot/archive/restore semantics, and its seed gate
+// carries the scheduler residual. This slice delivers exactly: the canonical mount over a
+// read-first cockpit composed from the daemon read families that EXIST TODAY, typed
+// disabled-named-gaps for every W3.2/W3.3-owned action, and typed route-missing absences for
+// the W3 rollup projections. Evidence: scripts/verify-hypervisor-operations-cockpit.mjs
+// (check:operations-cockpit — deliberately NOT a "-journey": the Operations journey is
+// SURF-operations' to earn behind W3.2/W3.3).
+//
+// SEED RESIDUAL, stated typed: the retained Scheduler capture in
+// apps/hypervisor/seed-ux-provenance.v1.json is provenance-qualified but its stable replay
+// renders Page-not-found, so the scheduler source stays typed-blocked in the seed gate — a
+// block record never opens work, and neither the error page nor the canonical shell is ever
+// substituted for the seed. Scheduler OBJECT truth (schedules, triggers, concurrency, failure
+// policy) is Automations-owned; scheduler HEALTH is Operations-owned — both renders below hold
+// that split. The T2 readout at /__ioi/operations is the rehome source and keeps serving
+// untouched (seed-preservation invariant).
+//
+// TYPED W3 ABSENCES stated, never simulated (surfaces/operations.md §2 route-missing rows):
+//   - unified infrastructure-jobs projection (subjects via subject_attachments) — no such
+//     route exists; this page composes per-family reads and never merges them into a
+//     fabricated jobs rollup;
+//   - RPO/RTO + degraded/partition posture rollup — route-missing;
+//   - capacity/utilization overview — route-missing (pool fields exist; no overview route).
+//
+// READ-FIRST BY CONTRACT: this slice declares zero actions. Canon: "Operations performs
+// admitted provider, placement, fencing, failover, and member actions" — but every such verb
+// on this estate is W3.2/W3.3-owned acceptance surface (fault injection, remediation,
+// failover execution, archive custody ops), so each renders as a typed disabled-named-gap
+// naming the daemon routes that exist, the reason, and the owning unit. Automation-run
+// remediation (re-run/pause/resume) is Automations-owned authority and its canonical mount is
+// live — those render as LIVE deep-links to /automations, never as gaps and never as verbs
+// minted here. The per-plane availability idiom is contract: an unavailable plane renders
+// "unknown, not zero", and a full daemon outage renders a typed unavailability page with zero
+// fabricated counts (the canon fallback-fixture rule, api.md:167-169).
+import { escHtml } from "../kit.mjs";
+
+const esc = escHtml;
+
+const LEGACY_ROUTE = "/__ioi/operations-cockpit";
+const CANONICAL_ROUTE = "/operations";
+
+// The protected T2 rehome source — keeps serving untouched until the W4 cutover.
+const SEED_READOUT = "/__ioi/operations";
+// LIVE deep-link targets on this estate (bound canonical mounts).
+const LINK_AUTOMATIONS = "/automations";
+const LINK_WORK = "/work";
+
+const SCOPE_MARKER = "partial-pre-w3-cockpit-slice";
+const SCOPE_NOTE = "Partial pre-W3 cockpit slice — NOT Operations completion. SURF-operations remains open: its full acceptance (injected-fault detection, typed incident open, authority preview, remediation/failover execution, receipts, readback, restart/rollback/support export) is W3.2/W3.3-owned, and its seed gate carries the typed-blocked scheduler residual. This slice composes only the daemon read families that exist today.";
+
+const JOBS_ROLLUP_ABSENCE = "typed W3 absence — no unified infrastructure-jobs projection route exists at the daemon (route-missing; surfaces/operations.md §2). The W3 build binds job subjects via subject_attachments; until it lands this page renders each family separately and never merges them into a fabricated jobs rollup.";
+const RPO_RTO_ABSENCE = "typed W3 absence — no RPO/RTO + degraded/partition posture rollup route exists at the daemon (route-missing). Composable posture stays per-family (failover, incidents, substrate); a rollup this page invented would be a simulated projection, so none renders.";
+const CAPACITY_ABSENCE = "typed W3 absence — no capacity/utilization overview route exists at the daemon (route-missing). Resource-pool records carry capacity fields, but the cross-pool overview is the W3 projection's to mint; this page will not derive one.";
+
+const FAULT_REMEDIATION_GAP = "disabled-named-gap — owning unit W3.2 (runtime-node and provider execution, admission, health, recovery: the fault matrix). SURF-operations' acceptance opens a typed incident and executes remediation against an injected runtime/provider/storage fault; no typed incident-open or infrastructure-remediation verb is wired on this pre-W3 slice. The environment incident records below are REAL daemon reads (GET /v1/hypervisor/incidents · GET /v1/hypervisor/recovery-attempts); only the authority-crossing verbs wait on W3.2.";
+const FAILOVER_EXECUTION_GAP = "disabled-named-gap — owning unit W3.2 (with the W3.3 restore ladder behind it). The daemon owns POST /v1/hypervisor/failover/run, POST /v1/hypervisor/failover/plans/:id/arm|disarm and POST /v1/hypervisor/failover/evaluate today, and every run parks wallet-gated at awaiting_authority_* — never automatic authority. This pre-W3 slice wires no authority-crossing verb: failover execution is SURF-operations acceptance surface that lands with the W3.2/W3.3 fault-injection/remediation matrix. The run and plan records below are REAL daemon reads.";
+const ARCHIVE_CUSTODY_GAP = "disabled-named-gap — owning unit W3.3 (snapshot, archive, backup, storage-profile, export, restore semantics). The daemon owns POST /v1/hypervisor/storage-archive-ops (export/verify/restore/repair, sealed-before-write, wallet-gated crossing) and the storage-backend credential/preflight lanes today; this pre-W3 slice wires none of them — a fresh-daemon restore with custody, retention, and deletion proof is W3.3's acceptance. The backend and incident records below are REAL daemon reads.";
+
+const SCHEDULER_SPLIT_NOTE = "Scheduler HEALTH is Operations-owned (this pane); scheduler OBJECT truth — schedules, triggers, concurrency, failure policy — is Automations-owned and lives at";
+const SEED_RESIDUAL_NOTE = "seed residual, typed: the retained Scheduler capture stays typed-blocked in seed-ux-provenance.v1.json (stable replay renders Page-not-found) — a block record never opens work, blocked renders are never substituted, and this pane is canon-first over the daemon scheduler-status family, claiming no seed parity.";
+
+// ---------------------------------------------------------------------------------------------
+// load — every read through the shared read client on the request-scoped identity capability.
+// ELEVEN per-family reads, every one a route that exists at the daemon TODAY (the operations
+// brief's §2 map); no home-cockpit-style rollup exists to read, so none is read.
+export async function load(ctx) {
+  const { createReadClient } = await import("../read-client.mjs");
+  const client = typeof ctx.daemonFetch === "function"
+    ? createReadClient({ daemon: "", fetchImpl: ctx.daemonFetch })
+    : createReadClient({ daemon: ctx.daemon });
+  const [
+    scheduler, operations, failoverRuns, failoverPlans, incidents, recovery,
+    providers, spend, storageBackends, storageIncidents, substrate,
+  ] = await Promise.all([
+    client.read("/v1/hypervisor/scheduler/status"),
+    client.read("/v1/hypervisor/operations"),
+    client.read("/v1/hypervisor/failover/runs"),
+    client.read("/v1/hypervisor/failover/plans"),
+    client.read("/v1/hypervisor/incidents"),
+    client.read("/v1/hypervisor/recovery-attempts"),
+    client.read("/v1/hypervisor/providers"),
+    client.read("/v1/hypervisor/provider-spend/reconciliation"),
+    client.read("/v1/hypervisor/storage-backends"),
+    client.read("/v1/hypervisor/storage-incidents"),
+    client.read("/v1/hypervisor/substrate/status"),
+  ]);
+  return {
+    scheduler, operations, failoverRuns, failoverPlans, incidents, recovery,
+    providers, spend, storageBackends, storageIncidents, substrate,
+  };
+}
+
+// No actions, deliberately: every Operations verb on this estate is W3.2/W3.3 acceptance
+// surface (typed disabled-named-gaps below), and automation-run remediation is Automations'
+// authority reached by live deep-link. A verb declared here would wire authority this slice
+// must not hold.
+export const actions = [];
+
+// ---------------------------------------------------------------------------------------------
+const pill = (text, cls) => `<span class="pill ${cls}">${esc(text)}</span>`;
+const scopeBanner = () => `<div class="scope" data-ioi-scope="${SCOPE_MARKER}">${esc(SCOPE_NOTE)}</div>`;
+const degraded = (result, plane) => `<div class="empty" data-ioi-degraded="${esc(result?.code || "daemon_unavailable")}" data-ioi-degraded-plane="${esc(plane)}">unavailable — <code>${esc(result?.code || "daemon_unavailable")}</code> (${esc(result?.message || "the plane did not answer")}). An unavailable plane renders <b>unknown, not zero</b> — zeros are never shown as truth.</div>`;
+const gapButton = (label, gap, unit, reason) => `<button class="act ghost" type="button" disabled data-ioi-named-gap="${esc(gap)}" data-ioi-owning-unit="${esc(unit)}" data-ioi-disabled-reason="${esc(reason)}">${esc(label)}</button>`;
+
+// ---- scheduler health (Operations owns HEALTH; Automations owns the OBJECT) -----------------
+function schedulerPane(scheduler, operations) {
+  const head = `<h2 id="ops-scheduler">Scheduler health</h2>
+    <p class="sub">${esc(SCHEDULER_SPLIT_NOTE)} <a href="${LINK_AUTOMATIONS}" data-ioi-scheduler-object-link>Automations →</a>. ${esc(SEED_RESIDUAL_NOTE)}</p>
+    <div class="seedblocked" data-ioi-seed-blocked="scheduler">scheduler seed source: typed-blocked in the seed gate (never substituted)</div>`;
+  const health = (() => {
+    if (!scheduler?.ok) return degraded(scheduler, "scheduler/status");
+    const p = scheduler.payload || {};
+    const liveness = String(p.liveness || "unknown");
+    const cls = liveness === "live" ? "ok" : liveness === "stale" ? "warn" : "muted";
+    const hb = p.heartbeat && typeof p.heartbeat === "object" ? p.heartbeat : null;
+    return `<div class="card"><div class="main">
+      <div class="name">loop liveness <span class="pill ${cls}" data-ioi-scheduler-liveness="${esc(liveness)}">${esc(liveness)}</span>${typeof p.age_seconds === "number" ? ` ${pill(`${p.age_seconds}s since last tick`, "muted")}` : ""}</div>
+      <div class="meta">${hb ? `last tick <code>${esc(String(hb.last_tick_at || ""))}</code> · ` : ""}heartbeat-derived (<code>GET /v1/hypervisor/scheduler/status</code>) — proves the last completed tick, never that the loop will tick again. Records-derived schedule posture: <code>GET /v1/hypervisor/operations</code>.</div>
+    </div></div>`;
+  })();
+  const specs = (() => {
+    if (!operations?.ok) return degraded(operations, "operations");
+    const scheduled = Array.isArray(operations.payload?.scheduler?.automations) ? operations.payload.scheduler.automations : [];
+    if (!scheduled.length) return `<div class="empty" data-ioi-honest-empty="scheduled-specs">No scheduled automations (<code>GET /v1/hypervisor/operations</code> scheduler posture) — honest absence, never fabricated.</div>`;
+    return `<div class="row">${pill(`${scheduled.length} scheduled`, "muted")}</div>` +
+      `<table><thead><tr><th>Automation</th><th>Enabled</th><th>Schedule</th><th>Next</th><th>Last</th><th>Object truth</th></tr></thead><tbody>` +
+      scheduled.slice(0, 8).map((a) => `<tr data-ioi-scheduled-spec-row>
+        <td>${esc(a.name || a.automation_id || "automation")} <code>${esc(a.automation_id || "")}</code></td>
+        <td>${a.enabled === false ? pill("paused", "warn") : pill("enabled", "ok")}</td>
+        <td><code>${esc(JSON.stringify(a.schedule_spec ?? null))}</code></td>
+        <td>${esc(String(a.next_run_at ?? "—"))}</td>
+        <td>${esc(String(a.last_run_at ?? "—"))}</td>
+        <td><a href="${LINK_AUTOMATIONS}">Automations →</a></td>
+      </tr>`).join("") + `</tbody></table>`;
+  })();
+  return `${head}${health}${specs}`;
+}
+
+// ---- execution health (runs / needs-attention / webhooks over the automation substrate) -----
+function executionPane(operations) {
+  const head = `<h2 id="ops-execution">Execution health</h2>
+    <p class="sub">The execution-health projection over the automation substrate (<code>GET /v1/hypervisor/operations</code>): what fired, what failed, what needs attention. Remediation (re-run · pause · resume) is <b>Automations-owned authority</b> — reached live at <a href="${LINK_AUTOMATIONS}" data-ioi-remediation-delegation>Automations →</a>, never minted here. Governed-work rollup: <a href="${LINK_WORK}">Work →</a>.</p>`;
+  if (!operations?.ok) return `${head}${degraded(operations, "operations")}`;
+  const runs = operations.payload?.runs || {};
+  const counts = `<div class="row">
+      ${pill(`${Number(runs.total || 0)} total`, "muted")}
+      ${pill(`${Number(runs.done || 0)} done`, "ok")}
+      ${pill(`${Number(runs.running || 0)} running`, "muted")}
+      ${pill(`${Number(runs.failed || 0)} failed`, Number(runs.failed || 0) > 0 ? "warn" : "muted")}
+    </div>`;
+  const failures = Array.isArray(runs.failures) ? runs.failures : [];
+  const failedRows = failures.length
+    ? failures.slice(0, 6).map((r) => `<div class="card" data-ioi-failed-run-row>
+        <div class="main"><div class="name">failed — ${esc(r.name || r.automation_id || r.execution_id || "run")} ${pill("needs attention", "warn")}</div>
+        <div class="meta"><code>${esc(r.execution_id || "")}</code>${r.finished_at ? ` · ${esc(r.finished_at)}` : ""}</div></div>
+        <a class="act ghost" href="${LINK_AUTOMATIONS}">remediate via Automations →</a></div>`).join("")
+    : `<div class="empty" data-ioi-honest-empty="runs">No failed runs — real zeros stated as absence (<code>GET /v1/hypervisor/operations</code>), never invented rows.</div>`;
+  const wh = operations.payload?.webhooks || {};
+  const webhookLine = `<div class="card"><div class="main"><div class="name">webhook health ${pill(`${Number(wh.accepted || 0)} accepted`, "ok")} ${pill(`${Number(wh.rejected || 0)} rejected`, Number(wh.rejected || 0) > 0 ? "warn" : "muted")}</div>
+      <div class="meta">trigger-event admissions over the automation substrate — evidence rows, never authority.</div></div></div>`;
+  const gap = `<div class="gapcard">${gapButton("Open typed incident", "w3-fault-remediation", "W3.2", FAULT_REMEDIATION_GAP)}
+      ${gapButton("Execute infrastructure remediation", "w3-fault-remediation", "W3.2", FAULT_REMEDIATION_GAP)}
+      <p class="sub" style="margin:8px 0 0;text-transform:none;letter-spacing:0">${esc(FAULT_REMEDIATION_GAP)}</p></div>`;
+  return `${head}${counts}${failedRows}${webhookLine}${gap}`;
+}
+
+// ---- cross-provider failover posture --------------------------------------------------------
+function failoverPane(failoverRuns, failoverPlans) {
+  const head = `<h2 id="ops-failover">Cross-provider failover</h2>
+    <p class="sub">Runs and plan posture over daemon truth (<code>GET /v1/hypervisor/failover/runs</code> · <code>GET /v1/hypervisor/failover/plans</code>). Every wallet-gated crossing parks at <code>awaiting_authority_*</code> with the exact challenge echoed — <b>never automatic authority</b>; a refused run is fail-closed evidence, not an error to hide.</p>`;
+  const runsBody = (() => {
+    if (!failoverRuns?.ok) return degraded(failoverRuns, "failover/runs");
+    const runs = Array.isArray(failoverRuns.payload?.runs) ? failoverRuns.payload.runs : [];
+    if (!runs.length) return `<div class="empty" data-ioi-honest-empty="failover-runs">No failover runs (<code>GET /v1/hypervisor/failover/runs</code>) — honest absence, never fabricated.</div>`;
+    return runs.slice(0, 6).map((r) => {
+      const status = String(r.status || "unknown");
+      const parked = status.startsWith("awaiting_authority");
+      const cls = parked ? "warn" : status === "refused" ? "warn" : status === "complete" ? "ok" : "muted";
+      const refusal = r.refusal && typeof r.refusal === "object" ? String(r.refusal.reason || "") : "";
+      return `<div class="card" data-ioi-failover-run-row>
+        <div class="main"><div class="name"><code>${esc(r.run_ref || r.run_id || "")}</code> ${pill(parked ? `parked — ${status.replace("awaiting_authority_", "")}` : status, cls)}</div>
+        <div class="meta">${esc(r.failure_condition || "")}${r.environment_ref ? ` · <code>${esc(r.environment_ref)}</code>` : ""}${refusal ? ` · refusal <code>${esc(refusal)}</code> (fail-closed)` : ""}</div></div>
+      </div>`;
+    }).join("");
+  })();
+  const plansBody = (() => {
+    if (!failoverPlans?.ok) return degraded(failoverPlans, "failover/plans");
+    const plans = Array.isArray(failoverPlans.payload?.plans) ? failoverPlans.payload.plans : [];
+    if (!plans.length) return `<div class="empty" data-ioi-honest-empty="failover-plans">No failover plans (<code>GET /v1/hypervisor/failover/plans</code>) — honest absence, never fabricated.</div>`;
+    return plans.slice(0, 6).map((p) => `<div class="card" data-ioi-failover-plan-row>
+        <div class="main"><div class="name"><code>${esc(p.plan_ref || p.plan_id || "")}</code> ${pill(String(p.readiness || "unknown"), p.readiness === "ready_daemon_custody" ? "ok" : "warn")}</div>
+        <div class="meta"><code>${esc(p.environment_ref || "")}</code> · a plan is preparation evidence; every mutation it leads to is wallet-gated at execution time</div></div>
+      </div>`).join("");
+  })();
+  const gap = `<div class="gapcard">${gapButton("Run failover", "w3-failover-execution", "W3.2", FAILOVER_EXECUTION_GAP)}
+      ${gapButton("Arm plan", "w3-failover-execution", "W3.2", FAILOVER_EXECUTION_GAP)}
+      ${gapButton("Disarm plan", "w3-failover-execution", "W3.2", FAILOVER_EXECUTION_GAP)}
+      ${gapButton("Evaluate conditions", "w3-failover-execution", "W3.2", FAILOVER_EXECUTION_GAP)}
+      <p class="sub" style="margin:8px 0 0;text-transform:none;letter-spacing:0">${esc(FAILOVER_EXECUTION_GAP)}</p></div>`;
+  return `${head}${runsBody}${plansBody}${gap}`;
+}
+
+// ---- environment failure incidents + recovery attempts --------------------------------------
+function incidentsPane(incidents, recovery) {
+  const head = `<h2 id="ops-incidents">Environment incidents &amp; recovery</h2>
+    <p class="sub">Environment failure incidents and recovery attempts over daemon truth (<code>GET /v1/hypervisor/incidents</code> · <code>GET /v1/hypervisor/recovery-attempts</code>) — the infrastructure lane; logical incidents live with Work.</p>`;
+  const incBody = (() => {
+    if (!incidents?.ok) return degraded(incidents, "incidents");
+    const rows = Array.isArray(incidents.payload?.incidents) ? incidents.payload.incidents : [];
+    if (!rows.length) return `<div class="empty" data-ioi-honest-empty="incidents">No environment failure incidents (<code>GET /v1/hypervisor/incidents</code>) — honest absence, never fabricated.</div>`;
+    return rows.slice(0, 6).map((i) => `<div class="card" data-ioi-incident-row>
+        <div class="main"><div class="name">${esc(i.kind || i.failure_condition || "incident")} ${pill(String(i.status || "open"), "warn")}</div>
+        <div class="meta"><code>${esc(i.environment_ref || i.incident_id || "")}</code>${i.opened_at ? ` · ${esc(i.opened_at)}` : ""}</div></div>
+      </div>`).join("");
+  })();
+  const recBody = (() => {
+    if (!recovery?.ok) return degraded(recovery, "recovery-attempts");
+    const rows = Array.isArray(recovery.payload?.recoveryAttempts) ? recovery.payload.recoveryAttempts : [];
+    if (!rows.length) return `<div class="empty" data-ioi-honest-empty="recovery-attempts">No recovery attempts (<code>GET /v1/hypervisor/recovery-attempts</code>) — honest absence, never fabricated.</div>`;
+    return rows.slice(0, 6).map((r) => `<div class="card" data-ioi-recovery-row>
+        <div class="main"><div class="name">recovery ${pill(String(r.status || r.outcome || "attempted"), "muted")}</div>
+        <div class="meta"><code>${esc(r.environment_ref || r.attempt_id || "")}</code></div></div>
+      </div>`).join("");
+  })();
+  return `${head}${incBody}${recBody}`;
+}
+
+// ---- provider health + customer-borne spend -------------------------------------------------
+function providersPane(providers) {
+  const head = `<h2 id="ops-providers">Provider health</h2>`;
+  if (!providers?.ok) return `${head}${degraded(providers, "providers")}`;
+  const rows = Array.isArray(providers.payload?.providers) ? providers.payload.providers : [];
+  const spendRule = String(providers.payload?.spend_rule || "BYO provider spend is customer-borne; the hypervisor records, governs, estimates, and reconciles — never hidden markup");
+  const body = rows.length
+    ? rows.slice(0, 10).map((p) => `<div class="card" data-ioi-provider-row>
+        <div class="main"><div class="name"><code>${esc(p.provider_ref || "")}</code> ${pill(String(p.status || "unknown"), p.status === "available" || p.status === "credential_verified" ? "ok" : "muted")}</div>
+        <div class="meta">${esc(p.reason || "")}</div></div>
+      </div>`).join("")
+    : `<div class="empty" data-ioi-honest-empty="providers">No providers registered (<code>GET /v1/hypervisor/providers</code>) — honest absence, never fabricated.</div>`;
+  return `${head}<p class="sub" data-ioi-spend-rule>${esc(spendRule)}</p>${body}`;
+}
+
+// ---- spend reconciliation -------------------------------------------------------------------
+function spendPane(spend) {
+  const head = `<h2 id="ops-spend">Provider spend reconciliation</h2>`;
+  if (!spend?.ok) return `${head}${degraded(spend, "provider-spend/reconciliation")}`;
+  const p = spend.payload || {};
+  const b = p.budget || {};
+  const warned = Array.isArray(p.incomplete_teardown_warnings) ? p.incomplete_teardown_warnings : [];
+  const warnRows = warned.length
+    ? warned.slice(0, 4).map((w) => `<div class="card" data-ioi-teardown-warning-row><div class="main"><div class="name">incomplete teardown ${pill("warning", "warn")}</div><div class="meta"><code>${esc(String(w.exposure_ref || ""))}</code> · ${esc(String(w.warning || ""))}</div></div></div>`).join("")
+    : "";
+  return `${head}
+    <p class="sub">Reserved estimates are never presented as spend; estimates stay unsettled until the customer's own provider bill (<code>GET /v1/hypervisor/provider-spend/reconciliation</code>).</p>
+    <div class="row">
+      ${pill(`headroom ${Number(b.remaining_headroom ?? 0)}`, "muted")}
+      ${pill(`actual spent ${Number(b.spent ?? 0)}`, "muted")}
+      ${pill(`reserved (open estimates) ${Number(b.reserved_open_estimates ?? 0)}`, "muted")}
+      ${pill(`open exposures ${Number(p.estimated_open_exposure_rate?.open_count ?? 0)}`, "muted")}
+      ${pill(`teardown finalized ${Number(p.teardown_finalized?.count ?? 0)}`, "muted")}
+      ${pill(`unsettled ${Number(p.unsettled_estimates?.count ?? 0)}`, "muted")}
+    </div>${warnRows}`;
+}
+
+// ---- storage custody ------------------------------------------------------------------------
+function storagePane(storageBackends, storageIncidents) {
+  const head = `<h2 id="ops-storage">Storage custody</h2>
+    <p class="sub">Backend health over daemon truth (<code>GET /v1/hypervisor/storage-backends</code> · <code>GET /v1/hypervisor/storage-incidents</code>). Custody rule, stated in-surface: storage backends hold payload bytes; they do not own operational truth — daemon-admitted sha256 state roots remain restore truth.</p>`;
+  const backendsBody = (() => {
+    if (!storageBackends?.ok) return degraded(storageBackends, "storage-backends");
+    const rows = Array.isArray(storageBackends.payload?.backends) ? storageBackends.payload.backends : [];
+    if (!rows.length) return `<div class="empty" data-ioi-honest-empty="storage-backends">No storage backends (<code>GET /v1/hypervisor/storage-backends</code>) — honest absence, never fabricated.</div>`;
+    return rows.slice(0, 6).map((b) => {
+      const state = String(b.health?.state || "unknown");
+      return `<div class="card" data-ioi-storage-backend-row>
+        <div class="main"><div class="name">${esc(b.display_name || b.account_id || "backend")} ${pill(b.kind || "", "muted")} ${pill(state, state === "available" ? "ok" : "warn")}</div>
+        <div class="meta"><code>${esc(b.account_ref || "")}</code> · ${Number(b.health?.objects || 0)} object(s) · ${Number(b.health?.open_incidents || 0)} open incident(s)</div></div>
+      </div>`;
+    }).join("");
+  })();
+  const incidentsBody = (() => {
+    if (!storageIncidents?.ok) return degraded(storageIncidents, "storage-incidents");
+    const rows = Array.isArray(storageIncidents.payload?.incidents) ? storageIncidents.payload.incidents : [];
+    const repairs = Array.isArray(storageIncidents.payload?.repair_receipts) ? storageIncidents.payload.repair_receipts : [];
+    const inc = rows.length
+      ? rows.slice(0, 4).map((i) => `<div class="card" data-ioi-storage-incident-row><div class="main"><div class="name">availability incident ${pill(String(i.status || "open"), "warn")}</div><div class="meta"><code>${esc(i.archive_ref || i.incident_id || "")}</code></div></div></div>`).join("")
+      : `<div class="empty" data-ioi-honest-empty="storage-incidents">No open storage incidents — honest absence, never fabricated.</div>`;
+    const rep = repairs.length ? `<div class="row">${pill(`${repairs.length} repair receipt(s)`, "muted")}</div>` : "";
+    return `${inc}${rep}`;
+  })();
+  const gap = `<div class="gapcard">${gapButton("Export archive", "w3-archive-custody-ops", "W3.3", ARCHIVE_CUSTODY_GAP)}
+      ${gapButton("Verify archive", "w3-archive-custody-ops", "W3.3", ARCHIVE_CUSTODY_GAP)}
+      ${gapButton("Restore", "w3-archive-custody-ops", "W3.3", ARCHIVE_CUSTODY_GAP)}
+      ${gapButton("Repair", "w3-archive-custody-ops", "W3.3", ARCHIVE_CUSTODY_GAP)}
+      <p class="sub" style="margin:8px 0 0;text-transform:none;letter-spacing:0">${esc(ARCHIVE_CUSTODY_GAP)}</p></div>`;
+  return `${head}${backendsBody}${incidentsBody}${gap}`;
+}
+
+// ---- substrate status chip ------------------------------------------------------------------
+function substratePane(substrate) {
+  const head = `<h2 id="ops-substrate">Substrate status</h2>`;
+  if (!substrate?.ok) return `${head}${degraded(substrate, "substrate/status")}`;
+  const p = substrate.payload || {};
+  const errs = Number(p.errors || 0);
+  return `${head}<div class="card"><div class="main">
+      <div class="name">admission engine ${pill(`${Number(p.admitted || 0)} admitted`, "ok")} <span class="pill ${errs > 0 ? "warn" : "muted"}" data-ioi-substrate-errors="${errs}">${errs} error(s)</span></div>
+      <div class="meta">${esc(String(p.mode || ""))}${p.engine_open_error ? ` · open error: <code>${esc(String(p.engine_open_error))}</code>` : ""}</div>
+    </div></div>`;
+}
+
+// ---- the typed W3 rollup absences -----------------------------------------------------------
+function rollupAbsences() {
+  return `<div class="gapcard" data-ioi-w3-absence="infrastructure_jobs_projection">
+      <b>Unified infrastructure-jobs projection absent — a typed W3 absence (route-missing).</b>
+      <p class="sub" style="margin:6px 0 0;text-transform:none;letter-spacing:0">${esc(JOBS_ROLLUP_ABSENCE)}</p>
+    </div>
+    <div class="gapcard" data-ioi-w3-absence="rpo_rto_rollup">
+      <b>RPO/RTO + degraded/partition rollup absent — a typed W3 absence (route-missing).</b>
+      <p class="sub" style="margin:6px 0 0;text-transform:none;letter-spacing:0">${esc(RPO_RTO_ABSENCE)}</p>
+    </div>
+    <div class="gapcard" data-ioi-w3-absence="capacity_utilization_overview">
+      <b>Capacity/utilization overview absent — a typed W3 absence (route-missing).</b>
+      <p class="sub" style="margin:6px 0 0;text-transform:none;letter-spacing:0">${esc(CAPACITY_ABSENCE)}</p>
+    </div>`;
+}
+
+// ---- full daemon outage: the canon fallback-fixture rule, held verbatim ---------------------
+const READ_KEYS = [
+  "scheduler", "operations", "failoverRuns", "failoverPlans", "incidents", "recovery",
+  "providers", "spend", "storageBackends", "storageIncidents", "substrate",
+];
+function daemonUnreachable(model) {
+  return READ_KEYS.every((key) => {
+    const r = model[key];
+    return r && r.ok === false && (r.code === "daemon_unavailable" || r.code === "read_timeout" || r.status === 0);
+  });
+}
+
+function unavailableView(model) {
+  const first = model.scheduler;
+  return `<div class="gapcard" data-ioi-daemon-unavailable="true">
+      <b>Daemon unreachable — infrastructure posture unavailable.</b>
+      <p class="sub" style="margin:6px 0 0;text-transform:none;letter-spacing:0">Every read failed typed (<code>${esc(first?.code || "daemon_unavailable")}</code>). Zero counts are fabricated and zero rows are shown rather than fixtures — the canon fallback-fixture rule (api.md:167-169): a fixture source must be visible and must never be presented as admitted runtime truth, so nothing is presented at all. The page returns when the daemon answers.</p>
+    </div>
+    <div class="row">
+      <a class="act ghost" href="${LINK_AUTOMATIONS}">Automations →</a>
+      <a class="act ghost" href="${LINK_WORK}">Work →</a>
+    </div>`;
+}
+
+// ---------------------------------------------------------------------------------------------
+export function render(model, ctx) {
+  const inner = daemonUnreachable(model)
+    ? `${scopeBanner()}${unavailableView(model)}${rollupAbsences()}`
+    : `${scopeBanner()}${rollupAbsences()}
+      ${schedulerPane(model.scheduler, model.operations)}
+      ${executionPane(model.operations)}
+      ${failoverPane(model.failoverRuns, model.failoverPlans)}
+      ${incidentsPane(model.incidents, model.recovery)}
+      ${providersPane(model.providers)}
+      ${spendPane(model.spend)}
+      ${storagePane(model.storageBackends, model.storageIncidents)}
+      ${substratePane(model.substrate)}`;
+  const css = `:root{color-scheme:dark}
+  body{margin:0;background:#0c0d10;color:#e6e7ea;font:14px/1.55 -apple-system,Segoe UI,Roboto,sans-serif}
+  .wrap{max-width:920px;margin:0 auto;padding:40px 24px 80px}
+  a{color:#8ab4ff}
+  .brand{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#6f7280;margin-bottom:8px}
+  h1{font-size:26px;margin:0 0 6px;letter-spacing:-.02em}
+  .sub{color:#9a9da6;margin:0 0 22px;max-width:720px;overflow-wrap:anywhere}
+  .row{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin:0 0 22px}
+  .act{padding:8px 14px;border-radius:8px;border:0;background:#fff;color:#111;font:inherit;font-weight:600;text-decoration:none;cursor:pointer}
+  .act:hover{background:#eee}
+  .act.ghost{background:transparent;color:#cbd0da;border:1px solid #2a2c33}
+  .act.ghost:hover{color:#fff;border-color:#3a3d45}
+  .act[disabled]{opacity:.45;cursor:not-allowed}
+  h2{font-size:13px;letter-spacing:.04em;text-transform:uppercase;color:#878a93;margin:26px 0 10px;font-weight:600}
+  .card{display:flex;align-items:center;gap:14px;padding:14px 16px;border:1px solid #24262d;border-radius:12px;background:#15171c;margin-bottom:8px;text-decoration:none;color:inherit}
+  .card .main{flex:1;min-width:0}
+  .card .name{font-weight:600;color:#fff}
+  .card .meta{color:#878a93;font-size:12.5px;margin-top:3px;overflow-wrap:anywhere}
+  .pill{display:inline-block;padding:2px 9px;border-radius:999px;font-size:11px;border:1px solid;white-space:nowrap;margin-left:8px}
+  .ok{color:#46c277;border-color:#235c3b;background:#11281b}
+  .warn{color:#d6a13a;border-color:#5c4a23;background:#28220f}
+  .muted{color:#9a9da6;border-color:#2a2c33}
+  .empty{color:#6f7280;padding:18px;border:1px dashed #24262d;border-radius:12px;overflow-wrap:anywhere;margin-bottom:8px}
+  .gapcard{padding:14px 16px;border:1px dashed #5c4a23;border-radius:12px;background:#15130c;margin:0 0 18px;overflow-wrap:anywhere}
+  .scope{padding:10px 14px;border:1px solid #2a3a5c;border-radius:10px;background:#0e1420;color:#9db4d8;font-size:12.5px;margin:0 0 18px;overflow-wrap:anywhere}
+  .seedblocked{padding:8px 12px;border:1px dashed #5c4a23;border-radius:8px;background:#15130c;color:#b8a06a;font-size:12px;margin:0 0 12px;overflow-wrap:anywhere}
+  code{font-size:11.5px;color:#aab;background:#0e0f13;padding:1px 5px;border-radius:4px}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin-bottom:8px}
+  th{text-align:left;color:#878a93;font-weight:600;font-size:11.5px;text-transform:uppercase;letter-spacing:.04em;padding:6px 10px;border-bottom:1px solid #24262d}
+  td{padding:8px 10px;border-bottom:1px solid #1b1d23;overflow-wrap:anywhere}
+  @media(max-width:760px){.wrap{padding:24px 14px 56px}.card{align-items:flex-start}table{display:block;overflow-x:auto;max-width:100%}}`;
+  const head = `<h1 id="ops-owner">Operations</h1>
+    <p class="sub">The infrastructure cockpit — scheduler health, execution health, cross-provider failover, environment incidents, provider health, customer-borne spend, storage custody, substrate status — read-first over the daemon families that exist today. The <a href="${SEED_READOUT}">T2 Operations readout →</a> is the rehome source and keeps serving untouched (seed-preservation invariant).</p>`;
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Operations · Hypervisor</title><style>${css}</style></head><body><div class="wrap"><div class="brand">IOI Hypervisor</div>${head}${inner}</div></body></html>`;
+}
+
+export const meta = {
+  slug: "operations",
+  route: LEGACY_ROUTE,
+  verifier: "scripts/verify-hypervisor-operations-cockpit.mjs",
+  certification: "n/a",
+};

--- a/docs/architecture/_meta/shipped-products.v1.json
+++ b/docs/architecture/_meta/shipped-products.v1.json
@@ -73,6 +73,7 @@
           "/__ioi/missions/incidents",
           "/__ioi/ontology/explorer",
           "/__ioi/ontology/manager",
+          "/__ioi/operations-cockpit",
           "/__ioi/packages/marketplace",
           "/__ioi/packages/registry",
           "/__ioi/pipeline",
@@ -113,8 +114,8 @@
           "/work/new-session",
           "/work/sessions"
         ],
-        "expected_count": 54,
-        "sha256": "7f3a790f853e578230fede3209a8d70f146ef846ff76a1e0836d47c24907f7c1",
+        "expected_count": 55,
+        "sha256": "f0729dce227df1c94be20f59125a87901cbc10af544bb5dccd2fd6a2b30afa01",
         "browser_verification_id": "served-surface-smoke"
       },
       "state_authority_mode": "daemon_authoritative_projection",


### PR DESCRIPTION
## Scope ruling

**NOT Operations completion.** SURF-operations stays **OPEN**: its manifest acceptance (injected-fault detection, typed incident open, authority preview, remediation/failover execution, receipts/events, owner-app readback, restart/rollback/support export) is **W3.2/W3.3-owned**, and its seed gate carries the **typed-blocked scheduler residual** — a block record never opens work, and this PR touches neither the seed-provenance file nor the seed graphs. Same scope-ruled shape as the /work and /home slices (#246/#247): a `-cockpit` verifier, **not** a `-journey`; every durable record in this cut is stamped partial pre-W3.

## The mount — three places, one cut

- `docs/architecture/_meta/shipped-products.v1.json` route inventory: `/__ioi/operations-cockpit` added, **54→55** with recomputed digest (`/operations` was already a v2 route-table row; the browser smoke's `assertManifestRoutes` pins count + digest).
- `scripts/smoke-product-surfaces.mjs` `canonicalSurfaceMounts`: derived from the new surface-registry row (`slug: operations`, `canonical_route: "/operations"`, fresh legacy lane `/__ioi/operations-cockpit`) — marker + ownership contract now assert the Operations owner at the canonical route.
- v2 route-table row for `/operations` re-ruled: the bound Operations surface module serves the canonical route (the W0.1 shell no longer shadows it); `serving_today` names the canonical mount, the fresh legacy lane, and the protected T2 seed `/__ioi/operations`, which keeps serving untouched (rehome source; seed-preservation invariant).
- The serve marker (`sendOwnedSurfaceHtml(..., servedRoute)`) names the mount that served: `x-ioi-surface-route: /operations` · `x-ioi-surface-owner: Operations`.

## Read families composed (compose only what exists — pinned mechanically at /v1)

Eleven per-family reads, zero fixture fallback, per-plane "unknown, not zero" degradation, daemon-outage typed unavailability page with zero fabricated counts (api.md:167-169):

`GET /v1/hypervisor/scheduler/status` · `GET /v1/hypervisor/operations` (execution health) · `GET /v1/hypervisor/failover/runs` · `GET /v1/hypervisor/failover/plans` · `GET /v1/hypervisor/incidents` · `GET /v1/hypervisor/recovery-attempts` · `GET /v1/hypervisor/providers` · `GET /v1/hypervisor/provider-spend/reconciliation` · `GET /v1/hypervisor/storage-backends` · `GET /v1/hypervisor/storage-incidents` · `GET /v1/hypervisor/substrate/status`

Scheduler split held: scheduler **HEALTH** renders here (liveness pinned value-equal to the daemon's own read); scheduler **OBJECT** truth (schedules/triggers/concurrency/failure policy) is Automations-owned and deep-links the live `/automations` mount. The customer-borne spend rule renders verbatim; reserved estimates are never presented as spend; a fail-closed REFUSED failover run renders its refusal reason verbatim as evidence.

## Every typed absence, with its owning unit

**Route-missing W3 projections (typed on the page, pinned mechanically at /v1 — never simulated):**
- `infrastructure_jobs_projection` — no unified infrastructure-jobs route exists; per-family reads are never merged into a fabricated jobs rollup (W3 backend build, subjects via `subject_attachments`).
- `rpo_rto_rollup` — no RPO/RTO + degraded/partition posture rollup route exists.
- `capacity_utilization_overview` — no cross-pool capacity overview route exists.

**Disabled-named-gaps (exact reason + owning unit on each control):**
- `w3-fault-remediation` — **W3.2**: typed incident open + infrastructure remediation (SURF-operations' fault-matrix acceptance); the incident/recovery records themselves are real reads.
- `w3-failover-execution` — **W3.2** (W3.3 restore ladder behind it): failover run/arm/disarm/evaluate; the daemon routes exist and park wallet-gated at `awaiting_authority_*` — never automatic authority; this slice wires no authority-crossing verb.
- `w3-archive-custody-ops` — **W3.3**: archive export/verify/restore/repair (`POST /v1/hypervisor/storage-archive-ops`, sealed-before-write) + backend credential/preflight crossings.

Automation-run remediation is **not** a gap: it is Automations-owned authority reached by a live delegation link to the `/automations` mount — Operations mints no authority of its own.

## The Home re-ruling (same cut, as the pins demanded)

`verify-hypervisor-home-cockpit.mjs` pinned the Operations absence REAL (`/operations` serves only the substrate shell) and Home's links as `data-ioi-named-gap="operations-mount"`. Both pins failed the day this mount landed and are re-ruled here:

- **Home links flipped live**: the pane header "Open Operations →" → `/operations`; parked-run rows → `/operations#ops-failover`; failed-run rows → `/operations#ops-execution` (all `data-ioi-operations-link`); the operations-mount disabled-named-gap renders nowhere; the outage page gains the Operations quick link.
- **home-cockpit verifier re-ruled**: asserts the live links + that the former gap is gone, and pins the mount REAL (200 under the Operations owner at the canonical route, cockpit scope marker present). `check:home-cockpit` stays green — **40/40**.
- `check:operations-cockpit` closes the loop from the other side: Home's flipped links resolve onto this mount.

## Gates run (all green locally, isolated daemon+serve from this branch's source)

- `check:operations-cockpit` **36/36** (new; wired in `package.json` + the CI journeys step exactly as `check:home-cockpit` is) — isolated daemon+serve spawn (healthz wait, bootstrap token from log, `ioi_session` cookie, `PRODUCT_UI_PORT`); mount + marker; real reads; mechanical /v1 pins (11 families exist, zero rollup families); honest-empty before seeding; seeded fixtures (scheduled automation, failover plan, fail-closed refused run, storage backend) render as real rows; Home's flipped links resolve; reload + daemon-restart survival of the read plane; typed outage page; 3-posture browser matrix.
- `check:home-cockpit` **40/40** · `check:work-cockpit` **46/46** · `check:governance-journey` 20/20 · `check:applications-journey` 27/27 · `check:projects-saga` 11/11.
- The five bundled npm gates: `check:architecture-contracts`, `check:architecture-docs`, `check:mutation-foundation`, `check:mutation-handlers`, `check:admission-evidence`.
- `check:shipped-products` + `test:shipped-products` (route inventory 54→55, digest recomputed).
- Browser-smoke route pin: scoped `smoke:product-surfaces` **3/3** on each of `/operations`, `/__ioi/operations-cockpit`, `/home` (manifest count+digest asserted at startup on every run).
- `check:seed-provenance` (untouched file, full tracked gate green) · `check:source-neutral` (all of apps/hypervisor clean) · `check:shell-parity` 6/6 · `check:ported-seed` 413/413 · `check:owned-product-ui` · `npm run lint` · `npm run typecheck`.
- **No Rust touched** — the daemon binary for all runs was built from this branch's unmodified Rust source; `cargo fmt`/`cargo test` not applicable to this cut.

The WatchEvents fence (DEF-SPA-WATCHEVENTS-1) was not widened; `docs/architecture/_meta/canon-to-code-delta.md` deliberately untouched (the closing ledger PR carries the rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)