### PR TITLE
feat(hypervisor): session writes are identity-first — rule E gated under every posture, principal-bound receipts; internal-dispatch token for daemon orchestration (closes the #246 finding; next-legs V Leg 3)

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-work-cockpit.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-work-cockpit.mjs
@@ -21,9 +21,11 @@
 //     receipt ref recorded; stop/archive stay typed absences;
 //   - bare /sessions answers the typed 410 at HTTP + body level (no redirect alias);
 //   - deep link ≡ click-nav; reload + daemon-restart survival;
-//   - identity posture PROBED HONESTLY, recorded not hidden (gated → typed refusal asserted;
-//     ungated under loopback dev posture → current truth asserted + FINDING row, the same
-//     W1.1/G-2 class the ontology/automations findings tracked — never gated surface-side);
+//   - the identity GATE (the #246 finding CLOSED — the #236/#240 W1.1/G-2 class): every session
+//     write verb refuses typed 401 request_principal_required for anonymous callers under
+//     loopback posture (rule E — before any record load, so no 404 existence oracle), the forged
+//     internal-dispatch token forwards inert, the serve lane surfaces the refusal verbatim, and
+//     the durable provision/teardown receipts bind acting_principal_ref (INV-37);
 //   - the 3-posture browser matrix on /work.
 //
 // Exit: 0 pass · 1 fail · 2 blocked (daemon binary missing).
@@ -158,6 +160,20 @@ function sessionFamilyRoutes(index) {
 
 const sessGet = async (ref) => (await jd(`/v1/hypervisor/sessions/${encodeURIComponent(ref)}`)).body?.session || null;
 
+// Persisted session receipt by kind + ref (INV-37 assertions read the DURABLE receipt, not the
+// response projection).
+const readSessionReceipt = (kind, ref) => {
+  try {
+    for (const f of fs.readdirSync(path.join(dataDir, "receipts"))) {
+      try {
+        const j = JSON.parse(fs.readFileSync(path.join(dataDir, "receipts", f), "utf8"));
+        if (j.kind === kind && j.session_ref === ref) return j;
+      } catch { /* not JSON */ }
+    }
+  } catch { /* no receipts yet */ }
+  return null;
+};
+
 async function run() {
   daemonPort = await freePort();
   DAEMON = `http://127.0.0.1:${daemonPort}`;
@@ -205,21 +221,28 @@ async function run() {
       && !idxStr.includes("harness-session-launches"),
     JSON.stringify(sessionLaunchPaths));
 
-  // -- identity posture: probed HONESTLY on the daemon, recorded not hidden ------------------
+  // -- identity GATE (the #246 finding CLOSED — the #236/#240 class): session writes are
+  // identity-first under EVERY posture, loopback included. The old FINDING(typed) rows are
+  // REPLACED by these hard assertions.
   const anonCreate = await jd("/v1/hypervisor/sessions", { method: "POST", body: JSON.stringify({}) }, false);
-  let anonProbeRef = "";
-  if (anonCreate.status === 401 || anonCreate.status === 403) {
-    ok("an unauthenticated direct daemon session create refuses TYPED (the family is identity-gated)",
-      !!(anonCreate.body?.error?.code || anonCreate.body?.code),
-      `${anonCreate.status}/${anonCreate.body?.error?.code || anonCreate.body?.code}`);
-  } else {
-    anonProbeRef = anonCreate.body?.session_ref || "";
-    ok("current truth asserted: an unauthenticated direct daemon session create CROSSES (202, admitted as user://local-operator) under loopback dev posture — the family is ungated on loopback",
-      anonCreate.status === 202 && anonCreate.body?.owner_ref === "user://local-operator" && !!anonProbeRef,
-      `status ${anonCreate.status} · owner ${anonCreate.body?.owner_ref}`);
-    ok("FINDING(typed): session writes cross with no identity envelope under loopback dev posture (W1.1/G-2 class)", true,
-      "session_request_owner (lifecycle_routes.rs) resolves no principal on unenforced loopback and adjudicates the caller as user://local-operator — the same class the ontology and automations findings tracked (both since closed identity-first); the exposed/enforced postures DO refuse typed (asserted next); the fix is the identity-first pull at the daemon, never a surface-side gate");
-  }
+  ok("GATE: an unauthenticated direct daemon session create refuses TYPED 401 request_principal_required under loopback dev posture — loopback is NOT an identity exemption for governed writes, and no session is admitted",
+    anonCreate.status === 401 && anonCreate.body?.error?.code === "request_principal_required",
+    `${anonCreate.status}/${anonCreate.body?.error?.code}`);
+  // Rule E ordering: the 401 is owed BEFORE the record load, so a bogus ref answers 401 (never
+  // the 404 existence oracle) on every write verb of the family.
+  const anonExecute = await jd("/v1/hypervisor/sessions/session:rule-e-probe/execute", { method: "POST", body: JSON.stringify({ intent: "probe" }) }, false);
+  const anonPorts = await jd("/v1/hypervisor/sessions/session:rule-e-probe/ports/revoke", { method: "POST", body: JSON.stringify({}) }, false);
+  const anonTeardown = await jd("/v1/hypervisor/sessions/session:rule-e-probe", { method: "DELETE" }, false);
+  ok("GATE rule E: anonymous execute + ports-revoke + teardown on an unknown ref ALL answer the typed 401 — identity precedes the record load, so no 404 existence oracle exists for anonymous callers",
+    [anonExecute, anonPorts, anonTeardown].every((r) => r.status === 401 && r.body?.error?.code === "request_principal_required"),
+    `${anonExecute.status}/${anonPorts.status}/${anonTeardown.status}`);
+  // The per-boot internal dispatch token (the daemon's own orchestration lane) is unforgeable
+  // from outside: a caller-supplied value forwards inert.
+  const forged = await jd("/v1/hypervisor/sessions", { method: "POST", body: JSON.stringify({}) }, false,
+    { "x-ioi-internal-dispatch": "idisp_forged0000000000000000000000000000000000000000000000000000000000" });
+  ok("GATE: a FORGED x-ioi-internal-dispatch token forwards inert — the anonymous create still refuses 401 (the per-boot secret lives only in daemon process memory and is never emitted)",
+    forged.status === 401 && forged.body?.error?.code === "request_principal_required",
+    `${forged.status}/${forged.body?.error?.code}`);
   // Exposure-marked anonymous create: enforcement is context-aware (auto mode enforces when
   // exposed) — the same anonymous body must refuse TYPED once the request is marked forwarded.
   const exposedAnon = await jd("/v1/hypervisor/sessions", { method: "POST", body: JSON.stringify({}) }, false, { "x-ioi-forwarded": "product-shell" });
@@ -288,9 +311,8 @@ async function run() {
     deepLink.text.includes("Overview (W0.6)")
       && deepLink.text.includes("W3 C-1 backend row")
       && deepLink.text.includes('data-ioi-w3-absence="subject_attachments"'));
-  ok("owner-filtered honest-empty: no sessions render for the fresh operator principal (session truth is owner-filtered before counts — the loopback probe's session never leaks in)",
-    deepLink.text.includes("No sessions for this principal yet")
-      && (!anonProbeRef || !deepLink.text.includes(anonProbeRef)));
+  ok("owner-filtered honest-empty: no sessions render for the fresh operator principal (session truth is owner-filtered before counts, and the gate admitted nothing anonymous to leak in)",
+    deepLink.text.includes("No sessions for this principal yet"));
 
   const freshSessions = await pageText(FRESH_SESSIONS);
   ok("the fresh legacy lane /__ioi/work-sessions serves the same sessions view",
@@ -337,26 +359,13 @@ async function run() {
     goneDeep.status === 410 && String(goneDeep.body.canonical_replacement_route || "").startsWith("/work/sessions"),
     `${goneDeep.status} → ${goneDeep.body.canonical_replacement_route}`);
 
-  // -- serve-lane identity posture: probed honestly, judged against the daemon posture --------
+  // -- serve-lane identity GATE: the ambient daemonFetch forwards the (absent) caller identity
+  // and the daemon's typed refusal surfaces on the PRG redirect — never a fake success.
   const anonServe = await act(FRESH_NEW_SESSION, "/actions/create-session", { initial_input: "anon serve-lane posture probe" }, { authenticated: false });
-  if (anonServe.q.get("refused")) {
-    ok("an anonymous serve-lane create surfaces the daemon's typed refusal on the PRG redirect (no session admitted)",
-      anonServe.status === 303 && !!anonServe.q.get("refused"), `refused=${anonServe.q.get("refused")}`);
-  } else {
-    const anonServeRef = anonServe.q.get("record") || "";
-    const anonServeRecord = (await jd(`/v1/hypervisor/sessions/${encodeURIComponent(anonServeRef)}`, {}, false)).body?.session || null;
-    ok("current truth asserted: an anonymous serve-lane create CROSSES and is adjudicated as the loopback operator (the serve lane inherits the daemon's loopback dev posture — the same FINDING, no second defect); the record reads back ONLY under that identity (owner scoping intact)",
-      anonServe.status === 303 && anonServe.q.get("acted") === "create-session"
-        && String(anonServe.q.get("receipt") || "").startsWith("receipt://hypervisor/session-provision/")
-        && anonServeRecord?.owner_ref === "user://local-operator"
-        && (await sessGet(anonServeRef)) === null,
-      `record ${anonServeRef} · owner ${anonServeRecord?.owner_ref}`);
-    if (anonServeRef) {
-      const anonTeardown = await jd(`/v1/hypervisor/sessions/${encodeURIComponent(anonServeRef)}`, { method: "DELETE" }, false);
-      ok("posture-probe hygiene: the probe session tears down under its own (loopback-operator) identity — the daemon-owned destructive verb works today",
-        anonTeardown.status === 200 && anonTeardown.body?.decision === "torn_down", `status ${anonTeardown.status}`);
-    }
-  }
+  ok("GATE: an anonymous serve-lane create surfaces the daemon's typed refusal on the PRG redirect (refused=request_principal_required, no acted/receipt — no session admitted)",
+    anonServe.status === 303 && anonServe.q.get("refused") === "request_principal_required"
+      && !anonServe.q.get("acted") && !anonServe.q.get("receipt"),
+    `refused=${anonServe.q.get("refused")}`);
 
   // -- the journey this slice DOES own: create → admitted readback ----------------------------
   const PROJECT_REF = "project:work-cockpit-slice";
@@ -383,6 +392,11 @@ async function run() {
   ok("ANTI-MASQUERADE PIN: subject_attachments is EXACTLY [] on the record even though project_ref was supplied — create hardcodes the empty set (the typed W3 C-1 absence) and project_ref stayed a session field",
     Array.isArray(record?.subject_attachments) && record.subject_attachments.length === 0,
     JSON.stringify(record?.subject_attachments));
+  const provisionReceipt = readSessionReceipt("hypervisor.session.provision", sessionRef);
+  ok("INV-37: the durable provision receipt binds acting_principal_ref — the identity-resolved creating principal (equal to the record owner, never the loopback operator, never client-supplied)",
+    !!provisionReceipt && provisionReceipt.acting_principal_ref === record?.owner_ref
+      && provisionReceipt.acting_principal_ref !== "user://local-operator",
+    `acting ${provisionReceipt?.acting_principal_ref}`);
 
   const detail = await pageText(`${SESSIONS_VIEW}?session=${encodeURIComponent(sessionRef)}`);
   const bindingAdmitted = record?.harness_binding && (record.harness_binding.profile_ref || record.harness_binding.harness);
@@ -473,6 +487,10 @@ async function run() {
   ok("teardown journeys clean: DELETE answers torn_down with the teardown receipt recorded — the one destructive session verb that exists today",
     teardown.status === 200 && teardown.body?.decision === "torn_down" && teardownReceipts.length === 1,
     `${teardown.status} · ${teardownReceipts[0] || "no receipt"}`);
+  const teardownReceipt = readSessionReceipt("hypervisor.session.teardown", sessionRef);
+  ok("INV-37: the durable teardown receipt is committed AND binds acting_principal_ref — the authenticated principal that performed the destructive verb",
+    teardownReceipt?.status === "committed" && teardownReceipt?.acting_principal_ref === record?.owner_ref,
+    `status ${teardownReceipt?.status} · acting ${teardownReceipt?.acting_principal_ref}`);
   const afterTeardown = await sessGet(sessionRef);
   ok("the record survives teardown as truth (lifecycle_state torn_down), and the sessions view renders it honestly",
     afterTeardown?.lifecycle_state === "torn_down"

--- a/crates/node/src/bin/hypervisor_daemon_routes/goalrun_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/goalrun_routes.rs
@@ -2307,9 +2307,17 @@ async fn self_get(url: &str) -> Option<Value> {
         .ok()
 }
 
-async fn self_post(url: &str, body: &Value) -> (u16, Value) {
+/// Self-POST carrying the per-boot internal dispatch token (#240 lane, extended by the #246
+/// session-write gate): candidate-session creates run inside spawned invocation workers with no
+/// caller HeaderMap in scope, so they cross the identity-gated Session family as the daemon's
+/// OWN dispatch. The token lives only in process memory and is never emitted in any response;
+/// a caller-supplied value can never match it. The goal-run start handler that authorizes the
+/// invocation remains a pinned admission-evidence open lead — when IT gains identity, the
+/// resolved principal should thread through here instead.
+async fn self_post_internal_dispatch(st: &DaemonState, url: &str, body: &Value) -> (u16, Value) {
     let response = reqwest::Client::new()
         .post(url)
+        .header("x-ioi-internal-dispatch", &st.internal_dispatch_token)
         .json(body)
         .timeout(Duration::from_millis(20000))
         .send()
@@ -9863,8 +9871,10 @@ async fn run_invocation(
         })
     };
 
-    // Isolated candidate session (its workspace IS the candidate namespace).
-    let (status, created) = self_post(
+    // Isolated candidate session (its workspace IS the candidate namespace). The Session family
+    // is identity-gated (#246); this spawned worker crosses as the daemon's own dispatch.
+    let (status, created) = self_post_internal_dispatch(
+        &st,
         &format!("{}/v1/hypervisor/sessions", st.base_url),
         &json!({
             "session_ref": candidate_session_ref,

--- a/crates/node/src/bin/hypervisor_daemon_routes/ioi_agent_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/ioi_agent_routes.rs
@@ -73,6 +73,55 @@ fn kernel_err(
     )
 }
 
+/// Identity-bearing headers forwarded on Session-family self-calls — the orchestration_routes
+/// precedent (#240): forwarding is OPPORTUNISTIC (an authenticated launch's cookie/bearer rides
+/// through so the created Session binds the REAL caller), and the per-boot internal dispatch
+/// token authenticates the daemon's own dispatch when no caller session resolves (#246 gate).
+/// A caller-supplied token value forwards inert — it can never match the per-boot secret,
+/// which is never emitted in any response.
+const SESSION_SELF_CALL_FORWARDED_HEADERS: &[&str] = &["authorization", "cookie"];
+
+/// Self-call the identity-gated Session family (create / execute): the inbound caller's
+/// identity headers forward verbatim, and the per-boot internal dispatch token marks the
+/// crossing as the daemon's own orchestration dispatch (the #240 lane).
+async fn self_call_session(
+    st: &DaemonState,
+    inbound: &axum::http::HeaderMap,
+    url: &str,
+    method: &str,
+    body: Option<&Value>,
+) -> (u16, Value) {
+    let client = reqwest::Client::new();
+    let mut builder = match method {
+        "GET" => client.get(url),
+        _ => client.post(url),
+    };
+    for name in SESSION_SELF_CALL_FORWARDED_HEADERS {
+        if let Some(value) = inbound.get(*name).and_then(|value| value.to_str().ok()) {
+            builder = builder.header(*name, value);
+        }
+    }
+    builder = builder.header("x-ioi-internal-dispatch", &st.internal_dispatch_token);
+    let builder = match body {
+        Some(payload) => builder.json(payload),
+        None => builder,
+    };
+    match builder
+        .timeout(Duration::from_millis(1_800_000))
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            (status, resp.json::<Value>().await.unwrap_or(Value::Null))
+        }
+        Err(err) => (
+            0,
+            json!({ "error": { "code": "self_call_failed", "message": err.to_string() } }),
+        ),
+    }
+}
+
 async fn self_call(url: &str, method: &str, body: Option<&Value>) -> (u16, Value) {
     let client = reqwest::Client::new();
     let builder = match method {
@@ -1491,7 +1540,9 @@ pub(crate) async fn handle_ioi_agent_launch(
                 "reconciliation": reconciliation,
             });
         } else {
-            let (status, executed) = self_call(
+            let (status, executed) = self_call_session(
+                &st,
+                &headers,
                 &format!(
                     "{}/v1/hypervisor/sessions/{}/execute",
                     st.base_url,
@@ -1626,7 +1677,9 @@ pub(crate) async fn handle_ioi_agent_launch(
             session_body["model_route_ref"] = json!(route_ref);
         }
     }
-    let (created_status, created) = self_call(
+    let (created_status, created) = self_call_session(
+        &st,
+        &headers,
         &format!("{}/v1/hypervisor/sessions", st.base_url),
         "POST",
         Some(&session_body),
@@ -1803,8 +1856,10 @@ pub(crate) async fn handle_ioi_agent_launch(
     } else {
         json!({ "intent": delivered_intent })
     };
+    // The Session execute arm is identity-gated (#246): the probe must cross AS the caller (or
+    // as the daemon's own dispatch) so the 403 it relays is the WALLET challenge, never a 401.
     let (challenge_status, mut challenge) =
-        self_call(&challenge_url, "POST", Some(&challenge_body)).await;
+        self_call_session(&st, &headers, &challenge_url, "POST", Some(&challenge_body)).await;
     if challenge_status != 403 {
         return bad(
             StatusCode::BAD_GATEWAY,

--- a/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
@@ -9768,6 +9768,65 @@ fn session_request_owner(
     Ok("user://local-operator".to_string())
 }
 
+/// Typed identity/scope refusal for the Session family (the ODK ontology #236 / automations #240
+/// precedent): the status is derived from the refusal kind; the body keeps the family's
+/// `{"error":{code,message}}` envelope so serve-lane refusal surfacing stays verbatim.
+fn session_scope_refusal(
+    error: super::substrate_store::RequestScopeRefusal,
+) -> (StatusCode, Json<Value>) {
+    use super::substrate_store::RequestScopeRefusal;
+    let status = match error {
+        RequestScopeRefusal::AuthenticationRequired
+        | RequestScopeRefusal::PrincipalIdentityInvalid => StatusCode::UNAUTHORIZED,
+        RequestScopeRefusal::TenantAuthorityRequired
+        | RequestScopeRefusal::ResourceScopeRequired
+        | RequestScopeRefusal::ResourceOwnerMismatch => StatusCode::FORBIDDEN,
+        RequestScopeRefusal::SubstrateUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+    };
+    (
+        status,
+        Json(json!({"error":{"code":error.code(),"message":error.message()}})),
+    )
+}
+
+/// Identity-first owner resolution for the Session WRITE verbs (create / execute / ports-revoke /
+/// teardown) — the #246 finding closed (the #236/#240 W1.1/G-2 class). Rule E: the typed 401 is
+/// owed BEFORE any record read, so an anonymous caller gets no existence oracle and no
+/// field-shape probe. Loopback posture is NOT an identity exemption for governed writes; the
+/// `user://local-operator` fallback in `session_request_owner` above remains a READ-lane
+/// projection convenience only (an anonymous loopback read projects the legacy local-operator
+/// scope, which after this gate can no longer acquire new writes over HTTP).
+///
+/// The daemon's OWN orchestration dispatches (ioi-agent launch, goal-run candidate sessions)
+/// cross with the per-boot internal dispatch token instead of a session — the #240 lane: the
+/// token lives only in process memory and is never emitted in any response, so a valid
+/// presentation can only originate from this daemon process. Those dispatches keep the
+/// historical loopback-operator attribution until their OWN handlers gain identity (both are
+/// pinned open leads in the admission-evidence H-baseline); a caller-authenticated launch
+/// forwards its cookie and binds the real principal instead.
+fn session_request_write_owner(
+    st: &DaemonState,
+    headers: &HeaderMap,
+) -> Result<String, (StatusCode, Json<Value>)> {
+    if deployment_auth_posture(&st.data_dir, headers) == "exposed_untrusted" {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(
+                json!({"error":{"code":"session_authenticated_principal_required","message":"An exposed Session endpoint requires enforced identity."}}),
+            ),
+        ));
+    }
+    match super::substrate_store::resolve_request_identity(&st.data_dir, headers) {
+        Ok(identity) => Ok(identity.principal_ref),
+        Err(error) => {
+            if super::orchestration_routes::internal_dispatch_authorized(st, headers) {
+                return Ok("user://local-operator".to_string());
+            }
+            Err(session_scope_refusal(error))
+        }
+    }
+}
+
 /// Cross-process registry lock. Its name is fixed and its directory is independently pinned;
 /// the lock serializes strict WAL census, reservation, provisioning, and recovery across daemon
 /// processes sharing one data directory.
@@ -10478,6 +10537,9 @@ fn prepare_session_create_bundle(
         "state_root_ref": environment_status.get("state_root_ref"),
         "initial_input_receipt_ref": initial_input_projection.as_ref().and_then(|projection| projection.get("receipt_ref")).cloned().unwrap_or(Value::Null),
         "owner_ref": owner_ref,
+        // INV-37: the create's acting principal IS the identity-resolved owner recorded in the
+        // reserved intent (the #246 gate) — deterministic under WAL replay, never re-derived.
+        "acting_principal_ref": owner_ref,
         "request_hash": request_hash,
         "created_at": created_at,
         "runtimeTruthSource": "daemon-runtime"
@@ -11419,7 +11481,7 @@ fn recover_pending_session_lifecycle(st: &DaemonState, mut record: Value) -> Res
             .and_then(Value::as_str)
             .ok_or_else(|| "pending port revoke has no receipt_ref".to_string())?;
         let ports = mark_session_ports_revoked(&record);
-        let receipt = json!({
+        let mut receipt = json!({
             "id": receipt_ref, "kind": "hypervisor.session.port_revoke",
             "session_ref": session_ref,
             "revoked_port": pending.get("revoked_port").cloned().unwrap_or(Value::Null),
@@ -11427,6 +11489,12 @@ fn recover_pending_session_lifecycle(st: &DaemonState, mut record: Value) -> Res
             "created_at": pending.get("created_at").cloned().unwrap_or(Value::Null),
             "committed_at": iso_now(), "runtimeTruthSource": "daemon-runtime"
         });
+        // INV-37: the replayed receipt binds the principal the PREPARED anchor recorded at
+        // admission. A pre-gate pending record has none; the field is then honestly absent —
+        // never defaulted, never fabricated at replay time.
+        if let Some(acting) = pending.get("acting_principal_ref").and_then(Value::as_str) {
+            receipt["acting_principal_ref"] = json!(acting);
+        }
         persist_session_lifecycle_stage(
             &st.data_dir,
             "receipts",
@@ -11463,7 +11531,7 @@ fn recover_pending_session_lifecycle(st: &DaemonState, mut record: Value) -> Res
             .unwrap_or(false);
         let _ = remove_session_workspace(workspace_root);
         let workspace_removed = present_before && !Path::new(workspace_root).exists();
-        let receipt = json!({
+        let mut receipt = json!({
             "id": receipt_ref, "kind": "hypervisor.session.teardown",
             "session_ref": session_ref,
             "revoked_port": pending.get("revoked_port").cloned().unwrap_or(Value::Null),
@@ -11471,6 +11539,11 @@ fn recover_pending_session_lifecycle(st: &DaemonState, mut record: Value) -> Res
             "created_at": pending.get("created_at").cloned().unwrap_or(Value::Null),
             "committed_at": iso_now(), "runtimeTruthSource": "daemon-runtime"
         });
+        // INV-37 at replay: bind the admission-time principal from the prepared anchor when it
+        // recorded one; a pre-gate pending record keeps the field honestly absent.
+        if let Some(acting) = pending.get("acting_principal_ref").and_then(Value::as_str) {
+            receipt["acting_principal_ref"] = json!(acting);
+        }
         persist_session_lifecycle_stage(
             &st.data_dir,
             "receipts",
@@ -11637,6 +11710,28 @@ fn load_owned_session_record(
     session_ref: &str,
 ) -> Result<Value, (StatusCode, Json<Value>)> {
     let owner_ref = session_request_owner(&st.data_dir, headers)?;
+    load_session_record_owned_by(st, &owner_ref, session_ref)
+}
+
+/// The WRITE-verb variant: identity resolves FIRST (rule E — the typed 401 precedes the record
+/// load, so no 404 existence oracle exists for anonymous callers), then ownership is judged.
+/// Returns the resolved acting principal alongside the record so mutation receipts can bind it
+/// (INV-37).
+fn load_owned_session_record_for_write(
+    st: &DaemonState,
+    headers: &HeaderMap,
+    session_ref: &str,
+) -> Result<(String, Value), (StatusCode, Json<Value>)> {
+    let owner_ref = session_request_write_owner(st, headers)?;
+    let record = load_session_record_owned_by(st, &owner_ref, session_ref)?;
+    Ok((owner_ref, record))
+}
+
+fn load_session_record_owned_by(
+    st: &DaemonState,
+    owner_ref: &str,
+    session_ref: &str,
+) -> Result<Value, (StatusCode, Json<Value>)> {
     let record = match load_session_record_strict(st, session_ref) {
         Ok(Some(record)) => record,
         Ok(None) => {
@@ -11698,7 +11793,10 @@ pub(crate) async fn handle_session_create(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> (StatusCode, Json<Value>) {
-    let owner_ref = match session_request_owner(&st.data_dir, &headers) {
+    // #246 finding closed — identity FIRST (rule E): an anonymous caller is owed the typed 401
+    // before any field validation runs, so no field-shape probe exists for unauthenticated
+    // callers under ANY posture. A Session is authored durable work, not an anonymous append.
+    let owner_ref = match session_request_write_owner(&st, &headers) {
         Ok(owner) => owner,
         Err(response) => return response,
     };
@@ -21225,9 +21323,12 @@ pub(crate) async fn handle_session_execute(
     Json(body): Json<Value>,
 ) -> (StatusCode, Json<Value>) {
     // Ownership is resolved before intent parsing and, critically, before the wallet gate can
-    // disclose policy/request hashes for another principal's Session.
-    let record = match load_owned_session_record(&st, &headers, &session_id) {
-        Ok(record) => record,
+    // disclose policy/request hashes for another principal's Session. Identity-first (rule E,
+    // #246): the typed 401 precedes the record load, so no existence oracle exists for
+    // anonymous callers; the daemon's own orchestration dispatches cross with the per-boot
+    // internal dispatch token.
+    let record = match load_owned_session_record_for_write(&st, &headers, &session_id) {
+        Ok((_acting_principal_ref, record)) => record,
         Err(response) => return response,
     };
     let workspace_root = record
@@ -21717,10 +21818,13 @@ pub(crate) async fn handle_session_ports_revoke(
     headers: HeaderMap,
     AxumPath(session_id): AxumPath<String>,
 ) -> (StatusCode, Json<Value>) {
-    let record = match load_owned_session_record(&st, &headers, &session_id) {
-        Ok(record) => record,
-        Err(response) => return response,
-    };
+    // #246 finding closed — identity FIRST (rule E): the typed 401 precedes the record load
+    // (no existence oracle); the resolved principal binds into the revoke receipt (INV-37).
+    let (acting_principal_ref, record) =
+        match load_owned_session_record_for_write(&st, &headers, &session_id) {
+            Ok(resolved) => resolved,
+            Err(response) => return response,
+        };
     let receipt_ref = format!(
         "receipt://hypervisor/session-port-revoke/{}",
         session_identity_digest(&session_id)
@@ -21736,6 +21840,7 @@ pub(crate) async fn handle_session_ports_revoke(
         "kind": "hypervisor.session.port_revoke",
         "session_ref": session_id,
         "revoked_port": expected_port,
+        "acting_principal_ref": acting_principal_ref,
         "status": "prepared",
         "created_at": created_at,
         "runtimeTruthSource": "daemon-runtime",
@@ -21765,7 +21870,7 @@ pub(crate) async fn handle_session_ports_revoke(
     if let Some(object) = pending.as_object_mut() {
         object.insert(
             "pending_port_revoke".into(),
-            json!({"receipt_ref":receipt_ref,"revoked_port":expected_port,"created_at":created_at}),
+            json!({"receipt_ref":receipt_ref,"revoked_port":expected_port,"acting_principal_ref":acting_principal_ref,"created_at":created_at}),
         );
         object.insert("latest_receipt_refs".into(), json!(receipt_refs.clone()));
     }
@@ -21784,6 +21889,7 @@ pub(crate) async fn handle_session_ports_revoke(
     let final_receipt = json!({
         "id": receipt_ref, "kind": "hypervisor.session.port_revoke",
         "session_ref": session_id, "revoked_port": revoked_port,
+        "acting_principal_ref": acting_principal_ref,
         "status": "committed", "created_at": created_at, "committed_at": iso_now(),
         "runtimeTruthSource": "daemon-runtime"
     });
@@ -22075,10 +22181,13 @@ pub(crate) async fn handle_session_teardown(
     headers: HeaderMap,
     AxumPath(session_id): AxumPath<String>,
 ) -> (StatusCode, Json<Value>) {
-    let record = match load_owned_session_record(&st, &headers, &session_id) {
-        Ok(record) => record,
-        Err(response) => return response,
-    };
+    // #246 finding closed — identity FIRST (rule E): the typed 401 precedes the record load
+    // (no existence oracle); the resolved principal binds into the teardown receipt (INV-37).
+    let (acting_principal_ref, record) =
+        match load_owned_session_record_for_write(&st, &headers, &session_id) {
+            Ok(resolved) => resolved,
+            Err(response) => return response,
+        };
     let workspace_root = record
         .get("workspace_root")
         .and_then(Value::as_str)
@@ -22103,6 +22212,7 @@ pub(crate) async fn handle_session_teardown(
         "session_ref": session_id,
         "revoked_port": expected_port,
         "workspace_removed": Value::Null,
+        "acting_principal_ref": acting_principal_ref,
         "status": "prepared",
         "created_at": created_at,
         "runtimeTruthSource": "daemon-runtime",
@@ -22136,6 +22246,7 @@ pub(crate) async fn handle_session_teardown(
                 "receipt_ref":receipt_ref, "revoked_port":expected_port,
                 "workspace_root":workspace_root,
                 "workspace_present_before":workspace_present_before,
+                "acting_principal_ref":acting_principal_ref,
                 "created_at":created_at
             }),
         );
@@ -22157,7 +22268,9 @@ pub(crate) async fn handle_session_teardown(
     let final_receipt = json!({
         "id": receipt_ref, "kind": "hypervisor.session.teardown",
         "session_ref": session_id, "revoked_port": revoked_port,
-        "workspace_removed": workspace_removed, "status": "committed",
+        "workspace_removed": workspace_removed,
+        "acting_principal_ref": acting_principal_ref,
+        "status": "committed",
         "created_at": created_at, "committed_at": iso_now(),
         "runtimeTruthSource": "daemon-runtime"
     });

--- a/crates/node/src/bin/hypervisor_daemon_routes/orchestration_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/orchestration_routes.rs
@@ -177,7 +177,10 @@ fn automation_scope_refusal(
 /// response, so a valid presentation can only originate from this daemon process. Internal
 /// dispatch is NOT a session: the run executes as the spec's stored `executor_identity`
 /// (the delegated durable authority), never as an ambient operator.
-fn internal_dispatch_authorized(st: &DaemonState, headers: &HeaderMap) -> bool {
+/// `pub(crate)` since the #246 session-write gate: the Session write lane admits the daemon's
+/// own orchestration dispatches (ioi-agent launch, goal-run candidate sessions) through this
+/// same per-boot token instead of a session — one token, one predicate, no second lane.
+pub(crate) fn internal_dispatch_authorized(st: &DaemonState, headers: &HeaderMap) -> bool {
     headers
         .get("x-ioi-internal-dispatch")
         .and_then(|v| v.to_str().ok())


### PR DESCRIPTION
## Finding closed

**Session writes ungated under loopback posture** (exposure-enforced postures did refuse 401) — the third identity-envelope finding of the W1.1/G-2 class, filed typed in #246 (next-legs IV Leg 3) on the daemon session family. Same class as the two already closed: ODK ontology writes (#236) and automations writes (#240).

The defect: `session_request_owner` (lifecycle_routes.rs) resolved no principal on unenforced loopback and adjudicated the caller as `user://local-operator`, so `POST /v1/hypervisor/sessions`, `POST :id/execute`, `POST :id/ports/revoke`, and `DELETE :id` all crossed anonymously. The family's writes flow through `persist_session_lifecycle_stage`/WAL helpers, so rule H's `persist_record` census never saw these handlers — which is exactly why this family needed the live-probe finding rather than the ratchet.

## The cut

- **Identity-first rule E** on all four write verbs: `session_request_write_owner` resolves identity via `substrate_store::resolve_request_identity` BEFORE any record load or field validation — typed `401 request_principal_required`, no 404 existence oracle, no field-shape probe. `exposed_untrusted` keeps its verbatim refusal. Reads stay ungated (house norm); the local-operator fallback is now read-lane projection only and can no longer acquire writes over HTTP.
- **INV-37 principal-bound receipts**: the durable provision receipt binds `acting_principal_ref` (the identity-resolved owner recorded in the reserved intent — deterministic under WAL replay); teardown + port-revoke bind the resolved principal into prepared + final receipts AND the pending anchors, so crash recovery replays the admission-time principal (pre-gate pending records keep the field honestly absent — never defaulted at replay, no `unwrap_or(Value::Null)`).
- **Internal dispatch (#240 pattern, not an open bypass)**: the daemon's own orchestration dispatches cross with the per-boot process-memory token — `self_call_session` (ioi-agent launch create/execute/challenge-relay) forwards the caller's cookie/authorization AND the token, so an authenticated launch binds the REAL principal (G-2 propagation, live-proven); the goal-run candidate-session create uses `self_post_internal_dispatch` (token-only in the spawned worker). `internal_dispatch_authorized` goes `pub(crate)` — one token, one predicate, no second lane. A forged token forwards inert (live-proven 401).
- **Verifier** (`check:work-cockpit`, CI-wired): the FINDING(typed) rows are REPLACED by hard gate assertions — anonymous daemon create 401; rule E on execute/ports-revoke/teardown against an unknown ref (401, never 404); forged-token inert; anonymous serve-lane create surfaces `refused=request_principal_required` on the PRG redirect with no receipt; durable provision + teardown receipts bind `acting_principal_ref` equal to the record owner and never the loopback operator. **48/48.**

## Live proof (isolated daemon + serve pair, fresh data dir)

Negative and positive both asserted:

```
anon create                       → 401 request_principal_required
anon execute   (bogus ref)        → 401 request_principal_required   (never 404 — rule E)
anon ports-revoke (bogus ref)     → 401 request_principal_required
anon teardown  (bogus ref)        → 401 request_principal_required
anon teardown  (REAL session)     → 401 request_principal_required   (no existence oracle)
anon create + FORGED idisp token  → 401 request_principal_required   (token forwards inert)
anon list (read, house norm)      → 200, owner-filtered empty
bootstrap → admitted create       → 202 · owner user://…0001 · provision receipt
   provision receipt              → acting_principal_ref == owner_ref == user://…0001
admitted teardown                 → 200 torn_down · committed receipt binds acting_principal_ref
anon ioi-agent launch             → session created via internal-dispatch lane (owner user://local-operator — historical attribution preserved; the launch handler itself is a pinned open lead)
authenticated ioi-agent launch    → created session binds the REAL principal (user://…0001)
```

## Sweep — every daemon governed-write family, live-probed anonymously under loopback

All **511 mutating route-method pairs** from the daemon's own `/v1` index were probed anonymously (`{}` body, isolated daemon). Headline: **42 families fully refuse anonymous mutation** (the session family now among them, CLOSED); **85 families still admit at least one anonymous verb under loopback**. Of the 359 admitted-anon probes, **133 map to handlers already pinned in the `check:admission-evidence` H-baseline** (typed open leads, tracked in CI), and **226 map to handlers rule H cannot see** (helper-mediated writes or validation-first paths — the same census blindness that hid the session family).

**Typed leftover (named, not silent):** the 226 rule-H-invisible loopback-ungated write verbs are program-scale (they span ~40 modules; largest: lifecycle_routes 57, nested-router families 40, ioi_intelligence 13, model-mount 11, odk 7, governance deletes 6, binding/terminals 6, plus the goal-orchestration and autonomous-systems ladders). They are NOT closed in this cut. Mechanical evidence: reproduce with an isolated daemon and anonymous probes of every mutating `/v1` route (the transcript's method); each probe names route → status → handler → H-baseline membership. This is the fourth-and-onward pull of the standing identity-envelope class: the H-baseline covers `persist_record`-visible handlers only, and a follow-up should either extend the rule-H census to the helper write seams (`persist_session_lifecycle_stage`, `admit_owner_scoped_write` wrappers, intelligence/odk `save` helpers) or land per-family cuts on the #236/#240/#246 pattern.

<details>
<summary><b>Family verdict table (127 families, live-probed)</b></summary>

| family | anon probes refused | verdict |
|---|---|---|
| /scim | 8/8 anon-refused | identity-gated (refuses anon) |
| /supervisor | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/agents | 0/8 anon-refused | loopback-ungated: 8 verb(s) admit anon (0 H-pinned, 8 rule-H-invisible) |
| /v1/chat | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/conversation-artifacts | 0/4 anon-refused | loopback-ungated: 4 verb(s) admit anon (1 H-pinned, 3 rule-H-invisible) |
| /v1/embeddings | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/event-streams | 2/2 anon-refused | identity-gated (refuses anon) |
| /v1/goal-orchestration | 0/40 anon-refused | loopback-ungated: 40 verb(s) admit anon (12 H-pinned, 28 rule-H-invisible) |
| /v1/hypervisor/agent-run-transcripts | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (1 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/agentops | 0/4 anon-refused | loopback-ungated: 4 verb(s) admit anon (0 H-pinned, 4 rule-H-invisible) |
| /v1/hypervisor/api-tokens | 2/2 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/approved-operations | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/artifact-availability-incidents | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/auth | 2/7 anon-refused | loopback-ungated: 5 verb(s) admit anon (3 H-pinned, 2 rule-H-invisible) |
| /v1/hypervisor/authority | 0/4 anon-refused | loopback-ungated: 4 verb(s) admit anon (2 H-pinned, 2 rule-H-invisible) |
| /v1/hypervisor/automation-affinities | 0/2 anon-refused | loopback-ungated: 2 verb(s) admit anon (0 H-pinned, 2 rule-H-invisible) |
| /v1/hypervisor/automation-executions | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/automations | 6/7 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/autonomous-systems | 0/13 anon-refused | loopback-ungated: 13 verb(s) admit anon (0 H-pinned, 13 rule-H-invisible) |
| /v1/hypervisor/backups | 3/4 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/budget | 0/2 anon-refused | loopback-ungated: 2 verb(s) admit anon (1 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/cloud-candidates | 0/2 anon-refused | loopback-ungated: 2 verb(s) admit anon (1 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/code-editor-adapter-launch-plans | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/collections | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/connectors | 1/11 anon-refused | loopback-ungated: 10 verb(s) admit anon (7 H-pinned, 3 rule-H-invisible) |
| /v1/hypervisor/custom-domain | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (1 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/data-sources | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/domain-apps | 7/7 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/domain-verifications | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (3 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/download-intents | 2/2 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/economics | 9/9 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/editor-access-leases | 1/2 anon-refused | loopback-ungated: 1 verb(s) admit anon (1 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/editor-host-provisioning-plans | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (1 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/editor-services | 0/5 anon-refused | loopback-ungated: 5 verb(s) admit anon (1 H-pinned, 4 rule-H-invisible) |
| /v1/hypervisor/env-config | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/env-files | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/environments | 3/9 anon-refused | loopback-ungated: 6 verb(s) admit anon (1 H-pinned, 5 rule-H-invisible) |
| /v1/hypervisor/eval-suites | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (3 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/exec | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/failover | 0/5 anon-refused | loopback-ungated: 5 verb(s) admit anon (1 H-pinned, 4 rule-H-invisible) |
| /v1/hypervisor/feedback-entries | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (3 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/foundry | 7/12 anon-refused | loopback-ungated: 5 verb(s) admit anon (5 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/governance | 1/16 anon-refused | loopback-ungated: 15 verb(s) admit anon (8 H-pinned, 7 rule-H-invisible) |
| /v1/hypervisor/guardrails | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/harness-bindings | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/harness-profiles | 0/5 anon-refused | loopback-ungated: 5 verb(s) admit anon (0 H-pinned, 5 rule-H-invisible) |
| /v1/hypervisor/harness-session-binding-admissions | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/harness-session-terminal-attachments | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/hypervisoros | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (0 H-pinned, 3 rule-H-invisible) |
| /v1/hypervisor/intelligence | 0/7 anon-refused | loopback-ungated: 7 verb(s) admit anon (4 H-pinned, 3 rule-H-invisible) |
| /v1/hypervisor/maintenance | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/managed-worker-instances | 3/3 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/managed-worker-lifecycle-admissions | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/marketplace | 12/12 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/mcp-gateway | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/memory-entries | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (0 H-pinned, 3 rule-H-invisible) |
| /v1/hypervisor/memory-mutation-proposals | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (3 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/memory-projections | 0/2 anon-refused | loopback-ungated: 2 verb(s) admit anon (0 H-pinned, 2 rule-H-invisible) |
| /v1/hypervisor/memory-spaces | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/model-route-mutation-admissions | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/model-routes | 0/8 anon-refused | loopback-ungated: 8 verb(s) admit anon (2 H-pinned, 6 rule-H-invisible) |
| /v1/hypervisor/model-weight-custody-admissions | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/odk/capability-lease-plans | 0/4 anon-refused | loopback-ungated: 4 verb(s) admit anon (3 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/odk/connector-mappings | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (2 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/odk/connector-sessions | 0/6 anon-refused | loopback-ungated: 6 verb(s) admit anon (5 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/odk/data-recipes | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (0 H-pinned, 3 rule-H-invisible) |
| /v1/hypervisor/odk/domain-ontologies | 3/3 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/odk/manifests | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (0 H-pinned, 3 rule-H-invisible) |
| /v1/hypervisor/odk/materialized-object-sets | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (1 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/odk/materializing-runs | 0/7 anon-refused | loopback-ungated: 7 verb(s) admit anon (5 H-pinned, 2 rule-H-invisible) |
| /v1/hypervisor/odk/ontology-projections | 0/5 anon-refused | loopback-ungated: 5 verb(s) admit anon (4 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/odk/policy-bound-data-views | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (0 H-pinned, 3 rule-H-invisible) |
| /v1/hypervisor/odk/surface-descriptors | 1/3 anon-refused | loopback-ungated: 2 verb(s) admit anon (1 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/odk/transformation-runs | 0/5 anon-refused | loopback-ungated: 5 verb(s) admit anon (4 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/oidc-config | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/org-invite | 2/2 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/outcome-deltas | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/packages | 5/5 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/physical-action-intent-admissions | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/placement | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (2 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/preferences | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (1 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/principals | 7/7 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/private-workspace-mount-admissions | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/product-surface-projections | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/projects | 1/3 anon-refused | loopback-ungated: 2 verb(s) admit anon (1 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/provider-accounts | 0/6 anon-refused | loopback-ungated: 6 verb(s) admit anon (6 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/provider-ladder | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/provider-ops | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (1 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/recipes | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/resource | 0/5 anon-refused | loopback-ungated: 5 verb(s) admit anon (4 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/restore-plans | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/retention | 3/3 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/runtime-host | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/scim-configurations | 2/2 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/scm-connect | 0/4 anon-refused | loopback-ungated: 4 verb(s) admit anon (2 H-pinned, 2 rule-H-invisible) |
| /v1/hypervisor/scm-connectors | 0/4 anon-refused | loopback-ungated: 4 verb(s) admit anon (4 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/scm-destination-bindings | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/scm-publication-proposals | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/secrets | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (2 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/service-composition-receipt-bundles | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/session-execution-bindings | 0/5 anon-refused | loopback-ungated: 5 verb(s) admit anon (0 H-pinned, 5 rule-H-invisible) |
| /v1/hypervisor/session-launch-recipe-admissions | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/session-turns | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (1 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/sessions | 4/4 anon-refused | CLOSED THIS CUT |
| /v1/hypervisor/skill-entries | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (0 H-pinned, 3 rule-H-invisible) |
| /v1/hypervisor/snapshots | 0/2 anon-refused | loopback-ungated: 2 verb(s) admit anon (1 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/sso-configurations | 2/2 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/state-machines | 0/3 anon-refused | loopback-ungated: 3 verb(s) admit anon (3 H-pinned, 0 rule-H-invisible) |
| /v1/hypervisor/storage-archive-ops | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/storage-backends | 0/5 anon-refused | loopback-ungated: 5 verb(s) admit anon (3 H-pinned, 2 rule-H-invisible) |
| /v1/hypervisor/storage-profiles | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/studio | 2/3 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/support-incidents | 2/2 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/terminals | 0/4 anon-refused | loopback-ungated: 4 verb(s) admit anon (0 H-pinned, 4 rule-H-invisible) |
| /v1/hypervisor/warm-pools | 0/2 anon-refused | loopback-ungated: 2 verb(s) admit anon (1 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/work-results | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/hypervisor/worker-package-install-admissions | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/hypervisor/workruns | 0/2 anon-refused | loopback-ungated: 2 verb(s) admit anon (0 H-pinned, 2 rule-H-invisible) |
| /v1/jobs | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/messages | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/model-mount | 22/33 anon-refused | loopback-ungated: 11 verb(s) admit anon (0 H-pinned, 11 rule-H-invisible) |
| /v1/responses | 1/1 anon-refused | identity-gated (refuses anon) |
| /v1/runs | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (1 H-pinned, 0 rule-H-invisible) |
| /v1/studio | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/subscriptions | 3/3 anon-refused | identity-gated (refuses anon) |
| /v1/tasks | 0/1 anon-refused | loopback-ungated: 1 verb(s) admit anon (0 H-pinned, 1 rule-H-invisible) |
| /v1/threads | 0/52 anon-refused | loopback-ungated: 52 verb(s) admit anon (10 H-pinned, 42 rule-H-invisible) |
</details>

## Gates run (all green locally)

- `npm run check:architecture-contracts` · `check:architecture-docs` · `check:mutation-foundation` · `check:mutation-handlers` — green
- `npm run check:admission-evidence` — green, **H-census 172/172: NO baseline delta** (the gated handlers were never in the H-baseline; rule H cannot see their helper-mediated writes)
- `cargo fmt --check` — clean; `cargo test -p ioi-node --bin hypervisor-daemon` — **713 passed, 0 failed** (no new failures; the previously-known flake did not reproduce)
- `check:work-cockpit` **48/48** · `check:home-cockpit` **40/40** (both against isolated daemon+serve pairs)
- `check:seed-provenance` — untouched-green (20 surfaces, 58 sources)
- Spot insurance on the touched shared files: `check:automations-journey` **44/44** · `check:ontology-journey` **36/36**
- WatchEvents fence (DEF-SPA-WATCHEVENTS-1) untouched, not widened
- `docs/architecture/_meta/canon-to-code-delta.md` untouched by instruction — the closing ledger PR carries the rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
