### PR TITLE
test(hypervisor): launch-chain closes at FILE granularity — every launch-family record, not just the run's own launch_id (next-legs VI Leg 3)

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs
@@ -469,6 +469,40 @@ async function run() {
       && persistedShadow.length === 0,
     persistedShadow.length ? persistedShadow.join(" | ") : `${persistedLaunches.length} record(s) clean`);
 
+  // -- next-legs VI Leg 3: FILE-GRANULARITY closure over the whole launch family ------------------
+  // The named residual from next-legs V: the key-set pins bound only THIS run's launch_id, so an
+  // extra launch-family file written under a DIFFERENT id was never key-set checked — a second
+  // spine could hide in a file the gate never looked at. The two assertions below close that by
+  // existence and by shape, over every file in the family directory.
+  const launchIdsOnDisk = persistedLaunches
+    .map((r) => r.json?.launch_id)
+    .filter((v) => typeof v === "string");
+  // Scoped precisely: only ONE launch has been produced at this point in the run (the delegation
+  // probe below produces a second). The label says "so far" because that is what it checks; the
+  // complete-family closure runs at the end of the journey.
+  ok("Leg 3 (file granularity, EXISTENCE so far): after the first produce the launch-family directory holds EXACTLY one file under exactly this run's launch_id — no extra launch-family record under any other id",
+    persistedLaunches.length === launchIdsOnDisk.length
+      && new Set(launchIdsOnDisk).size === 1
+      && launchIdsOnDisk[0] === launchId,
+    `${persistedLaunches.length} file(s), ids ${JSON.stringify([...new Set(launchIdsOnDisk)])}`);
+
+  // Shape, not just count: EVERY record in the family closes over one of the three admitted key
+  // sets. A file whose id differs, or whose key set carries an unexpected key, fails here even if
+  // its VALUES are individually allowlisted.
+  const keySetOf = (record) => {
+    const keys = Object.keys(record || {}).sort().join(",");
+    if (keys === [...EXPECTED_LAUNCH_RECORD_KEYS_PRODUCED].sort().join(",")) return "produced";
+    if (keys === EXPECTED_LAUNCH_RECORD_KEYS_STOPPED.join(",")) return "stopped";
+    if (keys === EXPECTED_LAUNCH_RECORD_KEYS_ARCHIVED.join(",")) return "archived";
+    return null;
+  };
+  const unclosedFiles = persistedLaunches
+    .filter((r) => keySetOf(r.json) === null)
+    .map((r) => `${r.file}:${Object.keys(r.json || {}).sort().join("|")}`);
+  ok("Leg 3 (file granularity, SHAPE): EVERY file in the launch family closes over one of the three admitted key sets (produced/stopped/archived) — an extra or renamed key in ANY record, not only this run's, is a second-spine shadow",
+    unclosedFiles.length === 0,
+    unclosedFiles.length ? unclosedFiles.join(" ; ") : `${persistedLaunches.length} file(s) closed`);
+
   // -- Finding 2: the harness binding names a REAL seeded hp_* profile + its EXACT frozen revision,
   //    and model-route availability was RECHECKED at the launch boundary (not a static literal). ----
   const profiles = await jd("/v1/hypervisor/harness-profiles");
@@ -644,6 +678,28 @@ async function run() {
       && replayedEvents.some((e) => e.event_kind === "harness_session.spawned")
       && !replayedEvents.some((e) => e.kind === "runtime.thread.opened" || e.event_kind === "runtime.thread.opened"),
     `${replayedEvents.length} event(s): ${replayedEvents.map((e) => e.event_kind).join(",")}`);
+
+  // -- next-legs VI Leg 3: COMPLETE-FAMILY closure, after every launch this run produces ----------
+  // The end-of-journey counterpart to the early existence check, and the real close of next-legs V's
+  // residual: by now the run has produced the main launch (stopped, then archived) and the
+  // delegation probe. The family must hold EXACTLY those two ids and nothing else — an extra
+  // launch-family file minted anywhere in the journey, under any id, fails here. Survives restart
+  // because it reads the durable directory after the daemon was killed and restarted above.
+  const finalLaunches = readFamilyRecords("harness-session-launches");
+  const finalIds = [...new Set(finalLaunches.map((r) => r.json?.launch_id).filter((v) => typeof v === "string"))].sort();
+  const expectedIds = [launchId, delegated.body?.launch_id].filter((v) => typeof v === "string").sort();
+  ok("Leg 3 (file granularity, COMPLETE FAMILY after restart): the launch-family directory holds EXACTLY the launch_ids this run produced — the main launch plus the delegation probe, one file each, no extra record under any other id",
+    finalLaunches.length === finalIds.length
+      && expectedIds.length === 2
+      && JSON.stringify(finalIds) === JSON.stringify(expectedIds),
+    `${finalLaunches.length} file(s) ids ${JSON.stringify(finalIds)} expected ${JSON.stringify(expectedIds)}`);
+
+  const finalUnclosed = finalLaunches
+    .filter((r) => keySetOf(r.json) === null)
+    .map((r) => `${r.file}:${Object.keys(r.json || {}).sort().join("|")}`);
+  ok("Leg 3 (file granularity, SHAPE after restart): EVERY file in the launch family still closes over one of the three admitted key sets — including the delegation-probe record, which no earlier key-set assertion ever read",
+    finalUnclosed.length === 0,
+    finalUnclosed.length ? finalUnclosed.join(" ; ") : `${finalLaunches.length} file(s) closed`);
 
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -72,8 +72,8 @@
       "id": "launch-chain",
       "npm_script": "check:launch-chain",
       "source": "apps/hypervisor/scripts/verify-hypervisor-launch-chain.mjs",
-      "runtime_assertions": 49,
-      "assertion_names_sha256": "f20a7a051d5699890c7e1563e6351ecb138dc540b1f8560ae2e8426c134c4fd5"
+      "runtime_assertions": 53,
+      "assertion_names_sha256": "9146d786e4518fec65774ac48588432145b5a8ce0449a0abf93e4d83405cc154"
     },
     {
       "id": "work-cockpit",


### PR DESCRIPTION
Reopened against `master` — the original #260 was auto-closed when its base branch (#259) was deleted on merge. Same content, rebuilt on the current master.

Closes the named residual carried out of next-legs V: *"launch-chain key-set pins bind only the run's own `launch_id` (an extra launch-family file under a different id is unseen)."* The value scan already swept every persisted file, but the **key-set close ran against exactly one record**, so a second-spine record minted under any other id was never key-set checked.

## Four assertions, at two points in the journey

| Assertion | What it closes |
|---|---|
| **EXISTENCE (so far)** | After the first produce, exactly one file under exactly this run's `launch_id` |
| **SHAPE** | Every file closes over one of the three admitted key sets — an extra or renamed key in *any* record fails even when its values are allowlisted |
| **COMPLETE FAMILY (after restart)** | At the end of the journey, exactly the two ids this run produced. Reads the durable directory *after* the daemon kill/restart, so it is recovery truth |
| **SHAPE (after restart)** | The same close over the complete family, including the delegation-probe record no earlier key-set assertion ever read |

The first label says *"so far"* because that is what it checks — the delegation probe produces a second launch later. A label may claim only what its assertion observes.

## Mutation-proven on its own finding

A rogue launch-family file under a different `launch_id` (`hsl_rogue_second_spine`, carrying a `shadow_planner` key) drives **both** new assertions RED. **The pre-existing assertions did not notice it** — 51/53, with only the two new ones failing. That is the direct evidence the residual was real. Restore returns 53/53.

## The other residual is NOT closed

The **fork delegation-SUCCESS path stays unexercised.** An assertion for it was written and **deleted before commit**: the verifier already exercises the delegation-*requested* path more strictly, pinning the planner's exact refusal code `runtime_thread_fork_control_agent_replay_required` and rejecting either-outcome, whereas the replacement accepted "forked OR refused". A weaker duplicate that claims more than it checks is the decorative-assertion class this program keeps finding. A genuine `forked` outcome needs a forkable source agent on the launch thread, which a fresh launch does not have.

Floor raised in the same commit that adds the assertions, per the ratchet: launch-chain **49 → 53**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)