### PR TITLE
docs(canon): product-UX end-shape declarations — reify-first onboarding, noun budget, projection-only Agent Map, default bounded-authority template (next-legs VIII Leg 1)

### DIFF
--- a/docs/architecture/components/hypervisor/core-clients-surfaces.md
+++ b/docs/architecture/components/hypervisor/core-clients-surfaces.md
@@ -427,6 +427,132 @@ Capability
   marketplace listings
 ```
 
+## Product-UX End Shape (declared 2026-08-12)
+
+This section declares the persistent-work-agent product-UX end state. Every
+behavior in it is a declared target over EXISTING owners — registration,
+binding, lineage, placement, authority, approval, receipt, and projection
+contracts that already have canonical homes. It introduces no new primitive,
+no new object family, no new protocol or runtime, and no new acceptance
+spine, and it asserts no usability or adoption uplift. Implementation pulls
+through the reserved thin measured-usability profile only after the
+`DEF-SEQ-1` substrate prerequisites close; nothing here schedules that work.
+
+### Reification Is The Primary Onboarding Journey
+
+The declared primary onboarding journey is reification, not creation:
+
+```text
+do a task conversationally
+  -> it succeeds
+  -> "Keep as Agent" promotes the run into a private Worker registration
+     draft whose composition is bound from the session's own lineage
+```
+
+Create-first composition remains the builder persona's path through Studio
+and the existing authoring surfaces; it is no longer the assumed entry
+funnel. The promotion mints nothing: private registration, Worker Builder
+binding, and session lineage all exist today, and the draft stays private
+under the aiagent.xyz **My workers** registration owner
+([`worker-marketplace.md`](../../domains/aiagent/worker-marketplace.md)).
+
+### Placement Defaults At Run One
+
+A first run defaults to eligible-auto placement. The local/hosted choice and
+its consequences — custody, privacy posture, cost, availability — live on
+inspection surfaces, not as a decision gate inside the first-run flow.
+Exposing placement consequences is satisfied by inspectability, never by
+interrogating a new user before the first task.
+
+### Surface Noun Budget
+
+Standing product rule: ordinary surfaces render at most three nouns —
+**Agent**, **Skill**, and **Schedule**. Every other canonical noun (Worker,
+Package, Automation, GoalRun, OutcomeRoom, ManagedWorkerInstance,
+HarnessProfile, and the rest) appears only on inspection and console
+surfaces. This is the product analog of the standing 30-second fresh-reader
+test for public copy: it is what makes "separation need not burden the
+ordinary UI" a checkable claim instead of a hope. The budget renames nothing
+and retires nothing; canonical objects keep their canonical names everywhere
+truth is inspected.
+
+### Delegation Is Conversational; The Typed Handoff Is The Record
+
+The ask is natural language. The bounded typed handoff is what the system
+RECORDS and renders — as a delegation edge on the Agent Map and a row in
+review — never an input form the user fills in. ADR 0034 is unchanged
+beneath this presentation: the delegation edge remains kernel thread-fork
+lineage, and the conversational surface adds no second delegation record.
+
+### The Agent Map Panel (projection-only)
+
+The **Agent Map** is a declared shared projection surface: a spatial graph
+of what an agent may touch, is touching, and has touched. It is available as
+a panel in Work and Operations and is projected in the aiagent.xyz managed
+console. Every datum it renders has an owner today:
+
+```text
+live presence         subject attachments
+delegation edges      thread-fork lineage (ADR 0034)
+what may be touched   authority scopes
+what was touched      effect admissions and receipts
+where work runs       placement / runtime assignments
+what changed          Agentgres heads
+what is waiting       the approval queue
+what was refused      typed refusals
+```
+
+Rendering semantics:
+
+```text
+nodes           artifacts, objects, and connectors within the agent's
+                reachable scope
+avatar          a live subject attachment, positioned on the node the agent
+                is currently touching
+boundary ring   the authority scope edge; reachable-but-untouched, touched,
+                and out-of-scope render differently
+edges           delegation lineage and effect flow
+pulse           a pending approval on the node it blocks, with a two-tap
+                approve/refuse decision
+flash           a typed refusal, rendered as its typed reason
+rail            receipts and heads beside the map, with click-through to
+                run review
+camera          auto-follow active work; frame the active cluster
+```
+
+Honesty guards, named now and binding on any implementation:
+
+- presence renders ONLY from a live subject attachment (the anti-masquerade
+  family);
+- a quiet node never implies a finished agent — silence is not success;
+- map states grant nothing (the pixel-certificate rule); and
+- the map feed is a pure function of durable records — when the panel is
+  pulled into implementation, it arrives WITH a `check:agent-map-projection`
+  purity/freshness verifier, mutation-tested like every other gate.
+
+The map mints nothing, owns nothing, and is never an orchestration or truth
+surface. Rendering it from anything other than owned durable records is the
+defect, not a shortcut.
+
+### Cost-Per-Run On Run Review
+
+Run review and the Agent Map rail carry a cost-per-run chip derived from the
+economics evidence fields (token mix, attempts, latency, outcomes) once
+those fields are collected. This is a pointer to the standing economics
+join, not a claim that the fields exist today.
+
+### Nonclaims
+
+- No usability, adoption, retention, or business uplift is asserted; a
+  better-than-incumbent UX remains a `target_defined` claim until the
+  acceptance journeys measure it against owner-backed implementations.
+- Every behavior above is a declared target over EXISTING owners; no new
+  primitive, object family, or acceptance spine is created, and no owner
+  boundary in this file or its related canon moves.
+- Implementation pulls through the reserved thin measured-usability profile
+  only after the `DEF-SEQ-1` substrate prerequisites close; declaration is
+  not scheduling.
+
 ## Hypervisor Core
 
 **Hypervisor Core** is the shared runtime/control substrate used by Hypervisor

--- a/docs/architecture/components/wallet-network/doctrine.md
+++ b/docs/architecture/components/wallet-network/doctrine.md
@@ -4,7 +4,7 @@ Status: canonical architecture authority.
 Canonical owner: this file for wallet.network authority doctrine; wallet product, exchange, route-source, exposure, protection, approval-inbox, and receipt doctrine lives in [`product-exchange-risk.md`](./product-exchange-risk.md); low-level scope APIs live in [`api-authority-scopes.md`](./api-authority-scopes.md).
 Supersedes: older generic capability-grant wording when it conflicts with `scope:*` authority grants.
 Superseded by: none.
-Last alignment pass: 2026-08-09.
+Last alignment pass: 2026-08-12.
 Doctrine status: canonical
 Implementation status: partial (capability-lease authority, sealed credentials, approval gates, the principal-to-approval-authority resolver, and exact grant-hash-keyed effect consumption with immutable replay receipts are live on named qualified owner paths; all affected shared-verifier and governed-authority registrations now route structural evidence through independent issuer resolution, deterministic atomic consumption, opaque admission revalidation, and retained route/final-invoker, concurrency, crash, denial, and replay proof; embedded account/factor/passkey/recovery APIs, guardian surfaces, key shards, and MPC vault are planned; the closed approval-ceremony context, temporal profile/evaluation input, review/effect-admission receipt profiles, context-bound v3 grant, and WalletReceipt v2 are target successor contracts; the wallet-interoperability surfaces — inbound external-wallet sign-in, outbound provider service, OIDC federation — are planned target contracts with no implementation, and the predecessor link_owner@v1 anchor store is superseded by them before any exposure)
 Implementation refs:
@@ -907,6 +907,29 @@ Each request binds the active constitution/profile roots, exact transition,
 system and membership IDs, evidence, budget/effect posture, expiry, revocation
 epoch, and the external governance decision required by that system. A worker
 may propose the request but cannot approve its own protected transition.
+
+## Default Bounded-Authority Template (declared 2026-08-12)
+
+The product ships one named default starter grant so a new user's first
+governed action and its receipt require no policy authoring:
+
+```text
+read-allowed
+consequential-denied
+exactly one narrowly scoped connector
+```
+
+The template is a product default composed from existing authority
+primitives — `scope:*` grants, capability leases, connector authority, and
+approval gates — and is explicitly NOT a new authority object, grant kind,
+or scope family. Read-class scopes are granted; consequential classes are
+denied by default; the single connector lease is narrow, expiring, and
+revocable like any other. The applied template is visible and editable on
+inspection surfaces, and editing it is ordinary grant/lease mutation under
+the same policy, ceremony, receipt, and revocation path. A template default
+narrows only; any widening is an explicit governed decision, never
+route-supplied, and the template never substitutes for per-action admission
+at the effect boundary.
 
 ## Risk Classes
 

--- a/docs/architecture/domains/aiagent/worker-marketplace.md
+++ b/docs/architecture/domains/aiagent/worker-marketplace.md
@@ -4,7 +4,7 @@ Status: canonical architecture authority.
 Canonical owner: this file for aiagent.xyz marketplace doctrine; low-level worker endpoints live in [`worker-endpoints.md`](./worker-endpoints.md).
 Supersedes: overlapping worker-marketplace plan prose when marketplace boundaries conflict.
 Superseded by: none.
-Last alignment pass: 2026-07-15.
+Last alignment pass: 2026-08-12.
 Doctrine status: canonical
 Implementation status: partial (draft object plane only:
 listings/candidates/reviews/offers; private/local-worker registration,
@@ -308,6 +308,19 @@ as ambient reusable access. aiagent.xyz records the exact
 composition and owner visibility, while the local Hypervisor/home domain owns
 pairing proof, adapter/MCP mediation, credentials, execution, and receipts.
 
+**Keep as Agent (declared 2026-08-12).** The same private registration owner
+carries the declared reification path from ordinary governed Hypervisor
+work: when a run succeeds, "Keep as Agent" promotes that run into a private
+Worker registration draft whose composition is bound from the session's own
+lineage — the exact model route, harness or adapter, tools, and policy
+posture the run actually used. This is a declared target over the existing
+registration and binding owners, not a new object or admission path: the
+draft is an ordinary **My workers** registration draft, private by default,
+and every later elevation — benchmark, listing, routing eligibility —
+remains the separate explicit promotion path above. Nothing publishes,
+benchmarks, widens authority, or creates a publisher profile because a run
+was kept.
+
 A reusable private registration binds at minimum:
 
 - owner or organization principal and visibility policy;
@@ -518,6 +531,15 @@ Auto-update may be allowed for low-risk compatible updates, but authority
 broadening, connector expansion, privacy posture changes, safety posture
 changes, benchmark-stale compositions, or major behavior changes require
 explicit review and rollback posture.
+
+The managed console also projects the shared Hypervisor **Agent Map** panel
+for installed instances (declared 2026-08-12): bounded presence, delegation
+lineage, effect flow, pending approvals, typed refusals, and the receipt
+rail, rendered over the same durable daemon/Agentgres-owned records the
+owner surfaces render
+([`core-clients-surfaces.md`](../../components/hypervisor/core-clients-surfaces.md)).
+The console projects that truth; it never owns it — map states grant
+nothing, and a quiet node never implies a finished agent.
 
 Hosted aiagent instances may run on an aiagent-operated Hypervisor fleet.
 Customer, local, enterprise, DePIN, TEE, or Private Workspace cTEE instances may


### PR DESCRIPTION
## What this declares

Target-canon declarations of the 2026-08-12 persistent-work-agent product-UX end state (packet run `2026-08-12-persistent-work-agent-owner-direction-product-ux-end-state`). Three files; every behavior is a declared target over EXISTING owners.

### E1–E8 (as declared here)

- **E1 — Reification is the primary onboarding journey.** Do a task conversationally → it succeeds → "Keep as Agent" promotes the run into a private Worker registration draft bound from the session's own lineage. Create-first remains the builder persona's path. No object changes: private registration, Worker Builder binding, and lineage all exist (`core-clients-surfaces.md` + `worker-marketplace.md`).
- **E2 — Placement defaults at run one.** Eligible-auto placement; the local/hosted choice and its consequences live on inspection surfaces, not a first-run decision gate.
- **E3 — Surface noun budget (standing product rule).** Ordinary surfaces render at most three nouns — Agent, Skill, Schedule; every other canonical noun appears only on inspection/console surfaces. Declared as the product analog of the standing 30-second fresh-reader test.
- **E4 — Delegation is conversational; the typed handoff is the record.** The system records and renders the bounded typed handoff (delegation edge + review row), never an input form. ADR 0034 unchanged beneath.
- **E5 — Agent Map as a canonical shared PROJECTION-ONLY surface.** Work/Operations panel; projected in the aiagent.xyz managed console. Nodes/avatar/boundary-ring/edges/pulse/flash/rail/camera semantics declared with the truth-owner table (subject attachments, thread-fork lineage, authority scopes, effect admissions/receipts, placement, Agentgres heads, approval queue, typed refusals).
- **E6 — KPIs** ride the acceptance-journey leg (not in this PR's file set); E7 here is what makes its zero-authoring bar possible.
- **E7 — Default bounded-authority template** (`wallet-network/doctrine.md`): read-allowed, consequential-denied, exactly one narrowly scoped connector; visible and editable on inspection; explicitly NOT a new authority object, grant kind, or scope family — a product default composed from existing primitives.
- **E8 — Cost-per-run pointer.** Run review and the map rail carry cost-per-run from the economics evidence fields once collected; no claim the fields exist today.

### The projection-only ruling and honesty guards

The Agent Map mints nothing, owns nothing, and is never an orchestration or truth surface; rendering it from anything other than owned durable records is the defect. Guards named now and binding on any implementation:

1. presence renders ONLY from a live subject attachment (anti-masquerade family);
2. a quiet node never implies a finished agent — silence is not success;
3. map states grant nothing (the pixel-certificate rule);
4. the map feed is a pure function of durable records and arrives WITH a `check:agent-map-projection` purity/freshness verifier when implemented, mutation-tested like every other gate.

### Nonclaims

No usability, adoption, retention, or business uplift is asserted; better-than-incumbent UX stays `target_defined` until the acceptance journeys measure it. No new primitive, object family, protocol, runtime, or acceptance spine. Implementation pulls through the reserved thin measured-usability profile only after the `DEF-SEQ-1` substrate prerequisites close — declaration is not scheduling.

### Deliberately NOT in this PR

The `_meta/source-of-truth-map.md` Agent Map projection row and the delta row ride a later leg — that file is touched by an open PR in the VII stack and these legs land after it, based on master. The E6 journey-acceptance amendments and the implementation-plan profile spec also ride later legs per the packet's patch map.

### Verification

- `node scripts/check-architecture-docs.mjs` → `Architecture docs OK — 177 files, 9 rules.` / `Work-item records OK — 7 records checked, 23 code anchors, 0 pending PR anchors.`
- `npm run check:architecture-contracts` → `Architecture contract projections are up to date.`
- Retired-string scan over all three files: 0 matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)