### PR TITLE
feat(w3.2): the economics join — a model invocation meters onto the ledger that prices it

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-provider-transport.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-provider-transport.mjs
@@ -1,18 +1,28 @@
 #!/usr/bin/env node
-// verify-hypervisor-provider-transport — W3.2 first cut (check:provider-transport).
+// verify-hypervisor-provider-transport — W3.2 (check:provider-transport).
 //
 // Proves, against an ISOLATED real daemon, that the ProviderTransport boundary is composed and not
 // shadowed: the invocation route resolves its endpoint from the model-route REGISTRY, refuses every
 // non-executable posture with a typed code, keeps credential custody with the CapabilityLease
-// gateway instead of reading a provider key from the process environment, and fabricates no
-// invocation record when it refuses.
+// gateway instead of reading a provider key from the process environment, fabricates no invocation
+// record when it refuses, and — since the economics join landed — meters what it observed onto the
+// ledger that prices it, or names the absence.
+//
+// WHAT THE JOIN ASSERTIONS ARE GUARDING AGAINST, stated so a later edit cannot quietly relax them:
+//   * a charge nobody can audit — the row must cite the invocation ref, and that ref must resolve;
+//   * a quantity the caller chose — the charged number is compared against the RECEIPT's observed
+//     counts, not against the join's own report of itself;
+//   * a zero that reads as free — an unmetered call mints NO row and says why;
+//   * a double charge on retry — the replayed invocation must leave the chain's head hash intact;
+//   * usage quietly becoming spend — a FinalDebit over the billed quote must still refuse.
 //
 // TWO LANES, and the split is deliberate:
-//   default (CI)  — the refusal ladder and non-fabrication. Needs no model provider, so it runs
-//                   anywhere and its assertion count is DETERMINISTIC (the verifier-floors pin
-//                   depends on that).
+//   default (CI)  — the refusal ladder, non-fabrication, and the billing block's request-SHAPE
+//                   half. Needs no model provider, so it runs anywhere and its assertion count is
+//                   DETERMINISTIC (the verifier-floors pin depends on that).
 //   --live        — the native-first e2e against a REAL provider: success, streaming, observed
-//                   token mix, latency, the typed kernel receipt, readback, and idempotent replay.
+//                   token mix, latency, the typed kernel receipt, readback, idempotent replay, and
+//                   the economics join end to end over a real quote and rate card.
 //                   NOT run in CI: GitHub Actions has no model provider. That absence is a named
 //                   residual, never a silent skip — the live lane is the evidence a human runs and
 //                   records, exactly like check:ported-seed:live.
@@ -208,6 +218,48 @@ async function run() {
       false, `route create failed: ${oai.status} ${JSON.stringify(oai.j?.error ?? {})}`);
   }
 
+  // ---------------------------------------------------------------- the billing block is REQUEST SHAPE
+  // These run with no provider ON PURPOSE. The economics join's world-state half (does this quote
+  // resolve, does it price model_tokens) needs a route that can actually execute, so it is proven
+  // in the live lane — but a join whose ONLY proof needs a model provider is a claim CI never
+  // checks. The shape half below is a pure function of the request, so it gates every commit.
+  const econInvoke = (economics, idem, route = "mrt_local_default") =>
+    jd("POST", `/v1/hypervisor/model-routes/${route}/invoke`, { prompt: "hello", economics }, { idem });
+
+  const econScalar = await econInvoke("work-quote://eqt_scalar", "econ-not-object");
+  ok("a non-object economics block is refused typed rather than coerced into a billing target",
+    econScalar.status === 400 && code(econScalar.j) === "model_invocation_economics_invalid",
+    `status ${econScalar.status} code ${code(econScalar.j)}`);
+
+  const econNoQuote = await econInvoke({ commercial_posture: "managed" }, "econ-no-quote");
+  ok("a billing block naming no quote is refused: a charge binds to exactly one quote",
+    econNoQuote.status === 400 && code(econNoQuote.j) === "model_invocation_economics_quote_ref_required",
+    `status ${econNoQuote.status} code ${code(econNoQuote.j)}`);
+
+  const econNoPosture = await econInvoke({ quote_ref: "work-quote://eqt_x" }, "econ-no-posture");
+  ok("a billing block naming no commercial posture is refused before anything is metered",
+    econNoPosture.status === 400 && code(econNoPosture.j) === "model_invocation_economics_posture_required",
+    `status ${econNoPosture.status} code ${code(econNoPosture.j)}`);
+
+  // The INV-37 idiom applied to HOW MUCH. A caller who can name their own token count can name
+  // their own bill, so every field that describes a charge rather than names a target is refused.
+  const econQuantity = await econInvoke(
+    { quote_ref: "work-quote://eqt_x", commercial_posture: "managed", quantity_units: 1 }, "econ-quantity");
+  ok("a caller-supplied charge quantity is refused — the amount billed is the amount OBSERVED",
+    econQuantity.status === 400
+      && code(econQuantity.j) === "model_invocation_economics_quantity_not_client_settable",
+    `status ${econQuantity.status} code ${code(econQuantity.j)}`);
+
+  // Same typed 400 on a route that does not exist. That is the proof the block is validated as
+  // request shape rather than after route resolution: it answers nothing about which routes exist,
+  // and it stays reachable on a machine where no route could ever execute.
+  const econUnknownRoute = await econInvoke(
+    { commercial_posture: "managed" }, "econ-unknown-route", "mrt_does_not_exist");
+  ok("the billing block is validated as request SHAPE — an unknown route answers the same typed 400, so it is neither an existence oracle nor gated on route health",
+    econUnknownRoute.status === 400
+      && code(econUnknownRoute.j) === "model_invocation_economics_quote_ref_required",
+    `status ${econUnknownRoute.status} code ${code(econUnknownRoute.j)}`);
+
   ok("the whole refusal ladder fabricated NO invocation record on disk",
     invocationFiles().length === 0, `${invocationFiles().length} record(s)`);
 
@@ -240,8 +292,43 @@ async function run() {
     const enabled = await jd("POST", `/v1/hypervisor/model-routes/${liveId}/enable`, {}, { idem: "live-enable" });
     ok("live: the route is activated", enabled.status === 200, `status ${enabled.status}`);
 
+    // ------------------------------------------------------------ the economics chain to bill against
+    // Built through the ledger's OWN routes, not seeded on disk: the join has to survive the same
+    // quote/rate-card/hold admission every other charge does, including the `model_tokens` meter
+    // class — which until this cut existed only in #[cfg(test)] rate-card fixtures.
+    const card = await jd("POST", "/v1/hypervisor/economics/rate-cards", {
+      currency_code: "USD", ioi_fee_policy_ref: "policy://ioi/fees", validity_seconds: 3600,
+      meter_rates: [{ meter_class: "model_tokens", work_credit_micro_units_per_meter_unit: 5, charge_component: "managed_model" }],
+    }, { idem: "econ-card" });
+    const cardRef = card.j?.rate_card?.object?.rate_card_ref ?? "";
+    const plan = await jd("POST", "/v1/hypervisor/economics/plans", {
+      rate_card_ref: cardRef, included_work_credit_units: 0, reset_policy: "non_resetting", validity_seconds: 3600,
+    }, { idem: "econ-plan" });
+    const planRef = plan.j?.plan?.object?.plan_ref ?? "";
+    const quote = await jd("POST", "/v1/hypervisor/economics/quotes", {
+      rate_card_ref: cardRef, plan_ref: planRef, work_ref: "work://ioi/provider-transport-live",
+      estimated_work_credit_units: 1_000_000, overrun_policy: "exact_additional_hold", max_attempt_count: 3,
+      allowed_commercial_postures: ["managed", "local"], validity_seconds: 600,
+    }, { idem: "econ-quote" });
+    const quoteRef = quote.j?.quote?.object?.quote_ref ?? "";
+    const quoteId = quoteRef.split("/").pop() ?? "";
+    const hold = await jd("POST", "/v1/hypervisor/economics/holds",
+      { quote_ref: quoteRef, amount_units: 1_000_000, hold_kind: "initial" }, { idem: "econ-hold" });
+    ok("live: a real rate card priced for `model_tokens` carries a quote and a covering hold",
+      card.status === 201 && plan.status === 201 && quote.status === 201 && hold.status === 201 && quoteId.startsWith("eqt_"),
+      `card ${card.status} plan ${plan.status} quote ${quote.status} hold ${hold.status} ${quoteId}`);
+
+    /** The DURABLE usage chain, read from the contract-validated ledger bundle — never self-report. */
+    const usageRows = async () => {
+      const bundle = await jd("GET", `/v1/hypervisor/economics/quotes/${quoteId}/ledger-bundle`);
+      return bundle.j?.ledger_bundle?.usage_records ?? [];
+    };
+    ok("live: the quote's usage chain is empty before any invocation bills against it",
+      (await usageRows()).length === 0, "0 rows");
+
     const invoked = await jd("POST", `/v1/hypervisor/model-routes/${liveId}/invoke`,
-      { prompt: "Reply with exactly the word: composed" }, { idem: "live-invoke-1" });
+      { prompt: "Reply with exactly the word: composed", economics: { quote_ref: quoteRef, commercial_posture: "managed" } },
+      { idem: "live-invoke-1" });
     const inv = invoked.j?.invocation ?? {};
     const receipt = inv.model_invocation_receipt ?? {};
     const evidence = inv.evidence ?? {};
@@ -264,22 +351,77 @@ async function run() {
       JSON.stringify(evidence.attempts?.[0] ?? {}));
     ok("live: latency is observed, not declared",
       (evidence.latency?.total_ms ?? 0) > 0, `${evidence.latency?.total_ms}ms`);
-    ok("live: the W4-F evidence gaps this cut cannot fill are NAMED in the record",
-      (evidence.evidence_gaps ?? []).includes("economics.usage_record"),
+    // The gap list is TRANSPORT-scoped now that the join exists. It used to carry
+    // `economics.usage_record` unconditionally — correct while nothing could be metered, and a lie
+    // on a metered call. Whether the charge landed is answered by `economics`, its only owner.
+    ok("live: the evidence gaps name only what the TRANSPORT could not observe, and no longer duplicate the join's answer",
+      (evidence.evidence_gaps ?? []).includes("token_mix.cache_read")
+        && !(evidence.evidence_gaps ?? []).includes("economics.usage_record"),
       JSON.stringify(evidence.evidence_gaps ?? []));
 
-    const readback = await jd("GET", `/v1/hypervisor/model-invocations/${inv.invocation_id}`);
+    // ------------------------------------------------------------ THE ECONOMICS JOIN
+    const econ = inv.economics ?? {};
+    const rows = await usageRows();
+    const row = rows[0] ?? {};
+    ok("live: the invocation MINTED a UsageRecord on the quote's hash-chained usage ledger",
+      econ.joined === true && rows.length === 1 && typeof econ.usage_ref === "string"
+        && row.usage_ref === econ.usage_ref && row.meter_class === "model_tokens",
+      `joined ${econ.joined} rows ${rows.length} ${row.usage_ref} ${row.meter_class}`);
+
+    // The quantity is not "a number the daemon reported"; it is arithmetic over the receipt's own
+    // observed counts. Comparing against the receipt rather than against the join's self-report is
+    // what makes this a check instead of an echo.
+    const observedTotal = (receipt.prompt_tokens ?? -1) + (receipt.completion_tokens ?? -1);
+    ok("live: the charged quantity EQUALS the receipt's observed token mix — input + output, not a declared number",
+      receipt.prompt_tokens > 0 && receipt.completion_tokens > 0
+        && row.quantity_units === observedTotal && econ.quantity_units === observedTotal
+        && row.quantity_units === evidence.token_mix.total,
+      `receipt ${receipt.prompt_tokens}+${receipt.completion_tokens}=${observedTotal} charged ${row.quantity_units}`);
+
+    // Pricing, checked against the quantity the row ACTUALLY carries — not against the expected
+    // one. Folding the expected quantity in here made this assertion fire whenever the quantity
+    // was wrong, which its label does not claim and which the assertion above already owns.
+    ok("live: the ledger priced the row from the QUOTE's rate card, and the daemon computed no charge of its own",
+      row.rate_work_credit_micro_units_per_meter_unit === 5
+        && row.charged_work_credits?.units === row.quantity_units * 5
+        && row.sequence === 1 && row.previous_usage_hash === null,
+      `rate ${row.rate_work_credit_micro_units_per_meter_unit} charged ${row.charged_work_credits?.units} seq ${row.sequence}`);
+
+    // Both directions, each resolved through a real route rather than by string comparison.
+    const joinKey = `model-invocation://${inv.invocation_id}`;
+    const backFromCharge = await jd("GET", `/v1/hypervisor/model-invocations/${inv.invocation_id}`);
+    ok("live: the join key resolves BOTH ways — the charge cites the invocation ref, and that ref reads back as the invocation",
+      (row.runtime_receipt_refs ?? []).includes(joinKey)
+        && econ.runtime_receipt_ref === joinKey
+        && backFromCharge.status === 200
+        && backFromCharge.j?.invocation?.economics?.usage_ref === row.usage_ref
+        && econ.chain_ref === `usage-chain://${quoteId}`,
+      `${joinKey} <-> ${row.usage_ref}`);
+
+    const readback = backFromCharge;
     ok("live: the invocation reads back durably with its receipt intact",
       readback.status === 200 && readback.j?.invocation?.model_invocation_receipt?.output_hash?.length === 32,
       `status ${readback.status}`);
 
+    // Each "no row was added" assertion below measures the DELTA it is responsible for. An earlier
+    // revision compared against an absolute chain length, so a double charge minted anywhere made
+    // all three go red and only one of them owned the defect.
+    const beforeReplay = (await usageRows()).length;
     const replay = await jd("POST", `/v1/hypervisor/model-routes/${liveId}/invoke`,
-      { prompt: "Reply with exactly the word: composed" }, { idem: "live-invoke-1" });
+      { prompt: "Reply with exactly the word: composed", economics: { quote_ref: quoteRef, commercial_posture: "managed" } },
+      { idem: "live-invoke-1" });
     ok("live: an idempotent replay returns the STORED record and spends no second provider call",
       replay.status === 200 && replay.j?.replayed === true
         && replay.j?.invocation?.invocation_id === inv.invocation_id,
       `replayed ${replay.j?.replayed}`);
+    const afterReplay = await usageRows();
+    ok("live: the replay billed NOTHING — it added no row and the chain head still hashes to the first one",
+      afterReplay.length === beforeReplay && afterReplay.at(-1).body_hash === row.body_hash,
+      `${beforeReplay} -> ${afterReplay.length} row(s)`);
 
+    // No billing block at all: an absent charge, named as absent. This is the distinction the whole
+    // join exists to preserve — W4-F must be able to tell "not metered" from "metered at zero".
+    const beforeStream = (await usageRows()).length;
     const streamed = await jd("POST", `/v1/hypervisor/model-routes/${liveId}/invoke`,
       { prompt: "Count: one two three", stream: true }, { idem: "live-invoke-stream" });
     const sEvidence = streamed.j?.invocation?.evidence ?? {};
@@ -288,6 +430,12 @@ async function run() {
         && typeof sEvidence.latency?.first_token_ms === "number"
         && sEvidence.latency.first_token_ms <= sEvidence.latency.total_ms,
       `first ${sEvidence.latency?.first_token_ms}ms total ${sEvidence.latency?.total_ms}ms`);
+    const sEcon = streamed.j?.invocation?.economics ?? {};
+    ok("live: an invocation naming no quote records a TYPED GAP and mints no row — absent cost never reads as zero cost",
+      sEcon.joined === false && sEcon.reason_code === "economics_join_not_requested"
+        && sEcon.gap === "economics.usage_record" && sEcon.usage_ref === undefined
+        && (await usageRows()).length === beforeStream,
+      `${sEcon.reason_code} · chain ${beforeStream} -> ${(await usageRows()).length}`);
 
     // The failure path, executed for real. The route must be active AND available before the
     // provider disappears — patching base_url would invalidate the probe and refuse at 409, which
@@ -296,9 +444,15 @@ async function run() {
     // So the route points at a TCP forwarder to the real provider. Every byte the daemon sees
     // during the probe is the genuine provider's; nothing here fabricates a provider response.
     // Killing the forwarder makes a healthy provider vanish exactly as a network partition would.
+    //
+    // It also COUNTS connections, which is how the ordering proof below is made observable rather
+    // than asserted: the daemon reaching this provider is a TCP connection here, and a step that
+    // must not spend a provider call must not produce one.
     const forwardPort = await freePort();
     const upstream = new URL(LIVE_BASE);
+    let forwardConnections = 0;
     const forwarder = net.createServer((client) => {
+      forwardConnections += 1;
       const target = net.connect(Number(upstream.port || 80), upstream.hostname, () => client.pipe(target).pipe(client));
       target.on("error", () => client.destroy());
       client.on("error", () => target.destroy());
@@ -315,15 +469,55 @@ async function run() {
       deadProbe.j?.availability?.state === "available", deadProbe.j?.availability?.state);
     await jd("POST", `/v1/hypervisor/model-routes/${deadId}/enable`, {}, { idem: "dead-enable" });
 
+    // ORDERING, OBSERVED. The route is active, available, and its provider is still reachable, so
+    // an invocation that reaches execution WILL open a connection here. Naming an unresolvable
+    // quote must refuse without opening one.
+    //
+    // An earlier revision of this assertion checked only that the answer was the ledger's 404 —
+    // and it passed with the preflight moved AFTER execution, because the refusal returns 404
+    // either way. That version proved nothing about ordering; the connection count does.
+    const beforePreflight = forwardConnections;
+    const preflight = await jd("POST", `/v1/hypervisor/model-routes/${deadId}/invoke`,
+      { prompt: "never sent", economics: { quote_ref: "work-quote://eqt_nonexistent", commercial_posture: "managed" } },
+      { idem: "dead-preflight" });
+    await new Promise((r) => setTimeout(r, 250));
+    ok("live: an unresolvable quote refuses typed WITHOUT opening a provider connection — the billing target resolves before the call is spent",
+      preflight.status === 404 && code(preflight.j) === "economics_quote_not_found"
+        && forwardConnections === beforePreflight,
+      `status ${preflight.status} code ${code(preflight.j)} · provider connections ${beforePreflight} -> ${forwardConnections}`);
+
     await new Promise((resolve) => forwarder.close(resolve));
+
+    const beforeFailed = (await usageRows()).length;
     const failed = await jd("POST", `/v1/hypervisor/model-routes/${deadId}/invoke`,
-      { prompt: "this provider is gone" }, { idem: "dead-invoke" });
+      { prompt: "this provider is gone", economics: { quote_ref: quoteRef, commercial_posture: "managed" } },
+      { idem: "dead-invoke" });
     const fInv = failed.j?.invocation ?? {};
     ok("live: a vanished provider produces an HONEST failure record, never a fabricated completion",
       fInv.outcome === "failed"
         && fInv.model_invocation_receipt?.error_class === "ProviderUnavailable"
         && fInv.evidence?.attempts?.[0]?.retryable === true,
       `outcome ${fInv.outcome} class ${fInv.model_invocation_receipt?.error_class}`);
+    // A failure the provider metered IS usage. This provider metered nothing, so the honest answer
+    // is a typed gap and no row — not a zero-quantity charge that would read as a free call.
+    ok("live: a failed invocation the provider metered NOTHING for records a typed gap and bills no row",
+      fInv.economics?.joined === false
+        && fInv.economics?.reason_code === "economics_join_token_mix_absent"
+        && (fInv.economics?.unreported ?? []).includes("input")
+        && fInv.economics?.outcome === "failed"
+        && (await usageRows()).length === beforeFailed,
+      `${fInv.economics?.reason_code} · chain ${beforeFailed} -> ${(await usageRows()).length}`);
+
+    // NO SPEND WITHOUT AUTHORITY. The join makes a charge real; it does not make it spendable. A
+    // FinalDebit over this exact billed quote still refuses without a live grant — asserted here,
+    // bound to the row the join actually minted, rather than in the abstract.
+    const debit = await jd("POST", "/v1/hypervisor/economics/final-debits",
+      { quote_ref: quoteRef }, { idem: "econ-debit-no-grant" });
+    // Subject: the REFUSAL. Chain length is asserted by the three assertions that own it; repeating
+    // it here would make this one go red for reasons its label does not claim.
+    ok("live: a metered UsageRecord authorizes NO spend — the FinalDebit over it still refuses without a live grant",
+      debit.status === 403 && code(debit.j) === "economics_spend_authority_required",
+      `status ${debit.status} code ${code(debit.j)}`);
   }
 
   const fails = results.filter((r) => !r.pass);

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -107,8 +107,8 @@
       "id": "provider-transport",
       "npm_script": "check:provider-transport",
       "source": "apps/hypervisor/scripts/verify-hypervisor-provider-transport.mjs",
-      "runtime_assertions": 13,
-      "assertion_names_sha256": "7a25506c7e2ea5ec9b1b2c7098c317288e6a8bc82ade9df0fc67857d7660d4fa"
+      "runtime_assertions": 18,
+      "assertion_names_sha256": "888792a93bafb12c6309dd08e2177fdbc5159f0a22977e6b08607a5670d442f7"
     }
   ],
   "excluded": [

--- a/crates/node/src/bin/hypervisor_daemon_routes/economics_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/economics_routes.rs
@@ -48,6 +48,17 @@ const KIND_OVERRUN: &str = "economics-overrun-decisions";
 const KIND_DEBIT: &str = "economics-final-debits";
 const KIND_ADJUSTMENT_CHAIN: &str = "economics-adjustment-chains";
 
+/// The meter class a model invocation charges under. Named here, in the ledger that prices it,
+/// rather than spelled as a literal at the invocation site — a meter class the rate card does not
+/// carry refuses at admission, and a typo would refuse as `economics_meter_unknown` and read like
+/// an operator's un-priced rate card rather than a daemon bug.
+pub(crate) const METER_MODEL_TOKENS: &str = "model_tokens";
+/// The usage-chain stream a quote's appends serialize through. The invocation join records this so
+/// a reader can walk from one invocation to the whole billed chain without re-deriving the tail.
+pub(crate) fn usage_chain_ref_for(quote_ref: &str) -> String {
+    format!("usage-chain://{}", tail_of(quote_ref))
+}
+
 const BUNDLE_CONTRACT_ID: &str = "schema://ioi/foundations/managed-work-billing-ledger-bundle/v1";
 const MAX_VALIDITY_SECONDS: u64 = 31_536_000; // one year
 const MICRO_PER_WORK_CREDIT: u64 = 1_000_000;
@@ -111,7 +122,7 @@ fn load(data_dir: &str, kind: &str, id: &str) -> Option<Value> {
     .ok()
 }
 
-fn now_ms() -> u64 {
+pub(crate) fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
@@ -1021,31 +1032,31 @@ fn cost_breakdown_from(body: &Value, currency: &str, posture: &str) -> Result<Va
     }))
 }
 
-fn append_usage(
+/// Everything the quote and its rate card determine about ONE metered append, resolved by exactly
+/// one function so a PREFLIGHT and the append itself can never disagree.
+///
+/// The two callers are asymmetric in cost, which is why the shared owner matters: an invocation
+/// preflights before it spends a provider call, and the append happens after. A preflight that says
+/// yes where the append then says no is a spent provider call with no bill; the reverse is a bill
+/// the caller was never warned about. A second copy of this resolution would drift into exactly one
+/// of those two.
+pub(crate) struct UsageTarget {
+    rate_work_credit_micro_units_per_meter_unit: u64,
+    charge_component: String,
+    currency_code: String,
+}
+
+/// PURE READ. Resolves and authorizes a metered append without admitting anything, so a probe on a
+/// path that then refuses leaves the substrate exactly as it found it.
+pub(crate) fn resolve_usage_target(
     data_dir: &str,
     caller: &WriteCaller,
-    body: &Value,
-) -> Result<(Value, usize), Reply> {
-    refuse_server_derived(
-        body,
-        &[
-            "body_hash",
-            "charged_work_credits",
-            "sequence",
-            "previous_usage_hash",
-            "occurred_at_ms",
-        ],
-    )?;
-    let quote_ref = require_ref(body, "quote_ref")?;
-    let meter_class = str_field(body, "meter_class").to_string();
-    let posture = str_field(body, "commercial_posture").to_string();
-    let quantity = units_field(body, "quantity_units", true)?.unwrap_or(0);
-    let coarse = body
-        .get("coarse_ocu_projection")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let now = now_ms();
-    let quote_id = tail_of(&quote_ref).to_string();
+    quote_ref: &str,
+    meter_class: &str,
+    posture: &str,
+    now: u64,
+) -> Result<UsageTarget, Reply> {
+    let quote_id = tail_of(quote_ref).to_string();
     let Some(quote) = load(data_dir, KIND_QUOTE, &quote_id) else {
         return Err(bad(
             StatusCode::NOT_FOUND,
@@ -1061,7 +1072,7 @@ fn append_usage(
     let quote_object = resolve_unexpired(&quote, "quote", now)?;
     if !quote_object["allowed_commercial_postures"]
         .as_array()
-        .is_some_and(|allowed| allowed.iter().any(|p| p.as_str() == Some(posture.as_str())))
+        .is_some_and(|allowed| allowed.iter().any(|p| p.as_str() == Some(posture)))
     {
         return Err(bad(
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -1092,7 +1103,7 @@ fn append_usage(
     let Some(meter) = card_object["meter_rates"].as_array().and_then(|rates| {
         rates
             .iter()
-            .find(|r| r["meter_class"].as_str() == Some(meter_class.as_str()))
+            .find(|r| r["meter_class"].as_str() == Some(meter_class))
     }) else {
         return Err(bad(
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -1100,10 +1111,78 @@ fn append_usage(
             "meter_class is not priced by the quote's rate card",
         ));
     };
-    let rate = meter["work_credit_micro_units_per_meter_unit"]
-        .as_u64()
-        .unwrap_or(0);
-    let component = meter["charge_component"].as_str().unwrap_or("");
+    Ok(UsageTarget {
+        rate_work_credit_micro_units_per_meter_unit: meter
+            ["work_credit_micro_units_per_meter_unit"]
+            .as_u64()
+            .unwrap_or(0),
+        charge_component: meter["charge_component"].as_str().unwrap_or("").to_string(),
+        currency_code: card_object["currency_code"]
+            .as_str()
+            .unwrap_or("USD")
+            .to_string(),
+    })
+}
+
+/// The FIRST production path for the `model_tokens` meter class. Until this cut the class existed
+/// only in `#[cfg(test)]` rate-card fixtures: nothing in the running daemon ever priced a model
+/// invocation, so `runtime_receipt_refs` — the registered contract's own binding from a charge back
+/// to the runtime evidence that earned it — had no producer either.
+///
+/// WHY A WRAPPER RATHER THAN A CALLER-BUILT BODY: [`append_usage`] reads `quantity_units` out of
+/// JSON. If the invocation path assembled that JSON itself, one later edit could let a request
+/// field reach it — and a caller who can name their own token count can name their own bill. The
+/// quantity crosses this boundary as a `u64` the transport OBSERVED, in a parameter that cannot
+/// carry a caller's value.
+pub(crate) fn append_model_token_usage(
+    data_dir: &str,
+    caller: &WriteCaller,
+    quote_ref: &str,
+    commercial_posture: &str,
+    observed_quantity_units: u64,
+    runtime_receipt_refs: &[String],
+) -> Result<(Value, usize), Reply> {
+    append_usage(
+        data_dir,
+        caller,
+        &json!({
+            "quote_ref": quote_ref,
+            "meter_class": METER_MODEL_TOKENS,
+            "quantity_units": observed_quantity_units,
+            "commercial_posture": commercial_posture,
+            "runtime_receipt_refs": runtime_receipt_refs,
+        }),
+    )
+}
+
+fn append_usage(
+    data_dir: &str,
+    caller: &WriteCaller,
+    body: &Value,
+) -> Result<(Value, usize), Reply> {
+    refuse_server_derived(
+        body,
+        &[
+            "body_hash",
+            "charged_work_credits",
+            "sequence",
+            "previous_usage_hash",
+            "occurred_at_ms",
+        ],
+    )?;
+    let quote_ref = require_ref(body, "quote_ref")?;
+    let meter_class = str_field(body, "meter_class").to_string();
+    let posture = str_field(body, "commercial_posture").to_string();
+    let quantity = units_field(body, "quantity_units", true)?.unwrap_or(0);
+    let coarse = body
+        .get("coarse_ocu_projection")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let now = now_ms();
+    let quote_id = tail_of(&quote_ref).to_string();
+    let target = resolve_usage_target(data_dir, caller, &quote_ref, &meter_class, &posture, now)?;
+    let rate = target.rate_work_credit_micro_units_per_meter_unit;
+    let component = target.charge_component.as_str();
     if coarse && component != "non_billable_telemetry" {
         return Err(bad(
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -1119,11 +1198,7 @@ fn append_usage(
             "quantity * rate exceeds the safe integer domain",
         ));
     };
-    let breakdown = cost_breakdown_from(
-        body,
-        card_object["currency_code"].as_str().unwrap_or("USD"),
-        &posture,
-    )?;
+    let breakdown = cost_breakdown_from(body, &target.currency_code, &posture)?;
     let refs = |key: &str| -> Vec<String> {
         body.get(key)
             .and_then(Value::as_array)

--- a/crates/node/src/bin/hypervisor_daemon_routes/provider_transport.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/provider_transport.rs
@@ -20,8 +20,13 @@
 //!     reproduce that bypass.
 //!   * retry and fallback DECISIONS — a transport classifies an error as retryable; only the router
 //!     decides whether to retry. This cut performs exactly one attempt and says so in the record.
-//!   * billing — the transport reports what it observed; the economics ledger owns what it cost.
-//!     No `UsageRecord` is written here (named residual, see the module tail).
+//!   * billing — the transport reports what it OBSERVED; the economics ledger owns what it COST.
+//!     The join below hands the ledger an observed quantity and lets it price, sequence, hash-chain
+//!     and refuse on its own terms. This module computes no rate, no charge, and no total: it does
+//!     not know what anything costs and must never learn.
+//!   * spend authorization — a `UsageRecord` records work done, and a `FinalDebit` spends. The
+//!     latter still demands a live grant through `require_spend_authority`, which this cut does not
+//!     touch. No quantity of usage ever becomes an authority to debit.
 //!
 //! HONESTY RULES enforced below, not merely described:
 //!   * Every token-mix and latency field the provider did NOT report is `null` — a TYPED GAP. It is
@@ -207,6 +212,16 @@ pub(crate) struct TransportFailure {
     pub total_latency_ms: u64,
     pub error_class: ModelRuntimeErrorClass,
     pub detail: String,
+    /// What the provider METERED before the call failed. Suppliers bill failed attempts: a request
+    /// that consumed input tokens and then hit a content filter, a stream that emitted tokens and
+    /// then stalled. Where the provider reports those counts they are real usage and the economics
+    /// join must see them, so this field exists on the failure path and not only on success.
+    ///
+    /// Empty here means the provider reported nothing, which is a typed gap — never an assertion
+    /// that the failed call was free. `OllamaTransport` reports a mix only on a `done` frame, so
+    /// every failure it produces today leaves this default; the field carries the SHAPE the second
+    /// transport needs rather than waiting to be retrofitted after a dialect that meters failures.
+    pub token_mix: TokenMix,
 }
 
 /// The boundary itself. One dialect per implementation; nothing above the wire belongs here.
@@ -312,6 +327,8 @@ impl ProviderTransport for OllamaTransport {
                     }],
                     total_latency_ms: latency,
                     error_class: class,
+                    // Nothing reached the provider, so nothing was metered.
+                    token_mix: TokenMix::default(),
                     detail: error.to_string(),
                 });
             }
@@ -339,6 +356,10 @@ impl ProviderTransport for OllamaTransport {
                 }],
                 total_latency_ms: latency,
                 error_class: class,
+                // Ollama reports no counts on an error status. A dialect that DOES report them on a
+                // 4xx populates this instead; zero-filling it here would bill the caller nothing for
+                // input the provider charged for.
+                token_mix: TokenMix::default(),
                 detail,
             });
         }
@@ -370,6 +391,7 @@ impl ProviderTransport for OllamaTransport {
                         }],
                         total_latency_ms: latency,
                         error_class: class,
+                        token_mix: TokenMix::default(),
                         detail: error.to_string(),
                     });
                 }
@@ -391,6 +413,8 @@ impl ProviderTransport for OllamaTransport {
                         }],
                         total_latency_ms: latency,
                         error_class: ModelRuntimeErrorClass::MalformedStructuredOutput,
+                        // The body did not parse, so no counts could be read out of it.
+                        token_mix: TokenMix::default(),
                         detail: error.to_string(),
                     });
                 }
@@ -481,6 +505,10 @@ async fn read_ollama_stream(
                     }],
                     total_latency_ms: latency,
                     error_class: ModelRuntimeErrorClass::StreamingStall,
+                    // Whatever the stream already reported travels with the failure. A `done` frame
+                    // followed by a stall is a metered call that did not complete, and the provider
+                    // bills it: carrying the mix here is what lets the join charge for it.
+                    token_mix: mix.clone(),
                     detail: format!("no stream frame for {STREAM_STALL_MS}ms"),
                 });
             }
@@ -501,6 +529,7 @@ async fn read_ollama_stream(
                     }],
                     total_latency_ms: latency,
                     error_class: class,
+                    token_mix: mix.clone(),
                     detail: error.to_string(),
                 });
             }
@@ -534,6 +563,178 @@ async fn read_ollama_stream(
     }
 
     Ok((output, mix, finish_reason, first_token_ms))
+}
+
+// ---------------------------------------------------------------- the economics join
+
+/// What a caller may say about billing, and nothing more. Two refs — WHICH quote to charge and
+/// under WHICH quoted posture — both of which the ledger independently re-authorizes.
+///
+/// What is deliberately absent is the point: there is no field here for a quantity, a meter class,
+/// a rate, or a receipt ref. A caller who can name their own token count can name their own bill,
+/// so the quantity reaches the ledger only as a `u64` this module OBSERVED at the wire. This is the
+/// same rule INV-37 applies to WHO, applied to HOW MUCH.
+struct EconomicsRequest {
+    quote_ref: String,
+    commercial_posture: String,
+}
+
+/// Fields that describe a charge rather than name a billing target. Accepting any of them would
+/// make the ledger's own server-derivation guarantees reachable from a request body.
+const CLIENT_SETTABLE_CHARGE_FIELDS: &[&str] = &[
+    "quantity_units",
+    "meter_class",
+    "runtime_receipt_refs",
+    "charged_work_credits",
+    "rate_work_credit_micro_units_per_meter_unit",
+    "cost_breakdown",
+    "sequence",
+];
+
+/// SHAPE ONLY — a pure function of the request, so it is reachable (and therefore provable) without
+/// a reachable provider. Whether the named quote actually RESOLVES for this caller is world state
+/// and is answered later by the ledger's own resolver, once the route itself is known executable.
+fn parse_economics_request(body: &Value) -> Result<Option<EconomicsRequest>, Reply> {
+    let Some(raw) = body.get("economics") else {
+        return Ok(None);
+    };
+    if raw.is_null() {
+        return Ok(None);
+    }
+    let Some(object) = raw.as_object() else {
+        return Err(bad(
+            StatusCode::BAD_REQUEST,
+            "model_invocation_economics_invalid",
+            "economics must be an object naming the quote this invocation bills against",
+        ));
+    };
+    if let Some(field) = CLIENT_SETTABLE_CHARGE_FIELDS
+        .iter()
+        .find(|field| object.contains_key(**field))
+    {
+        return Err(bad(
+            StatusCode::BAD_REQUEST,
+            "model_invocation_economics_quantity_not_client_settable",
+            format!(
+                "economics.{field} is derived from the observed invocation, never accepted from a caller: \
+                 the quantity charged is the token mix this daemon read off the provider response"
+            ),
+        ));
+    }
+    let field = |key: &str| {
+        object
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .unwrap_or("")
+            .to_string()
+    };
+    let quote_ref = field("quote_ref");
+    if quote_ref.is_empty() {
+        return Err(bad(
+            StatusCode::BAD_REQUEST,
+            "model_invocation_economics_quote_ref_required",
+            "economics.quote_ref is required: a charge binds to exactly one quote",
+        ));
+    }
+    let commercial_posture = field("commercial_posture");
+    if commercial_posture.is_empty() {
+        return Err(bad(
+            StatusCode::BAD_REQUEST,
+            "model_invocation_economics_posture_required",
+            "economics.commercial_posture is required and must be one the quote allows",
+        ));
+    }
+    Ok(Some(EconomicsRequest {
+        quote_ref,
+        commercial_posture,
+    }))
+}
+
+/// The join, run AFTER the invocation is admitted.
+///
+/// ORDER IS LOAD-BEARING and the alternative was considered and rejected. Appending usage first
+/// would let the invocation's own admission fail behind it, leaving a charge whose
+/// `runtime_receipt_refs` names a record that does not exist — precisely the unauditable charge the
+/// ledger refuses at `economics_usage_evidence_required`. Admitting first can instead leave an
+/// invocation whose join did not land, which this function reports as a TYPED GAP on the record
+/// rather than silence. An orphan charge is a lie; a named gap is not.
+///
+/// NEVER SYNTHESIZES. Every path that cannot produce a real quantity returns `joined: false` with a
+/// reason code. There is no branch here that writes a zero.
+fn join_economics(
+    data_dir: &str,
+    caller: &WriteCaller,
+    request: Option<&EconomicsRequest>,
+    observed: &TokenMix,
+    invocation_ref: &str,
+    outcome_state: &str,
+) -> Value {
+    let Some(request) = request else {
+        return json!({
+            "joined": false,
+            "reason_code": "economics_join_not_requested",
+            "gap": "economics.usage_record",
+            "message": "this invocation named no quote, so it is metered nowhere; W4-F reads this as an absent cost, never a zero one",
+        });
+    };
+    // A mix the provider did not report cannot become a quantity. Failed invocations reach here on
+    // the same terms as successful ones: where the provider metered the failed attempt the charge
+    // is real and lands, and where it reported nothing the gap is named.
+    let Some(quantity) = observed.total() else {
+        return json!({
+            "joined": false,
+            "reason_code": "economics_join_token_mix_absent",
+            "gap": "economics.usage_record",
+            "quote_ref": request.quote_ref,
+            "unreported": observed.unreported(),
+            "outcome": outcome_state,
+            "message": "the provider reported no usable token mix, so no quantity exists to charge; \
+                        a zero-quantity row would read as a free call rather than an unmeasured one",
+        });
+    };
+    match super::economics_routes::append_model_token_usage(
+        data_dir,
+        caller,
+        &request.quote_ref,
+        &request.commercial_posture,
+        quantity,
+        &[invocation_ref.to_string()],
+    ) {
+        Ok((usage, chain_length)) => json!({
+            "joined": true,
+            "usage_ref": usage["usage_ref"],
+            "quote_ref": request.quote_ref,
+            "chain_ref": super::economics_routes::usage_chain_ref_for(&request.quote_ref),
+            "chain_length": chain_length,
+            "sequence": usage["sequence"],
+            "meter_class": super::economics_routes::METER_MODEL_TOKENS,
+            "commercial_posture": request.commercial_posture,
+            "quantity_units": quantity,
+            // Say what the number MEANS. `model_tokens` prices one meter unit, and this cut charges
+            // input+output. Cache and reasoning classes are reported by no transport yet; folding
+            // an unreported class in as zero would understate a bill, and inventing a second meter
+            // class the rate card does not price would refuse at admission.
+            "quantity_basis": "token_mix.input + token_mix.output (observed); cache and reasoning classes are unreported by this transport and are folded in nowhere",
+            "charged_work_credits": usage["charged_work_credits"],
+            "rate_work_credit_micro_units_per_meter_unit": usage["rate_work_credit_micro_units_per_meter_unit"],
+            "runtime_receipt_ref": invocation_ref,
+            // The ledger charged the work; it did not authorize a spend. A FinalDebit still demands
+            // a live grant through require_spend_authority, and no usage row weakens that.
+            "authorizes_spend": false,
+        }),
+        Err((status, Json(refusal))) => json!({
+            "joined": false,
+            "reason_code": "economics_join_refused",
+            "gap": "economics.usage_record",
+            "quote_ref": request.quote_ref,
+            "quantity_units_observed": quantity,
+            "refusal_status": status.as_u16(),
+            // The ledger's own refusal, verbatim. Re-wording it here would mint a second vocabulary
+            // for the same condition.
+            "refusal": refusal,
+        }),
+    }
 }
 
 // ---------------------------------------------------------------- the route
@@ -586,6 +787,14 @@ pub(crate) async fn handle_model_route_invoke(
         );
     }
     let stream = body.get("stream").and_then(Value::as_bool).unwrap_or(false);
+    // Request SHAPE before world state, for the same reason the prompt is checked here: a
+    // malformed billing block is the caller's own error and is answerable without consulting the
+    // registry, the provider, or the ledger. It is also the only part of the join reachable on a
+    // machine with no model provider, which is what makes it CI-provable rather than a claim.
+    let economics_request = match parse_economics_request(&body) {
+        Ok(request) => request,
+        Err(response) => return response,
+    };
 
     // Replay before work: the same caller + idempotency key returns the stored record rather than
     // spending a second provider call.
@@ -667,6 +876,26 @@ pub(crate) async fn handle_model_route_invoke(
         );
     }
 
+    // (4b) billing PREFLIGHT — resolve the named quote BEFORE spending a provider call.
+    //
+    // The ledger's own resolver answers this, not a copy of its rules: a quote that does not
+    // resolve, is not this caller's, has expired, does not allow the named posture, or whose rate
+    // card does not price `model_tokens` refuses HERE, verbatim, while refusing is still free. The
+    // append after execution runs the same resolver, so a preflight that passes and an append that
+    // then refuses cannot disagree about the rules — only about elapsed time.
+    if let Some(request) = economics_request.as_ref() {
+        if let Err(response) = super::economics_routes::resolve_usage_target(
+            &st.data_dir,
+            &caller,
+            &request.quote_ref,
+            super::economics_routes::METER_MODEL_TOKENS,
+            &request.commercial_posture,
+            super::economics_routes::now_ms(),
+        ) {
+            return response;
+        }
+    }
+
     let base_url = route
         .pointer("/provider_binding/base_url")
         .and_then(Value::as_str)
@@ -696,7 +925,7 @@ pub(crate) async fn handle_model_route_invoke(
     let result = transport.invoke(&request).await;
 
     // (6) receipt — typed, and emitted on BOTH paths
-    let (receipt, evidence, outcome_state, http_status) = match &result {
+    let (receipt, evidence, outcome_state, http_status, observed_mix) = match &result {
         Ok(success) => {
             let receipt = ModelInvocationReceipt {
                 model_id: model_id.clone(),
@@ -726,16 +955,25 @@ pub(crate) async fn handle_model_route_invoke(
                 // comparison from reading absence as zero.
                 "evidence_gaps": evidence_gaps(&success.token_mix, price_schedule_ref.is_none()),
             });
-            (receipt, evidence, "succeeded", StatusCode::OK)
+            (
+                receipt,
+                evidence,
+                "succeeded",
+                StatusCode::OK,
+                success.token_mix.clone(),
+            )
         }
         Err(failure) => {
             let receipt = ModelInvocationReceipt {
                 model_id: model_id.clone(),
                 provider: transport.transport_kind().to_string(),
                 latency_ms: failure.total_latency_ms,
-                prompt_tokens: None,
-                completion_tokens: None,
-                total_tokens: None,
+                // Whatever the provider METERED before it failed. `None` where it reported nothing,
+                // which is the ordinary case for this transport; a supplier that bills a failed
+                // attempt reports counts here and they reach the receipt and the ledger alike.
+                prompt_tokens: failure.token_mix.input.map(|v| v as u32),
+                completion_tokens: failure.token_mix.output.map(|v| v as u32),
+                total_tokens: failure.token_mix.total().map(|v| v as u32),
                 streaming: stream,
                 structured_output_schema_hash: None,
                 // An empty output is hashed honestly rather than left absent: the receipt states
@@ -744,7 +982,7 @@ pub(crate) async fn handle_model_route_invoke(
                 error_class: Some(failure.error_class),
             };
             let evidence = json!({
-                "token_mix": TokenMix::default().to_json(),
+                "token_mix": failure.token_mix.to_json(),
                 "latency": { "total_ms": failure.total_latency_ms, "first_token_ms": Value::Null },
                 "attempts": failure.attempts.iter().map(TransportAttempt::to_json).collect::<Vec<_>>(),
                 "attempt_count": failure.attempts.len(),
@@ -754,9 +992,15 @@ pub(crate) async fn handle_model_route_invoke(
                 "outcome": "failed",
                 "error_class": failure.error_class.as_str(),
                 "detail": failure.detail,
-                "evidence_gaps": evidence_gaps(&TokenMix::default(), price_schedule_ref.is_none()),
+                "evidence_gaps": evidence_gaps(&failure.token_mix, price_schedule_ref.is_none()),
             });
-            (receipt, evidence, "failed", StatusCode::BAD_GATEWAY)
+            (
+                receipt,
+                evidence,
+                "failed",
+                StatusCode::BAD_GATEWAY,
+                failure.token_mix.clone(),
+            )
         }
     };
 
@@ -790,12 +1034,16 @@ pub(crate) async fn handle_model_route_invoke(
         "evidence": evidence,
     });
 
+    // The ref the invocation is ADMITTED under is the same string the charge cites as its runtime
+    // evidence. Deriving the join key from the admission ref rather than re-spelling it is what
+    // makes "the key resolves both ways" a property of the code and not of a convention.
+    let invocation_ref = format!("model-invocation://{invocation_id}");
     let commit: MutationCommit = match admit_owner_scoped_write(
         &st.data_dir,
         &caller,
         INVOCATION_NAMESPACE,
         KIND_INVOCATION,
-        &format!("model-invocation://{invocation_id}"),
+        &invocation_ref,
         "model_invocation.executed",
         None,
         &admitted,
@@ -804,9 +1052,24 @@ pub(crate) async fn handle_model_route_invoke(
         Err(response) => return response,
     };
 
+    // (7) the economics join — after admission, so the charge can cite a receipt that EXISTS.
+    //
+    // It lands on the projection beside `admitted_head` and `recorded_at`, the other two facts that
+    // are only knowable after admission. The admitted payload stays the pre-join transport
+    // observation and is not rewritten; the usage append is durably evented by the economics
+    // stream, which is its own owner. One fact, one owner: `evidence.evidence_gaps` names what the
+    // TRANSPORT could not observe, and `economics` names whether the charge landed.
     let mut record = admitted.clone();
     record["admitted_head"] = json!(commit.projection.head);
     record["recorded_at"] = json!(super::iso_now());
+    record["economics"] = join_economics(
+        &st.data_dir,
+        &caller,
+        economics_request.as_ref(),
+        &observed_mix,
+        &invocation_ref,
+        outcome_state,
+    );
     if persist_record(&st.data_dir, KIND_INVOCATION, &invocation_id, &record).is_err() {
         return bad(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -821,8 +1084,14 @@ pub(crate) async fn handle_model_route_invoke(
     )
 }
 
-/// Name every W4-F field this invocation could not supply. An economic comparison that cannot see
-/// its own gaps will read them as zeros.
+/// Name every W4-F field THIS TRANSPORT could not observe at the wire. An economic comparison that
+/// cannot see its own gaps will read them as zeros.
+///
+/// Scope changed when the economics join landed. This list used to also carry
+/// `economics.usage_record` unconditionally, which was correct while no invocation could ever be
+/// metered — and would now be a lie on every metered call. Whether the charge landed is answered by
+/// the record's `economics` block, which is the only owner of that fact; a gap list that guessed at
+/// it would be a second, staler answer to the same question.
 fn evidence_gaps(mix: &TokenMix, price_schedule_missing: bool) -> Vec<String> {
     let mut gaps: Vec<String> = mix
         .unreported()
@@ -832,9 +1101,6 @@ fn evidence_gaps(mix: &TokenMix, price_schedule_missing: bool) -> Vec<String> {
     if price_schedule_missing {
         gaps.push("price_schedule_ref".to_string());
     }
-    // Named residual, visible in every record rather than only in a ledger row: this cut observes
-    // and receipts, but does not yet join to the economics ledger.
-    gaps.push("economics.usage_record".to_string());
     gaps
 }
 


### PR DESCRIPTION
## What this closes

An invocation observed and receipted everything W4-F needs and wrote **no `UsageRecord`**. `economics.usage_record` sat in every invocation record's own `evidence_gaps`, and the `model_tokens` meter class existed only in `#[cfg(test)]` rate-card fixtures — nothing in the running daemon had ever priced a model call, so `runtime_receipt_refs` (the registered contract's own binding from a charge back to the evidence that earned it) had no producer either.

## The shape

- **`append_model_token_usage`** gives `model_tokens` its first production path. The invocation hands the ledger an OBSERVED `u64` and lets it price, sequence and hash-chain on its own terms. The quantity crosses that boundary in a parameter that cannot carry caller JSON — a caller who can name their own token count can name their own bill. Seven charge-describing request fields refuse typed: the INV-37 idiom applied to HOW MUCH rather than WHO.
- **`resolve_usage_target`** is ONE resolver shared by a pre-execution preflight and the append itself, so the two can never disagree about whether a charge is admissible. A preflight that passes where the append refuses is a spent provider call with no bill; the reverse is a bill nobody was warned about.
- **Order is load-bearing.** The invocation is ADMITTED first so the charge can cite a receipt that exists. Appending first could leave an orphan charge naming a record that never landed — precisely what `economics_usage_evidence_required` refuses. Admitting first can instead leave a join that did not land, which the record reports as a typed gap. An orphan charge is a lie; a named gap is not.

## Absent evidence stays absent (1b)

No branch writes a zero. An unreported mix mints **no row** and records `economics_join_token_mix_absent`, so W4-F can distinguish "not metered" from "metered at zero". `TransportFailure` now carries a token mix, because a provider that bills a failed attempt reports counts and the ledger must see them — Ollama reports none, so today that shape is carried rather than exercised.

## No spend without authority (1c)

`require_spend_authority` is not weakened anywhere. The live lane proves it, bound to the row the join actually minted: a `FinalDebit` over the billed quote still refuses `economics_spend_authority_required`.

## `evidence_gaps` narrows

It carried `economics.usage_record` unconditionally — true while nothing could be metered, a lie on every metered call. Whether the charge landed is now answered by the record's `economics` block, its only owner.

## Evidence

- `check:provider-transport` **13 → 18** CI assertions, **floor raised in this commit** (454 → 459 across 14 verifiers, `check:verifier-floors` green).
- **44/44 live against real Ollama qwen2.5:7b**: 36 in + 2 out observed → 38 charged at rate 5 → 190 micro work credits, sequence 1 with a null predecessor hash, join key resolving both ways, replay adding no row, vanished provider recorded as a typed gap, `FinalDebit` still refused.
- `cargo test -p ioi-node --bin hypervisor-daemon` **719/719**. `cargo fmt --check` clean. All five bundled gates green.

## Six mutations RED, each on its own finding

| Mutation | Result |
|---|---|
| drop the caller-quantity guard | CI 17/18 |
| zero-fill an absent mix | live, own assertion |
| move the preflight after execution | live, own assertion |
| charge input tokens only | live 43/44 |
| append under a self-derived key so a replay double-charges | live 43/44 |
| cite an unresolvable receipt ref | live 43/44 |

## Three assertions were re-aimed before they counted

- The **ordering** assertion first checked only that the answer was the ledger's 404 — and **passed** with the preflight moved after execution, because the refusal returns 404 either way. It proved nothing about ordering. It now counts provider connections through the forwarder, which is the thing that actually differs.
- The **pricing** assertion folded in the expected quantity, so it fired on a quantity defect its label did not claim. It now prices against the quantity the row carries.
- Three **"no row was added"** assertions compared absolute chain length and all went red together on one defect. Each now measures its own delta.

## Named residuals

- A transiently refused join is permanent for that invocation: replay is a pure read and does not retry it. The record says so.
- One `model_tokens` meter charges input+output at one rate. Cache and reasoning classes are reported by no transport yet and are folded in nowhere.
- CI still has no model provider, so the live lane stays human-run evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)