### PR TITLE
chore(hypervisor): rule-H census sees helper write seams — persist_*/save_*/*_write wrappers no longer hide a handler's writes (next-legs V Leg 2a)

### DIFF
--- a/scripts/audit-admission-evidence-provenance.mjs
+++ b/scripts/audit-admission-evidence-provenance.mjs
@@ -37,6 +37,11 @@
 //      The daemon's inbound auth middleware covers /v1/* when enforcement is on,
 //      so this is a pinned baseline (the known MEF-GAP-008 legacy surface), not
 //      a per-handler verdict. Fails only on growth or on a vanished baseline name.
+//      A write counts whether the handler calls a persist/remove primitive directly
+//      OR through a named persist_*/save_*/*_write helper seam (see WRITE_SEAMS) —
+//      so a handler whose only write path is a helper is no longer invisible to the
+//      census; the gate side is symmetric (see IDENTITY) so a seam-mediated identity
+//      resolution is recognized just as a seam-mediated write is counted.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -197,12 +202,58 @@ const RULE_F_RESOLVER = /resolve_principal_tenant_refs\s*\(/gu;
 const RULE_G = /x-ioi-principal|x-forwarded-user/gu;
 
 const SEAM_FILES = new Set(["lifecycle_routes.rs", "portal_session_exchange_routes.rs"]);
+// Identity/authority resolution seams. session_request_write_owner and
+// load_owned_session_record_for_write are the session-write identity-first seams:
+// each resolves the acting principal (typed 401 before any record load) and is
+// what the session write handlers call in place of an inline resolver — listing
+// them keeps the census's read of a handler's gate symmetric with its read of a
+// handler's writes, so a seam-mediated gate is recognized just as a seam-mediated
+// write is counted.
 const IDENTITY =
-  /\b(resolve_request_identity|require_write_caller|require_authenticated_org_admin|require_authenticated_principal|require_authenticated_admin|resolve_governance_reviewer|prepare_approval_patch_identity|resolve_principal|bind_request_resource_scope|authorize_scope)\s*\(/gu;
+  /\b(resolve_request_identity|session_request_write_owner|load_owned_session_record_for_write|require_write_caller|require_authenticated_org_admin|require_authenticated_principal|require_authenticated_admin|resolve_governance_reviewer|prepare_approval_patch_identity|resolve_principal|bind_request_resource_scope|authorize_scope)\s*\(/gu;
 const RECORD_READ =
   /\b(load|load_record|read_record_dir|find_by_key|read_owner_scoped_head|read_owner_scoped_history)\s*\(/gu;
-const MUTATION =
-  /\b(persist_record|persist_record_durable|remove_record|admit_owner_scoped_write|unlink_durable(?:_at)?|(?:std::)?fs::(?:write|remove_file|remove_dir_all|rename|create_dir_all))\s*\(/gu;
+// Helper write seams: named persist_*/save_*/*_write wrappers in the daemon route
+// modules (and the substrate_store seam) that each perform a durable write on a
+// handler's behalf — every entry here wraps persist_record / persist_record_durable
+// internally. Rule H counts a call to one of these as a mutation exactly as it counts
+// a direct persist, so a handler whose only write path is mediated by such a helper is
+// no longer invisible to the census. Re-derive by grepping the route dir for fns named
+// persist_*/save_*/*_write whose body calls persist_record[_durable]. Longest names are
+// listed before their prefixes so the alternation cannot short-match (the trailing `\(`
+// already guards this, but ordering keeps it obvious).
+const WRITE_SEAMS = [
+  "persist_and_complete_intent_locked",
+  "persist_and_complete_locked",
+  "persist_embedded_intent_locked",
+  "persist_exact_authority_receipt",
+  "persist_session_lifecycle_stage",
+  "persist_session_execution_stage",
+  "persist_session_create_stage",
+  "persist_run_with_bundle",
+  "persist_goal_run_atomic",
+  "persist_successor",
+  "persist_recipe",
+  "persist_required",
+  "persist_health",
+  "persist_atomic",
+  "persist_local",
+  "persist_plan",
+  "persist_env",
+  "persist_run",
+  "durable_write",
+  "save_deployment",
+  "save_workload",
+  "save_instance",
+  "save_service",
+  "save_profile",
+  "save_route",
+  "save_lease",
+].join("|");
+const MUTATION = new RegExp(
+  `\\b(persist_record|persist_record_durable|remove_record|admit_owner_scoped_write|unlink_durable(?:_at)?|${WRITE_SEAMS}|(?:std::)?fs::(?:write|remove_file|remove_dir_all|rename|create_dir_all))\\s*\\(`,
+  "gu",
+);
 
 // ------------------------------------------------------------------ pinned dispositions
 // Keyed file + rule + match key; `count` pins how many such sites exist today.
@@ -404,6 +455,54 @@ const H_BASELINE = [
   "transformation_run_routes.rs::handle_run_delete",
   "transformation_run_routes.rs::handle_run_dry_run",
   "transformation_run_routes.rs::handle_run_patch",
+  // Helper-write-seam additions (2026-08-11): these mutating handlers write only
+  // through a named persist_*/save_*/*_write helper, so the per-handler scan could
+  // not previously see them (WRITE_SEAMS made them visible). They join the baseline
+  // on exactly the same footing as every entry above — the middleware-covered legacy
+  // surface, each awaiting its W1.2-class handler-level reading; a pinned census
+  // entry, NOT a per-handler verdict. Growth beyond this set is red.
+  "attempt_finding_routes.rs::handle_attempt_create",
+  "attempt_finding_routes.rs::handle_attempt_transition",
+  "attempt_finding_routes.rs::handle_finding_create",
+  "attempt_finding_routes.rs::handle_finding_transition",
+  "editor_routes.rs::handle_editor_service_expose",
+  "editor_routes.rs::handle_editor_service_rebuild",
+  "editor_routes.rs::handle_editor_service_start",
+  "editor_routes.rs::handle_editor_service_stop",
+  "environment_routes.rs::handle_env_port_expose",
+  "environment_routes.rs::handle_env_port_unexpose",
+  "environment_routes.rs::handle_environment_create",
+  "environment_routes.rs::handle_environment_get",
+  "environment_routes.rs::handle_idle_sweep",
+  "goalrun_routes.rs::handle_goal_run_activation_draft",
+  "goalrun_routes.rs::handle_goal_run_activation_submit",
+  "goalrun_routes.rs::handle_goal_runs_create",
+  "harness_routes.rs::handle_harness_profile_select_default",
+  "hypervisor_environment_routes.rs::handle_environment_transition",
+  "hypervisoros_node_routes.rs::handle_node_transition",
+  "lifecycle_routes.rs::handle_subagent_cancel",
+  "lifecycle_routes.rs::handle_subagents_propagate_cancel",
+  "model_routes.rs::handle_model_route_patch",
+  "model_routes.rs::handle_model_route_select_default",
+  "placement_failover_routes.rs::handle_failover_plan_arm",
+  "placement_failover_routes.rs::handle_failover_plan_disarm",
+  "recipe_routes.rs::handle_recipe_create",
+  "resource_capability_offer_routes.rs::handle_match_create",
+  "system_amendment_routes.rs::handle_amendment",
+  "system_continuity_routes.rs::handle_migration_destination_acknowledgement",
+  "system_continuity_routes.rs::handle_transition",
+  "system_membership_routes.rs::handle_declare_desired_topology",
+  "system_membership_routes.rs::handle_transition",
+  "system_protected_transition_routes.rs::handle_transition",
+  "system_writer_routes.rs::handle_declare_failover_profile",
+  "system_writer_routes.rs::handle_lost_suffix_resolution",
+  "system_writer_routes.rs::handle_transition",
+  "verifier_challenge_routes.rs::handle_create",
+  "verifier_challenge_routes.rs::handle_transition",
+  "work_frontier_claim_routes.rs::handle_claim_acquire",
+  "work_frontier_claim_routes.rs::handle_claim_transition",
+  "work_frontier_claim_routes.rs::handle_frontier_create",
+  "work_frontier_claim_routes.rs::handle_frontier_transition",
 ];
 
 // ------------------------------------------------------------------ scan


### PR DESCRIPTION
## What

`check:admission-evidence`'s **rule H** censuses mutating daemon route handlers that carry no in-handler identity/authority call — the middleware-covered legacy surface, tracked as a pinned baseline that goes red on growth. It detected a write by matching a fixed set of write-primitive names (`persist_record`, `persist_record_durable`, `remove_record`, `fs::write`, …).

A handler whose only write path runs **through a named helper** — a `persist_*` / `save_*` / `*_write` wrapper that itself calls `persist_record[_durable]` — was invisible to the per-handler scan. The scan looked for the primitive in the handler's own span and never saw it, because the write happens one call deep in the helper. So that slice of the census could not be tracked, and new handlers of the same shape could be added without the ratchet noticing.

This is a **tooling-coverage / ratchet-visibility** change: it teaches the census to see helper-mediated writes so the baseline covers them and future growth is red. No handler behavior changes; no handler is gated in this cut.

## The change (one file: `scripts/audit-admission-evidence-provenance.mjs`)

1. **`WRITE_SEAMS`** — a documented list of the named `persist_*` / `save_*` / `*_write` helper wrappers in the route modules (and the substrate_store seam) that each wrap `persist_record` / `persist_record_durable`. These names join the `MUTATION` alternation, so rule H counts a call to one of them as a write exactly as it counts a direct persist. The set is mechanically re-derivable: grep the route dir for functions named `persist_*`/`save_*`/`*_write` whose body calls `persist_record[_durable]`.

   Seams added:
   ```
   persist_and_complete_intent_locked, persist_and_complete_locked,
   persist_embedded_intent_locked, persist_exact_authority_receipt,
   persist_session_lifecycle_stage, persist_session_execution_stage,
   persist_session_create_stage, persist_run_with_bundle, persist_goal_run_atomic,
   persist_successor, persist_recipe, persist_required, persist_health,
   persist_atomic, persist_local, persist_plan, persist_env, persist_run,
   durable_write, save_deployment, save_workload, save_instance, save_service,
   save_profile, save_route, save_lease
   ```

2. **Symmetric gate read** — `session_request_write_owner` and `load_owned_session_record_for_write` (the session-write identity-first seams introduced in #250) join the `IDENTITY` set. A handler that resolves its acting principal through one of these seams is now recognized as gated, just as a handler that writes through a helper seam is now recognized as writing. Keeping the two sides symmetric is what makes the session write handlers correctly read as gated rather than as bare writers.

3. **`H_BASELINE` +42** — the 42 previously-blind mutating handlers the extension makes visible are pinned into the baseline in a clearly-labeled block, on exactly the same footing as every existing entry: the middleware-covered legacy surface, each awaiting its W1.2-class handler-level reading — a pinned census entry, **not a per-handler verdict**. Growth beyond this set is red.

4. The rule-H header comment is updated to state that a write now counts whether it is a direct primitive or a named helper seam, and that the gate side is symmetric.

## Why the session handlers do not surface (proof the extension + #250 line up)

`persist_session_lifecycle_stage` is one of the added seams, and the session write handlers do call it — so making the seam visible could have surfaced them. It does **not**: #250 routed session-write identity through `session_request_write_owner` / `load_owned_session_record_for_write` (principal resolved, typed 401, before any record load; principal bound into the receipt). With those seams now in the `IDENTITY` set, the census reads the session write handlers as gated and they stay **out** of the census. #250's identity-first fix is now ratchet-visible.

## Ratchet self-test (red → green)

Same self-test discipline the gate already uses:

- **RED** — with a newly-visible seam-mediated handler left unpinned (`recipe_routes.rs::handle_recipe_create`, whose only write path is the `persist_recipe` seam), `--check` exits `1` and names it:
  `1 mutating handler(s) with no in-handler identity/authority call beyond the pinned baseline: recipe_routes.rs::handle_recipe_create`
- **GREEN** — pinned into `H_BASELINE`, `--check` exits `0`:
  `admission-evidence provenance OK — 85 files, 11 pinned lead(s), H-census 214/214 baseline.`

This confirms the seam extension makes helper-mediated handlers visible **and** that the ratchet still bites on new growth.

## Gates (all green from the worktree)

- `check:architecture-contracts` — projections up to date
- `check:architecture-docs` — OK (177 files, 8 rules)
- `check:mutation-foundation` — exit 0
- `check:mutation-handlers` — exit 0
- `check:admission-evidence` — exit 0 (H-census 214/214, 0 new / 0 stale / 0 gone)
- `check:source-neutral` — exit 0

No Rust touched (single `.mjs` + baseline change). Out of scope and untouched: seed-provenance / seed graphs, the WatchEvents fence, and `canon-to-code-delta.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
