### PR TITLE
docs: README parity cut — evidence-plane lead + retired-claims registry as rule 10 (next-legs VII Leg 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@
 
 **Alignment security for machine authority.**
 
-IOI is the Web4 execution substrate for autonomous software: a deterministic
-action boundary where workers can act under scoped authority, emit receipts,
-prove outcomes, and settle consequences.
+IOI is an authority, effect-admission, and evidence plane for consequential
+machine actions: a deterministic action boundary where workers act under
+scoped authority, emit receipts, produce attributable evidence supporting
+declared verification and acceptance, and settle consequences. It lets
+independently governed systems collaborate without sharing a runtime,
+database, or administrator.
 
-> **A programmable economy for hiring verifiable workers.**
+> **Keep your IDE. Keep your model. Put consequential execution behind IOI.**
 
 The internet learned to read, then write, then own. What it has never been able
 to do safely is act. IOI builds the final primitive: sovereign action that can
@@ -53,11 +56,19 @@ replayable, and settleable.
 | A workflow toy | Canonical operational state and replay |
 | A chain with AI bolted on | Settlement for completed machine labor |
 
+What crosses the boundary is bounded, attributable, challengeable work — not
+weights.
+
 ## Web4: The Action Layer
 
-IOI is the reference implementation of canonical Web4:
+IOI builds for Web4 — its working definition of the internet's action layer:
 
 > **Read + Write + Own + Act, with cryptographic determinism.**
+
+(A reference-implementation designation is a written contract no release has
+yet been designated under; which claims are working today, defined targets, or
+explicit nonclaims is typed per-claim in the
+[conformance ladder](docs/conformance/README.md).)
 
 <p align="center">
   <img src="docs/assets/readme-web4-equation.svg" alt="Web4 equals read plus write plus own plus act with cryptographic determinism." width="100%">
@@ -211,7 +222,7 @@ Stop renting tools. Hire workers.
 | [`packages/hypervisor-adapter-targets`](packages/hypervisor-adapter-targets) | Adapter target modules and host profiles (current: VS Code-family `code-editors/vscode-extension`), the editor-target registry (`editor-targets.manifest.json`), and ignored local host/build artifacts; reusable integration source, not product identity or runtime authority. |
 | [`apps/hypervisor`](apps/hypervisor) | Hypervisor App/Web client shell for sessions, projects, missions, Workbench, Foundry, provider/environment views, models, privacy, approvals, receipts, and runtime UX. |
 | [`apps/aiagent-xyz`](apps/aiagent-xyz) | Marketplace for bounded workers, manifests, benchmark profiles, managed instances, and autonomous capabilities. |
-| [`apps/sas-xyz`](apps/sas-xyz) | Marketplace for verified autonomous service outcomes and Worker Training contracts. |
+| [`apps/sas-xyz`](apps/sas-xyz) | Marketplace for governed autonomous service outcomes — every evidence item scoped to its named proposition — and Worker Training contracts. |
 | [`apps/developers-ioi-ai`](apps/developers-ioi-ai) | Developer-facing documentation and onboarding surface. |
 | [`apps/benchmarks`](apps/benchmarks) | Benchmark and scorecard surfaces. |
 | [`docs/architecture`](docs/architecture) | Canonical architecture authority. Start here when docs disagree. |
@@ -267,7 +278,9 @@ Desktop builds require the usual Electron system dependencies for your platform.
 
 IOI is active alpha research and engineering. Some surfaces are
 production-shaped; others are research prototypes or environment-dependent.
-The architecture is intentionally strict:
+The per-claim truth lives in the [conformance ladder](docs/conformance/README.md),
+which types every claim as working, a defined target, or an explicit nonclaim —
+the README never outruns it. The architecture is intentionally strict:
 
 > **Hypervisor Daemon executes. wallet.network authorizes. Agentgres remembers.
 > Storage backends preserve bytes. MoW routes. IOI L1 settles. Clients compose.

--- a/docs/architecture/foundations/internet-of-intelligence.md
+++ b/docs/architecture/foundations/internet-of-intelligence.md
@@ -4,7 +4,7 @@ Status: canonical architecture authority.
 Canonical owner: this file for the Internet of Intelligence category definition, its necessity argument, and the north-star network proof.
 Supersedes: the duplicated north-star network proof previously carried in both [`../_meta/start-here.md`](../_meta/start-here.md) and [`../README.md`](../README.md); scattered definitional use of the term across the domains tree.
 Superseded by: none.
-Last alignment pass: 2026-08-05.
+Last alignment pass: 2026-08-12.
 Doctrine status: canonical
 Implementation status: mixed (category definition; the network proof is an unmet target — see [`../_meta/implementation-matrix.md`](../_meta/implementation-matrix.md))
 Last implementation audit: 2026-08-05
@@ -31,7 +31,7 @@ Category definition:
 
 Short form:
 
-> **The IoI exchanges verified work, not weights.**
+> **The IoI exchanges bounded, attributable, challengeable work — not weights.**
 
 This definition is categorical: it names what the network *is*, independent of
 any IOI product. IOI's claim is to implement the canonical category, not to own

--- a/docs/assets/readme-hero.svg
+++ b/docs/assets/readme-hero.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="560" viewBox="0 0 1440 560" role="img" aria-labelledby="title desc">
   <title id="title">Internet of Intelligence Hero</title>
-  <desc id="desc">Dark cinematic IOI hero reading Alignment security for machine authority and a programmable economy for hiring verifiable workers.</desc>
+  <desc id="desc">Dark cinematic IOI hero reading Alignment security for machine authority and bounded, attributable, challengeable work — not weights.</desc>
   <defs>
     <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
       <stop offset="0" stop-color="#02050b"/>
@@ -82,7 +82,7 @@
   <text class="headline" x="72" y="270">for machine</text>
   <text class="headline" x="72" y="350" fill="#b8c8ff">authority.</text>
 
-  <text class="subhead" x="76" y="406">A programmable economy for hiring verifiable workers.</text>
+  <text class="subhead" x="76" y="406">Bounded, attributable, challengeable work — not weights.</text>
 
   <g transform="matrix(.42 0 0 .42 862.23 88.42)" filter="url(#glow)">
     <path fill="#3650c0" d="M295.299 434.631L295.299 654.116 485.379 544.373 295.299 434.631z"/>

--- a/scripts/check-architecture-docs.mjs
+++ b/scripts/check-architecture-docs.mjs
@@ -282,7 +282,55 @@ if (!workItemsOnly) {
   }
 }
 
-// 10-15 — the work-item status records, per `_meta/work-items/README.md`.
+// 10 — retired public claims stay retired, and their successors stay present.
+//      Canon narrowing (the sas one-liner; the outside-reader adoption ruling in the
+//      2026-08-12 delta block) retired a set of whole-outcome claim phrasings. This is
+//      a CLOSED set of named retirements, not an open denylist: every row is an exact
+//      string canon explicitly retired, and the successor anchors are pinned beside
+//      them so retirement and replacement cannot drift apart. `_meta` is excluded as a
+//      class — its records NARRATE retirements; a ledger row quoting one is not a
+//      claim. The README's hero SVG is scanned because it renders the front door's
+//      words as image text.
+{
+  const RETIRED_CLAIMS = [
+    ["programmable economy for hiring verifiable workers", "retired front-door tagline"],
+    ["prove outcomes", "whole-outcome proof claim; successor: attributable evidence supporting declared verification and acceptance"],
+    ["reference implementation of canonical web4", "designation exists only as an unsatisfied written contract"],
+    ["verified work, not weights", "flattened the assurance ladder; successor: bounded, attributable, challengeable work"],
+    ["verifiable autonomous outcomes", "retired sas claim (one-liner narrowing)"],
+    ["verified autonomous service outcomes", "retired sas claim (one-liner narrowing)"],
+  ];
+  const scanTargets = [
+    "README.md",
+    "docs/assets/readme-hero.svg",
+    ...files.map(rel).filter((f) => !f.startsWith("docs/architecture/_meta/")),
+  ];
+  for (const relFile of scanTargets) {
+    const target = path.join(root, relFile);
+    if (!fs.existsSync(target)) {
+      failures.push(`${relFile}: retired-claims scan target is missing`);
+      continue;
+    }
+    const text = fs.readFileSync(target, "utf8").toLowerCase();
+    for (const [phrase, label] of RETIRED_CLAIMS) {
+      if (text.includes(phrase)) {
+        failures.push(`${relFile}: carries the retired claim \`${phrase}\` (${label}) — canon retired this phrasing`);
+      }
+    }
+  }
+  const readme = fs.readFileSync(path.join(root, "README.md"), "utf8");
+  for (const anchor of [
+    "authority, effect-admission, and evidence plane",
+    "bounded, attributable, challengeable work",
+    "Keep your IDE. Keep your model. Put consequential execution behind IOI.",
+  ]) {
+    if (!readme.includes(anchor)) {
+      failures.push(`README.md: lost the successor formulation \`${anchor}\` — a retirement holds only while its replacement stands`);
+    }
+  }
+}
+
+// 11-16 — the work-item status records, per `_meta/work-items/README.md`.
 const workItemDir = path.join(root, WORK_ITEMS);
 const records = fs.existsSync(workItemDir)
   ? fs
@@ -407,7 +455,7 @@ if (failures.length > 0) {
   process.exit(1);
 }
 const count = (n, noun) => `${n} ${noun}${n === 1 ? "" : "s"}`;
-if (!workItemsOnly) console.log(`Architecture docs OK — ${files.length} files, 9 rules.`);
+if (!workItemsOnly) console.log(`Architecture docs OK — ${files.length} files, 10 rules.`);
 console.log(
   `Work-item records OK — ${count(records.length, "record")} checked, ${count(anchorCount, "code anchor")}, ${count(pending.length, "pending PR anchor")}.`,
 );


### PR DESCRIPTION
Executes Leg 1 (the P0 item) of the ruled adoption plan: the repo front door stops outclaiming merged canon.

**Copy:** lead moves to the authority/effect-admission/evidence-plane formulation + the ADR 0008 wedge line; "prove outcomes", the "programmable economy for hiring verifiable workers" tagline (including its baked-in copy in the hero SVG), and "reference implementation of canonical Web4" are retired; Web4 becomes IOI's working definition with an honest designation parenthetical; Status links the conformance ladder as the per-claim truth. The foundation short form adopts "bounded, attributable, challengeable work — not weights" at its source.

**Gate:** rule 10 = a retired-claims registry: a closed set of six exactly-named retired strings scanned across README + hero SVG + all docs roots (`_meta` excluded as a narrating class), paired with three pinned successor anchors. Mutation-proven both directions (retired-phrase RED in README and foundation files, lost-anchor RED, `_meta` narration GREEN).

Gates green: `check:architecture-docs` 177 files / 10 rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)