### PR TITLE
fix(hypervisor): W3.1 launch chain composes the real kernel planners — no second spine; exact-revision binding + model-route recheck (next-legs V Leg 2b)

### DIFF
--- a/apps/hypervisor/scripts/serve-product-ui.mjs
+++ b/apps/hypervisor/scripts/serve-product-ui.mjs
@@ -7508,6 +7508,12 @@ async function runSurfaceAction(hit, res, body) {
       res.writeHead(303, { Location: url, "Cache-Control": "no-cache" });
       res.end();
     };
+    // TYPED ACC-G ABSENCE (denial preserves composer input): on refusal the PRG redirect carries
+    // the typed refused code + reason + record, so the surface's denial STATE is preserved and
+    // re-rendered — but the operator's typed field VALUES are not echoed back into the form. Full
+    // ACC-G "denial re-populates the composer" (round-tripping submitted field values through the
+    // PRG boundary, bounded, for every surface action) is a follow-up UI packet, not this backend
+    // launch-chain repair; it is stated here rather than silently satisfied by state-only carry.
     const refuse = (code, message, target) => {
       const back2 = safeReturnPath(target, back);
       const url = `${back2}${back2.includes("?") ? "&" : "?"}${new URLSearchParams({ refused: code, reason: String(message || "").slice(0, 200), record: hit.recordId }).toString()}${embed ? "&embed=1" : ""}#ap-result`;

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -130,9 +130,11 @@ export const SURFACES = [
   // which keep serving untouched — seed-preservation invariant; the registry owner rename for
   // those seed rows is deferred to the full Work packet per the seed-ux-provenance
   // owner_mapping_note). Sessions renders lifecycle facts + the ADMITTED harness binding as
-  // session truth; New Session owns the ONE mutation the daemon admits today (create, 202 +
-  // provision receipt) with NO subject input — subject_attachments is hardcoded empty at the
-  // daemon (typed W3 C-1 absence). Evidence: check:work-cockpit.
+  // session truth; New Session owns the create mutation (202 + provision receipt) with NO subject
+  // input — subject_attachments is EXACTLY [] AT CREATE (no masquerade at create). The C-1 subject
+  // attachment now MATERIALIZES at LAUNCH via the W3.1 producer (POST harness-session-launches),
+  // not at create; the launch-chain + work-cockpit verifiers both prove the [] → daemon-resolved
+  // flip. Evidence: check:work-cockpit, check:launch-chain.
   { slug: "work", owner: "Work", title: "Work", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/work-cockpit", canonical_route: "/work", verifier: "scripts/verify-hypervisor-work-cockpit.mjs", certification: "n/a", capabilities: ["browse", "inspect"], operational_state: "inspect", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "work-sessions", owner: "Work", title: "Work / Sessions", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/work-sessions", canonical_route: "/work/sessions", verifier: "scripts/verify-hypervisor-work-cockpit.mjs", certification: "n/a", capabilities: ["browse", "filter", "select", "inspect", "transition"], operational_state: "act", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },
   { slug: "work-new-session", owner: "Work", title: "Work / New Session", icon: EXPLORER_APP_ICON_URI, route: "/__ioi/work-new-session", canonical_route: "/work/new-session", verifier: "scripts/verify-hypervisor-work-cockpit.mjs", certification: "n/a", capabilities: ["browse", "create"], operational_state: "act", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" },

--- a/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
@@ -183,15 +183,14 @@ const recomputeFrozenRevision = (prof) => {
   return { revisionRef: `harness-profile://daemon-resolved/${harnessSlug}/revision/${contentHash}`, contentHash };
 };
 
-// STRUCTURAL, ALLOWLIST-BY-CONSTRUCTION second-spine detector. A denylist ("does it match a known
-// kernel-control schema stem?") is defeated by any rename — moving the fake INTO this PR's own
-// `ioi.hypervisor.*` namespace, a `_v2` suffix, `control_state:"admitted_at_launch"`, a renamed
-// event_kind. So instead we assert the launch record's typed surface is EXACTLY the closed set of
-// values a correctly-composed launch may carry: any schema_version / payload_schema_version outside
-// LAUNCH_SCHEMA_ALLOWLIST, any control_state outside {observe,take_over,return_agent}, or any
-// event_kind/kind outside EVENT_KIND_ALLOWLIST is a shadow → RED. (Both the LAUNCH_SCHEMA_ALLOWLIST
-// contents and the daemon-side material shape must be edited together when a schema legitimately
-// changes — see the recomputeFrozenRevision note.)
+// VALUE allowlists — defence in depth BEHIND the M5b key-set close (chain additionalProperties:false
+// below). These prove approved vocab appears only on approved key names; they are NOT the security
+// boundary (a shadow built from only-allowlisted values on a NEW key is stopped by the key-set close,
+// not here). A denylist would be defeated by any rename (into ioi.hypervisor.*, a `_v2` suffix, a
+// renamed event_kind); the allowlist instead pins the exact set of values a correct launch RECORD
+// emits. Every entry is verified per-entry as actually emitted into the durable record/response;
+// LAUNCH_SCHEMA_ALLOWLIST and the daemon-side material shape must be edited together when a schema
+// legitimately changes (see the recomputeFrozenRevision note).
 const LAUNCH_SCHEMA_ALLOWLIST = new Set([
   // launch-family wrapper tags (this PR)
   "ioi.hypervisor.harness_session_launch.v1",
@@ -202,41 +201,55 @@ const LAUNCH_SCHEMA_ALLOWLIST = new Set([
   "ioi.hypervisor.harness_session_launch_managed_session_step.v1",
   "ioi.hypervisor.harness_session_launch_projection.v1",
   "ioi.hypervisor.harness_session_launch_events.v1",
-  // real composed kernel admissions / records the launch legitimately embeds (NOT second spine)
+  // real composed kernel admissions / records the launch legitimately embeds (NOT second spine),
+  // verified per-entry as actually emitted into the durable launch record (the recipe/binding REQUEST
+  // schemas were dropped as dead — they exist only in the in-memory planner requests, never persisted)
   "ioi.runtime.harness_session_binding_admission.v1",
   "ioi.runtime.harness_session_readiness.v1",
   "ioi.runtime.harness_session_spawn.v1",
   "ioi.runtime.harness_session_terminal_attach.v1",
   "ioi.runtime.harness_terminal_transcript_projection.v1",
   "ioi.runtime.hypervisor_session_launch_recipe_admission.v1",
-  "ioi.hypervisor.session_launch_recipe_admission_request.v1",
-  "ioi.hypervisor.session_launch_recipe.v1",
-  "ioi.hypervisor.new_session_target_binding.v1",
-  "ioi.hypervisor.harness_session_binding.v1",
 ]);
+// Kernel-NATIVE schema(s) the launch's admitted thread events carry ON THE STREAM (distinct from the
+// record's launch-family wrapper tags): runtime thread events are kernel event metadata under the
+// kernel's own generic runtime-event schema, never a launch-family mint.
+const STREAM_SCHEMA_ALLOWLIST = new Set(["ioi.runtime.event.v1"]);
+// control_state / event_kind values a REAL kernel planner can legitimately emit. These are kept even
+// though a clean no-delegation launch does not exercise them: a delegation-SUCCESS fork emits
+// thread.forked, and a launch on a thread with a real managed session emits managed_session.controlled
+// with an observe|take_over|return_agent control_state. Dropping them would false-positive real
+// planner output the first time those paths run. (Value-allowlisting is no longer the security
+// boundary — chain KEY-SET closure below is — so keeping the legitimate set is safe.)
 const CONTROL_STATE_ALLOWLIST = new Set(["observe", "take_over", "return_agent"]);
 const EVENT_KIND_ALLOWLIST = new Set(["thread.started", "harness_session.spawned", "thread.forked", "managed_session.controlled"]);
-// Structural walk of a parsed value → the offending typed values (empty ⇒ clean).
-const structuralViolations = (v, out = []) => {
+// The EXACT key set the launch record's `chain` object may carry (additionalProperties:false). This
+// is the TERMINATING close for M5b: a fabricated sibling (e.g. `shadow_managed_session`) fails on mere
+// PRESENCE of an unexpected KEY, whatever allowlisted values it hides inside.
+const EXPECTED_CHAIN_KEYS = ["first_runtime_event", "fork", "harness_binding_admission", "harness_binding_evidence", "launch_recipe_admission", "managed_session", "plan_admission", "readiness", "spawn", "subject_attachments", "terminal_attach", "thread"];
+// Structural walk of a parsed value → offending typed values, against a supplied schema allowlist.
+const structuralViolations = (v, schemaAllow, out = []) => {
   if (v === null || typeof v !== "object") return out;
-  if (Array.isArray(v)) { for (const x of v) structuralViolations(x, out); return out; }
+  if (Array.isArray(v)) { for (const x of v) structuralViolations(x, schemaAllow, out); return out; }
   for (const [k, val] of Object.entries(v)) {
-    if ((k === "schema_version" || k === "payload_schema_version") && typeof val === "string" && !LAUNCH_SCHEMA_ALLOWLIST.has(val)) out.push(`${k}=${val}`);
+    if ((k === "schema_version" || k === "payload_schema_version") && typeof val === "string" && !schemaAllow.has(val)) out.push(`${k}=${val}`);
     if (k === "control_state" && typeof val === "string" && !CONTROL_STATE_ALLOWLIST.has(val)) out.push(`control_state=${val}`);
     if ((k === "event_kind" || k === "kind") && typeof val === "string" && !EVENT_KIND_ALLOWLIST.has(val)) out.push(`${k}=${val}`);
-    structuralViolations(val, out);
+    structuralViolations(val, schemaAllow, out);
   }
   return out;
 };
 // Raw-bytes backstop (V1c): a record corrupted-unparseable while still carrying kernel tokens in its
-// bytes would parse to null and slip a structural (parsed) walk. Extract the same typed values by
-// regex from the raw text and apply the SAME allowlists, so a token in the bytes fails regardless of
-// parseability.
+// bytes would parse to null and slip the parsed walk. Extract the same typed values by regex from the
+// raw text and apply the SAME allowlists, so a token in the bytes fails regardless of parseability.
+// M6b: JSON-unescape the bytes first (\" and ") so an ESCAPED key `\"schema_version\"` cannot
+// slip the literal-keyed regex.
 const rawViolations = (text) => {
+  const norm = text.replace(/\\u0022/giu, '"').replace(/\\"/gu, '"');
   const out = [];
-  for (const m of text.matchAll(/"(?:payload_)?schema_version"\s*:\s*"([^"]*)"/gu)) if (!LAUNCH_SCHEMA_ALLOWLIST.has(m[1])) out.push(`raw schema=${m[1]}`);
-  for (const m of text.matchAll(/"control_state"\s*:\s*"([^"]*)"/gu)) if (!CONTROL_STATE_ALLOWLIST.has(m[1])) out.push(`raw control_state=${m[1]}`);
-  for (const m of text.matchAll(/"(?:event_kind|kind)"\s*:\s*"([^"]*)"/gu)) if (!EVENT_KIND_ALLOWLIST.has(m[1])) out.push(`raw ${m[1]}`);
+  for (const m of norm.matchAll(/"(?:payload_)?schema_version"\s*:\s*"([^"]*)"/gu)) if (!LAUNCH_SCHEMA_ALLOWLIST.has(m[1])) out.push(`raw schema=${m[1]}`);
+  for (const m of norm.matchAll(/"control_state"\s*:\s*"([^"]*)"/gu)) if (!CONTROL_STATE_ALLOWLIST.has(m[1])) out.push(`raw control_state=${m[1]}`);
+  for (const m of norm.matchAll(/"(?:event_kind|kind)"\s*:\s*"([^"]*)"/gu)) if (!EVENT_KIND_ALLOWLIST.has(m[1])) out.push(`raw ${m[1]}`);
   return out;
 };
 
@@ -338,11 +351,10 @@ async function run() {
   //    assertions), and (ii) the substrate is read back INDEPENDENTLY — the initial event is proven
   //    on the real agentgres stream at its substrate-stamped seq, and the durable record is scanned
   //    structurally — so a well-formed literal cannot masquerade as a real admission. --------------
-  ok("Finding 1 (step 5): the initial thread event is the kernel `thread.started` event with a substrate-stamped seq (0-indexed), a substrate_head field distinct from the kernel content-hash `resulting_head`, and an agentgres operation ref — NOT a launch-family `runtime.thread.opened` vocabulary (that these are the SUBSTRATE's real values, not literals, is proven by the /events cross-check below)",
+  ok("Finding 1 (step 5): the initial thread event is the kernel `thread.started` event with a substrate-stamped seq (0-indexed), a substrate_head field, and an agentgres operation ref — NOT a launch-family `runtime.thread.opened` vocabulary (that seq/head/op-ref are the SUBSTRATE's real values, not literals, is PROVEN by the /events cross-check below)",
     steps.thread_event_kind === "thread.started"
       && Number.isInteger(steps.thread_event_seq) && steps.thread_event_seq >= 0
       && typeof steps.thread_event_substrate_head === "string" && steps.thread_event_substrate_head.length > 0
-      && steps.thread_event_substrate_head !== steps.thread_event_resulting_head
       && typeof steps.thread_event_operation_ref === "string" && steps.thread_event_operation_ref.length > 0,
     `${steps.thread_event_kind} seq=${steps.thread_event_seq} head=${steps.thread_event_substrate_head}`);
 
@@ -367,12 +379,20 @@ async function run() {
       && spawnedOnStream != null && spawnedOnStream.event_kind === "harness_session.spawned" && spawnedOnStream.seq > openedOnStream.seq,
     openedOnStream ? `opened seq=${openedOnStream.seq} head=${openedOnStream.substrate_head} op=${openedOnStream.agentgres_operation_ref}` : "event NOT found on stream");
 
-  // -- Negative isolation (a): PROVE no launch-family chain record ever reaches the kernel stream. --
-  ok("negative isolation (a): the real kernel thread-orchestration stream carries ONLY the composed thread lifecycle events (thread.started | harness_session.spawned) — no launch-family chain record (no `chain` / `plan_admission` / `subject_attachments` / `harness_binding_admission` / `ioi.hypervisor.harness_session_launch*` schema) ever reaches the kernel stream",
+  // -- Negative isolation (a): the kernel stream carries KERNEL-NATIVE events only, and no launch
+  //    record. The launch's thread events are admitted under the kernel's own runtime-event schema
+  //    (ioi.runtime.event.v1) — NOT a launch-family payload_schema_version — and no chain record
+  //    reaches the stream. The stream events are themselves ALLOWLIST-SCANNED (payload schema ∈ the
+  //    kernel-native stream allowlist; event_kind ∈ the composed kinds), closing the gap where the
+  //    old launch-family `harness-session-launch-thread-event.v1` name evaded a record-only scan. --
+  const streamShadow = streamEvents.flatMap((e) => structuralViolations(e, STREAM_SCHEMA_ALLOWLIST));
+  ok("negative isolation (a): every event on the real kernel stream is a kernel-native runtime event (payload_schema_version ioi.runtime.event.v1, a kernel schema NOT a launch-family mint), event_kind ∈ {thread.started, harness_session.spawned}, and no launch record (chain/plan_admission/subject_attachments/harness_binding_admission or ioi.hypervisor.harness_session_launch* schema) reaches the stream",
     streamEvents.length >= 1
       && streamEvents.every((e) => ["thread.started", "harness_session.spawned"].includes(e.event_kind))
+      && streamEvents.every((e) => e.payload_schema_version === "ioi.runtime.event.v1")
+      && streamShadow.length === 0
       && !streamEvents.some((e) => e.chain != null || e.plan_admission != null || e.subject_attachments != null || e.harness_binding_admission != null || String(e.schema_version || "").startsWith("ioi.hypervisor.harness_session_launch")),
-    `${streamEvents.length} stream event(s): ${streamEvents.map((e) => e.event_kind).join(",")}`);
+    streamShadow.length ? streamShadow.join(" | ") : `${streamEvents.length} kernel-native event(s): ${streamEvents.map((e) => e.event_kind).join(",")}`);
 
   // -- Negative isolation (b): the REAL managed-session control route refuses a launch thread ref. --
   const shadowControl = await jd(`/v1/threads/${encodeURIComponent(steps.thread_ref)}/managed-sessions/control`, { method: "POST", body: JSON.stringify({ managed_session_id: `managed-session:${launchId}`, control_state: "observe" }) });
@@ -390,18 +410,30 @@ async function run() {
       && launch?.managed_session?.decision === "no_managed_session_at_launch"
       && launch?.managed_session?.control_planner === "plan_runtime_managed_session_control_from_replayed_events",
     JSON.stringify(launch?.managed_session));
-  // SAFETY — STRUCTURAL, ALLOWLIST-BY-CONSTRUCTION second-spine scan (Finding C): the launch's typed
-  // surface must be EXACTLY the closed set a correct launch may carry; anything else (a rename into
-  // ioi.hypervisor.*, a _v2 suffix, control_state:"admitted"/"admitted_at_launch"/"active", a renamed
-  // event_kind) is a shadow. Run over the HTTP response AND the durable on-disk record (parsed walk +
-  // raw-bytes backstop, so a corrupt-unparseable record carrying kernel tokens still FAILS).
-  const responseShadow = structuralViolations(launch);
-  ok("SAFETY (response, allowlist): the composed launch HTTP body's typed surface is EXACTLY the closed launch allowlist — every schema_version is a legit launch-family or composed-admission tag, every control_state is observe|take_over|return_agent, every event_kind is a composed thread lifecycle kind; anything else is a second-spine shadow",
+  // M5b TERMINATING FIX — CLOSED-WORLD OVER KEYS. The value allowlists prove approved vocab appears
+  // only on approved key NAMES; they say nothing about whether the KEY SET is expected. So a shadow
+  // sibling built from ONLY allowlisted values on a NEW key (e.g. `shadow_managed_session`) passes a
+  // value scan. Assert the launch record's `chain` KEY SET EQUALS the pinned expected set
+  // (additionalProperties:false): a shadow fails on mere PRESENCE of an unexpected key, whatever it
+  // contains. Read from the DURABLE record so it holds on disk, not just in the response.
+  const persistedLaunches = readFamilyRecords("harness-session-launches");
+  const mainRecord = persistedLaunches.map((r) => r.json).find((j) => j && j.launch_id === launchId);
+  const chainKeys = mainRecord?.chain ? Object.keys(mainRecord.chain).sort() : null;
+  ok("M5b (closed-world over KEYS): the durable launch record's `chain` KEY SET EQUALS the pinned expected set (additionalProperties:false) — a fabricated sibling record built from only-allowlisted values on a NEW key fails on PRESENCE, whatever it hides",
+    chainKeys != null && JSON.stringify(chainKeys) === JSON.stringify(EXPECTED_CHAIN_KEYS),
+    chainKeys ? chainKeys.join(",") : "no chain on durable record");
+
+  // SAFETY — STRUCTURAL value scan (defence in depth behind the key-set close): every schema_version /
+  // payload_schema_version / control_state / event_kind must be an allowlisted value (a rename into
+  // ioi.hypervisor.*, a _v2 suffix, control_state:"admitted", a bad event_kind → shadow). Run over the
+  // HTTP response AND the durable on-disk record (parsed walk + raw-bytes backstop with M6b unescape,
+  // so a corrupt-unparseable record — even one with ESCAPED keys — still FAILS).
+  const responseShadow = structuralViolations(launch, LAUNCH_SCHEMA_ALLOWLIST);
+  ok("SAFETY (response, value allowlist): every schema_version is a legit launch-family/composed-admission tag, every control_state ∈ {observe,take_over,return_agent}, every event_kind is a composed thread lifecycle kind — anything else is a second-spine shadow",
     responseShadow.length === 0,
     responseShadow.length ? responseShadow.join(" | ") : "clean");
-  const persistedLaunches = readFamilyRecords("harness-session-launches");
-  const persistedShadow = persistedLaunches.flatMap((r) => [...structuralViolations(r.json), ...rawViolations(r.text || "")]);
-  ok("SAFETY (durable, allowlist + raw backstop): the same allowlist scan over the PERSISTED launch record(s) on disk — parsed structural walk AND a raw-bytes regex backstop — finds NO out-of-allowlist typed value; a response that sanitizes while the durable record still wears a kernel token, or a corrupt-unparseable record carrying tokens in its bytes, FAILS here",
+  const persistedShadow = persistedLaunches.flatMap((r) => [...structuralViolations(r.json, LAUNCH_SCHEMA_ALLOWLIST), ...rawViolations(r.text || "")]);
+  ok("SAFETY (durable, value allowlist + raw backstop): the same value scan over the PERSISTED launch record(s) on disk — parsed walk AND a raw-bytes regex backstop (JSON-unescaped first) — finds NO out-of-allowlist value; a response that sanitizes while the durable record still wears a kernel token, or a corrupt-unparseable/escaped-key record carrying tokens, FAILS here",
     persistedLaunches.length >= 1
       && persistedLaunches.some((r) => (r.text || "").includes(launchId))
       && persistedShadow.length === 0,
@@ -488,7 +520,7 @@ async function run() {
       && delegatedFork.fork_planner === "plan_runtime_thread_fork_control"
       && delegatedFork.decision === "refused"
       && delegatedFork.code === "runtime_thread_fork_control_agent_replay_required"
-      && structuralViolations(delegated.body).length === 0,
+      && structuralViolations(delegated.body, LAUNCH_SCHEMA_ALLOWLIST).length === 0,
     `${delegatedFork.decision} · ${delegatedFork.code}`);
 
   // -- INV-37 durable receipt binds the acting principal ----------------------------------------

--- a/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
@@ -200,7 +200,9 @@ const LAUNCH_SCHEMA_ALLOWLIST = new Set([
   "ioi.hypervisor.harness_session_launch_fork_step.v1",
   "ioi.hypervisor.harness_session_launch_managed_session_step.v1",
   "ioi.hypervisor.harness_session_launch_projection.v1",
-  "ioi.hypervisor.harness_session_launch_events.v1",
+  // (harness_session_launch_events.v1 dropped: it is only the /events ENVELOPE schema — it appears in
+  // neither the durable record nor the produce response that this allowlist scans, so per "every entry
+  // must be demonstrably emitted into a scanned surface" it is not carried here.)
   // real composed kernel admissions / records the launch legitimately embeds (NOT second spine),
   // verified per-entry as actually emitted into the durable launch record (the recipe/binding REQUEST
   // schemas were dropped as dead — they exist only in the in-memory planner requests, never persisted)
@@ -223,10 +225,19 @@ const STREAM_SCHEMA_ALLOWLIST = new Set(["ioi.runtime.event.v1"]);
 // boundary — chain KEY-SET closure below is — so keeping the legitimate set is safe.)
 const CONTROL_STATE_ALLOWLIST = new Set(["observe", "take_over", "return_agent"]);
 const EVENT_KIND_ALLOWLIST = new Set(["thread.started", "harness_session.spawned", "thread.forked", "managed_session.controlled"]);
-// The EXACT key set the launch record's `chain` object may carry (additionalProperties:false). This
-// is the TERMINATING close for M5b: a fabricated sibling (e.g. `shadow_managed_session`) fails on mere
-// PRESENCE of an unexpected KEY, whatever allowlisted values it hides inside.
+// The EXACT key sets (additionalProperties:false, sorted) a correct launch record carries at every
+// level a second spine could hide — top-level record, chain, and the two provenance-bearing steps.
+// A fabricated sibling fails on mere PRESENCE of an unexpected KEY, whatever allowlisted values it
+// hides inside. Pinned from a clean run's DURABLE record (the assertions flag any drift).
+// The top-level key set is PATH-DEPENDENT: launch_terminalize (stop/archive) MUTATES it, adding
+// `lineage` + `{state}_at`. So the pin is STATE-AWARE — a strict-equality pin per lifecycle stage,
+// checked against the durable record at each stage. A top-level shadow at ANY stage → RED.
+const EXPECTED_LAUNCH_RECORD_KEYS_PRODUCED = ["acting_principal_ref", "chain", "created_at", "environment_ref", "head", "idempotency_key", "launch_id", "launch_ref", "lifecycle_state", "owner_ref", "receipt_refs", "request_hash", "revision", "runtimeTruthSource", "schema_version", "session_harness_binding", "session_model_route_binding", "session_ref", "workspace_root"];
+const EXPECTED_LAUNCH_RECORD_KEYS_STOPPED = [...EXPECTED_LAUNCH_RECORD_KEYS_PRODUCED, "lineage", "stopped_at"].sort();
+const EXPECTED_LAUNCH_RECORD_KEYS_ARCHIVED = [...EXPECTED_LAUNCH_RECORD_KEYS_STOPPED, "archived_at"].sort();
 const EXPECTED_CHAIN_KEYS = ["first_runtime_event", "fork", "harness_binding_admission", "harness_binding_evidence", "launch_recipe_admission", "managed_session", "plan_admission", "readiness", "spawn", "subject_attachments", "terminal_attach", "thread"];
+const EXPECTED_FORK_KEYS = ["decision", "fork_planner", "note", "schema_version"];
+const EXPECTED_MANAGED_SESSION_KEYS = ["available_control_states", "control_planner", "decision", "note", "schema_version"];
 // Structural walk of a parsed value → offending typed values, against a supplied schema allowlist.
 const structuralViolations = (v, schemaAllow, out = []) => {
   if (v === null || typeof v !== "object") return out;
@@ -337,13 +348,21 @@ async function run() {
     typeof steps.plan_ref === "string" && steps.plan_ref.startsWith("harness-session-launch-plan:")
       && typeof steps.thread_ref === "string" && steps.thread_ref.startsWith("thread:launch-")
       && typeof steps.thread_event_ref === "string" && steps.thread_event_ref.includes("/opened")
-      && steps.launch_recipe_ref != null
+      && typeof steps.launch_recipe_ref === "string" && steps.launch_recipe_ref.startsWith("target-binding:")
       && typeof steps.harness_binding_ref === "string" && steps.harness_binding_ref.startsWith("harness-session-binding:")
       && typeof steps.readiness_ref === "string" && steps.readiness_ref.startsWith("readiness:")
       && typeof steps.spawn_ref === "string" && steps.spawn_ref.startsWith("spawn:")
-      && steps.terminal_attach_ref != null
+      // Assert the ACTUAL terminal-attach ref shape, not the launch_step_ref schema_version fallback
+      // (a kernel rename would otherwise leave this passing on a schema-version string).
+      && typeof steps.terminal_attach_ref === "string" && steps.terminal_attach_ref.startsWith("harness-session-terminal-attach:")
       && typeof steps.first_runtime_event_ref === "string" && steps.first_runtime_event_ref.includes("/spawned"),
     JSON.stringify(steps));
+
+  // Load the DURABLE launch record ONCE, early — it is RECOVERY TRUTH (what the daemon serves after
+  // restart). The provenance and key-set assertions below read from it, so a durable-only forgery
+  // (response sanitized, disk fabricated) cannot pass.
+  const persistedLaunches = readFamilyRecords("harness-session-launches");
+  const mainRecord = persistedLaunches.map((r) => r.json).find((j) => j && j.launch_id === launchId);
 
   // -- Finding 1: the thread / fork / managed-session facts are the REAL kernel planners' output or
   //    an honest typed absence. The gate catches #252's second spine two independent ways: (i) the
@@ -398,30 +417,40 @@ async function run() {
   const shadowControl = await jd(`/v1/threads/${encodeURIComponent(steps.thread_ref)}/managed-sessions/control`, { method: "POST", body: JSON.stringify({ managed_session_id: `managed-session:${launchId}`, control_state: "observe" }) });
   ok("negative isolation (b): the REAL managed-session control route (POST /v1/threads/<launch-thread>/managed-sessions/control) REFUSES for the launch thread ref — read_agent_for_thread 404s first, so a crafted POST cannot ride the launch shadow into the kernel control planner",
     shadowControl.status === 404, `${shadowControl.status}`);
-  // Finding 1 (step 6/7) — PRESENCE-AND-VALUE of the composed launch-family shape (not inequality
-  // against absent keys). The real fork-planner INVOCATION is exercised at the delegation probe below;
-  // this early-return branch is asserted only for the honest typed-absence shape it actually carries.
-  ok("Finding 1 (step 6): with no delegation the fork is the typed launch-family absence — schema_version=ioi.hypervisor.harness_session_launch_fork_step.v1, decision=not_requested — carrying no kernel fork event (the real planner is exercised at the delegation probe)",
-    launch?.fork?.schema_version === "ioi.hypervisor.harness_session_launch_fork_step.v1"
-      && launch?.fork?.decision === "not_requested",
-    JSON.stringify(launch?.fork));
-  ok("Finding 1 (step 7): the managed-session step is the typed launch-family absence naming the REAL control planner — schema_version=ioi.hypervisor.harness_session_launch_managed_session_step.v1, decision=no_managed_session_at_launch, control_planner=plan_runtime_managed_session_control_from_replayed_events (control-over-existing, nothing to control at launch)",
-    launch?.managed_session?.schema_version === "ioi.hypervisor.harness_session_launch_managed_session_step.v1"
-      && launch?.managed_session?.decision === "no_managed_session_at_launch"
-      && launch?.managed_session?.control_planner === "plan_runtime_managed_session_control_from_replayed_events",
-    JSON.stringify(launch?.managed_session));
-  // M5b TERMINATING FIX — CLOSED-WORLD OVER KEYS. The value allowlists prove approved vocab appears
-  // only on approved key NAMES; they say nothing about whether the KEY SET is expected. So a shadow
-  // sibling built from ONLY allowlisted values on a NEW key (e.g. `shadow_managed_session`) passes a
-  // value scan. Assert the launch record's `chain` KEY SET EQUALS the pinned expected set
-  // (additionalProperties:false): a shadow fails on mere PRESENCE of an unexpected key, whatever it
-  // contains. Read from the DURABLE record so it holds on disk, not just in the response.
-  const persistedLaunches = readFamilyRecords("harness-session-launches");
-  const mainRecord = persistedLaunches.map((r) => r.json).find((j) => j && j.launch_id === launchId);
-  const chainKeys = mainRecord?.chain ? Object.keys(mainRecord.chain).sort() : null;
-  ok("M5b (closed-world over KEYS): the durable launch record's `chain` KEY SET EQUALS the pinned expected set (additionalProperties:false) — a fabricated sibling record built from only-allowlisted values on a NEW key fails on PRESENCE, whatever it hides",
-    chainKeys != null && JSON.stringify(chainKeys) === JSON.stringify(EXPECTED_CHAIN_KEYS),
-    chainKeys ? chainKeys.join(",") : "no chain on durable record");
+  // K2D — the provenance (decision + control_planner + schema) is read from the DURABLE record (the
+  // recovery truth the daemon serves after restart), NOT just the produce-time response; a durable-only
+  // substitution (response reads no_managed_session_at_launch while disk reads decision:"admitted",
+  // control_planner:"none_no_planner_ran") goes RED. The response is separately asserted to EQUAL the
+  // durable provenance, so a divergence in either direction fails.
+  const durFork = mainRecord?.chain?.fork || {};
+  const durManaged = mainRecord?.chain?.managed_session || {};
+  ok("Finding 1 (step 6) — DURABLE provenance: the on-disk fork step is the typed launch-family absence (schema_version=…_fork_step.v1, decision=not_requested), and the response fork EQUALS the durable fork — a durable-only forgery fails",
+    durFork.schema_version === "ioi.hypervisor.harness_session_launch_fork_step.v1"
+      && durFork.decision === "not_requested"
+      && JSON.stringify(launch?.fork) === JSON.stringify(durFork),
+    JSON.stringify(durFork));
+  ok("Finding 1 (step 7) — DURABLE provenance: the on-disk managed-session step is the typed absence naming the REAL control planner (decision=no_managed_session_at_launch, control_planner=plan_runtime_managed_session_control_from_replayed_events), and the response managed_session EQUALS the durable one — a durable-only substitution (decision:\"admitted\" on disk) goes RED",
+    durManaged.schema_version === "ioi.hypervisor.harness_session_launch_managed_session_step.v1"
+      && durManaged.decision === "no_managed_session_at_launch"
+      && durManaged.control_planner === "plan_runtime_managed_session_control_from_replayed_events"
+      && JSON.stringify(launch?.managed_session) === JSON.stringify(durManaged),
+    JSON.stringify(durManaged));
+  // CLOSED-WORLD OVER KEYS at every level a second spine can hide (all read from the DURABLE record):
+  //   M5b — chain siblings;  K3 — top-level siblings (outside chain);  K1 — nested siblings inside the
+  //   two provenance-bearing steps (fork / managed_session). Value allowlists prove approved vocab on
+  //   approved key NAMES; only the KEY-SET equality proves the key SET is expected, so a shadow built
+  //   from ONLY allowlisted values fails on mere PRESENCE of any unexpected key, whatever it hides.
+  const keysOf = (o) => (o && typeof o === "object" && !Array.isArray(o)) ? Object.keys(o).sort() : null;
+  const eqKeys = (o, expected) => { const k = keysOf(o); return k != null && JSON.stringify(k) === JSON.stringify(expected); };
+  ok("K3 (top-level closed-world, AT PRODUCE): the durable launch record's TOP-LEVEL key set EQUALS the pinned produced set (additionalProperties:false) — a sibling OUTSIDE chain (launch_record.shadow_*) fails on PRESENCE (the stopped/archived stages are pinned separately after terminalization)",
+    eqKeys(mainRecord, EXPECTED_LAUNCH_RECORD_KEYS_PRODUCED),
+    keysOf(mainRecord)?.join(",") || "no durable record");
+  ok("M5b (chain closed-world): the durable record's `chain` key set EQUALS the pinned expected set — a chain sibling (chain.shadow_managed_session) fails on PRESENCE, whatever allowlisted values it hides",
+    eqKeys(mainRecord?.chain, EXPECTED_CHAIN_KEYS),
+    keysOf(mainRecord?.chain)?.join(",") || "no chain");
+  ok("K1 (nested closed-world): the durable `chain.fork` and `chain.managed_session` key sets — the two steps carrying planner provenance — EQUAL their pinned expected sets, so a nested shadow (chain.managed_session.shadow_control) fails on PRESENCE",
+    eqKeys(mainRecord?.chain?.fork, EXPECTED_FORK_KEYS) && eqKeys(mainRecord?.chain?.managed_session, EXPECTED_MANAGED_SESSION_KEYS),
+    `fork=[${keysOf(mainRecord?.chain?.fork)}] managed=[${keysOf(mainRecord?.chain?.managed_session)}]`);
 
   // SAFETY — STRUCTURAL value scan (defence in depth behind the key-set close): every schema_version /
   // payload_schema_version / control_state / event_kind must be an allowlisted value (a rename into
@@ -476,8 +505,8 @@ async function run() {
       && withinTestWindow(recheck.rechecked_at)
       && recheck.derived_binding_availability_state === "daemon_verified",
     JSON.stringify(recheck));
-  ok("Finding 2 (availability CORRELATED, not hard-coded): the derived binding availability tracks the registry lifecycle the recheck READ — daemon_verified iff the mount read as lifecycle-active — so a hard-coded `daemon_verified` decoupled from the read would fail this biconditional",
-    (recheck.registry_lifecycle_status === "active") === (recheck.derived_binding_availability_state === "daemon_verified"),
+  ok("Finding 2 (availability CORRELATED, not hard-coded): the recheck actually READ registry_lifecycle_status=active AND DERIVED daemon_verified from it (asserted as the real values, not a biconditional that passes vacuously when both sides are false) — a mount read as non-active with a hard-coded daemon_verified fails the first conjunct",
+    recheck.registry_lifecycle_status === "active" && recheck.derived_binding_availability_state === "daemon_verified",
     `${recheck.registry_lifecycle_status} => ${recheck.derived_binding_availability_state}`);
   ok("Finding 2: the recheck honestly carries live token reachability as FALSE (the mount is daemon-verified; live serving is the W3.2 execute dependency) — the binding never over-claims what the readiness admits",
     recheck.model_route_reachable === false && launch?.readiness?.observed_substrate?.model_route_reachable === false,
@@ -562,6 +591,13 @@ async function run() {
   const stopReplay = await jd(`${LAUNCHES}/${encodeURIComponent(launchId)}/stop`, { method: "POST", body: JSON.stringify({ expected_head: head }) });
   ok("re-stopping is idempotent (already-stopped replays without a second effect)",
     stopReplay.status === 200 && stopReplay.body?.lifecycle_state === "stopped" && stopReplay.body?.replayed === true, `${stopReplay.status}`);
+  // K3 (state-aware, AFTER STOP): terminalize legitimately adds {lineage, stopped_at}; the durable
+  // top-level key set must equal the STOPPED pin exactly — a shadow injected during terminalization
+  // (also recovery truth) fails, and a legit stopped record passes.
+  const stoppedRecord = readFamilyRecords("harness-session-launches").map((r) => r.json).find((j) => j && j.launch_id === launchId);
+  ok("K3 (top-level closed-world, AFTER STOP): the durable record's top-level key set EQUALS the pinned STOPPED set (produced ∪ {lineage, stopped_at}) — a legit stopped record passes; a top-level shadow at this stage fails",
+    eqKeys(stoppedRecord, EXPECTED_LAUNCH_RECORD_KEYS_STOPPED),
+    keysOf(stoppedRecord)?.join(",") || "no stopped record");
 
   // -- archive terminalizes with lineage --------------------------------------------------------
   const stoppedHead = stop.body?.head;
@@ -574,6 +610,18 @@ async function run() {
   ok("the durable archive receipt binds acting_principal_ref and names the previous head as lineage (INV-37 + terminal lineage)",
     archiveReceipt && archiveReceipt.acting_principal_ref === producedReceipt?.acting_principal_ref
       && archiveReceipt.previous_head === stoppedHead);
+  // K3 (state-aware, AFTER ARCHIVE): archive adds {archived_at} on top of the stopped set.
+  const archivedRecord = readFamilyRecords("harness-session-launches").map((r) => r.json).find((j) => j && j.launch_id === launchId);
+  ok("K3 (top-level closed-world, AFTER ARCHIVE): the durable record's top-level key set EQUALS the pinned ARCHIVED set (stopped ∪ {archived_at}) — a legit archived record passes; a top-level shadow at this stage fails",
+    eqKeys(archivedRecord, EXPECTED_LAUNCH_RECORD_KEYS_ARCHIVED),
+    keysOf(archivedRecord)?.join(",") || "no archived record");
+  // Also pin chain/fork/managed-session key sets on the TERMINALIZED record — terminalize must not
+  // mutate the chain, so the same pins that held at produce hold after archive (recovery truth).
+  ok("K1/M5b (closed-world, AFTER ARCHIVE): the terminalized record's chain / chain.fork / chain.managed_session key sets are UNCHANGED from produce — terminalization added no nested shadow",
+    eqKeys(archivedRecord?.chain, EXPECTED_CHAIN_KEYS)
+      && eqKeys(archivedRecord?.chain?.fork, EXPECTED_FORK_KEYS)
+      && eqKeys(archivedRecord?.chain?.managed_session, EXPECTED_MANAGED_SESSION_KEYS),
+    `chain=[${keysOf(archivedRecord?.chain)}]`);
 
   // -- daemon kill / restart → recovery/replay converges byte-identical --------------------------
   const preRestart = await jd(`${LAUNCHES}/${encodeURIComponent(launchId)}`);

--- a/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
@@ -149,6 +149,14 @@ const readFamilyRecords = (family) => {
 // Canonical JSON with recursively SORTED object keys + compact separators — byte-matches Rust
 // serde_json::to_vec over a serde_json::Value (BTreeMap-backed: keys serialize sorted), so the
 // frozen-revision sha256 can be INDEPENDENTLY recomputed here and compared for EXACTNESS.
+// LATENT FRAGILITY (not reachable today, one schema change from silently breaking):
+//  - number encoding: JSON.stringify(1) === "1" but serde_json encodes an integer-valued f64 as
+//    "1.0"; the hashed material is currently all strings / bools / string-arrays, so no numbers
+//    reach this path. A numeric field entering the material would diverge.
+//  - key ordering: Object.keys().sort() orders by UTF-16 code units; Rust BTreeMap orders by UTF-8
+//    bytes. They agree across the BMP but diverge for keys above U+FFFF — none exist here.
+// The material shape below is HAND-DUPLICATED from the daemon's harness_profile_frozen_revision();
+// both sides must be edited together, and LAUNCH_SCHEMA_ALLOWLIST updated, when the shape changes.
 const canonicalJson = (v) => {
   if (v === null || typeof v !== "object") return JSON.stringify(v);
   if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
@@ -175,22 +183,60 @@ const recomputeFrozenRevision = (prof) => {
   return { revisionRef: `harness-profile://daemon-resolved/${harnessSlug}/revision/${contentHash}`, contentHash };
 };
 
-// STRUCTURAL second-spine detector (rename-resistant): recursively walk a value and collect the
-// kernel-shaped tokens a launch-family record must NEVER carry — a kernel thread-fork / managed-
-// session CONTROL schema name in EITHER dotted or hyphenated form, a `control_state` of "admitted",
-// or the retired launch-family thread-event vocabulary. It inspects field VALUES by shape, so a
-// rename of the fixed strings cannot defeat it. The REAL composed admissions (recipe / binding /
-// terminal-attach) carry their own kernel schemas and are deliberately NOT matched.
-const KERNEL_CONTROL_SCHEMA_RE = /^ioi\.runtime\.(thread[_-]fork[_-]control|managed[_-]session[_-]control)(?:[.\-]|$)/u;
-const collectShadowTokens = (v, out = []) => {
+// STRUCTURAL, ALLOWLIST-BY-CONSTRUCTION second-spine detector. A denylist ("does it match a known
+// kernel-control schema stem?") is defeated by any rename — moving the fake INTO this PR's own
+// `ioi.hypervisor.*` namespace, a `_v2` suffix, `control_state:"admitted_at_launch"`, a renamed
+// event_kind. So instead we assert the launch record's typed surface is EXACTLY the closed set of
+// values a correctly-composed launch may carry: any schema_version / payload_schema_version outside
+// LAUNCH_SCHEMA_ALLOWLIST, any control_state outside {observe,take_over,return_agent}, or any
+// event_kind/kind outside EVENT_KIND_ALLOWLIST is a shadow → RED. (Both the LAUNCH_SCHEMA_ALLOWLIST
+// contents and the daemon-side material shape must be edited together when a schema legitimately
+// changes — see the recomputeFrozenRevision note.)
+const LAUNCH_SCHEMA_ALLOWLIST = new Set([
+  // launch-family wrapper tags (this PR)
+  "ioi.hypervisor.harness_session_launch.v1",
+  "ioi.hypervisor.harness_session_launch_plan.v1",
+  "ioi.hypervisor.harness_session_launch_thread.v1",
+  "ioi.hypervisor.harness_session_launch_event_ref.v1",
+  "ioi.hypervisor.harness_session_launch_fork_step.v1",
+  "ioi.hypervisor.harness_session_launch_managed_session_step.v1",
+  "ioi.hypervisor.harness_session_launch_projection.v1",
+  "ioi.hypervisor.harness_session_launch_events.v1",
+  // real composed kernel admissions / records the launch legitimately embeds (NOT second spine)
+  "ioi.runtime.harness_session_binding_admission.v1",
+  "ioi.runtime.harness_session_readiness.v1",
+  "ioi.runtime.harness_session_spawn.v1",
+  "ioi.runtime.harness_session_terminal_attach.v1",
+  "ioi.runtime.harness_terminal_transcript_projection.v1",
+  "ioi.runtime.hypervisor_session_launch_recipe_admission.v1",
+  "ioi.hypervisor.session_launch_recipe_admission_request.v1",
+  "ioi.hypervisor.session_launch_recipe.v1",
+  "ioi.hypervisor.new_session_target_binding.v1",
+  "ioi.hypervisor.harness_session_binding.v1",
+]);
+const CONTROL_STATE_ALLOWLIST = new Set(["observe", "take_over", "return_agent"]);
+const EVENT_KIND_ALLOWLIST = new Set(["thread.started", "harness_session.spawned", "thread.forked", "managed_session.controlled"]);
+// Structural walk of a parsed value → the offending typed values (empty ⇒ clean).
+const structuralViolations = (v, out = []) => {
   if (v === null || typeof v !== "object") return out;
-  if (Array.isArray(v)) { for (const x of v) collectShadowTokens(x, out); return out; }
+  if (Array.isArray(v)) { for (const x of v) structuralViolations(x, out); return out; }
   for (const [k, val] of Object.entries(v)) {
-    if ((k === "schema_version" || k === "payload_schema_version") && typeof val === "string" && KERNEL_CONTROL_SCHEMA_RE.test(val)) out.push(`${k}=${val}`);
-    if (k === "control_state" && val === "admitted") out.push("control_state=admitted");
-    if ((k === "event_kind" || k === "kind") && (val === "runtime.thread.opened" || val === "runtime.thread.harness_spawned")) out.push(`${k}=${val}`);
-    collectShadowTokens(val, out);
+    if ((k === "schema_version" || k === "payload_schema_version") && typeof val === "string" && !LAUNCH_SCHEMA_ALLOWLIST.has(val)) out.push(`${k}=${val}`);
+    if (k === "control_state" && typeof val === "string" && !CONTROL_STATE_ALLOWLIST.has(val)) out.push(`control_state=${val}`);
+    if ((k === "event_kind" || k === "kind") && typeof val === "string" && !EVENT_KIND_ALLOWLIST.has(val)) out.push(`${k}=${val}`);
+    structuralViolations(val, out);
   }
+  return out;
+};
+// Raw-bytes backstop (V1c): a record corrupted-unparseable while still carrying kernel tokens in its
+// bytes would parse to null and slip a structural (parsed) walk. Extract the same typed values by
+// regex from the raw text and apply the SAME allowlists, so a token in the bytes fails regardless of
+// parseability.
+const rawViolations = (text) => {
+  const out = [];
+  for (const m of text.matchAll(/"(?:payload_)?schema_version"\s*:\s*"([^"]*)"/gu)) if (!LAUNCH_SCHEMA_ALLOWLIST.has(m[1])) out.push(`raw schema=${m[1]}`);
+  for (const m of text.matchAll(/"control_state"\s*:\s*"([^"]*)"/gu)) if (!CONTROL_STATE_ALLOWLIST.has(m[1])) out.push(`raw control_state=${m[1]}`);
+  for (const m of text.matchAll(/"(?:event_kind|kind)"\s*:\s*"([^"]*)"/gu)) if (!EVENT_KIND_ALLOWLIST.has(m[1])) out.push(`raw ${m[1]}`);
   return out;
 };
 
@@ -292,7 +338,7 @@ async function run() {
   //    assertions), and (ii) the substrate is read back INDEPENDENTLY — the initial event is proven
   //    on the real agentgres stream at its substrate-stamped seq, and the durable record is scanned
   //    structurally — so a well-formed literal cannot masquerade as a real admission. --------------
-  ok("Finding 1 (step 5): the initial thread event is the kernel `thread.started` event admitted onto the REAL event stream — it carries a substrate-stamped seq (0-indexed integer), a real substrate head (agentgres CAS head, not the kernel content-hash `resulting_head`), and an agentgres operation ref, NOT a launch-family `runtime.thread.opened` vocabulary",
+  ok("Finding 1 (step 5): the initial thread event is the kernel `thread.started` event with a substrate-stamped seq (0-indexed), a substrate_head field distinct from the kernel content-hash `resulting_head`, and an agentgres operation ref — NOT a launch-family `runtime.thread.opened` vocabulary (that these are the SUBSTRATE's real values, not literals, is proven by the /events cross-check below)",
     steps.thread_event_kind === "thread.started"
       && Number.isInteger(steps.thread_event_seq) && steps.thread_event_seq >= 0
       && typeof steps.thread_event_substrate_head === "string" && steps.thread_event_substrate_head.length > 0
@@ -309,14 +355,17 @@ async function run() {
   const streamEvents = streamAfterProduce.body?.events || [];
   const openedOnStream = streamEvents.find((e) => e.event_id === steps.thread_event_ref);
   const spawnedOnStream = streamEvents.find((e) => e.event_id === steps.first_runtime_event_ref);
-  ok("Finding 1 (step 5) INDEPENDENT READBACK: the event named by thread_event_ref is actually on the real kernel stream at the substrate-stamped seq the launch reported, carrying an agentgres_operation_ref; the spawned event follows it at a higher seq — proven by replaying the substrate, never by trusting the launch record",
+  ok("Finding 1 (step 5) INDEPENDENT READBACK: the event named by thread_event_ref is actually on the real kernel stream, and the launch record's self-reported seq, substrate_head, AND agentgres_operation_ref each EQUAL the substrate's own values read back from /events; the spawned event follows at a higher seq — a fabricated head/op-ref or a constant literal in the launch record goes RED here",
     streamAfterProduce.status === 200
       && openedOnStream != null
       && openedOnStream.event_kind === "thread.started"
       && openedOnStream.seq === steps.thread_event_seq
       && typeof openedOnStream.agentgres_operation_ref === "string" && openedOnStream.agentgres_operation_ref.length > 0
+      && openedOnStream.agentgres_operation_ref === steps.thread_event_operation_ref
+      && typeof openedOnStream.substrate_head === "string" && openedOnStream.substrate_head.length > 0
+      && openedOnStream.substrate_head === steps.thread_event_substrate_head
       && spawnedOnStream != null && spawnedOnStream.event_kind === "harness_session.spawned" && spawnedOnStream.seq > openedOnStream.seq,
-    openedOnStream ? `opened seq=${openedOnStream.seq} op=${openedOnStream.agentgres_operation_ref}` : "event NOT found on stream");
+    openedOnStream ? `opened seq=${openedOnStream.seq} head=${openedOnStream.substrate_head} op=${openedOnStream.agentgres_operation_ref}` : "event NOT found on stream");
 
   // -- Negative isolation (a): PROVE no launch-family chain record ever reaches the kernel stream. --
   ok("negative isolation (a): the real kernel thread-orchestration stream carries ONLY the composed thread lifecycle events (thread.started | harness_session.spawned) — no launch-family chain record (no `chain` / `plan_admission` / `subject_attachments` / `harness_binding_admission` / `ioi.hypervisor.harness_session_launch*` schema) ever reaches the kernel stream",
@@ -341,16 +390,18 @@ async function run() {
       && launch?.managed_session?.decision === "no_managed_session_at_launch"
       && launch?.managed_session?.control_planner === "plan_runtime_managed_session_control_from_replayed_events",
     JSON.stringify(launch?.managed_session));
-  // SAFETY — STRUCTURAL second-spine scan (Finding C: rename-resistant, catches dotted AND hyphenated
-  // kernel-control schema names + control_state:"admitted" + the retired thread-event vocabulary), run
-  // over BOTH the HTTP response and the DURABLE on-disk record.
-  const responseShadow = collectShadowTokens(launch);
-  ok("SAFETY (response, structural): a recursive walk of the composed launch HTTP body finds NO second-spine token — no kernel thread-fork/managed-session CONTROL schema (dotted or hyphenated), no control_state:\"admitted\", no runtime.thread.opened/harness_spawned vocabulary",
+  // SAFETY — STRUCTURAL, ALLOWLIST-BY-CONSTRUCTION second-spine scan (Finding C): the launch's typed
+  // surface must be EXACTLY the closed set a correct launch may carry; anything else (a rename into
+  // ioi.hypervisor.*, a _v2 suffix, control_state:"admitted"/"admitted_at_launch"/"active", a renamed
+  // event_kind) is a shadow. Run over the HTTP response AND the durable on-disk record (parsed walk +
+  // raw-bytes backstop, so a corrupt-unparseable record carrying kernel tokens still FAILS).
+  const responseShadow = structuralViolations(launch);
+  ok("SAFETY (response, allowlist): the composed launch HTTP body's typed surface is EXACTLY the closed launch allowlist — every schema_version is a legit launch-family or composed-admission tag, every control_state is observe|take_over|return_agent, every event_kind is a composed thread lifecycle kind; anything else is a second-spine shadow",
     responseShadow.length === 0,
     responseShadow.length ? responseShadow.join(" | ") : "clean");
   const persistedLaunches = readFamilyRecords("harness-session-launches");
-  const persistedShadow = persistedLaunches.flatMap((r) => collectShadowTokens(r.json));
-  ok("SAFETY (durable, structural): the same structural walk over the PERSISTED launch record(s) on disk (harness-session-launches family directory) finds NO second-spine token — a response that sanitizes while the durable record still wears a kernel schema name would FAIL here",
+  const persistedShadow = persistedLaunches.flatMap((r) => [...structuralViolations(r.json), ...rawViolations(r.text || "")]);
+  ok("SAFETY (durable, allowlist + raw backstop): the same allowlist scan over the PERSISTED launch record(s) on disk — parsed structural walk AND a raw-bytes regex backstop — finds NO out-of-allowlist typed value; a response that sanitizes while the durable record still wears a kernel token, or a corrupt-unparseable record carrying tokens in its bytes, FAILS here",
     persistedLaunches.length >= 1
       && persistedLaunches.some((r) => (r.text || "").includes(launchId))
       && persistedShadow.length === 0,
@@ -437,15 +488,15 @@ async function run() {
       && delegatedFork.fork_planner === "plan_runtime_thread_fork_control"
       && delegatedFork.decision === "refused"
       && delegatedFork.code === "runtime_thread_fork_control_agent_replay_required"
-      && collectShadowTokens(delegated.body).length === 0,
+      && structuralViolations(delegated.body).length === 0,
     `${delegatedFork.decision} · ${delegatedFork.code}`);
 
   // -- INV-37 durable receipt binds the acting principal ----------------------------------------
   const producedReceipt = readReceiptByKind("hypervisor.harness_session_launch.produced", launchRef);
-  ok("the durable produced receipt binds acting_principal_ref to the real operator principal (INV-37), never user://local-operator",
+  ok("the durable produced receipt binds acting_principal_ref to the real operator principal (INV-37), never user://local-operator, and its created_at lands inside the test window (a pinned anchor, not merely !1970)",
     producedReceipt && String(producedReceipt.acting_principal_ref || "").startsWith("user://")
       && producedReceipt.acting_principal_ref !== "user://local-operator"
-      && !producedReceipt.created_at.startsWith("1970"),
+      && withinTestWindow(producedReceipt.created_at),
     producedReceipt?.acting_principal_ref);
 
   // -- idempotent replay-to-stored-record -------------------------------------------------------

--- a/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
@@ -31,6 +31,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import net from "node:net";
+import crypto from "node:crypto";
 import { fileURLToPath } from "node:url";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -130,6 +131,76 @@ const countSessionRecords = () => {
   } catch { return 0; }
 };
 
+// Read every durable record persisted under a daemon family directory (the receipt-census pattern):
+// returns [{ file, text, json }] so an assertion can scan the PERSISTED bytes, not just an HTTP body.
+const readFamilyRecords = (family) => {
+  const out = [];
+  try {
+    for (const f of fs.readdirSync(path.join(dataDir, family))) {
+      if (!f.endsWith(".json")) continue;
+      const text = fs.readFileSync(path.join(dataDir, family, f), "utf8");
+      let json = null; try { json = JSON.parse(text); } catch { /* keep raw */ }
+      out.push({ file: f, text, json });
+    }
+  } catch { /* no such family yet */ }
+  return out;
+};
+
+// Canonical JSON with recursively SORTED object keys + compact separators — byte-matches Rust
+// serde_json::to_vec over a serde_json::Value (BTreeMap-backed: keys serialize sorted), so the
+// frozen-revision sha256 can be INDEPENDENTLY recomputed here and compared for EXACTNESS.
+const canonicalJson = (v) => {
+  if (v === null || typeof v !== "object") return JSON.stringify(v);
+  if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(v).sort().map((k) => `${JSON.stringify(k)}:${canonicalJson(v[k])}`).join(",")}}`;
+};
+const sha256Hex = (s) => crypto.createHash("sha256").update(s).digest("hex");
+
+// Recompute the daemon's frozen harness-profile revision from a profile record's ACTUAL content,
+// mirroring harness_profile_frozen_revision(): material = the exact fields + jcs-sha256 idiom.
+const recomputeFrozenRevision = (prof) => {
+  const harness = (typeof prof.harness === "string" && prof.harness) ? prof.harness : "hypervisor_worker";
+  const material = {
+    schema_version: "ioi.hypervisor.harness-profile-frozen-revision-jcs-sha256.v1",
+    profile_ref: prof.profile_ref ?? null,
+    profile_id: prof.profile_id ?? null,
+    harness,
+    adapter: prof.adapter ?? null,
+    capabilities: prof.capabilities ?? null,
+    model_binding: prof.model_binding ?? null,
+    lifecycle_status: prof.lifecycle?.status ?? null,
+  };
+  const contentHash = `sha256:${sha256Hex(canonicalJson(material))}`;
+  const harnessSlug = harness.replace(/[^A-Za-z0-9]/gu, "-");
+  return { revisionRef: `harness-profile://daemon-resolved/${harnessSlug}/revision/${contentHash}`, contentHash };
+};
+
+// STRUCTURAL second-spine detector (rename-resistant): recursively walk a value and collect the
+// kernel-shaped tokens a launch-family record must NEVER carry — a kernel thread-fork / managed-
+// session CONTROL schema name in EITHER dotted or hyphenated form, a `control_state` of "admitted",
+// or the retired launch-family thread-event vocabulary. It inspects field VALUES by shape, so a
+// rename of the fixed strings cannot defeat it. The REAL composed admissions (recipe / binding /
+// terminal-attach) carry their own kernel schemas and are deliberately NOT matched.
+const KERNEL_CONTROL_SCHEMA_RE = /^ioi\.runtime\.(thread[_-]fork[_-]control|managed[_-]session[_-]control)(?:[.\-]|$)/u;
+const collectShadowTokens = (v, out = []) => {
+  if (v === null || typeof v !== "object") return out;
+  if (Array.isArray(v)) { for (const x of v) collectShadowTokens(x, out); return out; }
+  for (const [k, val] of Object.entries(v)) {
+    if ((k === "schema_version" || k === "payload_schema_version") && typeof val === "string" && KERNEL_CONTROL_SCHEMA_RE.test(val)) out.push(`${k}=${val}`);
+    if (k === "control_state" && val === "admitted") out.push("control_state=admitted");
+    if ((k === "event_kind" || k === "kind") && (val === "runtime.thread.opened" || val === "runtime.thread.harness_spawned")) out.push(`${k}=${val}`);
+    collectShadowTokens(val, out);
+  }
+  return out;
+};
+
+// Test-window time anchor: a real recheck timestamp lands inside the run, not merely "not 1970".
+const runStartMs = Date.now();
+const withinTestWindow = (iso) => {
+  const t = Date.parse(iso);
+  return Number.isFinite(t) && t >= runStartMs - 300000 && t <= Date.now() + 300000;
+};
+
 async function run() {
   daemonPort = await freePort();
   DAEMON = `http://127.0.0.1:${daemonPort}`;
@@ -216,33 +287,74 @@ async function run() {
     JSON.stringify(steps));
 
   // -- Finding 1: the thread / fork / managed-session facts are the REAL kernel planners' output or
-  //    an honest typed absence — never a hand-minted record wearing a kernel schema name, never a
-  //    launch-family-only event vocabulary. These assertions would FAIL on the #252 second spine. --
-  ok("Finding 1 (step 5): the initial thread event is admitted onto the REAL kernel event stream — it carries the kernel `event_kind: thread.started` and the substrate's admission proof (an agentgres resulting_head), NOT a launch-family `runtime.thread.opened` inline vocabulary",
+  //    an honest typed absence. The gate catches #252's second spine two independent ways: (i) the
+  //    composed launch-family SHAPE no longer wears a kernel schema name (positive presence-and-value
+  //    assertions), and (ii) the substrate is read back INDEPENDENTLY — the initial event is proven
+  //    on the real agentgres stream at its substrate-stamped seq, and the durable record is scanned
+  //    structurally — so a well-formed literal cannot masquerade as a real admission. --------------
+  ok("Finding 1 (step 5): the initial thread event is the kernel `thread.started` event admitted onto the REAL event stream — it carries a substrate-stamped seq (0-indexed integer), a real substrate head (agentgres CAS head, not the kernel content-hash `resulting_head`), and an agentgres operation ref, NOT a launch-family `runtime.thread.opened` vocabulary",
     steps.thread_event_kind === "thread.started"
-      && typeof steps.thread_event_resulting_head === "string"
-      && steps.thread_event_resulting_head.startsWith("agentgres://runtime-events/"),
-    `${steps.thread_event_kind} · ${steps.thread_event_resulting_head}`);
-  ok("Finding 1 (step 6): with no delegation requested the fork is a typed `not_requested` naming the real fork planner (plan_runtime_thread_fork_control) — never a hand-minted admitted fork",
-    launch?.fork?.decision === "not_requested"
-      && launch?.fork?.fork_planner === "plan_runtime_thread_fork_control"
-      && launch?.fork?.schema_version !== "ioi.runtime.thread_fork_control.v1",
+      && Number.isInteger(steps.thread_event_seq) && steps.thread_event_seq >= 0
+      && typeof steps.thread_event_substrate_head === "string" && steps.thread_event_substrate_head.length > 0
+      && steps.thread_event_substrate_head !== steps.thread_event_resulting_head
+      && typeof steps.thread_event_operation_ref === "string" && steps.thread_event_operation_ref.length > 0,
+    `${steps.thread_event_kind} seq=${steps.thread_event_seq} head=${steps.thread_event_substrate_head}`);
+
+  // -- Hardening (Finding A): those admission fields are SELF-REPORTED by the launch record. Read the
+  //    event BACK from the substrate via /events (which replays agentgres, not the launch record) and
+  //    prove the produced event_id is on the stream at the substrate-stamped seq the launch reported,
+  //    carrying an agentgres operation ref. The substrate `seq` — not the kernel content-hash
+  //    `resulting_head` — is admission truth; a literal in the launch record cannot conjure it. -----
+  const streamAfterProduce = await jd(`${LAUNCHES}/${encodeURIComponent(launchId)}/events`);
+  const streamEvents = streamAfterProduce.body?.events || [];
+  const openedOnStream = streamEvents.find((e) => e.event_id === steps.thread_event_ref);
+  const spawnedOnStream = streamEvents.find((e) => e.event_id === steps.first_runtime_event_ref);
+  ok("Finding 1 (step 5) INDEPENDENT READBACK: the event named by thread_event_ref is actually on the real kernel stream at the substrate-stamped seq the launch reported, carrying an agentgres_operation_ref; the spawned event follows it at a higher seq — proven by replaying the substrate, never by trusting the launch record",
+    streamAfterProduce.status === 200
+      && openedOnStream != null
+      && openedOnStream.event_kind === "thread.started"
+      && openedOnStream.seq === steps.thread_event_seq
+      && typeof openedOnStream.agentgres_operation_ref === "string" && openedOnStream.agentgres_operation_ref.length > 0
+      && spawnedOnStream != null && spawnedOnStream.event_kind === "harness_session.spawned" && spawnedOnStream.seq > openedOnStream.seq,
+    openedOnStream ? `opened seq=${openedOnStream.seq} op=${openedOnStream.agentgres_operation_ref}` : "event NOT found on stream");
+
+  // -- Negative isolation (a): PROVE no launch-family chain record ever reaches the kernel stream. --
+  ok("negative isolation (a): the real kernel thread-orchestration stream carries ONLY the composed thread lifecycle events (thread.started | harness_session.spawned) — no launch-family chain record (no `chain` / `plan_admission` / `subject_attachments` / `harness_binding_admission` / `ioi.hypervisor.harness_session_launch*` schema) ever reaches the kernel stream",
+    streamEvents.length >= 1
+      && streamEvents.every((e) => ["thread.started", "harness_session.spawned"].includes(e.event_kind))
+      && !streamEvents.some((e) => e.chain != null || e.plan_admission != null || e.subject_attachments != null || e.harness_binding_admission != null || String(e.schema_version || "").startsWith("ioi.hypervisor.harness_session_launch")),
+    `${streamEvents.length} stream event(s): ${streamEvents.map((e) => e.event_kind).join(",")}`);
+
+  // -- Negative isolation (b): the REAL managed-session control route refuses a launch thread ref. --
+  const shadowControl = await jd(`/v1/threads/${encodeURIComponent(steps.thread_ref)}/managed-sessions/control`, { method: "POST", body: JSON.stringify({ managed_session_id: `managed-session:${launchId}`, control_state: "observe" }) });
+  ok("negative isolation (b): the REAL managed-session control route (POST /v1/threads/<launch-thread>/managed-sessions/control) REFUSES for the launch thread ref — read_agent_for_thread 404s first, so a crafted POST cannot ride the launch shadow into the kernel control planner",
+    shadowControl.status === 404, `${shadowControl.status}`);
+  // Finding 1 (step 6/7) — PRESENCE-AND-VALUE of the composed launch-family shape (not inequality
+  // against absent keys). The real fork-planner INVOCATION is exercised at the delegation probe below;
+  // this early-return branch is asserted only for the honest typed-absence shape it actually carries.
+  ok("Finding 1 (step 6): with no delegation the fork is the typed launch-family absence — schema_version=ioi.hypervisor.harness_session_launch_fork_step.v1, decision=not_requested — carrying no kernel fork event (the real planner is exercised at the delegation probe)",
+    launch?.fork?.schema_version === "ioi.hypervisor.harness_session_launch_fork_step.v1"
+      && launch?.fork?.decision === "not_requested",
     JSON.stringify(launch?.fork));
-  ok("Finding 1 (step 7): the managed-session step routes the real control planner (plan_runtime_managed_session_control_from_replayed_events); a fresh launch has none, so it is a typed absence naming the VALID states observe|take_over|return_agent — never a hand-minted `managed_session_control.v1` with the invalid control_state `admitted`",
-    launch?.managed_session?.decision === "no_managed_session_at_launch"
-      && launch?.managed_session?.control_planner === "plan_runtime_managed_session_control_from_replayed_events"
-      && JSON.stringify(launch?.managed_session?.available_control_states) === JSON.stringify(["observe", "take_over", "return_agent"])
-      && launch?.managed_session?.schema_version !== "ioi.runtime.managed_session_control.v1"
-      && launch?.managed_session?.control_state !== "admitted",
+  ok("Finding 1 (step 7): the managed-session step is the typed launch-family absence naming the REAL control planner — schema_version=ioi.hypervisor.harness_session_launch_managed_session_step.v1, decision=no_managed_session_at_launch, control_planner=plan_runtime_managed_session_control_from_replayed_events (control-over-existing, nothing to control at launch)",
+    launch?.managed_session?.schema_version === "ioi.hypervisor.harness_session_launch_managed_session_step.v1"
+      && launch?.managed_session?.decision === "no_managed_session_at_launch"
+      && launch?.managed_session?.control_planner === "plan_runtime_managed_session_control_from_replayed_events",
     JSON.stringify(launch?.managed_session));
-  const launchStr = JSON.stringify(launch);
-  ok("SAFETY: the composed launch carries NO second-spine shadow — no `ioi.runtime.thread_fork_control.v1` / `ioi.runtime.managed_session_control.v1` record, no invalid `control_state:\"admitted\"`, no `runtime.thread.opened`/`runtime.thread.harness_spawned` vocabulary",
-    !launchStr.includes("ioi.runtime.thread_fork_control.v1")
-      && !launchStr.includes("ioi.runtime.managed_session_control.v1")
-      && !launchStr.includes("\"control_state\":\"admitted\"")
-      && !launchStr.includes("runtime.thread.opened")
-      && !launchStr.includes("runtime.thread.harness_spawned"),
-    "no shadow tokens in the composed launch");
+  // SAFETY — STRUCTURAL second-spine scan (Finding C: rename-resistant, catches dotted AND hyphenated
+  // kernel-control schema names + control_state:"admitted" + the retired thread-event vocabulary), run
+  // over BOTH the HTTP response and the DURABLE on-disk record.
+  const responseShadow = collectShadowTokens(launch);
+  ok("SAFETY (response, structural): a recursive walk of the composed launch HTTP body finds NO second-spine token — no kernel thread-fork/managed-session CONTROL schema (dotted or hyphenated), no control_state:\"admitted\", no runtime.thread.opened/harness_spawned vocabulary",
+    responseShadow.length === 0,
+    responseShadow.length ? responseShadow.join(" | ") : "clean");
+  const persistedLaunches = readFamilyRecords("harness-session-launches");
+  const persistedShadow = persistedLaunches.flatMap((r) => collectShadowTokens(r.json));
+  ok("SAFETY (durable, structural): the same structural walk over the PERSISTED launch record(s) on disk (harness-session-launches family directory) finds NO second-spine token — a response that sanitizes while the durable record still wears a kernel schema name would FAIL here",
+    persistedLaunches.length >= 1
+      && persistedLaunches.some((r) => (r.text || "").includes(launchId))
+      && persistedShadow.length === 0,
+    persistedShadow.length ? persistedShadow.join(" | ") : `${persistedLaunches.length} record(s) clean`);
 
   // -- Finding 2: the harness binding names a REAL seeded hp_* profile + its EXACT frozen revision,
   //    and model-route availability was RECHECKED at the launch boundary (not a static literal). ----
@@ -252,20 +364,38 @@ async function run() {
     profilesStr.includes("hp_hypervisor_worker") && !profilesStr.includes("default_harness_profile"),
     `hp_hypervisor_worker present=${profilesStr.includes("hp_hypervisor_worker")}`);
   const bindingEvidence = launch?.harness_binding_evidence || {};
-  ok("Finding 2: the binding names the real seeded profile AND its EXACT frozen revision (harness-profile://daemon-resolved/<harness>/revision/sha256:...)",
-    bindingEvidence.harness_profile_ref === "hp_hypervisor_worker"
-      && typeof steps.harness_profile_revision_ref === "string"
-      && steps.harness_profile_revision_ref.startsWith("harness-profile://daemon-resolved/")
-      && steps.harness_profile_revision_ref.includes("/revision/sha256:"),
-    steps.harness_profile_revision_ref);
+  const workerProfile = readFamilyRecords("harness-profile-registry")
+    .map((r) => r.json)
+    .find((p) => p && p.profile_id === "hp_hypervisor_worker");
+  // Hardening (Finding B.2/B.3): prove the launch RESOLVED the real registry record (the fallback
+  // stub path was NOT taken) and named THAT record's own profile_id — not a compile-time constant.
+  ok("Finding 2 (resolved, not stub): the launch resolved a real registry hp_* record (harness_profile_resolved=true) and its harness_profile_ref equals the RESOLVED record's own profile_id — the #23115 fallback-stub path was NOT taken; `default_harness_profile` is absent from the registry",
+    bindingEvidence.harness_profile_resolved === true
+      && workerProfile != null
+      && bindingEvidence.harness_profile_ref === workerProfile.profile_id
+      && steps.harness_profile_resolved === true,
+    `resolved=${bindingEvidence.harness_profile_resolved} ref=${bindingEvidence.harness_profile_ref}`);
+  // Hardening (Finding B.1): prove EXACTNESS, not well-formedness. Recompute the frozen revision from
+  // the profile's ACTUAL on-disk content (the exact record the daemon froze) and compare — a stale,
+  // fabricated, hard-coded, or stub-derived revision FAILS this, where a `startsWith`/`includes` shape
+  // check would pass.
+  const recomputed = workerProfile ? recomputeFrozenRevision(workerProfile) : null;
+  ok("Finding 2 EXACTNESS: the frozen revision RECOMPUTED from hp_hypervisor_worker's actual on-disk content (jcs-sha256 over adapter/capabilities/model_binding/lifecycle) EQUALS the launch's revision ref AND content hash — a stale/fabricated/hard-coded/stub-derived revision fails this independent recomputation",
+    recomputed != null
+      && steps.harness_profile_revision_ref === recomputed.revisionRef
+      && bindingEvidence.harness_profile_content_hash === recomputed.contentHash,
+    recomputed ? `recomputed ${recomputed.contentHash} vs record ${bindingEvidence.harness_profile_content_hash}` : "profile not on disk");
   const recheck = bindingEvidence.model_route_recheck || {};
-  ok("Finding 2: model-route availability was RECHECKED at the launch boundary with a real registry read (route resolved + admitted lifecycle read + recheck timestamp) and the binding availability was DERIVED from it — not a static `daemon_verified` literal",
+  ok("Finding 2: model-route availability was RECHECKED at the launch boundary with a real registry read (route resolved + admitted lifecycle read + a recheck timestamp INSIDE the test window) and the binding availability was DERIVED from it — not a static `daemon_verified` literal",
     recheck.recheck_source === "daemon-model-route-registry"
       && recheck.route_resolved === true
       && typeof recheck.registry_lifecycle_status === "string"
-      && typeof recheck.rechecked_at === "string" && !recheck.rechecked_at.startsWith("1970")
+      && withinTestWindow(recheck.rechecked_at)
       && recheck.derived_binding_availability_state === "daemon_verified",
     JSON.stringify(recheck));
+  ok("Finding 2 (availability CORRELATED, not hard-coded): the derived binding availability tracks the registry lifecycle the recheck READ — daemon_verified iff the mount read as lifecycle-active — so a hard-coded `daemon_verified` decoupled from the read would fail this biconditional",
+    (recheck.registry_lifecycle_status === "active") === (recheck.derived_binding_availability_state === "daemon_verified"),
+    `${recheck.registry_lifecycle_status} => ${recheck.derived_binding_availability_state}`);
   ok("Finding 2: the recheck honestly carries live token reachability as FALSE (the mount is daemon-verified; live serving is the W3.2 execute dependency) — the binding never over-claims what the readiness admits",
     recheck.model_route_reachable === false && launch?.readiness?.observed_substrate?.model_route_reachable === false,
     `recheck=${recheck.model_route_reachable} readiness=${launch?.readiness?.observed_substrate?.model_route_reachable}`);
@@ -289,27 +419,26 @@ async function run() {
     Array.isArray(sessionAfter?.subject_attachments) && sessionAfter.subject_attachments.length >= 1
       && sessionAfter.subject_attachments.some((a) => a.subject_ref === launchRef),
     `${sessionAfter?.subject_attachments?.length} attachment(s)`);
-  ok("no second Session family was minted: exactly one session record on disk after launch (the launch hangs off the kernel-owned Session spine)",
-    countSessionRecords() === sessionsBeforeLaunch, `${countSessionRecords()} session record(s)`);
+  ok("no NEW session record was minted by the launch: the on-disk session count is UNCHANGED from before the launch (the launch hangs off the kernel-owned Session spine, not a second session family)",
+    countSessionRecords() === sessionsBeforeLaunch, `delta 0 (before=${sessionsBeforeLaunch}, after=${countSessionRecords()})`);
 
-  // -- Finding 1 (step 6), delegation REQUESTED: the fork routes the real kernel planner ---------
+  // -- Finding 1 (step 6), delegation REQUESTED: the fork routes the REAL kernel planner ---------
   // A delegation-requested launch routes plan_runtime_thread_fork_control; the launch thread has no
-  // forkable source agent, so the planner's own refusal ladder answers (agent_replay_required) and
-  // NO admitted fork is fabricated — the planner's typed output, never a hand-minted record.
+  // forkable source agent, so the planner's own refusal ladder answers with the SPECIFIC code
+  // runtime_thread_fork_control_agent_replay_required and fabricates no admitted fork.
   const delegated = await jd(LAUNCHES, { method: "POST", body: JSON.stringify({
     session_ref: sessionRef,
     idempotency_key: "delegation-probe",
     delegation: { reason: "verifier delegation probe", bounds: { budget: "parent_bounded" } },
   }) });
   const delegatedFork = delegated.body?.fork || {};
-  ok("Finding 1 (step 6): a delegation-requested launch routes the REAL fork planner (plan_runtime_thread_fork_control); its refusal ladder answers with a typed planner code and fabricates no admitted fork — never a hand-minted `ioi.runtime.thread_fork_control.v1` record",
+  ok("Finding 1 (step 6) REAL PLANNER EXERCISE: a delegation-requested launch routes plan_runtime_thread_fork_control; with no forkable source agent on the launch thread the planner answers the SPECIFIC refusal runtime_thread_fork_control_agent_replay_required (not either-outcome), fabricates no admitted fork, and the response carries no second-spine token",
     delegated.status === 200
       && delegatedFork.fork_planner === "plan_runtime_thread_fork_control"
-      && (delegatedFork.decision === "forked" || delegatedFork.decision === "refused")
-      && (delegatedFork.decision !== "refused" || String(delegatedFork.code || "").startsWith("runtime_thread_fork_control_"))
-      && delegatedFork.schema_version !== "ioi.runtime.thread_fork_control.v1"
-      && !JSON.stringify(delegated.body).includes("ioi.runtime.thread_fork_control.v1"),
-    `${delegatedFork.decision} · ${delegatedFork.code || "(forked)"}`);
+      && delegatedFork.decision === "refused"
+      && delegatedFork.code === "runtime_thread_fork_control_agent_replay_required"
+      && collectShadowTokens(delegated.body).length === 0,
+    `${delegatedFork.decision} · ${delegatedFork.code}`);
 
   // -- INV-37 durable receipt binds the acting principal ----------------------------------------
   const producedReceipt = readReceiptByKind("hypervisor.harness_session_launch.produced", launchRef);

--- a/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
@@ -203,11 +203,10 @@ async function run() {
       && String(launch?.receipt_ref || "").startsWith("receipt://hypervisor/harness-session-launch/produced/"),
     `${produce.status} ${launch?.lifecycle_state}`);
   const steps = launch?.chain_step_refs || {};
-  ok("every §6.1 step names a canonical ref: plan · thread · initial thread event · managed session · launch-recipe · harness-binding · readiness · spawn · terminal-attach · first runtime event",
+  ok("every §6.1 step names a canonical ref: plan · thread · initial thread event · launch-recipe · harness-binding · readiness · spawn · terminal-attach · first runtime event",
     typeof steps.plan_ref === "string" && steps.plan_ref.startsWith("harness-session-launch-plan:")
       && typeof steps.thread_ref === "string" && steps.thread_ref.startsWith("thread:launch-")
       && typeof steps.thread_event_ref === "string" && steps.thread_event_ref.includes("/opened")
-      && typeof steps.managed_session_ref === "string" && steps.managed_session_ref.startsWith("managed-session:")
       && steps.launch_recipe_ref != null
       && typeof steps.harness_binding_ref === "string" && steps.harness_binding_ref.startsWith("harness-session-binding:")
       && typeof steps.readiness_ref === "string" && steps.readiness_ref.startsWith("readiness:")
@@ -215,6 +214,62 @@ async function run() {
       && steps.terminal_attach_ref != null
       && typeof steps.first_runtime_event_ref === "string" && steps.first_runtime_event_ref.includes("/spawned"),
     JSON.stringify(steps));
+
+  // -- Finding 1: the thread / fork / managed-session facts are the REAL kernel planners' output or
+  //    an honest typed absence — never a hand-minted record wearing a kernel schema name, never a
+  //    launch-family-only event vocabulary. These assertions would FAIL on the #252 second spine. --
+  ok("Finding 1 (step 5): the initial thread event is admitted onto the REAL kernel event stream — it carries the kernel `event_kind: thread.started` and the substrate's admission proof (an agentgres resulting_head), NOT a launch-family `runtime.thread.opened` inline vocabulary",
+    steps.thread_event_kind === "thread.started"
+      && typeof steps.thread_event_resulting_head === "string"
+      && steps.thread_event_resulting_head.startsWith("agentgres://runtime-events/"),
+    `${steps.thread_event_kind} · ${steps.thread_event_resulting_head}`);
+  ok("Finding 1 (step 6): with no delegation requested the fork is a typed `not_requested` naming the real fork planner (plan_runtime_thread_fork_control) — never a hand-minted admitted fork",
+    launch?.fork?.decision === "not_requested"
+      && launch?.fork?.fork_planner === "plan_runtime_thread_fork_control"
+      && launch?.fork?.schema_version !== "ioi.runtime.thread_fork_control.v1",
+    JSON.stringify(launch?.fork));
+  ok("Finding 1 (step 7): the managed-session step routes the real control planner (plan_runtime_managed_session_control_from_replayed_events); a fresh launch has none, so it is a typed absence naming the VALID states observe|take_over|return_agent — never a hand-minted `managed_session_control.v1` with the invalid control_state `admitted`",
+    launch?.managed_session?.decision === "no_managed_session_at_launch"
+      && launch?.managed_session?.control_planner === "plan_runtime_managed_session_control_from_replayed_events"
+      && JSON.stringify(launch?.managed_session?.available_control_states) === JSON.stringify(["observe", "take_over", "return_agent"])
+      && launch?.managed_session?.schema_version !== "ioi.runtime.managed_session_control.v1"
+      && launch?.managed_session?.control_state !== "admitted",
+    JSON.stringify(launch?.managed_session));
+  const launchStr = JSON.stringify(launch);
+  ok("SAFETY: the composed launch carries NO second-spine shadow — no `ioi.runtime.thread_fork_control.v1` / `ioi.runtime.managed_session_control.v1` record, no invalid `control_state:\"admitted\"`, no `runtime.thread.opened`/`runtime.thread.harness_spawned` vocabulary",
+    !launchStr.includes("ioi.runtime.thread_fork_control.v1")
+      && !launchStr.includes("ioi.runtime.managed_session_control.v1")
+      && !launchStr.includes("\"control_state\":\"admitted\"")
+      && !launchStr.includes("runtime.thread.opened")
+      && !launchStr.includes("runtime.thread.harness_spawned"),
+    "no shadow tokens in the composed launch");
+
+  // -- Finding 2: the harness binding names a REAL seeded hp_* profile + its EXACT frozen revision,
+  //    and model-route availability was RECHECKED at the launch boundary (not a static literal). ----
+  const profiles = await jd("/v1/hypervisor/harness-profiles");
+  const profilesStr = JSON.stringify(profiles.body);
+  ok("Finding 2: the bound profile `hp_hypervisor_worker` is a REAL registry hp_* profile (it resolves), while the #252 `default_harness_profile` is ABSENT from the registry",
+    profilesStr.includes("hp_hypervisor_worker") && !profilesStr.includes("default_harness_profile"),
+    `hp_hypervisor_worker present=${profilesStr.includes("hp_hypervisor_worker")}`);
+  const bindingEvidence = launch?.harness_binding_evidence || {};
+  ok("Finding 2: the binding names the real seeded profile AND its EXACT frozen revision (harness-profile://daemon-resolved/<harness>/revision/sha256:...)",
+    bindingEvidence.harness_profile_ref === "hp_hypervisor_worker"
+      && typeof steps.harness_profile_revision_ref === "string"
+      && steps.harness_profile_revision_ref.startsWith("harness-profile://daemon-resolved/")
+      && steps.harness_profile_revision_ref.includes("/revision/sha256:"),
+    steps.harness_profile_revision_ref);
+  const recheck = bindingEvidence.model_route_recheck || {};
+  ok("Finding 2: model-route availability was RECHECKED at the launch boundary with a real registry read (route resolved + admitted lifecycle read + recheck timestamp) and the binding availability was DERIVED from it — not a static `daemon_verified` literal",
+    recheck.recheck_source === "daemon-model-route-registry"
+      && recheck.route_resolved === true
+      && typeof recheck.registry_lifecycle_status === "string"
+      && typeof recheck.rechecked_at === "string" && !recheck.rechecked_at.startsWith("1970")
+      && recheck.derived_binding_availability_state === "daemon_verified",
+    JSON.stringify(recheck));
+  ok("Finding 2: the recheck honestly carries live token reachability as FALSE (the mount is daemon-verified; live serving is the W3.2 execute dependency) — the binding never over-claims what the readiness admits",
+    recheck.model_route_reachable === false && launch?.readiness?.observed_substrate?.model_route_reachable === false,
+    `recheck=${recheck.model_route_reachable} readiness=${launch?.readiness?.observed_substrate?.model_route_reachable}`);
+
   ok("readiness is the honest client-PTY-attach gate: ready, and it carries the observed substrate probe rather than over-claiming a live model",
     launch?.readiness?.decision === "ready"
       && launch?.readiness?.readiness_state === "ready_for_harness_pty_attach"
@@ -236,6 +291,25 @@ async function run() {
     `${sessionAfter?.subject_attachments?.length} attachment(s)`);
   ok("no second Session family was minted: exactly one session record on disk after launch (the launch hangs off the kernel-owned Session spine)",
     countSessionRecords() === sessionsBeforeLaunch, `${countSessionRecords()} session record(s)`);
+
+  // -- Finding 1 (step 6), delegation REQUESTED: the fork routes the real kernel planner ---------
+  // A delegation-requested launch routes plan_runtime_thread_fork_control; the launch thread has no
+  // forkable source agent, so the planner's own refusal ladder answers (agent_replay_required) and
+  // NO admitted fork is fabricated — the planner's typed output, never a hand-minted record.
+  const delegated = await jd(LAUNCHES, { method: "POST", body: JSON.stringify({
+    session_ref: sessionRef,
+    idempotency_key: "delegation-probe",
+    delegation: { reason: "verifier delegation probe", bounds: { budget: "parent_bounded" } },
+  }) });
+  const delegatedFork = delegated.body?.fork || {};
+  ok("Finding 1 (step 6): a delegation-requested launch routes the REAL fork planner (plan_runtime_thread_fork_control); its refusal ladder answers with a typed planner code and fabricates no admitted fork — never a hand-minted `ioi.runtime.thread_fork_control.v1` record",
+    delegated.status === 200
+      && delegatedFork.fork_planner === "plan_runtime_thread_fork_control"
+      && (delegatedFork.decision === "forked" || delegatedFork.decision === "refused")
+      && (delegatedFork.decision !== "refused" || String(delegatedFork.code || "").startsWith("runtime_thread_fork_control_"))
+      && delegatedFork.schema_version !== "ioi.runtime.thread_fork_control.v1"
+      && !JSON.stringify(delegated.body).includes("ioi.runtime.thread_fork_control.v1"),
+    `${delegatedFork.decision} · ${delegatedFork.code || "(forked)"}`);
 
   // -- INV-37 durable receipt binds the acting principal ----------------------------------------
   const producedReceipt = readReceiptByKind("hypervisor.harness_session_launch.produced", launchRef);
@@ -302,10 +376,13 @@ async function run() {
   ok("after restart the owned Session still carries the materialized subject attachment (durable, not a process-memory fact)",
     Array.isArray(sessionPost?.subject_attachments) && sessionPost.subject_attachments.some((a) => a.subject_ref === launchRef));
   const eventsPost = await jd(`${LAUNCHES}/${encodeURIComponent(launchId)}/events`);
-  ok("the reconstructed chain events replay after restart, distinguished as reconstructed (the initial thread event survives)",
+  const replayedEvents = eventsPost.body?.events || [];
+  ok("Finding 1: /events REPLAYS the launch thread from the REAL kernel event stream after restart — the durable events read back are the kernel `thread.started` + `harness_session.spawned` facts (each carrying a substrate seq + resulting_head), NOT a launch-family `runtime.thread.opened` vocabulary",
     eventsPost.status === 200 && eventsPost.body?.reconstructed === true
-      && (eventsPost.body?.events || []).some((e) => e.kind === "runtime.thread.opened"),
-    `${(eventsPost.body?.events || []).length} event(s)`);
+      && replayedEvents.some((e) => e.event_kind === "thread.started" && typeof e.seq === "number" && typeof e.resulting_head === "string")
+      && replayedEvents.some((e) => e.event_kind === "harness_session.spawned")
+      && !replayedEvents.some((e) => e.kind === "runtime.thread.opened" || e.event_kind === "runtime.thread.opened"),
+    `${replayedEvents.length} event(s): ${replayedEvents.map((e) => e.event_kind).join(",")}`);
 
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);

--- a/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
@@ -1132,12 +1132,13 @@ fn replay_runtime_events(
         for projection in history {
             let mut event = projection.operation.payload.clone();
             if let Some(object) = event.as_object_mut() {
-                // Sequence + head are the substrate's facts about the event, stamped
-                // on read from the admitted projection rather than stored in the
-                // authored bytes. Surfacing the real head lets a reader cross-check a
-                // produce-time `substrate_head` against the stream's actual head.
+                // Sequence is the substrate's fact about the event, stamped on read
+                // from the admitted projection rather than stored in the authored bytes.
+                // The substrate HEAD is deliberately NOT surfaced here: this shared read
+                // also feeds the managed-session planner on the produce path, so keeping it
+                // head-free means nothing on the write path carries an extra field. The
+                // /events read route surfaces the head via replay_stream_events_with_substrate_head.
                 object.insert("seq".to_string(), json!(projection.seq));
-                object.insert("substrate_head".to_string(), json!(projection.head));
             }
             if replay_kind == "turn"
                 && turn_id.is_some_and(|wanted| {
@@ -1170,6 +1171,42 @@ fn replay_runtime_events(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default())
+}
+
+/// Read-route ONLY: replay an admitted stream and additionally surface the substrate
+/// `projection.head` per event. This is used exclusively by the /events read route so a reader can
+/// cross-check a produce-time `substrate_head` against the stream's actual head — and `substrate_head`
+/// is therefore a pure read-shape field, NEVER planner input (the shared `replay_runtime_events` that
+/// also feeds the managed-session planner on the produce path stays head-free). Legacy streams (never
+/// a launch thread) carry no substrate head and delegate to the head-free replay.
+fn replay_stream_events_with_substrate_head(
+    st: &DaemonState,
+    event_stream_id: &str,
+) -> Result<Vec<Value>, AppError> {
+    use ioi_services::agentic::runtime::event_stream_admission as admission;
+
+    if admission::classify_stream(&st.data_dir, event_stream_id)
+        == admission::StreamHoming::Admitted
+    {
+        let tail = admission::stream_tail(event_stream_id);
+        let history = crate::substrate_store::read_event_stream_history(
+            &st.data_dir,
+            admission::THREAD_ORCHESTRATION_NAMESPACE,
+            &tail,
+        )
+        .map_err(|refusal| AppError(StatusCode::BAD_GATEWAY, refusal.to_string()))?;
+        let mut events = Vec::with_capacity(history.len());
+        for projection in history {
+            let mut event = projection.operation.payload.clone();
+            if let Some(object) = event.as_object_mut() {
+                object.insert("seq".to_string(), json!(projection.seq));
+                object.insert("substrate_head".to_string(), json!(projection.head));
+            }
+            events.push(event);
+        }
+        return Ok(events);
+    }
+    replay_runtime_events(st, "stream", event_stream_id, None)
 }
 
 /// Project the runtime event list for a thread (or a run) via the kernel event
@@ -22665,8 +22702,13 @@ fn admit_launch_thread_event(
         "status": "admitted",
         "actor": "operator",
         "created_at": now,
-        "component_kind": "harness_session_launch_thread",
-        "payload_schema_version": "ioi.runtime.harness-session-launch-thread-event.v1",
+        "component_kind": "thread_lifecycle",
+        // Kernel-NATIVE runtime-event schema (the kernel's own generic thread-event payload schema,
+        // runtime_thread_event.rs `runtime_payload_schema_version` → "ioi.runtime.event.v1"). Runtime
+        // thread events are kernel event metadata, NOT registered wire contracts (only the admission
+        // RECORDS are registered) — so the launch admits its thread events under the kernel's own
+        // schema rather than minting an unregistered launch-family name onto the kernel stream.
+        "payload_schema_version": "ioi.runtime.event.v1",
         "payload": {
             "launch_ref": launch_ref,
             "session_ref": session_ref,
@@ -23488,7 +23530,7 @@ pub(crate) async fn handle_session_launch_events(
                 .map(|thread_ref| format!("{thread_ref}:events"))
         })
         .unwrap_or_default();
-    let events = match replay_runtime_events(&st, "stream", &event_stream_id, None) {
+    let events = match replay_stream_events_with_substrate_head(&st, &event_stream_id) {
         Ok(events) => events,
         Err(AppError(status, message)) => {
             return (

--- a/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
@@ -96,6 +96,9 @@ use ioi_services::agentic::runtime::kernel::runtime_thread_event::{
     RUNTIME_THREAD_EVENT_REPLAY_REQUEST_SCHEMA_VERSION,
     RUNTIME_THREAD_TURN_PROJECTION_REQUEST_SCHEMA_VERSION,
 };
+use ioi_services::agentic::runtime::kernel::runtime_thread_fork_control::{
+    RuntimeThreadForkControlRequest, RUNTIME_THREAD_FORK_CONTROL_REQUEST_SCHEMA_VERSION,
+};
 use ioi_services::agentic::runtime::kernel::runtime_tool_catalog::RuntimeToolCatalogProjectionRequest;
 use ioi_services::agentic::runtime::kernel::runtime_workspace_change_control::{
     RuntimeWorkspaceChangeControlRequest, RuntimeWorkspaceChangeProjectionRequest,
@@ -22464,29 +22467,44 @@ fn session_launch_recipe_request(project_ref: &str) -> Value {
     })
 }
 
+/// The seeded native-worker profile the launch binds — a REAL registry hp_* profile (Finding 2:
+/// never the registry-absent `default_harness_profile`). `hp_hypervisor_worker` is the daemon's
+/// Lane A native worker; `ensure_seed` admits it active with `execution_wiring = lane_a_host_spawn`.
+const LAUNCH_HARNESS_PROFILE_ID: &str = "hp_hypervisor_worker";
+
 /// The canonical HarnessSessionBinding governance-admission request (the exact profile / adapter /
 /// model-route / workspace-mount / privacy / authority / receipt-policy binding the daemon gate
 /// requires before a harness may launch). Same planner as
 /// POST /v1/hypervisor/harness-session-binding-admissions.
-fn session_harness_binding_request() -> Value {
+///
+/// Finding 2: the harness selection names the REAL seeded `hp_hypervisor_worker` profile (not the
+/// registry-absent `default_harness_profile`), and `model_route_availability_state` /
+/// `model_route_ref` are DERIVED from a launch-boundary recheck of the daemon-owned model-route
+/// registry — never a static `daemon_verified` literal. The caller computes `availability_state`
+/// from the real read (`model_route_launch_recheck`); an unavailable route is refused by the
+/// kernel planner rather than over-claimed here.
+fn session_harness_binding_request(
+    model_route_ref: &str,
+    model_route_availability_state: &str,
+) -> Value {
     // The binding ref must ENCODE the session route (the planner's route-binding check): the first
     // segment is `session-route:sessions/mission.default/project:ioi` with every non-alphanumeric
     // replaced by `-`. These are the known-admitting canonical coordinates.
     json!({
         "schema_version": "ioi.hypervisor.harness_session_binding.v1",
-        "session_binding_ref": "harness-session-binding:session-route-sessions-mission-default-project-ioi:harness-profile-default_harness_profile:model-config-local-codex-oss-qwen",
+        "session_binding_ref": "harness-session-binding:session-route-sessions-mission-default-project-ioi:harness-profile-hp_hypervisor_worker:model-config-local-hypervisor-worker",
         "session_route_ref": "session-route:sessions/mission.default/project:ioi",
-        "harness_selection_ref": "harness-profile:default_harness_profile",
+        "harness_selection_ref": "harness-profile:hp_hypervisor_worker",
         "harness_selection_kind": "harness_profile",
-        "harness_label": "Default Harness Profile",
+        "harness_label": "Hypervisor Worker (native)",
         "harness_truth_boundary": "daemon-owned",
-        "harness_launch_route_ref": "harness-route:default-harness-profile/local-model",
-        "harness_profile_ref": "default_harness_profile",
-        "model_configuration_ref": "model-config:local/codex-oss-qwen",
-        "model_configuration_label": "Local Codex OSS / Qwen route",
-        "model_route_ref": "model-route:hypervisor/default-local",
+        "harness_launch_route_ref": "harness-route:hp-hypervisor-worker/local-model",
+        "harness_profile_ref": LAUNCH_HARNESS_PROFILE_ID,
+        "model_configuration_ref": "model-config:local/hypervisor-worker",
+        "model_configuration_label": "Local hypervisor-worker route",
+        "model_route_ref": model_route_ref,
         "model_route_policy": "hypervisor_model_mount",
-        "model_route_availability_state": "daemon_verified",
+        "model_route_availability_state": model_route_availability_state,
         "model_route_endpoint_refs": ["model-endpoint:hypervisor/default-local"],
         "model_route_loaded_instance_refs": ["model-instance:hypervisor/default-local"],
         "workspace_mount_policy": "ctee_private_workspace",
@@ -22504,6 +22522,306 @@ fn session_harness_binding_request() -> Value {
         "receipt_refs": ["receipt://harness-session-binding/admit"],
         "state_root": "agentgres://state-root/harness-session-binding/admit",
     })
+}
+
+/// Canonical `sha256:<hex>` over a value's JSON bytes — the frozen-revision idiom the GoalRun
+/// activation planner uses (goalrun_routes.rs) to pin an EXACT daemon-resolved component revision.
+fn launch_sha256_canonical(value: &Value) -> String {
+    format!(
+        "sha256:{}",
+        sha256_hex_bytes(&serde_json::to_vec(value).unwrap_or_default())
+    )
+}
+
+/// Freeze the EXACT revision of the daemon-resolved harness profile the launch binds, reusing the
+/// GoalRun activation idiom `harness-profile://daemon-resolved/<harness>/revision/<sha256>`. The
+/// revision content-addresses the profile's stable released shape (adapter / capabilities / model
+/// binding / lifecycle), so ACC-G is met at the bytes: a launch names not just a profile id but the
+/// precise revision it bound. Returns `(revision_ref, content_hash)`.
+fn harness_profile_frozen_revision(profile: &Value) -> (String, String) {
+    let harness = profile
+        .get("harness")
+        .and_then(Value::as_str)
+        .unwrap_or("hypervisor_worker");
+    let material = json!({
+        "schema_version": "ioi.hypervisor.harness-profile-frozen-revision-jcs-sha256.v1",
+        "profile_ref": profile.get("profile_ref"),
+        "profile_id": profile.get("profile_id"),
+        "harness": harness,
+        "adapter": profile.get("adapter"),
+        "capabilities": profile.get("capabilities"),
+        "model_binding": profile.get("model_binding"),
+        "lifecycle_status": profile.pointer("/lifecycle/status"),
+    });
+    let content_hash = launch_sha256_canonical(&material);
+    let harness_slug: String = harness
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let revision_ref =
+        format!("harness-profile://daemon-resolved/{harness_slug}/revision/{content_hash}");
+    (revision_ref, content_hash)
+}
+
+/// The launch-boundary model-route recheck (Finding 2): a REAL read of the daemon-owned model-route
+/// registry, never a static literal. Resolves the default route, reads its admitted lifecycle +
+/// registry availability, and derives the binding's availability enum from that read — an
+/// unresolved or non-active mount yields `unavailable`/`missing`, which the kernel binding planner
+/// then refuses under the hypervisor-model-mount policy. Live token reachability is a DISTINCT truth
+/// carried by the readiness record; this recheck verifies the MOUNT, not that a model serves now.
+struct ModelRouteRecheck {
+    route_ref: String,
+    availability_state: &'static str,
+    evidence: Value,
+}
+
+fn model_route_launch_recheck(
+    data_dir: &str,
+    substrate: &ExecutionSubstrate,
+    now: &str,
+) -> ModelRouteRecheck {
+    super::model_routes::ensure_seed(data_dir);
+    let route = read_record_dir(data_dir, super::model_routes::RECORD_DIR)
+        .into_iter()
+        .find(|r| r.get("default_route").and_then(Value::as_bool) == Some(true));
+    let route_ref = route
+        .as_ref()
+        .and_then(|r| r.get("route_ref").and_then(Value::as_str))
+        .unwrap_or("model-route:mrt_local_default")
+        .to_string();
+    let lifecycle_status = route
+        .as_ref()
+        .and_then(|r| r.pointer("/lifecycle/status").and_then(Value::as_str))
+        .unwrap_or("missing")
+        .to_string();
+    let registry_availability_state = route
+        .as_ref()
+        .and_then(|r| r.pointer("/availability/state").and_then(Value::as_str))
+        .unwrap_or("missing")
+        .to_string();
+    let resolved = route.is_some();
+    // Derived from the REAL read: an admitted-active mount is daemon-verified as a MOUNT; anything
+    // else is honestly unavailable/missing (and the kernel binding refuses it).
+    let availability_state = if resolved && lifecycle_status == "active" {
+        "daemon_verified"
+    } else if resolved {
+        "unavailable"
+    } else {
+        "missing"
+    };
+    let evidence = json!({
+        "recheck_source": "daemon-model-route-registry",
+        "route_ref": route_ref,
+        "route_resolved": resolved,
+        "registry_lifecycle_status": lifecycle_status,
+        "registry_availability_state": registry_availability_state,
+        "derived_binding_availability_state": availability_state,
+        "model_route_reachable": substrate.model_route,
+        "rechecked_at": now,
+        "note": "launch-boundary read of the daemon-owned model-route registry; live token reachability is the readiness record's separate truth",
+    });
+    ModelRouteRecheck {
+        route_ref,
+        availability_state,
+        evidence,
+    }
+}
+
+/// Admit ONE launch thread event onto the REAL kernel event stream (Finding 1, step 5): shaped by
+/// the kernel and admitted through `admit_and_persist_event` (CAS heads, typed 409/422), NOT a
+/// launch-family-only inline vocabulary. The returned value carries the substrate's admission proof
+/// (`seq`, `resulting_head`, `agentgres_operation_ref`) alongside a caller-named `event_id` that
+/// still reads as the launch's `.../opened` | `.../spawned` step.
+fn admit_launch_thread_event(
+    st: &DaemonState,
+    event_stream_id: &str,
+    thread_ref: &str,
+    launch_id: &str,
+    event_kind: &str,
+    step: &str,
+    launch_ref: &str,
+    session_ref: &str,
+    now: &str,
+) -> Result<Value, AppError> {
+    let event = json!({
+        "event_id": format!("thread-event:{launch_id}/{step}"),
+        "event_stream_id": event_stream_id,
+        "thread_id": thread_ref,
+        "turn_id": "",
+        "item_id": format!("{thread_ref}:item:harness_session_launch:{step}"),
+        "idempotency_key": format!("thread:{thread_ref}:harness_session_launch.{step}"),
+        "source": "hypervisor_session_launch",
+        "source_event_kind": "HarnessSessionLaunch.ThreadEvent",
+        "event_kind": event_kind,
+        "status": "admitted",
+        "actor": "operator",
+        "component_kind": "harness_session_launch_thread",
+        "payload_schema_version": "ioi.runtime.harness-session-launch-thread-event.v1",
+        "payload": {
+            "launch_ref": launch_ref,
+            "session_ref": session_ref,
+            "step": step,
+        },
+        "receipt_refs": [format!("receipt://hypervisor/harness-session-launch/thread/{launch_id}/{step}")],
+        "policy_decision_refs": [],
+        "artifact_refs": [],
+        "rollback_refs": [],
+        "redaction_profile": "internal",
+        "evidence_refs": [
+            "runtime_thread_event_rust_owned",
+            "agentgres_thread_event_truth_required",
+        ],
+        "runtimeTruthSource": "daemon-runtime",
+    });
+    admit_and_persist_event(st, event)
+}
+
+/// Map an event-admission `AppError` into the launch producer's typed failure response, tagging the
+/// composition stage so a substrate refusal is legible (and fabricates no launch).
+fn launch_event_admission_failure(stage: &str, error: AppError) -> (StatusCode, Json<Value>) {
+    let AppError(status, message) = error;
+    (
+        status,
+        Json(json!({"error":{
+            "code": "session_launch_thread_event_admission_failed",
+            "message": message,
+            "stage": stage,
+        }})),
+    )
+}
+
+/// Compose the launch's (optional) bounded delegation through the REAL fork KERNEL PLANNER
+/// (`plan_runtime_thread_fork_control`), Finding 1 step 6 — never a hand-minted
+/// `ioi.runtime.thread_fork_control.v1` record. Bounded delegation is composed only when the caller
+/// requests it; the honest default is a typed `not_requested`, never a fabricated child thread.
+/// When requested, the planner's refusal ladder stays intact: a typed refusal (e.g. no forkable
+/// source agent on the launch thread) is recorded as `refused` with the planner's own code, and NO
+/// admitted fork is fabricated. On success the planner's `thread.forked` event is admitted onto the
+/// real kernel event stream.
+fn compose_launch_fork(
+    st: &DaemonState,
+    body: &Value,
+    thread_ref: &str,
+    event_stream_id: &str,
+    workspace_root: &str,
+    now: &str,
+) -> Result<Value, (StatusCode, Json<Value>)> {
+    let Some(delegation) = body.get("delegation").filter(|value| value.is_object()) else {
+        return Ok(json!({
+            "decision": "not_requested",
+            "note": "no bounded delegation requested; no child thread fabricated",
+            "fork_planner": "plan_runtime_thread_fork_control",
+        }));
+    };
+    let request: RuntimeThreadForkControlRequest = serde_json::from_value(json!({
+        "schema_version": RUNTIME_THREAD_FORK_CONTROL_REQUEST_SCHEMA_VERSION,
+        "operation": "thread_fork",
+        "operation_kind": "thread.fork",
+        "thread_id": thread_ref,
+        "event_stream_id": event_stream_id,
+        "state_dir": st.data_dir,
+        "request": {
+            "workspace_root": workspace_root,
+            "reason": delegation.get("reason"),
+            "bounds": delegation.get("bounds"),
+            "requested_by": "operator",
+            "created_at": now,
+        },
+    }))
+    .map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error":{"code":"session_launch_fork_request_invalid","message":error.to_string(),"stage":"thread_fork_control"}})),
+        )
+    })?;
+    match RuntimeKernelService::new().plan_runtime_thread_fork_control(&request) {
+        Ok(record) => {
+            let admitted = admit_and_persist_event(st, record.event)
+                .map_err(|error| launch_event_admission_failure("thread_fork_control", error))?;
+            Ok(json!({
+                "decision": "forked",
+                "fork_planner": "plan_runtime_thread_fork_control",
+                "forked_thread_id": record.forked_thread_id,
+                "forked_agent_id": record.agent_id,
+                "event": admitted,
+            }))
+        }
+        Err(error) => Ok(json!({
+            "decision": "refused",
+            "fork_planner": "plan_runtime_thread_fork_control",
+            "code": error.code(),
+            "message": error.message(),
+            "note": "the real fork planner refused; no admitted fork fabricated (bounded delegation requires a forkable source agent on the thread)",
+        })),
+    }
+}
+
+/// Compose the launch's managed-session step through the REAL control KERNEL PLANNER
+/// (`plan_runtime_managed_session_control_from_replayed_events`), Finding 1 step 7 — never a
+/// hand-minted `ioi.runtime.managed_session_control.v1` record with the invalid
+/// `control_state: "admitted"`. The control planner is a control-over-existing primitive
+/// (observe | take_over | return_agent) that reads prior managed-session records from the thread's
+/// REAL replayed event stream. A fresh harness launch produces NO managed session, so the planner's
+/// honest `record_required` refusal is recorded as a typed absence (mirroring the fork's
+/// `not_requested`); once a real sandbox managed session exists on the thread, the SAME planner
+/// composes its `managed_session.controlled` transition and it is admitted onto the real stream.
+fn compose_launch_managed_session(
+    st: &DaemonState,
+    thread_ref: &str,
+    event_stream_id: &str,
+    launch_id: &str,
+    now: &str,
+) -> Result<Value, (StatusCode, Json<Value>)> {
+    let events = replay_runtime_events(st, "stream", event_stream_id, None)
+        .map_err(|error| launch_event_admission_failure("managed_session_control", error))?;
+    let managed_session_id = format!("managed-session:{launch_id}");
+    let request: RuntimeManagedSessionControlRequest = serde_json::from_value(json!({
+        "schema_version": RUNTIME_MANAGED_SESSION_CONTROL_REQUEST_SCHEMA_VERSION,
+        "operation": "managed_session_control",
+        "operation_kind": "managed_session.control",
+        "thread_id": thread_ref,
+        "event_stream_id": event_stream_id,
+        "state_dir": st.data_dir,
+        "managed_session_id": managed_session_id,
+        "control_state": "observe",
+        "request": { "created_at": now, "requested_by": "operator" },
+    }))
+    .map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error":{"code":"session_launch_managed_session_request_invalid","message":error.to_string(),"stage":"managed_session_control"}})),
+        )
+    })?;
+    match RuntimeKernelService::new()
+        .plan_runtime_managed_session_control_from_replayed_events(&request, &events)
+    {
+        Ok(record) => {
+            let admitted = admit_and_persist_event(st, record.event).map_err(|error| {
+                launch_event_admission_failure("managed_session_control", error)
+            })?;
+            Ok(json!({
+                "decision": "controlled",
+                "control_planner": "plan_runtime_managed_session_control_from_replayed_events",
+                "managed_session_ref": record.managed_session_id,
+                "control_state": record.control_state,
+                "event": admitted,
+            }))
+        }
+        Err(error) if error.code() == "runtime_managed_session_control_record_required" => {
+            Ok(json!({
+                "decision": "no_managed_session_at_launch",
+                "control_planner": "plan_runtime_managed_session_control_from_replayed_events",
+                "available_control_states": ["observe", "take_over", "return_agent"],
+                "note": "a harness launch produces no managed session; managed-session control composes the real kernel planner only once a sandbox managed session exists on the thread",
+            }))
+        }
+        Err(error) => Err((
+            StatusCode::BAD_GATEWAY,
+            Json(
+                json!({"error":{"code":error.code(),"message":error.message(),"stage":"managed_session_control"}}),
+            ),
+        )),
+    }
 }
 
 /// Real readiness evidence for the client-PTY-attach gate. The DECISION is about whether the
@@ -22559,11 +22877,11 @@ fn launch_spawn_record(
         "launch_id": format!("launch:{launch_id}"),
         "session_binding_ref": session_binding_ref,
         "session_route_ref": "session-route:sessions/mission.default/project:ioi",
-        "harness_selection_ref": "harness-profile:default_harness_profile",
+        "harness_selection_ref": "harness-profile:hp_hypervisor_worker",
         "agent_harness_adapter_id": "generic_cli_local",
-        "model_configuration_ref": "model-config:local/codex-oss-qwen",
-        "model_route_ref": "model-route:hypervisor/default-local",
-        "model_name": "codex-oss-qwen",
+        "model_configuration_ref": "model-config:local/hypervisor-worker",
+        "model_route_ref": "model-route:mrt_local_default",
+        "model_name": "hypervisor-worker",
         "workspace_ref": format!("workspace://{launch_id}"),
         "workspace_root": workspace_root,
         "terminal_session_ref": format!("terminal:{launch_id}"),
@@ -22656,18 +22974,31 @@ fn launch_projection(record: &Value, replayed: bool) -> Value {
         "spawned": !step("/spawn").is_null(),
         "subject_attachments": step("/subject_attachments"),
         "readiness": step("/readiness"),
+        // Finding 1 — fork / managed-session are the real planners' output or an honest typed
+        // absence; the full objects are exposed so a reader (and the verifier) can see the composed
+        // kernel event / decision, never a hand-minted schema-named record.
+        "fork": step("/fork"),
+        "managed_session": step("/managed_session"),
+        // Finding 2 — the exact frozen profile revision + the launch-boundary model-route recheck.
+        "harness_binding_evidence": step("/harness_binding_evidence"),
         "chain_step_refs": {
             "plan_ref": launch_step_ref(&step("/plan_admission"), &["plan_ref"]),
             "thread_ref": chain.pointer("/thread/thread_ref").cloned().unwrap_or(Value::Null),
-            "thread_event_ref": chain.pointer("/thread/initial_event/event_ref").cloned().unwrap_or(Value::Null),
-            "fork_ref": launch_step_ref(&step("/fork"), &["fork_ref", "decision"]),
+            // The admitted kernel event id (`.../opened`) — the event carries the substrate's real
+            // admission proof (seq / resulting_head / agentgres_operation_ref) below.
+            "thread_event_ref": chain.pointer("/thread/initial_event/event_id").cloned().unwrap_or(Value::Null),
+            "thread_event_kind": chain.pointer("/thread/initial_event/event_kind").cloned().unwrap_or(Value::Null),
+            "thread_event_resulting_head": chain.pointer("/thread/initial_event/resulting_head").cloned().unwrap_or(Value::Null),
+            "fork_decision": launch_step_ref(&step("/fork"), &["decision"]),
+            "managed_session_decision": launch_step_ref(&step("/managed_session"), &["decision"]),
             "managed_session_ref": launch_step_ref(&step("/managed_session"), &["managed_session_ref"]),
             "launch_recipe_ref": launch_step_ref(&step("/launch_recipe_admission"), &["target_binding_ref", "recipe_ref"]),
             "harness_binding_ref": launch_step_ref(&step("/harness_binding_admission"), &["session_binding_ref"]),
+            "harness_profile_revision_ref": launch_step_ref(&step("/harness_binding_evidence"), &["harness_profile_revision_ref"]),
             "readiness_ref": launch_step_ref(&step("/readiness"), &["readiness_id"]),
             "spawn_ref": launch_step_ref(&step("/spawn"), &["spawn_id"]),
             "terminal_attach_ref": launch_step_ref(&step("/terminal_attach"), &["terminal_attach_id", "attach_id", "schema_version"]),
-            "first_runtime_event_ref": chain.pointer("/first_runtime_event/event_ref").cloned().unwrap_or(Value::Null),
+            "first_runtime_event_ref": chain.pointer("/first_runtime_event/event_id").cloned().unwrap_or(Value::Null),
         },
         "receipt_ref": record.pointer("/receipt_refs/0"),
         "latest_receipt_refs": record.get("receipt_refs"),
@@ -22753,8 +23084,10 @@ pub(crate) async fn handle_session_launch_create(
         .unwrap_or("")
         .to_string();
 
-    // Compose the chain fully IN MEMORY first: any planner refusal returns here, BEFORE any durable
-    // write — denial fabricates no launch, record, receipt, subject attachment, or row.
+    // Compose the REFUSABLE planners fully IN MEMORY first: any planner refusal returns here,
+    // BEFORE any durable write — denial fabricates no launch, record, receipt, subject attachment,
+    // row, or admitted event. The REAL kernel event-stream writes (steps 5-7, below) are ordered
+    // strictly after every refusable planner has admitted.
 
     // Step 8 — HypervisorSessionLaunchRecipeAdmission (canonical kernel planner).
     let launch_recipe_admission = match kernel.admit_hypervisor_session_launch_recipe(
@@ -22771,10 +23104,29 @@ pub(crate) async fn handle_session_launch_create(
             )
         }
     };
-    // Step 9 — HarnessSessionBindingAdmission (canonical kernel planner).
-    let harness_binding_admission = match kernel
-        .admit_harness_session_binding(&session_harness_binding_request(), &now)
-    {
+
+    // Finding 2 — exact-revision harness binding. Load the REAL seeded `hp_hypervisor_worker`
+    // profile from the registry and freeze its EXACT revision (sha256), and RECHECK the model route
+    // at the launch boundary with a real read of the daemon-owned registry. The binding's
+    // availability enum is derived from that read — never a static `daemon_verified` literal.
+    super::harness_routes::ensure_seed(&st.data_dir);
+    let harness_profile_record =
+        super::harness_routes::load_profile_record(&st.data_dir, LAUNCH_HARNESS_PROFILE_ID)
+            .unwrap_or_else(|| json!({"profile_ref": format!("harness-profile:{LAUNCH_HARNESS_PROFILE_ID}"), "profile_id": LAUNCH_HARNESS_PROFILE_ID, "harness": "hypervisor_worker"}));
+    let (harness_profile_revision_ref, harness_profile_content_hash) =
+        harness_profile_frozen_revision(&harness_profile_record);
+    let substrate = ExecutionSubstrate::probe();
+    let route_recheck = model_route_launch_recheck(&st.data_dir, &substrate, &now);
+
+    // Step 9 — HarnessSessionBindingAdmission (canonical kernel planner), fed the rechecked
+    // availability + real route ref. An unavailable route is refused by the planner, not over-claimed.
+    let harness_binding_admission = match kernel.admit_harness_session_binding(
+        &session_harness_binding_request(
+            &route_recheck.route_ref,
+            route_recheck.availability_state,
+        ),
+        &now,
+    ) {
         Ok(record) => record,
         Err(error) => {
             return (
@@ -22791,8 +23143,8 @@ pub(crate) async fn handle_session_launch_create(
         .unwrap_or("harness-session-binding:launch")
         .to_string();
 
-    // Step 10 — readiness evidence (real substrate probe). Only a ready binding may spawn.
-    let substrate = ExecutionSubstrate::probe();
+    // Step 10 — readiness evidence (real substrate probe, reused from the route recheck). Only a
+    // ready binding may spawn.
     let session_ready = !workspace_root.is_empty()
         && session_record
             .get("lifecycle_state")
@@ -22807,7 +23159,7 @@ pub(crate) async fn handle_session_launch_create(
     );
 
     // Step 11 — spawn + terminal attachment (HarnessSessionTerminalAttach planner) when ready.
-    let (spawn, terminal_attach, first_runtime_event) = if session_ready {
+    let (spawn, terminal_attach) = if session_ready {
         let spawn = launch_spawn_record(&launch_id, &session_binding_ref, &workspace_root, &now);
         let terminal_attach = match kernel.admit_harness_session_terminal_attach(
             &json!({"session_spawn": spawn, "session_readiness": readiness}),
@@ -22823,26 +23175,81 @@ pub(crate) async fn handle_session_launch_create(
                 )
             }
         };
-        let first_event = json!({
-            "schema_version": "ioi.runtime.thread.event.v1",
-            "event_ref": format!("thread-event:{launch_id}/spawned"),
-            "thread_ref": format!("thread:launch-{launch_id}"),
-            "kind": "runtime.thread.harness_spawned",
-            "sequence": 1,
-            "launch_ref": launch_ref,
-            "session_ref": session_ref,
-            "spawn_id": format!("spawn:{launch_id}"),
-            "created_at": now,
-            "runtimeTruthSource": "daemon-runtime",
-        });
-        (spawn, terminal_attach, first_event)
+        (spawn, terminal_attach)
     } else {
-        (Value::Null, Value::Null, Value::Null)
+        (Value::Null, Value::Null)
     };
 
-    // Steps 4-7 — daemon-resolved plan / thread + initial event / (optional) fork / managed session
-    // control + the materialized typed subject attachment. These are runtime-truth records hung off
-    // the owned Session, not a second session family.
+    // ---- Every refusable planner admitted. Steps 5-7 are the REAL kernel event-stream / planner
+    // compositions (Finding 1): the launch's thread events are admitted onto the real kernel event
+    // stream, and fork / managed-session are the real planners' output or an honest typed absence —
+    // never a hand-minted record wearing a kernel schema name, never a launch-family-only vocabulary.
+    let thread_ref = format!("thread:launch-{launch_id}");
+    let event_stream_id = format!("{thread_ref}:events");
+
+    // Step 5 — initial thread event admitted onto the REAL kernel event stream (CAS heads).
+    let initial_event = match admit_launch_thread_event(
+        &st,
+        &event_stream_id,
+        &thread_ref,
+        &launch_id,
+        "thread.started",
+        "opened",
+        &launch_ref,
+        &session_ref,
+        &now,
+    ) {
+        Ok(event) => event,
+        Err(error) => return launch_event_admission_failure("thread_initial_event", error),
+    };
+    // Step 5b — first runtime event (harness spawned) admitted onto the same real stream when ready.
+    let first_runtime_event = if session_ready {
+        match admit_launch_thread_event(
+            &st,
+            &event_stream_id,
+            &thread_ref,
+            &launch_id,
+            "harness_session.spawned",
+            "spawned",
+            &launch_ref,
+            &session_ref,
+            &now,
+        ) {
+            Ok(event) => event,
+            Err(error) => {
+                return launch_event_admission_failure("thread_first_runtime_event", error)
+            }
+        }
+    } else {
+        Value::Null
+    };
+
+    // Step 6 — (optional) bounded delegation through the REAL fork planner (refusal ladder intact).
+    let fork = match compose_launch_fork(
+        &st,
+        &body,
+        &thread_ref,
+        &event_stream_id,
+        &workspace_root,
+        &now,
+    ) {
+        Ok(record) => record,
+        Err(response) => return response,
+    };
+    // Step 7 — managed-session control through the REAL control planner (typed absence when none).
+    let managed_session = match compose_launch_managed_session(
+        &st,
+        &thread_ref,
+        &event_stream_id,
+        &launch_id,
+        &now,
+    ) {
+        Ok(record) => record,
+        Err(response) => return response,
+    };
+
+    // Step 4 — daemon-resolved launch plan + the materialized typed subject attachment. These are
+    // launch-owned runtime-truth records hung off the owned Session, not a second session family.
     let plan_admission = json!({
         "schema_version": SESSION_LAUNCH_PLAN_SCHEMA_VERSION,
         "plan_ref": format!("harness-session-launch-plan:{launch_id}"),
@@ -22856,44 +23263,17 @@ pub(crate) async fn handle_session_launch_create(
         "runtimeTruthSource": "daemon-runtime",
     });
     let thread = json!({
-        "thread_ref": format!("thread:launch-{launch_id}"),
-        "initial_event": {
-            "schema_version": "ioi.runtime.thread.event.v1",
-            "event_ref": format!("thread-event:{launch_id}/opened"),
-            "thread_ref": format!("thread:launch-{launch_id}"),
-            "kind": "runtime.thread.opened",
-            "sequence": 0,
-            "launch_ref": launch_ref,
-            "session_ref": session_ref,
-            "created_at": now,
-            "runtimeTruthSource": "daemon-runtime",
-        }
+        "thread_ref": thread_ref,
+        "event_stream_id": event_stream_id,
+        "initial_event": initial_event,
     });
-    // Step 6 — bounded delegation is admitted only when requested; the honest default is a typed
-    // "not requested", never a fabricated child thread.
-    let fork = match body.get("delegation").filter(|value| value.is_object()) {
-        Some(delegation) => json!({
-            "schema_version": "ioi.runtime.thread_fork_control.v1",
-            "fork_ref": format!("thread-fork:{launch_id}"),
-            "decision": "admitted",
-            "parent_thread_ref": format!("thread:launch-{launch_id}"),
-            "child_thread_ref": format!("thread:launch-{launch_id}/child"),
-            "bounds": delegation.get("bounds").cloned().unwrap_or(json!({"budget":"parent_bounded"})),
-            "created_at": now,
-            "runtimeTruthSource": "daemon-runtime",
-        }),
-        None => {
-            json!({"decision": "not_requested", "note": "no bounded delegation requested; no child thread fabricated"})
-        }
-    };
-    let managed_session = json!({
-        "schema_version": "ioi.runtime.managed_session_control.v1",
-        "managed_session_ref": format!("managed-session:{launch_id}"),
-        "control_state": "admitted",
-        "session_ref": session_ref,
-        "thread_ref": format!("thread:launch-{launch_id}"),
-        "created_at": now,
-        "runtimeTruthSource": "daemon-runtime",
+    // Finding 2 evidence — the EXACT frozen profile revision the launch bound + the launch-boundary
+    // model-route recheck, alongside the kernel binding admission (kept whole for its projection).
+    let harness_binding_evidence = json!({
+        "harness_profile_ref": LAUNCH_HARNESS_PROFILE_ID,
+        "harness_profile_revision_ref": harness_profile_revision_ref,
+        "harness_profile_content_hash": harness_profile_content_hash,
+        "model_route_recheck": route_recheck.evidence,
     });
     let subject_attachments = launch_subject_attachments(&launch_ref, project_ref.as_deref(), &now);
 
@@ -22931,6 +23311,7 @@ pub(crate) async fn handle_session_launch_create(
             "subject_attachments": subject_attachments,
             "launch_recipe_admission": launch_recipe_admission,
             "harness_binding_admission": harness_binding_admission,
+            "harness_binding_evidence": harness_binding_evidence,
             "readiness": readiness,
             "spawn": spawn,
             "terminal_attach": terminal_attach,
@@ -23010,8 +23391,13 @@ pub(crate) async fn handle_session_launch_get(
     }
 }
 
-/// GET /v1/hypervisor/harness-session-launches/:id/events — the launch's composed chain events
-/// (owner-filtered), including the initial + first-runtime thread events.
+/// GET /v1/hypervisor/harness-session-launches/:id/events — the launch's thread events REPLAYED
+/// from the REAL kernel event stream (owner-filtered). Finding 1: the events are queryable through
+/// the daemon's classified event-stream replay (Agentgres), NOT reconstructed from a launch-family
+/// inline vocabulary — so the `thread.started` / `harness_session.spawned` events read back here are
+/// the same admitted facts every other event-stream reader sees. `reconstructed` is honestly
+/// whether they were replayed from the durable stream (they always are today; the field is retained
+/// so a future non-durable branch would read as `false`).
 pub(crate) async fn handle_session_launch_events(
     State(st): State<Arc<DaemonState>>,
     headers: HeaderMap,
@@ -23029,23 +23415,37 @@ pub(crate) async fn handle_session_launch_events(
             ),
         );
     };
-    let mut events: Vec<Value> = Vec::new();
-    if let Some(event) = record.pointer("/chain/thread/initial_event") {
-        events.push(event.clone());
-    }
-    if let Some(event) = record
-        .pointer("/chain/first_runtime_event")
-        .filter(|value| !value.is_null())
-    {
-        events.push(event.clone());
-    }
+    let event_stream_id = record
+        .pointer("/chain/thread/event_stream_id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            record
+                .pointer("/chain/thread/thread_ref")
+                .and_then(Value::as_str)
+                .map(|thread_ref| format!("{thread_ref}:events"))
+        })
+        .unwrap_or_default();
+    let events = match replay_runtime_events(&st, "stream", &event_stream_id, None) {
+        Ok(events) => events,
+        Err(AppError(status, message)) => {
+            return (
+                status,
+                Json(
+                    json!({"error":{"code":"session_launch_events_replay_failed","message":message}}),
+                ),
+            )
+        }
+    };
+    let reconstructed = !events.is_empty();
     (
         StatusCode::OK,
         Json(json!({
             "schema_version": "ioi.hypervisor.harness_session_launch_events.v1",
             "launch_ref": record.get("launch_ref"),
             "thread_ref": record.pointer("/chain/thread/thread_ref"),
-            "reconstructed": true,
+            "event_stream_id": event_stream_id,
+            "reconstructed": reconstructed,
             "events": events,
             "at": iso_now(),
         })),
@@ -24109,14 +24509,46 @@ mod launch_chain_composition_tests {
     #[test]
 
     fn harness_binding_request_admits() {
+        // Finding 2: the launch names the real seeded `hp_hypervisor_worker` profile and a
+        // recheck-derived availability state (an admitted-active local mount => daemon_verified).
         let admitted = RuntimeKernelService::new()
             .admit_harness_session_binding(
-                &session_harness_binding_request(),
+                &session_harness_binding_request(
+                    "model-route:mrt_local_default",
+                    "daemon_verified",
+                ),
                 "2026-08-11T00:00:00.000Z",
             )
             .expect("harness binding admits");
 
         assert_eq!(admitted["decision"], "admitted");
+        assert_eq!(admitted["harness_profile_ref"], "hp_hypervisor_worker");
+        assert_eq!(
+            admitted["harness_selection_ref"],
+            "harness-profile:hp_hypervisor_worker"
+        );
+    }
+
+    #[test]
+    fn harness_profile_frozen_revision_is_deterministic_and_exact() {
+        let profile = json!({
+            "profile_ref": "harness-profile:hp_hypervisor_worker",
+            "profile_id": "hp_hypervisor_worker",
+            "harness": "hypervisor_worker",
+            "adapter": {"execution_wiring": "lane_a_host_spawn"},
+            "capabilities": {"tool_use": true},
+            "model_binding": {"model_route_policy": "registry_routes"},
+            "lifecycle": {"status": "active"},
+        });
+        let (revision_ref, content_hash) = harness_profile_frozen_revision(&profile);
+        assert!(revision_ref
+            .starts_with("harness-profile://daemon-resolved/hypervisor-worker/revision/sha256:"));
+        assert!(content_hash.starts_with("sha256:"));
+        // A change to the released shape changes the revision (exact-revision binding, ACC-G).
+        let mut mutated = profile.clone();
+        mutated["capabilities"] = json!({"tool_use": false});
+        let (mutated_ref, _) = harness_profile_frozen_revision(&mutated);
+        assert_ne!(revision_ref, mutated_ref);
     }
 
     #[test]

--- a/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
@@ -1071,6 +1071,13 @@ fn admit_runtime_event_onto_stream(
     if let Some(object) = result.as_object_mut() {
         object.insert("seq".to_string(), json!(admitted.projection.seq));
         object.insert("replayed".to_string(), json!(admitted.replayed));
+        // Surface the REAL post-admission substrate head (agentgres CAS head), not just the
+        // kernel-shaped content-hash `resulting_head`. This is the substrate's own fact about where
+        // the event landed; callers that want admission proof read THIS, not the shaped literal.
+        object.insert(
+            "substrate_head".to_string(),
+            json!(admitted.projection.head),
+        );
     }
     Ok(result)
 }
@@ -22655,6 +22662,7 @@ fn admit_launch_thread_event(
         "event_kind": event_kind,
         "status": "admitted",
         "actor": "operator",
+        "created_at": now,
         "component_kind": "harness_session_launch_thread",
         "payload_schema_version": "ioi.runtime.harness-session-launch-thread-event.v1",
         "payload": {
@@ -22673,7 +22681,35 @@ fn admit_launch_thread_event(
         ],
         "runtimeTruthSource": "daemon-runtime",
     });
-    admit_and_persist_event(st, event)
+    let admitted = admit_and_persist_event(st, event)?;
+    Ok(launch_admitted_event_ref(&admitted, step))
+}
+
+/// A COMPACT launch-family reference to an admitted kernel event. The launch-family record stores
+/// THIS reference — never the full kernel event object — so a launch-family record NEVER embeds a
+/// shape wearing a kernel schema name (rename-forward: no future cross-family scanner or
+/// pattern-match can read a launch-family record as kernel truth). The authoritative event lives on
+/// the real kernel event stream (readable via the launch's /events replay); this ref carries only
+/// the event's identity + the substrate's admission proof (`seq` / `resulting_head`) under a
+/// launch-family schema tag, so the projection can name it without duplicating kernel truth.
+fn launch_admitted_event_ref(admitted: &Value, step: &str) -> Value {
+    json!({
+        "schema_version": "ioi.hypervisor.harness_session_launch_event_ref.v1",
+        "step": step,
+        "event_id": admitted.get("event_id"),
+        "event_kind": admitted.get("event_kind"),
+        "event_stream_id": admitted.get("event_stream_id"),
+        // Substrate truth about the admission: `seq` is stamped by the substrate at admit time (and
+        // re-stamped on replay), `substrate_head` is the real agentgres CAS head, and
+        // `agentgres_operation_ref` is the admitted operation. These are what a reader verifies
+        // against the stream — not the kernel-shaped content-hash `resulting_head` (kept for lineage).
+        "seq": admitted.get("seq"),
+        "substrate_head": admitted.get("substrate_head"),
+        "agentgres_operation_ref": admitted.get("agentgres_operation_ref"),
+        "resulting_head": admitted.get("resulting_head"),
+        "idempotency_key": admitted.get("idempotency_key"),
+        "runtimeTruthSource": "daemon-runtime",
+    })
 }
 
 /// Map an event-admission `AppError` into the launch producer's typed failure response, tagging the
@@ -22708,6 +22744,7 @@ fn compose_launch_fork(
 ) -> Result<Value, (StatusCode, Json<Value>)> {
     let Some(delegation) = body.get("delegation").filter(|value| value.is_object()) else {
         return Ok(json!({
+            "schema_version": "ioi.hypervisor.harness_session_launch_fork_step.v1",
             "decision": "not_requested",
             "note": "no bounded delegation requested; no child thread fabricated",
             "fork_planner": "plan_runtime_thread_fork_control",
@@ -22739,14 +22776,17 @@ fn compose_launch_fork(
             let admitted = admit_and_persist_event(st, record.event)
                 .map_err(|error| launch_event_admission_failure("thread_fork_control", error))?;
             Ok(json!({
+                "schema_version": "ioi.hypervisor.harness_session_launch_fork_step.v1",
                 "decision": "forked",
                 "fork_planner": "plan_runtime_thread_fork_control",
                 "forked_thread_id": record.forked_thread_id,
                 "forked_agent_id": record.agent_id,
-                "event": admitted,
+                // Compact ref to the admitted kernel event — never the full kernel event object.
+                "event_ref": launch_admitted_event_ref(&admitted, "thread_fork"),
             }))
         }
         Err(error) => Ok(json!({
+            "schema_version": "ioi.hypervisor.harness_session_launch_fork_step.v1",
             "decision": "refused",
             "fork_planner": "plan_runtime_thread_fork_control",
             "code": error.code(),
@@ -22800,15 +22840,18 @@ fn compose_launch_managed_session(
                 launch_event_admission_failure("managed_session_control", error)
             })?;
             Ok(json!({
+                "schema_version": "ioi.hypervisor.harness_session_launch_managed_session_step.v1",
                 "decision": "controlled",
                 "control_planner": "plan_runtime_managed_session_control_from_replayed_events",
                 "managed_session_ref": record.managed_session_id,
                 "control_state": record.control_state,
-                "event": admitted,
+                // Compact ref to the admitted kernel event — never the full kernel event object.
+                "event_ref": launch_admitted_event_ref(&admitted, "managed_session_control"),
             }))
         }
         Err(error) if error.code() == "runtime_managed_session_control_record_required" => {
             Ok(json!({
+                "schema_version": "ioi.hypervisor.harness_session_launch_managed_session_step.v1",
                 "decision": "no_managed_session_at_launch",
                 "control_planner": "plan_runtime_managed_session_control_from_replayed_events",
                 "available_control_states": ["observe", "take_over", "return_agent"],
@@ -22988,7 +23031,15 @@ fn launch_projection(record: &Value, replayed: bool) -> Value {
             // admission proof (seq / resulting_head / agentgres_operation_ref) below.
             "thread_event_ref": chain.pointer("/thread/initial_event/event_id").cloned().unwrap_or(Value::Null),
             "thread_event_kind": chain.pointer("/thread/initial_event/event_kind").cloned().unwrap_or(Value::Null),
+            // Substrate truth about the initial admission (verifiable against the /events replay):
+            // `seq` + real `substrate_head` + `agentgres_operation_ref`. `resulting_head` is the
+            // kernel-shaped content-hash literal, retained for lineage — NOT the admission proof.
+            "thread_event_seq": chain.pointer("/thread/initial_event/seq").cloned().unwrap_or(Value::Null),
+            "thread_event_substrate_head": chain.pointer("/thread/initial_event/substrate_head").cloned().unwrap_or(Value::Null),
+            "thread_event_operation_ref": chain.pointer("/thread/initial_event/agentgres_operation_ref").cloned().unwrap_or(Value::Null),
             "thread_event_resulting_head": chain.pointer("/thread/initial_event/resulting_head").cloned().unwrap_or(Value::Null),
+            "harness_profile_ref": launch_step_ref(&step("/harness_binding_evidence"), &["harness_profile_ref"]),
+            "harness_profile_resolved": launch_step_ref(&step("/harness_binding_evidence"), &["harness_profile_resolved"]),
             "fork_decision": launch_step_ref(&step("/fork"), &["decision"]),
             "managed_session_decision": launch_step_ref(&step("/managed_session"), &["decision"]),
             "managed_session_ref": launch_step_ref(&step("/managed_session"), &["managed_session_ref"]),
@@ -23110,9 +23161,14 @@ pub(crate) async fn handle_session_launch_create(
     // at the launch boundary with a real read of the daemon-owned registry. The binding's
     // availability enum is derived from that read — never a static `daemon_verified` literal.
     super::harness_routes::ensure_seed(&st.data_dir);
-    let harness_profile_record =
-        super::harness_routes::load_profile_record(&st.data_dir, LAUNCH_HARNESS_PROFILE_ID)
-            .unwrap_or_else(|| json!({"profile_ref": format!("harness-profile:{LAUNCH_HARNESS_PROFILE_ID}"), "profile_id": LAUNCH_HARNESS_PROFILE_ID, "harness": "hypervisor_worker"}));
+    // Whether the launch actually RESOLVED the seeded profile from the registry. A false here means
+    // the fallback stub was taken (no exact-revision binding is possible) — the evidence carries the
+    // marker so a reader can refuse to treat a stub-derived revision as real.
+    let harness_profile_record_opt =
+        super::harness_routes::load_profile_record(&st.data_dir, LAUNCH_HARNESS_PROFILE_ID);
+    let harness_profile_resolved = harness_profile_record_opt.is_some();
+    let harness_profile_record = harness_profile_record_opt
+        .unwrap_or_else(|| json!({"profile_ref": format!("harness-profile:{LAUNCH_HARNESS_PROFILE_ID}"), "profile_id": LAUNCH_HARNESS_PROFILE_ID, "harness": "hypervisor_worker"}));
     let (harness_profile_revision_ref, harness_profile_content_hash) =
         harness_profile_frozen_revision(&harness_profile_record);
     let substrate = ExecutionSubstrate::probe();
@@ -23263,14 +23319,18 @@ pub(crate) async fn handle_session_launch_create(
         "runtimeTruthSource": "daemon-runtime",
     });
     let thread = json!({
+        "schema_version": "ioi.hypervisor.harness_session_launch_thread.v1",
         "thread_ref": thread_ref,
         "event_stream_id": event_stream_id,
         "initial_event": initial_event,
     });
     // Finding 2 evidence — the EXACT frozen profile revision the launch bound + the launch-boundary
     // model-route recheck, alongside the kernel binding admission (kept whole for its projection).
+    // `harness_profile_ref` is the RESOLVED record's own id (not a compile-time echo), and
+    // `harness_profile_resolved` marks whether the registry lookup succeeded (vs the fallback stub).
     let harness_binding_evidence = json!({
-        "harness_profile_ref": LAUNCH_HARNESS_PROFILE_ID,
+        "harness_profile_ref": harness_profile_record.get("profile_id"),
+        "harness_profile_resolved": harness_profile_resolved,
         "harness_profile_revision_ref": harness_profile_revision_ref,
         "harness_profile_content_hash": harness_profile_content_hash,
         "model_route_recheck": route_recheck.evidence,

--- a/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/lifecycle_routes.rs
@@ -1132,10 +1132,12 @@ fn replay_runtime_events(
         for projection in history {
             let mut event = projection.operation.payload.clone();
             if let Some(object) = event.as_object_mut() {
-                // Sequence is the substrate's fact about the event, stamped
-                // on read from the admitted projection rather than stored in
-                // the authored bytes.
+                // Sequence + head are the substrate's facts about the event, stamped
+                // on read from the admitted projection rather than stored in the
+                // authored bytes. Surfacing the real head lets a reader cross-check a
+                // produce-time `substrate_head` against the stream's actual head.
                 object.insert("seq".to_string(), json!(projection.seq));
+                object.insert("substrate_head".to_string(), json!(projection.head));
             }
             if replay_kind == "turn"
                 && turn_id.is_some_and(|wanted| {


### PR DESCRIPTION
## What this repairs

Repairs #252 (36ca2b9a4). The W3.1 launch producer's mechanics were real — identity-first rule E at each boundary, INV-37 principal-bound receipts, stop/archive CAS, byte-identical daemon-restart recovery/replay — but two blocking findings stood, both verified at the bytes on master:

- **Finding 1 (second spine):** the producer hand-minted records wearing kernel schema names and a launch-family event vocabulary never admitted to the kernel event stream.
- **Finding 2 (binding not exact-revision):** the harness selection hand-pinned `default_harness_profile` (absent from the registry) and hand-asserted `model_route_availability_state: "daemon_verified"` with no launch-time read.

Both are now **composed through the present kernel planners**, not shadowed. The canonical layering rule (`core-clients-surfaces.md`) is honored: a launch resolves the exact daemon-owned thread-event / thread-fork / managed-session records; it does not write a second public spine.

## Finding 1 — each step composed through the real planner (call site)

| Step | Planner routed | Call site | Deleted hand-minted shape |
|------|----------------|-----------|---------------------------|
| 5 — initial + spawned thread events | `admit_and_persist_event` → `admit_runtime_event_onto_stream` (real kernel event stream, CAS heads) | `admit_launch_thread_event` in `lifecycle_routes.rs` | inline `thread:launch-*` / `runtime.thread.opened` / `runtime.thread.harness_spawned` vocabulary |
| 6 — bounded delegation (fork) | `plan_runtime_thread_fork_control` | `compose_launch_fork` → kernel `RuntimeThreadForkControlCore` | hand-minted `ioi.runtime.thread_fork_control.v1` "admitted" record |
| 7 — managed session | `plan_runtime_managed_session_control_from_replayed_events` | `compose_launch_managed_session` | hand-minted `ioi.runtime.managed_session_control.v1` with invalid `control_state:"admitted"` |

**Fork-planner path:** `crates/services/src/agentic/runtime/kernel/runtime_thread_fork_control.rs` (`RuntimeThreadForkControlCore::plan`), exposed at `kernel/mod.rs:1161`. This is the first daemon routing of it.

Step 5's events are admitted onto the real Agentgres stream; `/events` replays that substrate stream (not a launch-family vocabulary). The shared admission path now also **surfaces the real substrate CAS head** (`substrate_head`) plus `seq` and `agentgres_operation_ref`, so a reader verifies against the substrate, not the kernel-shaped content-hash `resulting_head`.

## Finding 2 — exact-revision binding + launch-boundary model-route recheck

- **Real seeded profile + exact revision:** the binding names `hp_hypervisor_worker` (the daemon's seeded Lane A native worker) and freezes its EXACT revision via the GoalRun frozen-revision idiom — `harness-profile://daemon-resolved/<harness>/revision/sha256:<hash>` — derived from the real loaded profile record. A `harness_profile_resolved` marker records whether the registry lookup succeeded (vs the fallback stub), and the evidence names the resolved record's own `profile_id`.
- **Model-route recheck:** `model_route_launch_recheck` performs a real read of the daemon-owned model-route registry at the launch boundary and DERIVES the binding availability enum from it. Live token reachability is carried honestly as `false` (the mount is daemon-verified; live serving is the W3.2 execute dependency); the recheck evidence records both the registry availability and live reachability, so the binding never over-claims what the readiness admits.

## Step 7 — NAMED RESIDUAL (not a clean complete)

Managed-session control is a control-over-existing primitive (`observe | take_over | return_agent`) that reads prior managed-session records from the thread's real replayed event stream. **A fresh harness launch produces no managed session, so step 7 is an honest typed absence** (`decision: no_managed_session_at_launch`) that names the real planner and the valid states; the same planner composes a `managed_session.controlled` transition once a real sandbox managed session exists on the thread. This is a **named residual**, deliberately not folded into "complete." No `agents` record is minted to make the control route reachable (minting a precondition to make a step look exercised would be the same species of dishonesty as the second spine); negative-isolation (b) below proves the real control route `404`s for a launch thread ref.

## Safety — replay-path contamination

**Verdict: no contamination.** #252's hand-minted records lived inline in the launch record's `chain` and were never admitted to the event stream, so no real replay path could consume them. **Rename-forward** hardens this going forward: the launch-family fork/managed-session/thread sub-records now carry launch-family schema tags and store admitted kernel events as **compact refs** (never the full kernel event), so a launch-family record never wears a kernel schema name (grep-confirmed: the two fake schema names now appear only in doc-comments).

## The verifier is now FALSIFIABLE (check:launch-chain 28 → 43), mutation-verified

The prior gate was decorative: it passed on self-reported / absent-key evidence and could not fail on a regression. Every assertion is now backed by independent evidence:

- **Step 5** is proven on the real stream by an INDEPENDENT `/events` readback (the produced `event_id` is on the substrate at the substrate-stamped `seq`, carrying an `agentgres_operation_ref`; the substrate head is distinct from the content-hash literal).
- **Negative isolation (a):** the kernel stream carries ONLY the composed thread lifecycle events — no launch-family chain record ever reaches it.
- **Negative isolation (b):** the REAL managed-session control route (`POST /v1/threads/<launch-thread>/managed-sessions/control`) `404`s (via `read_agent_for_thread`) — no crafted POST rides the launch shadow into the kernel.
- **Finding 2** recomputes the frozen revision from the profile's actual on-disk content (jcs-sha256, sorted-key canonical matching serde_json) and compares for EXACTNESS; asserts `harness_profile_resolved` (stub path NOT taken) and that `harness_profile_ref` equals the resolved record's id; correlates derived availability with the registry lifecycle read; pins the recheck timestamp to the test window.
- **Structural second-spine scan** (rename-resistant: catches dotted OR hyphenated kernel CONTROL schema names + `control_state:"admitted"` + the retired thread vocabulary) runs over BOTH the HTTP response AND the durable on-disk record.
- **Delegation probe** asserts the SPECIFIC planner refusal code (`runtime_thread_fork_control_agent_replay_required`), not either-outcome.

**Mutation test (acceptance criterion, self-run):** injecting a nonexistent profile id (forces the fallback stub) and a `control_state:"admitted"` shadow drives the gate to **38/43** with five specific FAILs — Finding 2 (resolved, not stub), Finding 2 EXACTNESS, SAFETY(response, structural), SAFETY(durable, structural), and the delegation-body scan. Reverted; the clean tree is 43/43.

## Minors

- **ACC-G "denial preserves composer input":** typed absence at the surface-action `refuse()` site (denial state is preserved; re-populating field values is a follow-up UI packet).
- **Stale "hardcoded empty" comment** on the Work registry row corrected to note the `[]` → daemon-resolved subject-attachment flip at LAUNCH.
- **/events `reconstructed`** honestly derived from the stream replay; the "exactly one session record" label corrected to the sound delta check.

## Gates (all green from the worktree)

- `check:launch-chain` **43/43** (mutation-verified falsifiable), `check:work-cockpit` **51/51**, `check:home-cockpit` **40/40**
- `cargo test -p ioi-node --bin hypervisor-daemon` **719/719**, `cargo fmt --check`
- `check:admission-evidence` 214/214, `check:mutation-foundation`, `check:mutation-handlers`, `check:architecture-contracts`, `check:architecture-docs`, `check:shipped-products`, `check:seed-provenance`, `check:source-neutral`

Not merged — for independent byte re-verification before merge. The WatchEvents fence and `canon-to-code-delta.md` ledger were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review round 3 — closed three verifier vacuity holes (mutation-confirmed)

An independent from-source review (8 mutations + 3 vacuity attacks) confirmed the DAEMON repair is unbreakable and my four anticipated mutations go RED — but three UNanticipated mutations + one vacuity hole passed the verifier green (the same overclaim class this PR fixes). Fixed (verifier-only, plus one small daemon read-path addition):

- **FIX 1 — allowlist, not denylist.** The "structural" scan was anchored `^ioi\.runtime\.` with two hardcoded stems, so a rename into this PR's own `ioi.hypervisor.*` namespace, a `_v2` suffix, `control_state:"admitted_at_launch"/"active"`, or a renamed event_kind all walked through. Replaced with an **allowlist by construction**: the launch record's typed surface must be EXACTLY the closed set a correct launch may carry (enumerated launch-family + composed-admission schema tags; `control_state ∈ {observe,take_over,return_agent}`; event_kind ∈ the composed thread-lifecycle kinds) — anything else is a shadow. Runs over the response AND the durable record, with a **raw-bytes backstop** so a corrupt-unparseable record carrying kernel tokens in its bytes (which parses to `null` and slips a parsed walk) still FAILS.
- **FIX 2 — head/op-ref cross-check.** `replay_runtime_events` now also surfaces the substrate `projection.head`, so the `/events` readback CROSS-CHECKS the launch record's self-reported `substrate_head` AND `agentgres_operation_ref` against the stream's own values — a constant `sha256:0000…` head or a `fabricated://…` op-ref (previously asserted nonempty but never compared) now goes RED.
- **FIX 3 — pinned anchor.** The INV-37 receipt `created_at` check swapped from `!startsWith("1970")` to the `withinTestWindow` anchor.
- A latent-fragility comment on `canonicalJson` (JSON number encoding vs serde_json `1.0`; UTF-16 vs UTF-8 key ordering — neither reachable today; JS/Rust material hand-duplicated, edit together with the allowlist).

**Mutation test (self-run, all RED, reverted; clean tree 43/43):**

| Mutation | Result |
|----------|--------|
| M2b — rename into `ioi.hypervisor.thread_fork_control.v1` + `control_state:"admitted_at_launch"` | RED — allowlist scan (response + durable + raw backstop) |
| M4b — constant-literal `substrate_head` | RED — `/events` readback cross-check |
| M4d — fabricated `agentgres_operation_ref` | RED — `/events` readback cross-check |
| V1c — corrupt-unparseable durable record carrying kernel tokens in raw bytes | RED — raw-bytes backstop |

`check:launch-chain` is now **43/43** with four named regressions confirmed RED. All other gates re-run green (work 51/51, home 40/40, cargo test 719/719, fmt, admission-evidence 214/214, mutation-foundation/-handlers, architecture-contracts/-docs, shipped-products, seed-provenance, source-neutral).


---

## Review round 4 (terminal) — M5b closed-world over KEYS + kernel-native thread-event schema

Round-3 fixes held, but review found **M5b**: a fabricated second spine built from ONLY allowlisted values on a NEW key passed green — #252's defect verbatim. The scan was a name-and-KEY allowlist (approved vocab on approved key NAMES), proving nothing about whether the record's KEY SET is expected.

- **M5b — the terminating close (closed-world over KEYS).** The verifier now asserts the durable launch record's `chain` KEY SET EQUALS a pinned expected set (`additionalProperties:false`). A fabricated sibling (`shadow_managed_session`) fails on mere PRESENCE of an unexpected key, whatever allowlisted values it hides. The value allowlists are now explicitly defence-in-depth behind this.
- **Kernel-native thread-event schema (the substantive `:371` question).** The launch's admitted thread events carried `payload_schema_version: "ioi.runtime.harness-session-launch-thread-event.v1"` — an **unregistered launch-family name on the kernel stream**. Decision: runtime thread events are kernel event **metadata**, not registered wire contracts (only the admission RECORDS are registered; the kernel's own generic runtime-event schema is `ioi.runtime.event.v1`). So the launch now carries the **kernel-native** schema (`ioi.runtime.event.v1`, `component_kind: thread_lifecycle`) rather than minting a launch-family name — and the verifier ALSO allowlist-scans the stream events. No contract registered; `check:architecture-contracts` stays green.
- **M6b — escaped-key backstop.** The raw-bytes backstop JSON-unescapes (`\"`→`"`) before the regex, so an escaped key `\"schema_version\"` in an unparseable record cannot slip it.
- **substrate_head is READ-ROUTE ONLY.** Reverted from the shared `replay_runtime_events` (which also feeds the managed-session planner on the produce path) into a dedicated `replay_stream_events_with_substrate_head` used only by the `/events` read route — so `substrate_head` is never planner input. The readback still cross-checks it (M4b/M4d).
- Deleted the `:345` tautology; dropped 4 dead allowlist entries (recipe/binding REQUEST schemas, verified per-entry as never persisted) while KEEPING every real-planner-emittable value (`thread.forked`, `managed_session.controlled`, `observe|take_over|return_agent`); reworded the "closed set" claim to key-set closure.

**Mutation test (self-run, all confirmed):**

| Mutation | Result |
|----------|--------|
| M5b — allowlisted-value sibling on a NEW chain key | RED — **KEY-SET** assertion (the value scan correctly did NOT flag it, proving the close is the key set, not values) |
| M2b — rename into `ioi.hypervisor.*` + `control_state:"admitted_at_launch"` | RED — value scan (response + durable + raw) |
| M4b — constant `substrate_head` | RED — `/events` readback cross-check |
| M4d — fabricated `agentgres_operation_ref` | RED — `/events` readback cross-check |
| M6b — escaped-key unparseable record | RED — raw backstop (after unescape) |
| V1c — plain unparseable record with kernel tokens | RED — raw backstop |
| **False-positive** — legit `control_state:"observe"` on the existing managed_session key | **GREEN** — real planner output is not flagged |

**Coverage residual (ledger):** the fork planner delegation-SUCCESS path (Ok branch emitting `thread.forked` + a child thread) is NOT exercised — only the REFUSAL path (`agent_replay_required`) is, because the launch thread has no forkable source agent. A future second spine would most plausibly reappear there; the false-positive check proves a legit `thread.forked` value would not trip the scan, but the success PATH itself remains unexercised.

`check:launch-chain` is now **44/44** with six regressions confirmed RED and a false-positive confirmed GREEN. All other gates re-run green.


---

## Review round 5 (terminal) — durable-record second-spine attacks (K1/K2D/K3) closed

Round-4 held, but three attacks put a fabricated second spine ON DISK at green: the key-set close was single-level (`chain` only) and provenance was checked only on the produce-time response. All three now read the **durable record** (recovery truth). Verifier-only; daemon unchanged.

- **K3 — top-level sibling.** Pin the launch record's TOP-LEVEL key set (`additionalProperties:false`), **state-aware** across the lifecycle because `launch_terminalize` mutates it (adds `lineage` + `{state}_at`). Pinned sets: **PRODUCED (19)**, **AFTER STOP = produced ∪ {lineage, stopped_at} (21)**, **AFTER ARCHIVE = stopped ∪ {archived_at} (22)** — checked at all three stages, so a sibling outside `chain` fails at ANY stage while a legit terminalized record passes.
- **K1 — nested sibling.** Pin the key sets of `chain.fork` (`[decision, fork_planner, note, schema_version]`) and `chain.managed_session` (`[available_control_states, control_planner, decision, note, schema_version]`) from the durable record — a nested shadow (`chain.managed_session.shadow_control`) fails on PRESENCE even with an unchanged chain key set and allowlisted values.
- **K2D — durable-only substitution (the recovery-truth attack).** The decision/control_planner provenance now reads from the durable record AND asserts the response EQUALS it — a forgery that sanitizes the response while writing `decision:"admitted"` to disk goes RED.
- **Minors:** dropped `harness_session_launch_events.v1` (only the /events envelope schema, never in a scanned surface); asserted the real terminal-attach ref shape (`harness-session-terminal-attach:`) instead of the schema_version fallback; made the availability assertion non-vacuous (asserts the actual `active`/`daemon_verified` state).

**Mutation test (self-run, all confirmed):**

| Mutation | Result | Caught by |
|----------|--------|-----------|
| M5b — chain sibling (allowlisted values, new key) | RED | chain KEY-SET |
| K1 — nested shadow in `chain.managed_session` | RED | managed_session KEY-SET |
| K3 — top-level sibling | RED | top-level KEY-SET at **produce + stop + archive** |
| K4 — missing chain key | RED | chain KEY-SET (strict equality) |
| K2D — durable-only substitution (disk fabricated, response honest) | RED | durable provenance |
| M2b — schema rename into `ioi.hypervisor.*` + control_state | RED | value scan (response + durable + raw) |
| M4b / M4d — constant substrate_head / fabricated op-ref | RED | /events readback cross-check |
| M6b / V1c — escaped-key / plain unparseable record w/ tokens | RED | raw backstop (M6b after unescape) |
| **False-positive** — legit produced/stopped/archived record | **GREEN** at all three stages | passes every key-set + durable-provenance pin |

`check:launch-chain` is now **49/49** with ten regressions RED and a false-positive-at-three-stages GREEN. All gates re-run green (work 51/51, home 40/40, cargo test 719/719, fmt, admission-evidence 214/214, mutation-foundation/-handlers, contracts/docs, shipped-products, seed-provenance, source-neutral).
