### PR TITLE
docs(canon): H2B core/embodied split + portable-authority-v3 criteria and negative-fixture contract (next-legs VII Leg 4)

### DIFF
--- a/docs/architecture/_meta/execution-horizons.md
+++ b/docs/architecture/_meta/execution-horizons.md
@@ -4,7 +4,7 @@ Status: canonical architecture note.
 Canonical owner: this file for the horizon framing that separates the launch wedge from long-horizon breadth without narrowing canon.
 Supersedes: readings of the canon that mistake speculative breadth for current shipped surface, or that treat horizon labels as scope deletion.
 Superseded by: none.
-Last alignment pass: 2026-07-29.
+Last alignment pass: 2026-08-12.
 Doctrine status: canonical
 Implementation status: mixed (this note classifies; subject owners carry per-file status)
 Last implementation audit: 2026-07-05
@@ -303,8 +303,8 @@ sovereign-local-completeness runner and isolated-egress harness, and the
 discipline to refuse partial credit — `incomplete` is not a weaker pass.
 
 What it unlocks, in order: the second proof is Horizon 2A continuity across
-two failure domains (same machinery, one more node); the third is Horizon 2B
-useful distributed work; Horizon 3's two-sovereign-DAS AIIP proof remains the
+two failure domains (same machinery, one more node); the third is Horizon 2B's
+core profile of useful distributed digital work; Horizon 3's two-sovereign-DAS AIIP proof remains the
 minimum credible Internet-of-Intelligence demonstration and inherits two
 already-proven sovereign endpoints instead of proving three new things at
 once.
@@ -502,7 +502,14 @@ can orchestrate a useful distributed autonomous system.
 ### Horizon 2B — useful same-system distributed work
 
 Run a non-trivial GoalRun/workload whose complementary roles execute across the admitted
-nodes while remaining one system:
+nodes while remaining one system. The horizon carries two independently
+scheduled profiles: **H2B-core** proves distributed digital work with
+continuity and failure handling and is what Horizon 3 inherits; **H2B-embodied**
+proves the physical/HIL/fleet profile, may run later or in parallel, and gates
+embodied promotion only. The two-sovereign AIIP proof needs distributed digital
+continuity, not fleet physicality — bundling them gated Horizon 3 falsely.
+
+#### H2B-core — distributed digital work
 
 - bind GoalRun/RoleTopology work, runtime assignments, capability/resource
   offers, and claim leases to the stable `system_id`, deployment profile, and
@@ -515,7 +522,10 @@ nodes while remaining one system:
   completion or external effects are not silently duplicated;
 - expose logical roles, physical placement, active/superseded leases, world or
   task-state freshness, coordination epochs, effect status, and recovery
-  through Systems, Work, Operations, and Provenance;
+  through Systems, Work, Operations, and Provenance.
+
+#### H2B-embodied — physical, HIL, and fleet/swarm profile (later or parallel)
+
 - compile one exact `EmbodiedRuntimeGraphManifest` into at least `edge` and
   `site` footprints, with a `micro` safety/control target represented in HIL or
   an equivalent bounded target; prove that deployment placement changes do not
@@ -549,9 +559,11 @@ failure domains do not by themselves create sovereign peers; if a participant
 requires its own constitution, operational truth, admission authority, and
 independent exit, model it as a separate DAS and cross AIIP in Horizon 3. This
 proof is explicitly unbuilt until the contracts and conformance evidence exist.
-Together, Horizon 2A and 2B are the first evidence that L0 is more than an
-application wrapper; they are not yet an Internet-of-Intelligence or
-multi-party network proof.
+Together, Horizon 2A and H2B-core are the first evidence that L0 is more than
+an application wrapper; they are not yet an Internet-of-Intelligence or
+multi-party network proof. H2B-embodied extends the same system contract to
+physical execution and gates embodied promotion only — Horizon 3 does not wait
+on it.
 
 ## Horizon 3 — two sovereign DASs over AIIP
 
@@ -756,16 +768,20 @@ delta and the deferred UX backlog):
    Campaign-owned production mutation.
 10. Same-system two-node continuity proof — Horizon 2's join, catch-up, root,
    fenced promotion, replay, drain, and unchanged-authority demonstration.
-11. Useful same-system distributed-work proof — Horizon 2B's typed
+11. Useful same-system distributed-work proof — H2B-core's typed
     role-to-membership runtime assignments, allocation leases, shared-state
     watermarks, coordination epochs, partition/rejoin/rebalance, fenced
-    reassignment, and duplicate/ambiguous-effect reconciliation; include the
-    native embodied graph compiler/admission contract, `micro`/`edge`/`site`
-    resolution, physical-stream compatibility, proposal-only action chunks,
-    transactional activation, LocalControlSupervisor final-veto behavior,
-    space-time reservations, and the staged backend-neutral proof matrix while
-    keeping deterministic control and safety local. This step remains unbuilt
-    until the named conformance evidence exists.
+    reassignment, and duplicate/ambiguous-effect reconciliation. This step
+    remains unbuilt until the named conformance evidence exists, and it is the
+    distributed-work evidence steps 12–13 inherit.
+11b. Embodied same-system profile (parallel or later; gates embodied promotion
+    only, never step 12 or 13) — H2B-embodied's native embodied graph
+    compiler/admission contract, `micro`/`edge`/`site` resolution,
+    physical-stream compatibility, proposal-only action chunks, transactional
+    activation, LocalControlSupervisor final-veto behavior, space-time
+    reservations, and the staged backend-neutral proof matrix while keeping
+    deterministic control and safety local. This step remains unbuilt until the
+    named conformance evidence exists.
 12. AIIP discovery, exact-root collaboration terms negotiation, standards
     bindings, participation, portable exit, and federated admission —
     `CollaborationTerms`, `OutcomeRoomDiscovery`, typed participation,

--- a/docs/architecture/_meta/execution-horizons.md
+++ b/docs/architecture/_meta/execution-horizons.md
@@ -774,14 +774,14 @@ delta and the deferred UX backlog):
     reassignment, and duplicate/ambiguous-effect reconciliation. This step
     remains unbuilt until the named conformance evidence exists, and it is the
     distributed-work evidence steps 12–13 inherit.
-11b. Embodied same-system profile (parallel or later; gates embodied promotion
-    only, never step 12 or 13) — H2B-embodied's native embodied graph
-    compiler/admission contract, `micro`/`edge`/`site` resolution,
+    **11b — embodied same-system profile** (parallel or later; gates embodied
+    promotion only, never step 12 or 13) — H2B-embodied's native embodied
+    graph compiler/admission contract, `micro`/`edge`/`site` resolution,
     physical-stream compatibility, proposal-only action chunks, transactional
     activation, LocalControlSupervisor final-veto behavior, space-time
     reservations, and the staged backend-neutral proof matrix while keeping
-    deterministic control and safety local. This step remains unbuilt until the
-    named conformance evidence exists.
+    deterministic control and safety local. This step remains unbuilt until
+    the named conformance evidence exists.
 12. AIIP discovery, exact-root collaboration terms negotiation, standards
     bindings, participation, portable exit, and federated admission —
     `CollaborationTerms`, `OutcomeRoomDiscovery`, typed participation,

--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -94,7 +94,7 @@ paths are commitments to write that contract, not evidence it exists.
 | Authority Gateway attach lane (`ActionRequestEnvelope`, gateway receipts, `AuthorityGatewayProfile`, graduation) | `hypervisor-core/authority-gateway-attach-lane.md` | `named_target` |
 | Two-sovereign-DAS AIIP proof (Horizon 3) | `hypervisor-core/aiip-two-sovereign-das.md` | `named_target` |
 | OutcomeRoom `federated_admission` | `hypervisor-core/outcome-room-federated-admission.md` | `named_target` |
-| Portable authority (`AuthorityGrantEnvelope` v3 chain) | `hypervisor-core/portable-authority-v3.md` | `named_target` |
+| Portable authority (`AuthorityGrantEnvelope` v3 chain) | [`hypervisor-core/portable-authority-v3.md`](./hypervisor-core/portable-authority-v3.md) | `target_defined` (criteria and negative-fixture corpus written; no verifier, fixtures, or runner exists) |
 | Model-route rights enforcement (standalone) | covered inside [`institutional-learning-boundary.md`](./hypervisor-core/institutional-learning-boundary.md) route cases; standalone target `hypervisor-core/model-route-rights.md` | `named_target` |
 | Bounded improvement campaign (Horizon 1B) | `hypervisor-core/bounded-improvement-campaign.md` | `named_target` |
 | Improvement assurance profiles (executable ladder incl. protected build / threshold recovery) | `hypervisor-core/improvement-assurance-profiles.md` | `named_target` |

--- a/docs/conformance/hypervisor-core/portable-authority-v3.md
+++ b/docs/conformance/hypervisor-core/portable-authority-v3.md
@@ -31,6 +31,14 @@ below, labels claiming only what the assertion checks, and independent
 evidence from the durable record. A runner that cannot go red on its own
 negative fixtures does not certify this target.
 
+Two criteria name fields the v3 envelope must ADD: the registered v2 schema
+carries per-grant `max_budget_microusd`/`max_calls` only — no delegation-depth
+limit, no re-delegation right, and no cumulative-descendant budget exists in
+any registered contract today. CPA-5 and CPA-6 are therefore target
+definitions of new v3 surface, not claims about existing fields, and the v3
+wire contract must define them (and `authority-and-access.md`'s v3 section
+must enumerate them) before either criterion is testable.
+
 ## Conformance criteria
 
 ### CPA-1 — Complete ancestor chain and parent-holder issuance
@@ -46,11 +54,14 @@ classes, budget, calls, and validity, while retaining or adding caveats and
 approval requirements. Equality is narrowing; any widening on any axis at any
 depth is a refusal, not a warning.
 
-### CPA-3 — System identity and versioned issuer key sets
+### CPA-3 — Issuer identity, versioned key sets, and audience/holder binding
 
-Issuer identity binds to a system identity with versioned key sets; a
-signature that verifies against a key outside the issuer's declared,
-version-valid set is a refusal even when cryptographically valid.
+Issuer identity binds to the canonical issuer union (`system://`, `wallet://`,
+`org://`, or `policy://`) with versioned key sets; a signature that verifies
+against a key outside the issuer's declared, version-valid set is a refusal
+even when cryptographically valid. Presentation binds to the grant's declared
+`audience` and `holder_id`/`holder_key_id`; a chain presented by the wrong
+holder or against an unnamed audience is a refusal.
 
 ### CPA-4 — Revocation snapshots and freshness
 
@@ -106,6 +117,9 @@ any fixture fails the whole target.
   each distinct from structural refusal.
 - **NF-8 depth exhaustion** — declared depth exceeded; re-delegation by a
   holder without the right.
+- **NF-9 wrong audience or holder** — a chain presented by a holder other than
+  the leaf's declared `holder_id`/`holder_key_id`, or against an audience the
+  grant does not name.
 
 ## Relationship to current v2
 

--- a/docs/conformance/hypervisor-core/portable-authority-v3.md
+++ b/docs/conformance/hypervisor-core/portable-authority-v3.md
@@ -1,0 +1,116 @@
+# Portable authority v3 conformance
+
+Status: target conformance contract. Current master registers the v2 grant
+wire contract, invariants, fixtures, and generated projections, but the full
+multi-hop chain is prose doctrine, not machine enforcement: no portable
+Ed25519/JCS verifier, no offline CLI, and no negative-fixture corpus exist,
+and network key discovery, trust-root acquisition, transparency
+infrastructure, and universal revocation distribution remain separate planned
+work.
+Canonical inputs:
+[`authority-and-access.md`](../../architecture/foundations/objects/authority-and-access.md),
+[`invariants.md`](../../architecture/foundations/invariants.md),
+[`security-privacy-policy-invariants.md`](../../architecture/foundations/security-privacy-policy-invariants.md),
+and
+[`verifiable-bounded-agency.md`](../../architecture/foundations/verifiable-bounded-agency.md).
+Last audited: 2026-08-12.
+
+## Scope and honest implementation posture
+
+This target binds the successor (`v3`) `AuthorityGrantEnvelope` chain contract:
+what a conforming verifier must accept, what it must refuse, and what evidence
+each disposition carries. Everything below is a target. Nothing here claims a
+verifier, fixture, runner, or release exists; the criteria define what would
+have to pass before any portable-authority claim is made. The prose doctrine
+(finite, acyclic, strictly narrowing delegation with ancestor validation) is
+already canonical; this file is where that doctrine becomes falsifiable.
+
+A future runner for this target is subject to the standing verifier
+discipline: falsifiable by mutation, closed-world over the refusal classes
+below, labels claiming only what the assertion checks, and independent
+evidence from the durable record. A runner that cannot go red on its own
+negative fixtures does not certify this target.
+
+## Conformance criteria
+
+### CPA-1 — Complete ancestor chain and parent-holder issuance
+
+A conforming verifier accepts a grant only with the complete ancestor chain
+present, each child issued by its parent holder key, and rejects any chain
+with a missing, unordered, or out-of-family ancestor.
+
+### CPA-2 — Strict narrowing at every hop
+
+Every child may only narrow scopes, primitive capabilities, resources, risk
+classes, budget, calls, and validity, while retaining or adding caveats and
+approval requirements. Equality is narrowing; any widening on any axis at any
+depth is a refusal, not a warning.
+
+### CPA-3 — System identity and versioned issuer key sets
+
+Issuer identity binds to a system identity with versioned key sets; a
+signature that verifies against a key outside the issuer's declared,
+version-valid set is a refusal even when cryptographically valid.
+
+### CPA-4 — Revocation snapshots and freshness
+
+Verification operates over a caller-supplied locally trusted key set and a
+bounded-freshness signed revocation snapshot. A stale snapshot beyond the
+declared freshness bound, or a revoked ancestor at any depth, is a refusal;
+absence of revocation data is never treated as proof of non-revocation.
+
+### CPA-5 — Delegation depth and re-delegation rights
+
+Delegation depth limits and re-delegation permission bits are enforced at
+every hop. A chain that exceeds declared depth, or contains a hop issued by a
+holder without re-delegation rights, is a refusal.
+
+### CPA-6 — Resource, call, spend, and descendant budgets
+
+Budgets declared on an ancestor bind the whole subtree. The verifier enforces
+per-grant and cumulative-descendant budget arithmetic; exhaustion is a typed
+refusal distinct from structural invalidity.
+
+### CPA-7 — Final effect-admission receipt binding
+
+A chain verdict is not an effect. The accepted-chain evidence binds into the
+final effect-admission receipt at the executing boundary, so a reviewer can
+join the exact chain, snapshot, and budgets to the exact admitted effect.
+Verification without admission binding certifies nothing about execution.
+
+### CPA-8 — Portable offline verification
+
+The verifier is portable (Ed25519/JCS profile) and runs offline from the
+chain, key set, and snapshot alone — no network key discovery, trust-root
+acquisition, or transparency dependency. Those remain separate planned work
+and are out of scope here; a verifier that silently reaches the network to
+resolve trust is non-conforming.
+
+## Negative-fixture corpus (required before any pass is claimed)
+
+Every fixture must produce its named typed refusal; an either-outcome pass on
+any fixture fails the whole target.
+
+- **NF-1 widened child** — any axis widened at any depth (scope, capability,
+  resource, risk class, budget, validity, caveat removal).
+- **NF-2 cycle** — a chain that revisits any grant or issuer-holder edge.
+- **NF-3 stale ancestor state** — revocation snapshot older than the declared
+  freshness bound for the chain being verified.
+- **NF-4 revoked ancestor** — revocation at every tested depth, not only the
+  leaf's parent.
+- **NF-5 wrong issuer** — valid signature from a key outside the issuer's
+  versioned key set; and a correct key signing a hop it does not hold.
+- **NF-6 replay** — a chain or verification transcript presented outside its
+  validity window or against a different effect than the one bound.
+- **NF-7 budget exhaustion** — per-grant and cumulative-descendant exhaustion,
+  each distinct from structural refusal.
+- **NF-8 depth exhaustion** — declared depth exceeded; re-delegation by a
+  holder without the right.
+
+## Relationship to current v2
+
+The registered v2 grant contract and its fixtures are implementation
+precedent, not partial credit toward this target. v3 conformance is claimed
+only when the criteria above pass together with the negative corpus, and any
+claim is scoped to exactly the profile verified — never to network trust
+distribution, transparency, or discovery, which stay separate planned work.


### PR DESCRIPTION
Executes Leg 4 of the ruled outside-reader adoption plan (internal-docs run `2026-08-12-fused-outside-reader-critique-adoption-plan`).

**H2B split.** Horizon 2B now carries two independently scheduled profiles: **H2B-core** (distributed digital work with continuity and failure handling — what Horizon 3 inherits) and **H2B-embodied** (physical/HIL/fleet; parallel or later; gates embodied promotion only). Build-sequence item 11 splits into 11/11b the same way. Removes false gating only — no requirement was deleted; H3 remains demand-gated by its own "positive cooperation surplus" clause.

**portable-authority-v3.** The named target gets its contract: CPA-1..8 criteria and the NF-1..8 negative-fixture corpus (widened children, cycles, stale ancestors, revoked ancestors, wrong issuers, replay, budget/depth exhaustion — each with a named typed refusal; either-outcome passes fail the target). README row advances `named_target` → `target_defined` (contract written; no verifier, fixtures, or runner exists). The future runner is bound to the standing verifier discipline inside the target itself. No graph reorder: executable enforcement pulls when a real cross-hop journey exists.

Gates: `check:architecture-docs` 178 files / 9 rules green; contract projections unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)