### PR TITLE
feat(hypervisor): W3.2 first cut — ProviderTransport boundary + the first REGISTRY-driven model invocation, typed kernel receipt, W4-F evidence at the wire (next-legs VI Leg 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,7 @@ jobs:
           npm run check:home-cockpit --workspace=@ioi/hypervisor-app
           npm run check:operations-cockpit --workspace=@ioi/hypervisor-app
           npm run check:projects-saga --workspace=@ioi/hypervisor-app
+          npm run check:provider-transport --workspace=@ioi/hypervisor-app
 
       # The floor the verifier family never had. Every verifier above is pinned at the number of
       # assertions it actually EXECUTED; deleting assertions from any of them was silently green

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -25,6 +25,8 @@
     "check:home-cockpit": "node scripts/verify-hypervisor-home-cockpit.mjs",
     "check:operations-cockpit": "node scripts/verify-hypervisor-operations-cockpit.mjs",
     "check:projects-saga": "node scripts/verify-hypervisor-projects-saga.mjs",
+    "check:provider-transport": "node scripts/verify-hypervisor-provider-transport.mjs",
+    "check:provider-transport:live": "node scripts/verify-hypervisor-provider-transport.mjs --live",
     "check:verifier-floors": "node scripts/check-verifier-floors.mjs",
     "check:ported-seed:live": "node scripts/verify-hypervisor-ported-seed-invariant.mjs --live",
     "check:owned-product-ui": "node scripts/verify-owned-product-ui.mjs",

--- a/apps/hypervisor/scripts/verify-hypervisor-provider-transport.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-provider-transport.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+// verify-hypervisor-provider-transport — W3.2 first cut (check:provider-transport).
+//
+// Proves, against an ISOLATED real daemon, that the ProviderTransport boundary is composed and not
+// shadowed: the invocation route resolves its endpoint from the model-route REGISTRY, refuses every
+// non-executable posture with a typed code, keeps credential custody with the CapabilityLease
+// gateway instead of reading a provider key from the process environment, and fabricates no
+// invocation record when it refuses.
+//
+// TWO LANES, and the split is deliberate:
+//   default (CI)  — the refusal ladder and non-fabrication. Needs no model provider, so it runs
+//                   anywhere and its assertion count is DETERMINISTIC (the verifier-floors pin
+//                   depends on that).
+//   --live        — the native-first e2e against a REAL provider: success, streaming, observed
+//                   token mix, latency, the typed kernel receipt, readback, and idempotent replay.
+//                   NOT run in CI: GitHub Actions has no model provider. That absence is a named
+//                   residual, never a silent skip — the live lane is the evidence a human runs and
+//                   records, exactly like check:ported-seed:live.
+//
+// The live lane does NOT emit a verifier census: it executes more assertions than the CI lane, and
+// a census from it would collide with the floor pinned for the lane CI actually runs.
+//
+// Exit: 0 pass · 1 fail · 2 blocked (daemon binary missing, or --live with no reachable provider).
+//   IOI_HYPERVISOR_DAEMON_BINARY  default target/debug/hypervisor-daemon
+//   IOI_PROVIDER_TRANSPORT_LIVE_BASE_URL  default http://127.0.0.1:11434
+//   IOI_PROVIDER_TRANSPORT_LIVE_MODEL     default qwen2.5:7b
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+const LIVE = process.argv.includes("--live");
+const LIVE_BASE = process.env.IOI_PROVIDER_TRANSPORT_LIVE_BASE_URL ?? "http://127.0.0.1:11434";
+const LIVE_MODEL = process.env.IOI_PROVIDER_TRANSPORT_LIVE_MODEL ?? "qwen2.5:7b";
+
+let OWNER = "";
+const code = (j) => j?.code ?? j?.error?.code ?? "";
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => {
+    const { port } = srv.address();
+    srv.close(() => resolve(port));
+  });
+  srv.on("error", reject);
+});
+
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try {
+  fs.accessSync(daemonBinary, fs.constants.X_OK);
+} catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-provider-transport-"));
+let daemon = null;
+let daemonPort = 0;
+let DAEMON = "";
+let SESSION = "";
+
+const jd = (method, p, body, { auth = true, idem = null } = {}) => fetch(`${DAEMON}${p}`, {
+  method,
+  headers: {
+    ...(body ? { "content-type": "application/json" } : {}),
+    ...(auth && SESSION ? { cookie: `ioi_session=${SESSION}` } : {}),
+  },
+  // The shared write path reads owner_ref and idempotency_key from the BODY, not from headers.
+  ...(body ? { body: JSON.stringify(idem ? { owner_ref: OWNER, idempotency_key: idem, ...body } : body) } : {}),
+}).then(async (r) => ({ status: r.status, j: await r.json().catch(() => ({})) }))
+  .catch((e) => ({ status: 0, j: { transport_error: String(e) } }));
+
+/** Count durable invocation records on disk — the daemon's own answer never certifies absence. */
+const invocationFiles = () => {
+  try {
+    return fs.readdirSync(path.join(dataDir, "model-invocations")).filter((f) => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+};
+
+function cleanup() {
+  try { daemon?.kill("SIGTERM"); } catch { /* already gone */ }
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+async function run() {
+  daemonPort = await freePort();
+  DAEMON = `http://127.0.0.1:${daemonPort}`;
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${daemonPort}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      // Deliberately dead: nothing in this verifier may reach a provider through the boot-time
+      // environment singleton. Every successful call below must come from a REGISTRY record.
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1/v1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = "";
+  daemon.stdout.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { log = `${log}${c}`.slice(-64000); });
+  await waitFor(`${DAEMON}/healthz`, 30000);
+
+  const token = log.match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  if (token) {
+    const boot = await jd("POST", "/v1/hypervisor/auth/bootstrap", {
+      token, password: "provider-transport-bootstrap-v1", email: "provider-transport@ioi.local",
+    }, { auth: false });
+    SESSION = boot.j?.session_token ?? "";
+  }
+  ok("operator bootstrap yields an authenticated session", SESSION.startsWith("ioi_sess_"), SESSION.slice(0, 12));
+
+  const who = (await jd("GET", "/v1/hypervisor/auth/whoami")).j || {};
+  OWNER = (who.principal?.tenant_refs || []).find((t) => typeof t === "string" && t.startsWith("org://")) || "";
+  ok("the session authenticates a principal with an org:// owner tenant to admit under", !!OWNER, OWNER || "no owner tenant");
+
+  // ---------------------------------------------------------------- identity first (rule E)
+  const anon = await jd("POST", "/v1/hypervisor/model-routes/mrt_local_default/invoke",
+    { prompt: "hello" }, { auth: false, idem: "anon-must-401" });
+  ok("rule E: an anonymous invoke is refused BEFORE any record read (401, never 404)",
+    anon.status === 401, `status ${anon.status} code ${code(anon.j)}`);
+
+  const anonRead = await jd("GET", "/v1/hypervisor/model-invocations/does-not-exist", null, { auth: false });
+  ok("rule E: an anonymous readback is refused before the existence question is answered",
+    anonRead.status === 401, `status ${anonRead.status}`);
+
+  ok("no invocation record exists after the anonymous attempts (nothing fabricated)",
+    invocationFiles().length === 0, `${invocationFiles().length} record(s)`);
+
+  // ---------------------------------------------------------------- INV-37: WHO is server-resolved
+  const whoSupplied = await jd("POST", "/v1/hypervisor/model-routes/mrt_local_default/invoke",
+    { prompt: "hello", acting_principal_ref: "user://someone-else" }, { idem: "inv37-must-refuse" });
+  ok("INV-37: a body carrying an actor field is refused, not honoured",
+    whoSupplied.status === 400 && code(whoSupplied.j) === "identity_not_client_settable",
+    `status ${whoSupplied.status} code ${code(whoSupplied.j)}`);
+
+  // ---------------------------------------------------------------- the refusal ladder
+  const unknown = await jd("POST", "/v1/hypervisor/model-routes/mrt_does_not_exist/invoke",
+    { prompt: "hello" }, { idem: "unknown-route" });
+  ok("an unknown route 404s and executes nothing",
+    unknown.status === 404 && code(unknown.j) === "model_route_not_found",
+    `status ${unknown.status} code ${code(unknown.j)}`);
+
+  const emptyPrompt = await jd("POST", "/v1/hypervisor/model-routes/mrt_local_default/invoke",
+    { prompt: "   " }, { idem: "empty-prompt" });
+  ok("an empty prompt is refused typed before any provider contact",
+    emptyPrompt.status === 400 && code(emptyPrompt.j) === "model_invocation_prompt_required",
+    `status ${emptyPrompt.status} code ${code(emptyPrompt.j)}`);
+
+  // A declared (never probed) route is not executable: availability is proof, not a default.
+  const declared = await jd("POST", "/v1/hypervisor/model-routes", {
+    model_id: "verify-transport:none", transport: "ollama",
+    base_url: "http://127.0.0.1:1", display_name: "unreachable transport route",
+  }, { idem: "declared-route" });
+  const declaredId = declared.j?.route?.route_id ?? "";
+  ok("a route can be declared for the refusal proofs", declared.status === 201 && declaredId.length > 0, declaredId);
+
+  const notExecutable = await jd("POST", `/v1/hypervisor/model-routes/${declaredId}/invoke`,
+    { prompt: "hello" }, { idem: "declared-not-executable" });
+  ok("a declared-but-unprobed route refuses typed: availability is never assumed",
+    notExecutable.status === 409 && code(notExecutable.j) === "model_route_not_executable",
+    `status ${notExecutable.status} code ${code(notExecutable.j)}`);
+
+  // openai_compatible is admitted by the REGISTRY but has no transport implementation. The honest
+  // answer is 501, not a silent fallback onto the one transport that does exist.
+  const oai = await jd("POST", "/v1/hypervisor/model-routes", {
+    model_id: "gpt-4o-mini", transport: "openai_compatible",
+    base_url: "https://example.invalid/v1", display_name: "no transport implementation",
+    api_key_env: "VERIFY_TRANSPORT_KEY_NAME",
+  }, { idem: "oai-route" });
+  const oaiId = oai.j?.route?.route_id ?? "";
+  if (oaiId) {
+    const oaiInvoke = await jd("POST", `/v1/hypervisor/model-routes/${oaiId}/invoke`,
+      { prompt: "hello" }, { idem: "oai-invoke" });
+    // Exactly 501 and exactly this code. An earlier revision of this assertion also accepted 409,
+    // and passed on the 409 — the label claimed a refusal the assertion never observed. The handler
+    // now checks transport support before availability so the claimed refusal is the reachable one.
+    ok("a transport with no implementation refuses 501 — it never falls back to another provider",
+      oaiInvoke.status === 501 && code(oaiInvoke.j) === "provider_transport_unimplemented",
+      `status ${oaiInvoke.status} code ${code(oaiInvoke.j)}`);
+  } else {
+    ok("a transport with no implementation refuses 501 — it never falls back to another provider",
+      false, `route create failed: ${oai.status} ${JSON.stringify(oai.j?.error ?? {})}`);
+  }
+
+  ok("the whole refusal ladder fabricated NO invocation record on disk",
+    invocationFiles().length === 0, `${invocationFiles().length} record(s)`);
+
+  ok("the daemon never reached the boot-time env upstream (127.0.0.1:1) for any of the above",
+    !log.includes("127.0.0.1:1/v1 responded"), "env singleton unused");
+
+  // ---------------------------------------------------------------- live native-first e2e
+  if (LIVE) {
+    let reachable = false;
+    try {
+      const tags = await fetch(`${LIVE_BASE}/api/tags`, { signal: AbortSignal.timeout(2000) });
+      reachable = tags.ok;
+    } catch { reachable = false; }
+    if (!reachable) {
+      console.error(`BLOCKED: --live requires a reachable provider at ${LIVE_BASE}`);
+      cleanup();
+      process.exit(2);
+    }
+
+    const liveRoute = await jd("POST", "/v1/hypervisor/model-routes", {
+      model_id: LIVE_MODEL, transport: "ollama", base_url: LIVE_BASE, display_name: "live native route",
+    }, { idem: "live-route" });
+    const liveId = liveRoute.j?.route?.route_id ?? "";
+    ok("live: a native route is declared from the registry", liveRoute.status === 201 && liveId.length > 0, liveId);
+
+    const probe = await jd("POST", `/v1/hypervisor/model-routes/${liveId}/probe`, null, { idem: "live-probe" });
+    ok("live: the probe reports the REAL provider catalog as available",
+      probe.j?.availability?.state === "available", probe.j?.availability?.state);
+
+    const enabled = await jd("POST", `/v1/hypervisor/model-routes/${liveId}/enable`, {}, { idem: "live-enable" });
+    ok("live: the route is activated", enabled.status === 200, `status ${enabled.status}`);
+
+    const invoked = await jd("POST", `/v1/hypervisor/model-routes/${liveId}/invoke`,
+      { prompt: "Reply with exactly the word: composed" }, { idem: "live-invoke-1" });
+    const inv = invoked.j?.invocation ?? {};
+    const receipt = inv.model_invocation_receipt ?? {};
+    const evidence = inv.evidence ?? {};
+    ok("live: a real model invocation succeeds through the REGISTRY endpoint",
+      invoked.status === 200 && inv.outcome === "succeeded", `status ${invoked.status} outcome ${inv.outcome}`);
+    ok("live: the receipt is the TYPED kernel ModelInvocationReceipt shape",
+      typeof receipt.model_id === "string" && typeof receipt.provider === "string"
+        && typeof receipt.latency_ms === "number" && Array.isArray(receipt.output_hash),
+      `model ${receipt.model_id} provider ${receipt.provider} latency ${receipt.latency_ms}ms`);
+    ok("live: the observed token mix carries REAL provider counts",
+      (evidence.token_mix?.input ?? 0) > 0 && (evidence.token_mix?.output ?? 0) > 0,
+      `in ${evidence.token_mix?.input} out ${evidence.token_mix?.output}`);
+    ok("live: unreported token classes are typed gaps, never zero-filled",
+      evidence.token_mix?.cache_read === null && evidence.token_mix?.reasoning === null
+        && (evidence.token_mix?.unreported ?? []).includes("cache_read"),
+      JSON.stringify(evidence.token_mix?.unreported ?? []));
+    ok("live: attempt lineage is recorded with a classified outcome",
+      Array.isArray(evidence.attempts) && evidence.attempts.length === 1
+        && evidence.attempts[0].outcome === "succeeded" && evidence.attempts[0].error_class === null,
+      JSON.stringify(evidence.attempts?.[0] ?? {}));
+    ok("live: latency is observed, not declared",
+      (evidence.latency?.total_ms ?? 0) > 0, `${evidence.latency?.total_ms}ms`);
+    ok("live: the W4-F evidence gaps this cut cannot fill are NAMED in the record",
+      (evidence.evidence_gaps ?? []).includes("economics.usage_record"),
+      JSON.stringify(evidence.evidence_gaps ?? []));
+
+    const readback = await jd("GET", `/v1/hypervisor/model-invocations/${inv.invocation_id}`);
+    ok("live: the invocation reads back durably with its receipt intact",
+      readback.status === 200 && readback.j?.invocation?.model_invocation_receipt?.output_hash?.length === 32,
+      `status ${readback.status}`);
+
+    const replay = await jd("POST", `/v1/hypervisor/model-routes/${liveId}/invoke`,
+      { prompt: "Reply with exactly the word: composed" }, { idem: "live-invoke-1" });
+    ok("live: an idempotent replay returns the STORED record and spends no second provider call",
+      replay.status === 200 && replay.j?.replayed === true
+        && replay.j?.invocation?.invocation_id === inv.invocation_id,
+      `replayed ${replay.j?.replayed}`);
+
+    const streamed = await jd("POST", `/v1/hypervisor/model-routes/${liveId}/invoke`,
+      { prompt: "Count: one two three", stream: true }, { idem: "live-invoke-stream" });
+    const sEvidence = streamed.j?.invocation?.evidence ?? {};
+    ok("live: the streaming lane completes and times its FIRST token separately from the total",
+      streamed.status === 200 && streamed.j?.invocation?.outcome === "succeeded"
+        && typeof sEvidence.latency?.first_token_ms === "number"
+        && sEvidence.latency.first_token_ms <= sEvidence.latency.total_ms,
+      `first ${sEvidence.latency?.first_token_ms}ms total ${sEvidence.latency?.total_ms}ms`);
+
+    // The failure path, executed for real. The route must be active AND available before the
+    // provider disappears — patching base_url would invalidate the probe and refuse at 409, which
+    // proves route hygiene rather than transport failure handling.
+    //
+    // So the route points at a TCP forwarder to the real provider. Every byte the daemon sees
+    // during the probe is the genuine provider's; nothing here fabricates a provider response.
+    // Killing the forwarder makes a healthy provider vanish exactly as a network partition would.
+    const forwardPort = await freePort();
+    const upstream = new URL(LIVE_BASE);
+    const forwarder = net.createServer((client) => {
+      const target = net.connect(Number(upstream.port || 80), upstream.hostname, () => client.pipe(target).pipe(client));
+      target.on("error", () => client.destroy());
+      client.on("error", () => target.destroy());
+    });
+    await new Promise((resolve) => forwarder.listen(forwardPort, "127.0.0.1", resolve));
+
+    const deadRoute = await jd("POST", "/v1/hypervisor/model-routes", {
+      model_id: LIVE_MODEL, transport: "ollama",
+      base_url: `http://127.0.0.1:${forwardPort}`, display_name: "provider vanishes",
+    }, { idem: "dead-route" });
+    const deadId = deadRoute.j?.route?.route_id ?? "";
+    const deadProbe = await jd("POST", `/v1/hypervisor/model-routes/${deadId}/probe`, null, { idem: "dead-probe" });
+    ok("live: the forwarded route probes available from the REAL provider catalog",
+      deadProbe.j?.availability?.state === "available", deadProbe.j?.availability?.state);
+    await jd("POST", `/v1/hypervisor/model-routes/${deadId}/enable`, {}, { idem: "dead-enable" });
+
+    await new Promise((resolve) => forwarder.close(resolve));
+    const failed = await jd("POST", `/v1/hypervisor/model-routes/${deadId}/invoke`,
+      { prompt: "this provider is gone" }, { idem: "dead-invoke" });
+    const fInv = failed.j?.invocation ?? {};
+    ok("live: a vanished provider produces an HONEST failure record, never a fabricated completion",
+      fInv.outcome === "failed"
+        && fInv.model_invocation_receipt?.error_class === "ProviderUnavailable"
+        && fInv.evidence?.attempts?.[0]?.retryable === true,
+      `outcome ${fInv.outcome} class ${fInv.model_invocation_receipt?.error_class}`);
+  }
+
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed${LIVE ? " (live)" : ""}`);
+  // The live lane runs MORE assertions than CI does; emitting its census would collide with the
+  // floor pinned for the CI lane.
+  if (!LIVE) emitVerifierCensus({ verifierId: "provider-transport", sourceUrl: import.meta.url, results });
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}
+
+run().catch((error) => {
+  console.error(`FAIL provider-transport — ${error?.stack || error}`);
+  cleanup();
+  process.exit(1);
+});

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -102,6 +102,13 @@
       "source": "apps/hypervisor/scripts/verify-hypervisor-projects-saga.mjs",
       "runtime_assertions": 11,
       "assertion_names_sha256": "9816111389711e17fd8a94074a18eaf6d5cd94edf5e4f1ba75d71e5d31be42b3"
+    },
+    {
+      "id": "provider-transport",
+      "npm_script": "check:provider-transport",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-provider-transport.mjs",
+      "runtime_assertions": 13,
+      "assertion_names_sha256": "7a25506c7e2ea5ec9b1b2c7098c317288e6a8bc82ade9df0fc67857d7660d4fa"
     }
   ],
   "excluded": [

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -142,6 +142,8 @@ mod policy_bound_data_view_routes;
 mod portal_session_exchange_routes;
 #[path = "hypervisor_daemon_routes/provider_routes.rs"]
 mod provider_routes;
+#[path = "hypervisor_daemon_routes/provider_transport.rs"]
+mod provider_transport;
 #[path = "hypervisor_daemon_routes/recipe_routes.rs"]
 mod recipe_routes;
 #[path = "hypervisor_daemon_routes/resource_capability_offer_routes.rs"]
@@ -2394,6 +2396,16 @@ async fn async_main() -> anyhow::Result<()> {
         .route(
             "/v1/hypervisor/model-routes/:id/probe",
             post(model_routes::handle_model_route_probe),
+        )
+        // W3.2 first cut: the first daemon-issued model call whose endpoint comes from the
+        // REGISTRY rather than the boot-time environment singleton.
+        .route(
+            "/v1/hypervisor/model-routes/:id/invoke",
+            post(provider_transport::handle_model_route_invoke),
+        )
+        .route(
+            "/v1/hypervisor/model-invocations/:id",
+            get(provider_transport::handle_model_invocation_get),
         )
         .route(
             "/v1/hypervisor/model-routes/:id/enable",

--- a/crates/node/src/bin/hypervisor_daemon_routes/provider_transport.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/provider_transport.rs
@@ -1,0 +1,873 @@
+//! ProviderTransport (W3.2, first cut) — the provider-protocol adaptation boundary, and the first
+//! daemon-issued model invocation whose endpoint comes from the model-route REGISTRY rather than a
+//! boot-time environment singleton.
+//!
+//! Canon: `docs/architecture/components/model-router/doctrine.md` §Provider Transport Boundary and
+//! §Route Economic Comparison (filed 2026-08-12, next-legs VI Leg 0b).
+//!
+//! WHAT THIS OWNS (the replaceable transport concern):
+//!   * request/response normalization for one provider dialect;
+//!   * streaming and cancellation protocol handling;
+//!   * error normalization and retryability CLASSIFICATION;
+//!   * the observed evidence a response carries — token mix, latency breakdown, finish condition.
+//!
+//! WHAT IT MUST NEVER OWN (each already has a kernel owner; taking one would mint a second spine):
+//!   * route selection and admission — the registry decides, this module only executes what it is
+//!     handed. `model_routes::load_route_record` is the reader; there is no second census here.
+//!   * credential custody — `lifecycle_routes::authorize_capability_lease` is THE crossing. A
+//!     credentialed route is REFUSED here, typed, rather than reading a process env var: the env
+//!     path (`resolve_inference`) bypasses the lease gateway entirely and this module will not
+//!     reproduce that bypass.
+//!   * retry and fallback DECISIONS — a transport classifies an error as retryable; only the router
+//!     decides whether to retry. This cut performs exactly one attempt and says so in the record.
+//!   * billing — the transport reports what it observed; the economics ledger owns what it cost.
+//!     No `UsageRecord` is written here (named residual, see the module tail).
+//!
+//! HONESTY RULES enforced below, not merely described:
+//!   * Every token-mix and latency field the provider did NOT report is `null` — a TYPED GAP. It is
+//!     never zero-filled, and never derived. A synthesized measurement is worse than an absent one
+//!     because it reads as evidence.
+//!   * A failed invocation is receipted with the same care as a successful one. The attempt, its
+//!     classified error, its latency, and its typed outcome are durable. A provider that is
+//!     unreachable produces an honest `ProviderUnavailable` record, never a fabricated completion.
+//!   * The receipt is the TYPED `ModelInvocationReceipt` from the kernel
+//!     (`ioi_services::agentic::runtime::kernel::inference`), not a fresh ad-hoc `json!` shape.
+//!     That struct existed and had never been constructed anywhere in `crates/node/`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::Json;
+use serde_json::{json, Value};
+use sha2::Digest;
+
+use ioi_services::agentic::runtime::kernel::inference::{
+    ModelInvocationReceipt, ModelRuntimeErrorClass,
+};
+
+use super::mutation_event_foundation::{
+    admit_owner_scoped_write, replay_stable_id, require_write_caller, scope_refusal_reply,
+    MutationCommit, WriteCaller,
+};
+use super::{persist_record, DaemonState};
+
+const INVOCATION_NAMESPACE: &str = "hypervisor-model-invocations";
+const KIND_INVOCATION: &str = "model-invocations";
+const SCHEMA_VERSION: &str = "ioi.hypervisor.model-invocation.v1";
+/// One attempt per invocation in this cut. Retry/fallback DECISIONS belong to the router; the
+/// field exists so a later router can extend the lineage rather than re-shape the record.
+const ATTEMPTS_THIS_CUT: usize = 1;
+/// Wall-clock ceiling for one invocation. Exceeding it is `Timeout`, classified, never silent.
+const INVOKE_TIMEOUT_MS: u64 = 120_000;
+/// A stream that produces no further chunk for this long is a stall, distinct from a slow model.
+const STREAM_STALL_MS: u64 = 30_000;
+
+type Reply = (StatusCode, Json<Value>);
+
+fn bad(status: StatusCode, code: &str, message: impl Into<String>) -> Reply {
+    (
+        status,
+        Json(json!({ "ok": false, "error": { "code": code, "message": message.into() } })),
+    )
+}
+
+fn safe(seg: &str) -> String {
+    seg.replace(
+        |c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_',
+        "_",
+    )
+}
+
+fn digest_hex(bytes: &[u8]) -> String {
+    format!("{:x}", sha2::Sha256::digest(bytes))
+}
+
+fn load_invocation(data_dir: &str, id: &str) -> Option<Value> {
+    serde_json::from_slice(
+        &std::fs::read(
+            std::path::Path::new(data_dir)
+                .join(KIND_INVOCATION)
+                .join(format!("{}.json", safe(id))),
+        )
+        .ok()?,
+    )
+    .ok()
+}
+
+// ---------------------------------------------------------------- the transport contract
+
+/// What a transport is asked to do. Everything here is resolved by an owner ABOVE the transport:
+/// the endpoint and model by the registry, the credential by the lease gateway.
+pub(crate) struct TransportRequest {
+    pub base_url: String,
+    pub model_id: String,
+    pub prompt: String,
+    pub stream: bool,
+    /// Resolved through the CapabilityLease gateway when the route is credentialed. `None` means
+    /// the route declared no credential requirement — never "we could not find one".
+    pub credential: Option<String>,
+}
+
+/// The observed token mix. Every field is optional BECAUSE providers differ in what they report,
+/// and an unreported quantity is a typed gap. Zero would be a lie; these stay `None`.
+#[derive(Default, Clone)]
+pub(crate) struct TokenMix {
+    pub input: Option<u64>,
+    pub output: Option<u64>,
+    pub cache_read: Option<u64>,
+    pub cache_write: Option<u64>,
+    pub reasoning: Option<u64>,
+}
+
+impl TokenMix {
+    fn total(&self) -> Option<u64> {
+        match (self.input, self.output) {
+            (Some(i), Some(o)) => Some(i + o),
+            _ => None,
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        json!({
+            "input": self.input,
+            "output": self.output,
+            "cache_read": self.cache_read,
+            "cache_write": self.cache_write,
+            "reasoning": self.reasoning,
+            "total": self.total(),
+            "unreported": self.unreported(),
+        })
+    }
+
+    /// Naming the gaps is the point: a consumer must be able to tell "the provider does not report
+    /// cache tokens" from "this call used no cache".
+    fn unreported(&self) -> Vec<&'static str> {
+        let mut gaps = Vec::new();
+        if self.input.is_none() {
+            gaps.push("input");
+        }
+        if self.output.is_none() {
+            gaps.push("output");
+        }
+        if self.cache_read.is_none() {
+            gaps.push("cache_read");
+        }
+        if self.cache_write.is_none() {
+            gaps.push("cache_write");
+        }
+        if self.reasoning.is_none() {
+            gaps.push("reasoning");
+        }
+        gaps
+    }
+}
+
+/// One attempt against one provider. Attempts are the lineage a later router extends; there was no
+/// attempt lineage of any spelling in this repository before this cut.
+pub(crate) struct TransportAttempt {
+    pub index: usize,
+    pub latency_ms: u64,
+    pub first_token_ms: Option<u64>,
+    pub http_status: Option<u16>,
+    pub outcome: &'static str,
+    pub error_class: Option<ModelRuntimeErrorClass>,
+    pub retryable: bool,
+    pub detail: Option<String>,
+}
+
+impl TransportAttempt {
+    fn to_json(&self) -> Value {
+        json!({
+            "attempt_index": self.index,
+            "latency_ms": self.latency_ms,
+            "first_token_ms": self.first_token_ms,
+            "http_status": self.http_status,
+            "outcome": self.outcome,
+            "error_class": self.error_class.map(|c| c.as_str()),
+            "retryable": self.retryable,
+            "detail": self.detail,
+        })
+    }
+}
+
+pub(crate) struct TransportOutcome {
+    pub output: String,
+    pub token_mix: TokenMix,
+    pub attempts: Vec<TransportAttempt>,
+    pub total_latency_ms: u64,
+    pub first_token_ms: Option<u64>,
+    pub finish_reason: Option<String>,
+    pub streaming: bool,
+}
+
+pub(crate) struct TransportFailure {
+    pub attempts: Vec<TransportAttempt>,
+    pub total_latency_ms: u64,
+    pub error_class: ModelRuntimeErrorClass,
+    pub detail: String,
+}
+
+/// The boundary itself. One dialect per implementation; nothing above the wire belongs here.
+#[allow(async_fn_in_trait)]
+pub(crate) trait ProviderTransport {
+    fn transport_kind(&self) -> &'static str;
+
+    /// The verbatim price-schedule ref this transport can attribute a call to, when the route
+    /// carries one. `None` is a typed gap the economics join must surface, never a zero price.
+    fn price_schedule_ref(&self, route: &Value) -> Option<String> {
+        route
+            .pointer("/provider_binding/price_schedule_ref")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    }
+
+    async fn invoke(
+        &self,
+        request: &TransportRequest,
+    ) -> Result<TransportOutcome, TransportFailure>;
+}
+
+// ---------------------------------------------------------------- the one native implementation
+
+/// Ollama, the only transport the registry admits as executable today
+/// (`model_routes.rs`: "only ollama-transport routes are bindable for session execution").
+/// Native-first: this implementation is what DEFINES the contract above. No adapted or absorbed
+/// transport may claim to conform until this one has executed end to end.
+pub(crate) struct OllamaTransport;
+
+impl OllamaTransport {
+    /// Provider failures are classified, never flattened to "error". The taxonomy is the kernel's
+    /// existing `ModelRuntimeErrorClass` — this module maps onto it rather than inventing a second.
+    fn classify(error: &reqwest::Error) -> (ModelRuntimeErrorClass, bool) {
+        if error.is_timeout() {
+            return (ModelRuntimeErrorClass::Timeout, true);
+        }
+        if error.is_connect() {
+            return (ModelRuntimeErrorClass::ProviderUnavailable, true);
+        }
+        if error.is_decode() {
+            return (ModelRuntimeErrorClass::MalformedStructuredOutput, false);
+        }
+        (ModelRuntimeErrorClass::UnknownProviderError, false)
+    }
+
+    fn classify_status(status: u16) -> (ModelRuntimeErrorClass, bool) {
+        match status {
+            429 => (ModelRuntimeErrorClass::RateLimited, true),
+            // Ollama answers 404 for a model it does not hold — an unavailable provider capability,
+            // not a malformed request.
+            404 => (ModelRuntimeErrorClass::ProviderUnavailable, false),
+            413 => (ModelRuntimeErrorClass::ContextOverflow, false),
+            500..=599 => (ModelRuntimeErrorClass::ProviderUnavailable, true),
+            _ => (ModelRuntimeErrorClass::UnknownProviderError, false),
+        }
+    }
+}
+
+impl ProviderTransport for OllamaTransport {
+    fn transport_kind(&self) -> &'static str {
+        "ollama"
+    }
+
+    async fn invoke(
+        &self,
+        request: &TransportRequest,
+    ) -> Result<TransportOutcome, TransportFailure> {
+        let started = Instant::now();
+        let url = format!("{}/api/chat", request.base_url.trim_end_matches('/'));
+        let body = json!({
+            "model": request.model_id,
+            "messages": [{ "role": "user", "content": request.prompt }],
+            "stream": request.stream,
+        });
+
+        let client = reqwest::Client::new();
+        let mut builder = client
+            .post(&url)
+            .timeout(Duration::from_millis(INVOKE_TIMEOUT_MS))
+            .json(&body);
+        // A credential is attached only when an owner above resolved one. This module never reads
+        // a key from the environment — that path bypasses the lease gateway.
+        if let Some(token) = request.credential.as_deref() {
+            builder = builder.bearer_auth(token);
+        }
+
+        let response = match builder.send().await {
+            Ok(response) => response,
+            Err(error) => {
+                let (class, retryable) = Self::classify(&error);
+                let latency = started.elapsed().as_millis() as u64;
+                return Err(TransportFailure {
+                    attempts: vec![TransportAttempt {
+                        index: 0,
+                        latency_ms: latency,
+                        first_token_ms: None,
+                        http_status: None,
+                        outcome: "failed",
+                        error_class: Some(class),
+                        retryable,
+                        detail: Some(error.to_string()),
+                    }],
+                    total_latency_ms: latency,
+                    error_class: class,
+                    detail: error.to_string(),
+                });
+            }
+        };
+
+        let status = response.status().as_u16();
+        if !response.status().is_success() {
+            let (class, retryable) = Self::classify_status(status);
+            let latency = started.elapsed().as_millis() as u64;
+            let detail = response.text().await.unwrap_or_default();
+            let detail = format!(
+                "upstream HTTP {status}: {}",
+                detail.chars().take(240).collect::<String>()
+            );
+            return Err(TransportFailure {
+                attempts: vec![TransportAttempt {
+                    index: 0,
+                    latency_ms: latency,
+                    first_token_ms: None,
+                    http_status: Some(status),
+                    outcome: "failed",
+                    error_class: Some(class),
+                    retryable,
+                    detail: Some(detail.clone()),
+                }],
+                total_latency_ms: latency,
+                error_class: class,
+                detail,
+            });
+        }
+
+        // Streaming and non-streaming are one protocol here: NDJSON frames versus a single object.
+        // Both paths derive first-token latency from the same clock, so the field means the same
+        // thing in either mode.
+        let (output, mix, finish_reason, first_token_ms) = if request.stream {
+            match read_ollama_stream(response, started).await {
+                Ok(parts) => parts,
+                Err(failure) => return Err(failure),
+            }
+        } else {
+            let text = match response.text().await {
+                Ok(text) => text,
+                Err(error) => {
+                    let (class, retryable) = Self::classify(&error);
+                    let latency = started.elapsed().as_millis() as u64;
+                    return Err(TransportFailure {
+                        attempts: vec![TransportAttempt {
+                            index: 0,
+                            latency_ms: latency,
+                            first_token_ms: None,
+                            http_status: Some(status),
+                            outcome: "failed",
+                            error_class: Some(class),
+                            retryable,
+                            detail: Some(error.to_string()),
+                        }],
+                        total_latency_ms: latency,
+                        error_class: class,
+                        detail: error.to_string(),
+                    });
+                }
+            };
+            let frame: Value = match serde_json::from_str(&text) {
+                Ok(frame) => frame,
+                Err(error) => {
+                    let latency = started.elapsed().as_millis() as u64;
+                    return Err(TransportFailure {
+                        attempts: vec![TransportAttempt {
+                            index: 0,
+                            latency_ms: latency,
+                            first_token_ms: None,
+                            http_status: Some(status),
+                            outcome: "failed",
+                            error_class: Some(ModelRuntimeErrorClass::MalformedStructuredOutput),
+                            retryable: false,
+                            detail: Some(error.to_string()),
+                        }],
+                        total_latency_ms: latency,
+                        error_class: ModelRuntimeErrorClass::MalformedStructuredOutput,
+                        detail: error.to_string(),
+                    });
+                }
+            };
+            let content = frame
+                .pointer("/message/content")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let elapsed = started.elapsed().as_millis() as u64;
+            (
+                content,
+                ollama_token_mix(&frame),
+                frame
+                    .get("done_reason")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                Some(elapsed),
+            )
+        };
+
+        let latency = started.elapsed().as_millis() as u64;
+        Ok(TransportOutcome {
+            output,
+            token_mix: mix,
+            attempts: vec![TransportAttempt {
+                index: 0,
+                latency_ms: latency,
+                first_token_ms,
+                http_status: Some(status),
+                outcome: "succeeded",
+                error_class: None,
+                retryable: false,
+                detail: None,
+            }],
+            total_latency_ms: latency,
+            first_token_ms,
+            finish_reason,
+            streaming: request.stream,
+        })
+    }
+}
+
+/// Ollama reports `prompt_eval_count` / `eval_count` and nothing about cache or reasoning tokens.
+/// Those two stay `None` — the provider does not report them, which is a gap, not a zero.
+fn ollama_token_mix(frame: &Value) -> TokenMix {
+    TokenMix {
+        input: frame.get("prompt_eval_count").and_then(Value::as_u64),
+        output: frame.get("eval_count").and_then(Value::as_u64),
+        cache_read: None,
+        cache_write: None,
+        reasoning: None,
+    }
+}
+
+/// Read an NDJSON stream to completion, timing the first content frame and detecting a stall.
+async fn read_ollama_stream(
+    response: reqwest::Response,
+    started: Instant,
+) -> Result<(String, TokenMix, Option<String>, Option<u64>), TransportFailure> {
+    use futures::StreamExt;
+
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+    let mut output = String::new();
+    let mut mix = TokenMix::default();
+    let mut finish_reason = None;
+    let mut first_token_ms = None;
+
+    loop {
+        let next =
+            tokio::time::timeout(Duration::from_millis(STREAM_STALL_MS), stream.next()).await;
+        let chunk = match next {
+            // A stall is its own class: the provider accepted the request and then stopped
+            // producing. Reporting it as Timeout would erase that distinction.
+            Err(_) => {
+                let latency = started.elapsed().as_millis() as u64;
+                return Err(TransportFailure {
+                    attempts: vec![TransportAttempt {
+                        index: 0,
+                        latency_ms: latency,
+                        first_token_ms,
+                        http_status: Some(200),
+                        outcome: "failed",
+                        error_class: Some(ModelRuntimeErrorClass::StreamingStall),
+                        retryable: true,
+                        detail: Some(format!("no stream frame for {STREAM_STALL_MS}ms")),
+                    }],
+                    total_latency_ms: latency,
+                    error_class: ModelRuntimeErrorClass::StreamingStall,
+                    detail: format!("no stream frame for {STREAM_STALL_MS}ms"),
+                });
+            }
+            Ok(None) => break,
+            Ok(Some(Err(error))) => {
+                let (class, retryable) = OllamaTransport::classify(&error);
+                let latency = started.elapsed().as_millis() as u64;
+                return Err(TransportFailure {
+                    attempts: vec![TransportAttempt {
+                        index: 0,
+                        latency_ms: latency,
+                        first_token_ms,
+                        http_status: Some(200),
+                        outcome: "failed",
+                        error_class: Some(class),
+                        retryable,
+                        detail: Some(error.to_string()),
+                    }],
+                    total_latency_ms: latency,
+                    error_class: class,
+                    detail: error.to_string(),
+                });
+            }
+            Ok(Some(Ok(bytes))) => bytes,
+        };
+
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+        while let Some(newline) = buffer.find('\n') {
+            let line = buffer[..newline].trim().to_string();
+            buffer.drain(..=newline);
+            if line.is_empty() {
+                continue;
+            }
+            let Ok(frame) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if let Some(piece) = frame.pointer("/message/content").and_then(Value::as_str) {
+                if !piece.is_empty() && first_token_ms.is_none() {
+                    first_token_ms = Some(started.elapsed().as_millis() as u64);
+                }
+                output.push_str(piece);
+            }
+            if frame.get("done").and_then(Value::as_bool) == Some(true) {
+                mix = ollama_token_mix(&frame);
+                finish_reason = frame
+                    .get("done_reason")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+            }
+        }
+    }
+
+    Ok((output, mix, finish_reason, first_token_ms))
+}
+
+// ---------------------------------------------------------------- the route
+
+/// POST /v1/hypervisor/model-routes/:id/invoke
+///
+/// The first daemon-issued model call whose endpoint comes from the registry. Composition order,
+/// each step owned elsewhere:
+///   1. identity FIRST (rule E) — `require_write_caller` before any record is read, so an anonymous
+///      caller is owed 401 before a 404 can act as an existence oracle;
+///   2. INV-37 — the acting principal is resolved server-side; a body carrying a WHO field refuses;
+///   3. route resolution — `model_routes::load_route_record`, then the registry's own executable
+///      predicate (active + available + ollama). No second census, no second predicate;
+///   4. credential — a credentialed route is refused TYPED here rather than read from the process
+///      environment, because custody belongs to the CapabilityLease gateway;
+///   5. execution — `ProviderTransport::invoke`;
+///   6. receipt — the TYPED kernel `ModelInvocationReceipt`, admitted through the shared write path
+///      with expected-head CAS, then projected. Failure is receipted as carefully as success.
+pub(crate) async fn handle_model_route_invoke(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<String>,
+    Json(body): Json<Value>,
+) -> Reply {
+    // (1) identity before any record read
+    let caller: WriteCaller = match require_write_caller(&st.data_dir, &headers, &body) {
+        Ok(caller) => caller,
+        Err(response) => return response,
+    };
+    // (2) INV-37 — server-resolved actor
+    let acting_principal_ref = match super::lifecycle_routes::resolve_acting_principal_ref(
+        &st.data_dir,
+        &headers,
+        &body,
+    ) {
+        Ok(actor_ref) => actor_ref,
+        Err((status, value)) => return (status, Json(value)),
+    };
+
+    let prompt = body
+        .get("prompt")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if prompt.trim().is_empty() {
+        return bad(
+            StatusCode::BAD_REQUEST,
+            "model_invocation_prompt_required",
+            "an invocation carries a non-empty prompt",
+        );
+    }
+    let stream = body.get("stream").and_then(Value::as_bool).unwrap_or(false);
+
+    // Replay before work: the same caller + idempotency key returns the stored record rather than
+    // spending a second provider call.
+    let invocation_id = replay_stable_id(
+        "model_invocation",
+        &caller.owner_ref,
+        &caller.idempotency_key,
+    );
+    if let Some(existing) = load_invocation(&st.data_dir, &invocation_id) {
+        return (
+            StatusCode::OK,
+            Json(json!({ "ok": true, "replayed": true, "invocation": existing })),
+        );
+    }
+
+    // (3) route resolution through the registry's own reader
+    let Some(route) = super::model_routes::load_route_record(&st.data_dir, &id) else {
+        return bad(
+            StatusCode::NOT_FOUND,
+            "model_route_not_found",
+            "no model route exists at this id",
+        );
+    };
+    let transport_kind = route
+        .pointer("/provider_binding/transport")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let lifecycle = route
+        .pointer("/lifecycle/status")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let availability = route
+        .pointer("/availability/state")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    // Transport support is checked BEFORE availability, deliberately. A route whose transport has
+    // no implementation can never execute no matter how healthy its provider is, so answering
+    // "not executable (availability)" would name the wrong blocker — and would make this refusal
+    // unreachable in practice, since an unimplemented transport never probes to `available`.
+    if transport_kind != "ollama" {
+        // The honest boundary, not a stub: no other transport is admitted for execution yet, and
+        // this cut will not pretend otherwise.
+        return bad(
+            StatusCode::NOT_IMPLEMENTED,
+            "provider_transport_unimplemented",
+            format!(
+                "transport '{transport_kind}' has no admitted ProviderTransport implementation"
+            ),
+        );
+    }
+    if lifecycle != "active" || availability != "available" {
+        return bad(
+            StatusCode::CONFLICT,
+            "model_route_not_executable",
+            format!(
+                "route lifecycle '{lifecycle}' / availability '{availability}' is not an executable pair; probe the route first"
+            ),
+        );
+    }
+
+    // (4) credential custody stays with the lease gateway
+    let credential_posture = route
+        .get("credential_posture")
+        .and_then(Value::as_str)
+        .unwrap_or("no_credentials_required");
+    // `no_credentials_required` is the registry's own default for an ollama route (model_routes.rs
+    // credential-posture resolution). It is the ONLY posture that needs no crossing; every other
+    // posture names a credential this cut cannot obtain without the lease gateway.
+    if credential_posture != "no_credentials_required" {
+        return bad(
+            StatusCode::NOT_IMPLEMENTED,
+            "provider_credential_lease_unimplemented",
+            format!(
+                "route credential posture '{credential_posture}' requires a CapabilityLease-resolved provider credential; \
+                 no model-route credential lease is minted or consumed yet, and this transport will not read a provider key \
+                 from the process environment"
+            ),
+        );
+    }
+
+    let base_url = route
+        .pointer("/provider_binding/base_url")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let model_id = route
+        .pointer("/model/model_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let route_ref = route
+        .get("route_ref")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    // (5) execution
+    let transport = OllamaTransport;
+    let price_schedule_ref = transport.price_schedule_ref(&route);
+    let request = TransportRequest {
+        base_url: base_url.clone(),
+        model_id: model_id.clone(),
+        prompt: prompt.clone(),
+        stream,
+        credential: None,
+    };
+    let result = transport.invoke(&request).await;
+
+    // (6) receipt — typed, and emitted on BOTH paths
+    let (receipt, evidence, outcome_state, http_status) = match &result {
+        Ok(success) => {
+            let receipt = ModelInvocationReceipt {
+                model_id: model_id.clone(),
+                provider: transport.transport_kind().to_string(),
+                latency_ms: success.total_latency_ms,
+                prompt_tokens: success.token_mix.input.map(|v| v as u32),
+                completion_tokens: success.token_mix.output.map(|v| v as u32),
+                total_tokens: success.token_mix.total().map(|v| v as u32),
+                streaming: success.streaming,
+                structured_output_schema_hash: None,
+                output_hash: sha2::Sha256::digest(success.output.as_bytes()).into(),
+                error_class: None,
+            };
+            let evidence = json!({
+                "token_mix": success.token_mix.to_json(),
+                "latency": {
+                    "total_ms": success.total_latency_ms,
+                    "first_token_ms": success.first_token_ms,
+                },
+                "attempts": success.attempts.iter().map(TransportAttempt::to_json).collect::<Vec<_>>(),
+                "attempt_count": success.attempts.len(),
+                "finish_reason": success.finish_reason,
+                "streaming": success.streaming,
+                "price_schedule_ref": price_schedule_ref,
+                "outcome": "succeeded",
+                // W4-F consumes these. Naming what is NOT collected keeps a later economic
+                // comparison from reading absence as zero.
+                "evidence_gaps": evidence_gaps(&success.token_mix, price_schedule_ref.is_none()),
+            });
+            (receipt, evidence, "succeeded", StatusCode::OK)
+        }
+        Err(failure) => {
+            let receipt = ModelInvocationReceipt {
+                model_id: model_id.clone(),
+                provider: transport.transport_kind().to_string(),
+                latency_ms: failure.total_latency_ms,
+                prompt_tokens: None,
+                completion_tokens: None,
+                total_tokens: None,
+                streaming: stream,
+                structured_output_schema_hash: None,
+                // An empty output is hashed honestly rather than left absent: the receipt states
+                // that nothing was produced, and the hash proves which nothing.
+                output_hash: sha2::Sha256::digest(b"").into(),
+                error_class: Some(failure.error_class),
+            };
+            let evidence = json!({
+                "token_mix": TokenMix::default().to_json(),
+                "latency": { "total_ms": failure.total_latency_ms, "first_token_ms": Value::Null },
+                "attempts": failure.attempts.iter().map(TransportAttempt::to_json).collect::<Vec<_>>(),
+                "attempt_count": failure.attempts.len(),
+                "finish_reason": Value::Null,
+                "streaming": stream,
+                "price_schedule_ref": price_schedule_ref,
+                "outcome": "failed",
+                "error_class": failure.error_class.as_str(),
+                "detail": failure.detail,
+                "evidence_gaps": evidence_gaps(&TokenMix::default(), price_schedule_ref.is_none()),
+            });
+            (receipt, evidence, "failed", StatusCode::BAD_GATEWAY)
+        }
+    };
+
+    let receipt_json = match serde_json::to_value(&receipt) {
+        Ok(value) => value,
+        Err(error) => {
+            return bad(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "model_invocation_receipt_unserializable",
+                error.to_string(),
+            )
+        }
+    };
+
+    // The admitted payload carries no clock and no head — a wall-clock field makes every retry
+    // byte-different and silently defeats replay.
+    let admitted = json!({
+        "schema_version": SCHEMA_VERSION,
+        "invocation_id": invocation_id,
+        "owner_ref": caller.owner_ref,
+        "acting_principal_ref": acting_principal_ref,
+        "route_id": id,
+        "route_ref": route_ref,
+        "transport": transport.transport_kind(),
+        "model_id": model_id,
+        "base_url": base_url,
+        "prompt_hash": format!("sha256:{}", digest_hex(prompt.as_bytes())),
+        "outcome": outcome_state,
+        "attempts_this_cut": ATTEMPTS_THIS_CUT,
+        "model_invocation_receipt": receipt_json,
+        "evidence": evidence,
+    });
+
+    let commit: MutationCommit = match admit_owner_scoped_write(
+        &st.data_dir,
+        &caller,
+        INVOCATION_NAMESPACE,
+        KIND_INVOCATION,
+        &format!("model-invocation://{invocation_id}"),
+        "model_invocation.executed",
+        None,
+        &admitted,
+    ) {
+        Ok(commit) => commit,
+        Err(response) => return response,
+    };
+
+    let mut record = admitted.clone();
+    record["admitted_head"] = json!(commit.projection.head);
+    record["recorded_at"] = json!(super::iso_now());
+    if persist_record(&st.data_dir, KIND_INVOCATION, &invocation_id, &record).is_err() {
+        return bad(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "model_invocation_persistence_failed",
+            "the invocation is admitted but its projection could not be written; replay to reconcile",
+        );
+    }
+
+    (
+        http_status,
+        Json(json!({ "ok": outcome_state == "succeeded", "invocation": record })),
+    )
+}
+
+/// Name every W4-F field this invocation could not supply. An economic comparison that cannot see
+/// its own gaps will read them as zeros.
+fn evidence_gaps(mix: &TokenMix, price_schedule_missing: bool) -> Vec<String> {
+    let mut gaps: Vec<String> = mix
+        .unreported()
+        .into_iter()
+        .map(|field| format!("token_mix.{field}"))
+        .collect();
+    if price_schedule_missing {
+        gaps.push("price_schedule_ref".to_string());
+    }
+    // Named residual, visible in every record rather than only in a ledger row: this cut observes
+    // and receipts, but does not yet join to the economics ledger.
+    gaps.push("economics.usage_record".to_string());
+    gaps
+}
+
+/// GET /v1/hypervisor/model-invocations/:id — readback of one admitted invocation.
+///
+/// Identity resolves BEFORE the record is read: an anonymous caller is owed 401 rather than a 404
+/// that would answer "does this id exist?" for free.
+pub(crate) async fn handle_model_invocation_get(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<String>,
+) -> Reply {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers) {
+        Ok(identity) => identity,
+        Err(refusal) => return scope_refusal_reply(refusal),
+    };
+    let Some(record) = load_invocation(&st.data_dir, &id) else {
+        return bad(
+            StatusCode::NOT_FOUND,
+            "model_invocation_not_found",
+            "no model invocation exists at this id",
+        );
+    };
+    let tenant_authorized = record["owner_ref"]
+        .as_str()
+        .is_some_and(|owner_ref| identity.authorizes_tenant(owner_ref));
+    if !tenant_authorized {
+        return scope_refusal_reply(
+            super::substrate_store::RequestScopeRefusal::ResourceScopeRequired,
+        );
+    }
+    (
+        StatusCode::OK,
+        Json(json!({ "ok": true, "invocation": record })),
+    )
+}


### PR DESCRIPTION
**Stacked on #258** (needs Leg 1's floors gate) — retarget to `master` before that base merges.

Native-first, per the 2026-08-12 absorption ruling: **one native provider executed end to end defines the contract** before any adapted transport conforms to it. That e2e is real — a live Ollama `qwen2.5:7b` invocation through the daemon, **36 input / 2 output tokens observed, streaming first-token 86ms against 371ms total**.

## What was true before this cut

Mapped from source, not assumed:

- The daemon's only real provider client was a **boot-time singleton built from process env** (`resolve_inference` reads `OPENAI_API_KEY` directly), bypassing the CapabilityLease gateway entirely. **No code path** let a model-route registry record supply the endpoint or credential for a daemon-issued model call — the registry's only execution effect was exporting an env var + argv into a spawned node shim.
- The typed `ModelInvocationReceipt` kernel struct existed and had **never been constructed anywhere in `crates/node/`**. The daemon wrote an ad-hoc `json!` shape with no latency, no output hash, no error class.
- **Attempt lineage did not exist under any spelling** (`attempt_lineage` / `AttemptLineage` / `attempt-lineage`: zero hits repo-wide).

## What this cut adds

`provider_transport.rs` — the boundary canon named at Leg 0b:

- **`trait ProviderTransport`** owns only the replaceable transport concern: request/response normalization, streaming + cancellation, error normalization and retryability *classification*, and the evidence a response carries.
- **`OllamaTransport`**, the one native implementation. Real HTTP, real NDJSON streaming, stall detection distinct from timeout, provider failures mapped onto the kernel's existing `ModelRuntimeErrorClass` taxonomy rather than a second one.
- **`POST /v1/hypervisor/model-routes/:id/invoke`** composes existing owners in order: identity first (rule E) → INV-37 server-resolved actor → the registry's own `load_route_record` → credential custody left with the lease gateway → transport → typed receipt through the shared write path. `GET /v1/hypervisor/model-invocations/:id` reads back.

## Composed, not shadowed — the #252 precedent held deliberately

| Concern | This cut |
|---|---|
| Route reading | `model_routes::load_route_record` — no second census |
| Writes | `require_write_caller` / `replay_stable_id` / `admit_owner_scoped_write` / `admitted_stamp`. `model_routes.rs` is the outlier that does *not* use the shared write path; this cut did not copy it |
| Receipt | The **typed kernel struct**, serialized — not a fresh shape |
| Credentials | A credentialed route is **refused 501** rather than reading a provider key from the environment |

Reproducing the env bypass would have been the easy path, and is exactly the second-spine defect.

## W4-F evidence at the wire

Cheap here, expensive to retrofit. Every invocation records the observed token mix, attempt lineage, latency including first-token, finish condition, and the verbatim price-schedule ref when the route carries one. **Every field the provider did not report is `null` *and* named in `unreported`** — Ollama reports no cache or reasoning tokens, so those are typed gaps, never zero-filled. `evidence_gaps` names what this cut cannot fill at all, including `economics.usage_record`, so a later economic comparison cannot read absence as zero.

**Failure is receipted as carefully as success.** A vanished provider produces a durable record with `outcome: failed`, `error_class: ProviderUnavailable`, and a retryable attempt — never a fabricated completion.

## Verification — `check:provider-transport`, two lanes

**CI lane 13/13** (deterministic, needs no provider): rule-E 401 before any record read on both invoke and readback; INV-37 refusal of a client-supplied actor; unknown route 404; empty prompt 400; declared-but-unprobed route 409 (availability is never assumed); unimplemented transport 501 (never a silent fallback onto the one transport that exists); and two non-fabrication proofs reading the durable directory directly rather than trusting the daemon's answer.

**Live lane 28/28** against real Ollama: success through the registry endpoint, typed receipt shape, real token counts, typed gaps for unreported classes, attempt lineage, observed latency, named evidence gaps, durable readback, idempotent replay spending no second provider call, streaming first-token timing, and the vanished-provider failure record.

The vanished-provider proof uses a **TCP forwarder to the real provider**, killed between probe and invoke. Every byte the daemon sees during the probe is genuine; nothing fabricates a provider response. Patching `base_url` was tried first and rejected — it invalidates the probe and refuses at 409, which would have proven route hygiene while the label claimed transport failure handling.

### A decorative assertion caught in my own verifier

The 501 assertion initially **also accepted 409, and passed on the 409** — the label claimed a refusal the assertion never observed. Root cause was ordering: availability was checked before transport support, making `provider_transport_unimplemented` unreachable. The handler now checks transport support first (the more accurate blocker: an unimplemented transport can never execute however healthy its provider), and the assertion demands exactly 501 and exactly that code.

### Leg 1's closed world bit for real

Registering this verifier in CI made the floors gate go **RED with `unregistered_ci_verifier`** naming it, before its row existed. Floors now pin **14 verifiers at 450 runtime assertions**.

## Named residuals — tracked, not waived

- **Economics join** — no `UsageRecord` is written; the `model_tokens` meter class exists only in test fixtures today. Named in every record's `evidence_gaps`.
- **Credentialed transports** — refuse 501 until a model-route CapabilityLease is minted and consumed.
- **One attempt per invocation**; retry/fallback *decisions* stay with the router.
- **CI has no model provider**, so the live lane is not CI-gated. A named residual, never a silent skip.
- **`openai_compatible`** remains registry-admitted but transport-unimplemented.

`cargo build --locked` green · `cargo fmt --check` clean · floors green at 14/450 · `check:architecture-docs` and `check:shipped-products` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)