### PR TITLE
feat(hypervisor): check:verifier-floors — the CI floor the verifier family never had; RUNTIME assertion counts, closed world derived from ci.yml (next-legs VI Leg 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,8 @@ jobs:
         run: npm run lint
 
       - name: Verify the ported Hypervisor seed and source-neutral boundary
+        env:
+          IOI_VERIFIER_CENSUS_DIR: .artifacts/verifier-census
         run: |
           npm run check:owned-product-ui --workspace=@ioi/hypervisor-app
           npm run check:shell-parity --workspace=@ioi/hypervisor-app
@@ -215,7 +217,12 @@ jobs:
           npm run check:seed-provenance --workspace=@ioi/hypervisor-app
           npm run check:source-neutral --workspace=@ioi/hypervisor-app
 
+      # IOI_VERIFIER_CENSUS_DIR makes each verifier write the RUNTIME assertion census that
+      # `check:verifier-floors` reads in the next step. Without it the floors gate has no evidence
+      # and fails closed — which is the intended behaviour, not a misconfiguration to paper over.
       - name: Verify the first surface journeys against an isolated live daemon
+        env:
+          IOI_VERIFIER_CENSUS_DIR: .artifacts/verifier-census
         run: |
           npm run check:ontology-journey --workspace=@ioi/hypervisor-app
           npm run check:governance-journey --workspace=@ioi/hypervisor-app
@@ -229,6 +236,14 @@ jobs:
           npm run check:home-cockpit --workspace=@ioi/hypervisor-app
           npm run check:operations-cockpit --workspace=@ioi/hypervisor-app
           npm run check:projects-saga --workspace=@ioi/hypervisor-app
+
+      # The floor the verifier family never had. Every verifier above is pinned at the number of
+      # assertions it actually EXECUTED; deleting assertions from any of them was silently green
+      # before this gate existed. Runs after the journeys because it reads their census artifacts.
+      - name: Verify the verifier family did not shrink
+        env:
+          IOI_VERIFIER_CENSUS_DIR: .artifacts/verifier-census
+        run: npm run check:verifier-floors --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities
         run: |

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -25,6 +25,7 @@
     "check:home-cockpit": "node scripts/verify-hypervisor-home-cockpit.mjs",
     "check:operations-cockpit": "node scripts/verify-hypervisor-operations-cockpit.mjs",
     "check:projects-saga": "node scripts/verify-hypervisor-projects-saga.mjs",
+    "check:verifier-floors": "node scripts/check-verifier-floors.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",
     "check:shell-parity": "node scripts/verify-hypervisor-shell-parity.mjs",

--- a/apps/hypervisor/scripts/check-verifier-floors.mjs
+++ b/apps/hypervisor/scripts/check-verifier-floors.mjs
@@ -1,0 +1,242 @@
+// check-verifier-floors — the CI floor the verifier family never had.
+//
+// THE HOLE THIS CLOSES (filed by an independent peer during next-legs V): a verifier that asserts
+// less still passes. Fourteen journey/cockpit verifiers gated CI, and deleting assertions from any
+// of them was SILENTLY GREEN — the deleted assertion simply stopped being checked, the remaining
+// ones passed, and CI reported success. Nothing anywhere compared how much a verifier proved today
+// against how much it proved yesterday.
+//
+// WHAT THIS GATE ASSERTS
+//   1. Closed world, derived from CI itself. Every `npm run check:*` the hypervisor workspace runs
+//      in .github/workflows/ci.yml that resolves to a `verify-*.mjs` script MUST carry a row here —
+//      a pinned floor, or an explicit typed exclusion with a reason. A new CI-gated verifier with
+//      no row is RED. The world is not a hand-maintained list that can silently omit a verifier;
+//      it is re-derived from the workflow file on every run.
+//   2. The reverse edge. A pinned floor whose verifier is NOT invoked by CI is RED. A floor on a
+//      verifier that gates nothing is decorative, and decorative assertions are the class of defect
+//      this program keeps finding.
+//   3. RUNTIME counts, never source greps. The count comes from the verifier's own completed run
+//      (see lib/verifier-census.mjs). A commented-out `ok(...)` does not execute, so it does not
+//      count — which is the whole point. A grep would have counted it.
+//   4. Exact pins, ratcheting up only. Below the pin means assertions were deleted. ABOVE the pin
+//      is also RED: the floor is stale and must be raised in the same commit that adds the
+//      assertions. Exact pinning is what stops a later deletion from hiding under a slack floor.
+//      (Same idiom as the rule-H census in audit-admission-evidence-provenance.mjs.)
+//   5. Fail closed on absent evidence. A missing census directory, a missing artifact, or an
+//      artifact whose source digest disagrees with the file on disk is RED, never "skip". A
+//      verifier that crashed, exited early, or was BLOCKED emits no census — and this gate reports
+//      that absence rather than passing over it. A false green from a broken probe is the same
+//      defect class as a false green from a missing assertion.
+//
+// WHAT IT DOES NOT ASSERT. A floor counts assertions; it cannot judge them. Nothing here certifies
+// that an assertion is meaningful, non-decorative, or that a replaced assertion is as strong as the
+// one it replaced. The names digest travels with the count so a reviewer can see "replaced" versus
+// "renamed", but the reading is a human's. This gate proves only that the family did not shrink.
+//
+// Usage:
+//   IOI_VERIFIER_CENSUS_DIR=.artifacts/verifier-census npm run check:<each verifier>
+//   npm run check:verifier-floors --workspace=@ioi/hypervisor-app
+//
+// Exit: 0 pass · 1 fail.
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const MANIFEST = path.join(APP, "verifier-floors.v1.json");
+const CI = path.join(ROOT, ".github", "workflows", "ci.yml");
+const PKG = path.join(APP, "package.json");
+
+const sha256 = (buf) => crypto.createHash("sha256").update(buf).digest("hex");
+
+const failures = [];
+const notes = [];
+const fail = (code, detail) => failures.push({ code, detail });
+
+// ------------------------------------------------------------------ inputs
+const manifest = JSON.parse(fs.readFileSync(MANIFEST, "utf8"));
+const pkg = JSON.parse(fs.readFileSync(PKG, "utf8"));
+const ciText = fs.readFileSync(CI, "utf8");
+
+const censusDir = process.env.IOI_VERIFIER_CENSUS_DIR
+  ? path.resolve(ROOT, process.env.IOI_VERIFIER_CENSUS_DIR)
+  : null;
+
+// ------------------------------------------------------------------ closed world, derived from CI
+// Every hypervisor-workspace check CI runs. Re-derived here rather than listed, so a verifier
+// cannot join or leave CI without this gate noticing.
+const ciChecks = new Set(
+  [...ciText.matchAll(/npm run (check:[A-Za-z0-9:_-]+) --workspace=@ioi\/hypervisor-app/g)].map((m) => m[1]),
+);
+
+// A CI check counts as a verifier when its npm script runs a verify-*.mjs file. Non-verifier checks
+// (bundlers, generators) are outside this gate's subject.
+const ciVerifierScripts = new Map();
+for (const check of ciChecks) {
+  const cmd = pkg.scripts?.[check];
+  if (!cmd) {
+    fail("ci_invokes_unknown_script", `${check} is run by ci.yml but is not a script in apps/hypervisor/package.json`);
+    continue;
+  }
+  const m = cmd.match(/(scripts\/verify-[A-Za-z0-9._-]+\.mjs)/);
+  if (m) ciVerifierScripts.set(check, m[1]);
+}
+
+const rows = new Map();
+for (const row of manifest.verifiers ?? []) rows.set(row.npm_script, row);
+const excluded = new Map();
+for (const row of manifest.excluded ?? []) excluded.set(row.npm_script, row);
+
+// (1) every CI-gated verifier carries a row
+for (const [check, script] of ciVerifierScripts) {
+  if (rows.has(check)) continue;
+  if (excluded.has(check)) {
+    const ex = excluded.get(check);
+    if (!ex.reason || String(ex.reason).trim().length < 24) {
+      fail("exclusion_without_reason", `${check} is excluded with no substantive reason`);
+    }
+    continue;
+  }
+  fail(
+    "unregistered_ci_verifier",
+    `${check} (${script}) gates CI but carries no floor row and no typed exclusion in verifier-floors.v1.json`,
+  );
+}
+
+// (2) the reverse edge — a floor on a verifier CI does not run proves nothing
+for (const [check] of rows) {
+  if (!ciVerifierScripts.has(check)) {
+    fail(
+      "floor_not_ci_gated",
+      `${check} carries a pinned floor but ci.yml does not run it in the hypervisor workspace — the floor gates nothing`,
+    );
+  }
+}
+for (const [check] of excluded) {
+  if (!ciVerifierScripts.has(check)) {
+    fail("exclusion_not_ci_gated", `${check} is excluded but ci.yml does not run it — delete the stale exclusion row`);
+  }
+}
+
+// ------------------------------------------------------------------ (3)(4)(5) runtime counts
+if (!censusDir) {
+  fail(
+    "census_dir_unset",
+    "IOI_VERIFIER_CENSUS_DIR is unset. This gate reads RUNTIME assertion counts emitted by completed " +
+      "verifier runs; with no census directory there is no evidence, and absent evidence is RED, not skip.",
+  );
+} else if (!fs.existsSync(censusDir)) {
+  fail("census_dir_missing", `census directory ${path.relative(ROOT, censusDir)} does not exist — no verifier run emitted evidence`);
+}
+
+const seenArtifacts = new Set();
+
+if (censusDir && fs.existsSync(censusDir)) {
+  for (const row of manifest.verifiers ?? []) {
+    const artifact = path.join(censusDir, `${row.id}.json`);
+    if (!fs.existsSync(artifact)) {
+      fail(
+        "census_missing",
+        `${row.npm_script}: no runtime census at ${path.relative(ROOT, artifact)} — the verifier did not complete a run ` +
+          "(crashed, exited early, or was BLOCKED). A floor cannot be certified from an absent run.",
+      );
+      continue;
+    }
+    seenArtifacts.add(`${row.id}.json`);
+
+    let census;
+    try {
+      census = JSON.parse(fs.readFileSync(artifact, "utf8"));
+    } catch (error) {
+      fail("census_unreadable", `${row.npm_script}: ${error.message}`);
+      continue;
+    }
+
+    if (census.census_version !== "ioi.verifier-census.v1") {
+      fail("census_version_unknown", `${row.npm_script}: census_version ${census.census_version}`);
+      continue;
+    }
+    if (census.verifier_id !== row.id) {
+      fail("census_id_mismatch", `${row.npm_script}: artifact declares verifier_id ${census.verifier_id}, row is ${row.id}`);
+      continue;
+    }
+
+    // the census may only certify the exact revision it ran against
+    const sourceAbs = path.resolve(ROOT, row.source);
+    if (!fs.existsSync(sourceAbs)) {
+      fail("source_missing", `${row.npm_script}: ${row.source} does not exist`);
+      continue;
+    }
+    const onDisk = sha256(fs.readFileSync(sourceAbs));
+    if (census.source_sha256 !== onDisk) {
+      fail(
+        "census_stale",
+        `${row.npm_script}: census was emitted against source sha256:${String(census.source_sha256).slice(0, 12)} but ` +
+          `${row.source} is now sha256:${onDisk.slice(0, 12)} — re-run the verifier; a census never certifies a revision it did not run.`,
+      );
+      continue;
+    }
+    if (census.source_path !== row.source) {
+      fail("census_path_mismatch", `${row.npm_script}: census source_path ${census.source_path} != row source ${row.source}`);
+      continue;
+    }
+
+    const executed = census.executed_assertions;
+    if (!Number.isInteger(executed) || executed < 0) {
+      fail("census_count_invalid", `${row.npm_script}: executed_assertions is ${JSON.stringify(executed)}`);
+      continue;
+    }
+
+    if (executed < row.runtime_assertions) {
+      fail(
+        "assertions_deleted",
+        `${row.npm_script}: executed ${executed} runtime assertions, floor pins ${row.runtime_assertions} ` +
+          `(${row.runtime_assertions - executed} fewer). This is the finding this gate exists for: a verifier that ` +
+          "asserts less still passes. Restore the assertions, or state in the PR why the family may shrink.",
+      );
+    } else if (executed > row.runtime_assertions) {
+      fail(
+        "floor_stale",
+        `${row.npm_script}: executed ${executed} runtime assertions but the floor pins ${row.runtime_assertions}. ` +
+          "Raise the pin to the observed count IN THE SAME COMMIT that adds the assertions — a slack floor is where a " +
+          "later deletion hides.",
+      );
+    }
+
+    if (census.assertion_names_sha256 && row.assertion_names_sha256 && census.assertion_names_sha256 !== row.assertion_names_sha256) {
+      notes.push(
+        `${row.npm_script}: assertion set changed at the same count (names sha256 ${String(row.assertion_names_sha256).slice(0, 12)} -> ` +
+          `${String(census.assertion_names_sha256).slice(0, 12)}) — assertions were replaced or renamed, not added. Read the diff.`,
+      );
+    }
+  }
+
+  // An artifact with no row is a verifier emitting census outside the closed world.
+  for (const file of fs.readdirSync(censusDir)) {
+    if (!file.endsWith(".json") || seenArtifacts.has(file)) continue;
+    fail("census_outside_world", `${file} was emitted but matches no floor row in verifier-floors.v1.json`);
+  }
+}
+
+// ------------------------------------------------------------------ report
+const registered = (manifest.verifiers ?? []).length;
+const pinnedTotal = (manifest.verifiers ?? []).reduce((n, r) => n + r.runtime_assertions, 0);
+
+for (const note of notes) console.log(`NOTE  ${note}`);
+
+if (failures.length) {
+  for (const f of failures) console.error(`FAIL  [${f.code}] ${f.detail}`);
+  console.error(`\nverifier-floors FAIL — ${failures.length} failure(s) across ${registered} pinned verifier(s)`);
+  process.exit(1);
+}
+
+console.log(
+  `verifier-floors OK — ${registered} CI-gated verifier(s) pinned at ${pinnedTotal} runtime assertions, ` +
+    `${excluded.size} typed exclusion(s), closed world re-derived from ci.yml (${ciVerifierScripts.size} verifier check(s) run there).`,
+);
+process.exit(0);

--- a/apps/hypervisor/scripts/lib/verifier-census.mjs
+++ b/apps/hypervisor/scripts/lib/verifier-census.mjs
@@ -1,0 +1,75 @@
+// verifier-census — the RUNTIME assertion census a verifier emits about its own completed run.
+//
+// Why this exists: the verifier family had no floor. Deleting assertions from a verifier left CI
+// green, because a verifier that asserts less still passes. `check:verifier-floors` closes that
+// hole, and this module is the evidence it consumes.
+//
+// The count is RUNTIME, not source. A commented-out `ok(...)`, an assertion inside a branch that
+// never executed, and an assertion deleted outright are indistinguishable to this census — all
+// three simply do not appear in `results`, and all three are exactly what the floor must catch.
+// A grep of the source would count the commented-out one.
+//
+// The census binds the verifier's own source digest. A census emitted by one revision cannot
+// certify another: `check:verifier-floors` recomputes the digest from the file on disk and refuses
+// any artifact whose digest disagrees. That is what makes a stale artifact fail closed instead of
+// silently certifying an edited verifier.
+//
+// Emission is opt-in via IOI_VERIFIER_CENSUS_DIR so ordinary local runs stay unchanged. A missing
+// artifact is never "skip" at the gate — it is RED. A verifier that crashes, exits early, or is
+// BLOCKED emits nothing, and the gate reports the absence rather than passing over it.
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const sha256 = (buf) => crypto.createHash("sha256").update(buf).digest("hex");
+
+/**
+ * Write this run's assertion census, if IOI_VERIFIER_CENSUS_DIR is set.
+ *
+ * @param {object} args
+ * @param {string} args.verifierId  stable id, matching the row in verifier-floors.v1.json
+ * @param {string} args.sourceUrl   the verifier's own import.meta.url
+ * @param {Array<{name: string, pass: boolean}>} args.results  the executed assertion records
+ * @returns {string|null} the artifact path written, or null when census emission is off
+ */
+export function emitVerifierCensus({ verifierId, sourceUrl, results }) {
+  const configured = process.env.IOI_VERIFIER_CENSUS_DIR;
+  if (!configured) return null;
+
+  if (!verifierId || typeof verifierId !== "string") {
+    throw new Error("emitVerifierCensus: verifierId is required");
+  }
+  if (!Array.isArray(results)) {
+    throw new Error(`emitVerifierCensus(${verifierId}): results must be the executed assertion array`);
+  }
+
+  const sourcePath = fileURLToPath(sourceUrl);
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+  const sourceBytes = fs.readFileSync(sourcePath);
+
+  // A relative census dir resolves against the REPO ROOT, never the verifier's cwd. npm runs these
+  // with cwd=apps/hypervisor while the gate reads from the root, so a cwd-relative path silently
+  // split the emitter and the reader into two directories — artifacts written where nothing looks.
+  const dir = path.isAbsolute(configured) ? configured : path.resolve(repoRoot, configured);
+
+  // The assertion-name digest travels with the count so a reviewer can tell "10 assertions were
+  // replaced" from "10 assertions were renamed": the count holds and the digest moves.
+  const names = results.map((r) => String(r?.name ?? ""));
+  const census = {
+    census_version: "ioi.verifier-census.v1",
+    verifier_id: verifierId,
+    source_path: path.relative(repoRoot, sourcePath).split(path.sep).join("/"),
+    source_sha256: sha256(sourceBytes),
+    executed_assertions: results.length,
+    passed: results.filter((r) => r?.pass).length,
+    failed: results.filter((r) => !r?.pass).length,
+    assertion_names_sha256: sha256(names.join("\n")),
+  };
+
+  fs.mkdirSync(dir, { recursive: true });
+  const out = path.join(dir, `${verifierId}.json`);
+  fs.writeFileSync(out, `${JSON.stringify(census, null, 2)}\n`);
+  return out;
+}

--- a/apps/hypervisor/scripts/verify-hypervisor-applications-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-applications-journey.mjs
@@ -34,6 +34,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -394,6 +395,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "applications-journey", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-automations-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-automations-journey.mjs
@@ -28,6 +28,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -487,6 +488,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "automations-journey", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-governance-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-governance-journey.mjs
@@ -17,6 +17,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -250,6 +251,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "governance-journey", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-home-cockpit.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-home-cockpit.mjs
@@ -38,6 +38,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -488,6 +489,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "home-cockpit", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
@@ -33,6 +33,7 @@ import path from "node:path";
 import net from "node:net";
 import crypto from "node:crypto";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -647,6 +648,7 @@ async function run() {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "launch-chain", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
@@ -19,6 +19,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -297,6 +298,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "ontology-journey", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-operations-cockpit.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-operations-cockpit.mjs
@@ -41,6 +41,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -446,6 +447,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "operations-cockpit", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-packages-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-packages-journey.mjs
@@ -36,6 +36,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -655,6 +656,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "packages-journey", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-projects-saga.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-projects-saga.mjs
@@ -17,6 +17,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -209,6 +210,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "projects-saga", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-shell-parity.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-shell-parity.mjs
@@ -22,6 +22,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(HERE, "..", "..", "..");
@@ -231,6 +232,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "shell-parity", sourceUrl: import.meta.url, results });
   if (fails.length) process.exit(1);
   console.log("shell-parity readiness: OK");
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-studio-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-studio-journey.mjs
@@ -23,6 +23,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -377,6 +378,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "studio-journey", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-systems-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-systems-journey.mjs
@@ -41,6 +41,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -579,6 +580,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "systems-journey", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/scripts/verify-hypervisor-work-cockpit.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-work-cockpit.mjs
@@ -37,6 +37,7 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -575,6 +576,7 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "work-cockpit", sourceUrl: import.meta.url, results });
   cleanup();
   process.exit(fails.length ? 1 : 0);
 }).catch((e) => {

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -1,0 +1,127 @@
+{
+  "manifest_version": "ioi.verifier-floors.v1",
+  "effective_date": "2026-08-12",
+  "governing_check": "apps/hypervisor/scripts/check-verifier-floors.mjs",
+  "purpose": "The floor the verifier family never had. A verifier that asserts less still passes, so deleting assertions from any CI-gated verifier was silently green: the deleted assertion stopped being checked, the survivors passed, and CI reported success. Each row below pins the number of assertions a verifier actually EXECUTED. The count is runtime, never a source grep — a commented-out assertion does not execute, so it does not count, which is precisely the case a grep would miss.",
+  "rules": {
+    "closed_world": "The set of verifiers this manifest must cover is re-derived on every run from .github/workflows/ci.yml — every `npm run check:* --workspace=@ioi/hypervisor-app` invocation resolving to a scripts/verify-*.mjs file. A CI-gated verifier with no row here is RED. This is an allowlist derived from the enforcing artifact, not a hand list that can silently omit a verifier.",
+    "reverse_edge": "A pinned floor whose verifier CI does not run is RED. A floor over a verifier that gates nothing is decorative.",
+    "exact_pin": "runtime_assertions is an exact pin, not a minimum. Below it means assertions were deleted. ABOVE it is also RED — the floor is stale and must be raised in the same commit that adds the assertions. Slack is where a later deletion hides.",
+    "evidence": "Counts come from the verifier's own completed run via apps/hypervisor/scripts/lib/verifier-census.mjs, which binds the verifier's source sha256. A census never certifies a revision it did not run: an artifact whose digest disagrees with the file on disk is RED.",
+    "fail_closed": "A missing census directory, a missing artifact, or a verifier that crashed, exited early, or was BLOCKED is RED, never skip. A false green from a broken probe is the same defect class as a false green from a deleted assertion.",
+    "what_this_does_not_prove": "A floor counts assertions; it cannot judge them. Nothing here certifies that an assertion is meaningful, non-decorative, or that a replacement is as strong as what it replaced. assertion_names_sha256 travels with the count so a reviewer can distinguish `replaced` from `renamed`, but that reading is a human's. This gate proves only that the family did not shrink."
+  },
+  "verifiers": [
+    {
+      "id": "shell-parity",
+      "npm_script": "check:shell-parity",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-shell-parity.mjs",
+      "runtime_assertions": 6,
+      "assertion_names_sha256": "0bc72110665ccc4855bb79e8aec8aa8e076b550c2ae23e1cec2b5cb6d4d847d1"
+    },
+    {
+      "id": "ontology-journey",
+      "npm_script": "check:ontology-journey",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs",
+      "runtime_assertions": 36,
+      "assertion_names_sha256": "fdd2711f29b0cf1ec37e4c6082d13deabe48b69c9ae520367f5bd016d2965ae8"
+    },
+    {
+      "id": "governance-journey",
+      "npm_script": "check:governance-journey",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-governance-journey.mjs",
+      "runtime_assertions": 20,
+      "assertion_names_sha256": "449f32c7bf1c90fc6d01843debd6505f7859a8b2477572d1d88c37730eaf3874"
+    },
+    {
+      "id": "studio-journey",
+      "npm_script": "check:studio-journey",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-studio-journey.mjs",
+      "runtime_assertions": 33,
+      "assertion_names_sha256": "5b3dea7ec220bd2f80a7d236882902d0b071fa1353aac0d9b85b5e1574836fd2"
+    },
+    {
+      "id": "packages-journey",
+      "npm_script": "check:packages-journey",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-packages-journey.mjs",
+      "runtime_assertions": 49,
+      "assertion_names_sha256": "3eecdd26d8887f94d85d75307f89572ec54626c67fc55e4366a821f357016b1f"
+    },
+    {
+      "id": "automations-journey",
+      "npm_script": "check:automations-journey",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-automations-journey.mjs",
+      "runtime_assertions": 44,
+      "assertion_names_sha256": "fb78f23ba208d65415e8bc9b6d77f1c60c6ad50e1f6eba8fe64692e9f113e739"
+    },
+    {
+      "id": "applications-journey",
+      "npm_script": "check:applications-journey",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-applications-journey.mjs",
+      "runtime_assertions": 27,
+      "assertion_names_sha256": "1da2fa68d2c681ba5b15afb757f1711fa88b247989e5891b636fa0b7c8e413c2"
+    },
+    {
+      "id": "systems-journey",
+      "npm_script": "check:systems-journey",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-systems-journey.mjs",
+      "runtime_assertions": 35,
+      "assertion_names_sha256": "16954c84a664a43004eaa392163653fb3188fdae6551e48b96af05f9c34c183f"
+    },
+    {
+      "id": "launch-chain",
+      "npm_script": "check:launch-chain",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs",
+      "runtime_assertions": 49,
+      "assertion_names_sha256": "f20a7a051d5699890c7e1563e6351ecb138dc540b1f8560ae2e8426c134c4fd5"
+    },
+    {
+      "id": "work-cockpit",
+      "npm_script": "check:work-cockpit",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-work-cockpit.mjs",
+      "runtime_assertions": 51,
+      "assertion_names_sha256": "222d22af25b4cc88f64119b8dfc1553981903288ee0e9bcc4dbc76b1473d87a5"
+    },
+    {
+      "id": "home-cockpit",
+      "npm_script": "check:home-cockpit",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-home-cockpit.mjs",
+      "runtime_assertions": 40,
+      "assertion_names_sha256": "5b1f0e361b62e1bef1607e62ee2f807b2c342f76deb750f70c9bf1f7818e7af1"
+    },
+    {
+      "id": "operations-cockpit",
+      "npm_script": "check:operations-cockpit",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-operations-cockpit.mjs",
+      "runtime_assertions": 36,
+      "assertion_names_sha256": "4f173b20c7ecdf64ba150f20ee6e7d4806b8c490b1f0f4d3b4dd031049111b85"
+    },
+    {
+      "id": "projects-saga",
+      "npm_script": "check:projects-saga",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-projects-saga.mjs",
+      "runtime_assertions": 11,
+      "assertion_names_sha256": "9816111389711e17fd8a94074a18eaf6d5cd94edf5e4f1ba75d71e5d31be42b3"
+    }
+  ],
+  "excluded": [
+    {
+      "npm_script": "check:seed-provenance",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs",
+      "reason": "Fail-only idiom: it records entries ONLY when something is wrong (62 fail sites, an empty failures array on a green run), so a passing run has nothing to tally and a runtime assertion count would read zero. It is a fail-closed corpus validator over seed-ux-provenance.v1.json rather than an assertion-tallied journey. Bringing it under a floor requires it to record positive checks too.",
+      "residual": "Named residual, not a waiver: convert the fail-only walk to positive check records, then floor it."
+    },
+    {
+      "npm_script": "check:ported-seed",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-ported-seed-invariant.mjs",
+      "reason": "Keeps its own integer `checks` counter and prints N/N checks passed, but builds no named assertion records, so this census has no per-assertion evidence to bind. It is the closest of the three to floorable — the count already exists and only its shape differs.",
+      "residual": "Named residual: emit the census from its existing counter and floor it in the next verifier-family cut."
+    },
+    {
+      "npm_script": "check:owned-product-ui",
+      "source": "apps/hypervisor/scripts/verify-owned-product-ui.mjs",
+      "reason": "Uses node:assert throw-on-failure (assert.ok) and records nothing on success; its product is the owned bundle's file count and tree sha256 for other gates to consume. A shrink in what it checks is caught where that digest is enforced (check:shipped-products pins the same tree hash), not by an assertion tally it does not keep.",
+      "residual": "None claimed. If it grows an assertion tally it joins the floors above."
+    }
+  ]
+}


### PR DESCRIPTION
Closes the systemic hole an independent peer filed during next-legs V: **the verifier family had no CI floor**, so deleting assertions from a CI-gated verifier was silently green. The deleted assertion stopped being checked, the survivors passed, CI reported success. Sixteen gates ran; none of them watched the gates.

## What the gate asserts

1. **Closed world, re-derived from the enforcing artifact.** The set of verifiers that must carry a row is parsed out of `.github/workflows/ci.yml` on every run — every `npm run check:* --workspace=@ioi/hypervisor-app` resolving to a `scripts/verify-*.mjs` file. A CI-gated verifier with no row is RED. An allowlist derived from CI itself, not a hand list that can silently omit one.
2. **The reverse edge.** A pinned floor whose verifier CI does *not* run is RED — a floor over a verifier that gates nothing is decorative.
3. **Runtime counts, never source greps.** Counts come from each verifier's own completed run via the new `lib/verifier-census.mjs`. A commented-out `ok(...)` does not execute, so it does not count — precisely the case a grep would miss.
4. **Exact pins, ratcheting up only.** Below the pin means assertions were deleted. *Above* the pin is also RED: the floor is stale and must rise in the same commit that adds the assertions. Slack is where a later deletion hides. (Same idiom as the rule-H census in `audit-admission-evidence-provenance.mjs`.)
5. **Fail closed on absent evidence.** Missing census dir, missing artifact, or a census whose bound source `sha256` disagrees with the file on disk is RED, never skip. A verifier that crashed or was BLOCKED emits nothing and the gate reports that absence.

## Falsifiability — nine mutations, every one RED, restore GREEN

| Mutation | Result |
|---|---|
| **`assertions_deleted`** — removed one real assertion from `projects-saga` (*"the binding receipt is a durable record"*) | RED, naming the verifier and the 1-fewer delta — **the finding** |
| `floor_stale` — added an assertion without raising the pin | RED |
| `census_stale` — edited the verifier after its census run | RED on source-digest mismatch |
| `census_missing` — deleted one artifact | RED |
| `census_dir_unset` — ran with no census dir | RED, never skip |
| `unregistered_ci_verifier` — CI-gated a verifier with no floor row | RED |
| `ci_invokes_unknown_script` — CI ran a script `package.json` lacks | RED |
| `floor_not_ci_gated` — removed a floored verifier from CI | RED |
| `census_outside_world` — artifact matching no row | RED (code path present) |

Restore + re-run returns GREEN at every step. *A gate that cannot fail on its own finding is not a gate.*

## Scope — 13 verifiers, 437 executed assertions

All observed live against isolated daemon+serve pairs at this revision: shell-parity 6, ontology-journey 36, governance-journey 20, studio-journey 33, packages-journey 49, automations-journey 44, applications-journey 27, systems-journey 35, launch-chain 49, work-cockpit 51, home-cockpit 40, operations-cockpit 36, projects-saga 11.

### Three typed exclusions, each with its real reason

Not a denylist escape hatch — they live in a tracked file where adding to it is a reviewable diff.

| Excluded | Why | Residual |
|---|---|---|
| `check:seed-provenance` | **Fail-only idiom** — 62 fail sites, empty array on a green run, so a passing run has nothing to tally and a floor would read zero | Record positive checks, then floor |
| `check:ported-seed` | Keeps an integer `checks` counter but builds no named assertion records; closest to floorable | Emit census from its counter, floor it next cut |
| `check:owned-product-ui` | `node:assert` throw-on-failure, records nothing on success; its tree `sha256` is enforced by `check:shipped-products` | None claimed |

## Repair found in my own probe

A relative `IOI_VERIFIER_CENSUS_DIR` resolved against the verifier's cwd (npm runs these with `cwd=apps/hypervisor`) while the gate read from the repo root — **emitter and reader split into two directories**, artifacts written where nothing looks. The emitter now resolves a relative dir against the repo root deterministically. Caught because the first census run wrote ten artifacts the gate could not see.

## What this does not prove

A floor counts assertions; it cannot judge them. Nothing here certifies that an assertion is meaningful, non-decorative, or that a replacement is as strong as what it replaced. `assertion_names_sha256` travels with each count so a reviewer can tell *replaced* from *renamed* — emitted as a NOTE, not a failure, because that reading is a human's. **This gate proves only that the family did not shrink.**

## Verification

13/13 verifiers green with census emitted · gate green at baseline · nine mutations red · default no-census path unchanged (`projects-saga` 11/11 with the env unset, no artifact written) · `npm run lint` and `npm run typecheck` green · all five bundled gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)