### PR TITLE
feat(verifiers): bring the two convertible floor exclusions under the gate

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-ported-seed-invariant.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ported-seed-invariant.mjs
@@ -1,11 +1,29 @@
 #!/usr/bin/env node
 
+// verify-hypervisor-ported-seed-invariant — the ported-seed preservation invariant.
+//
+// CENSUS SHAPE (next-legs IX Leg 4). This verifier was one of three typed exclusions from
+// `check:verifier-floors`: it kept an integer counter and printed `N/N checks passed`, but built no
+// NAMED assertion records, so the floors gate had no per-assertion evidence to bind. It now emits a
+// census and carries a floor.
+//
+// WHY THE NAMED COUNT IS SMALL AND THE ASSERTION COUNT IS LARGE. Nothing this verifier checks was
+// removed or weakened — every assertion still executes, and `assert.ok` still throws on the first
+// failure. What changed is RECORDING GRANULARITY: the per-file and per-route sweeps record ONE named
+// result each rather than one per item. That is deliberate. A census of ~400 per-asset results would
+// pin the floor to the owned bundle's file COUNT, and that fact already has an owner —
+// `check:shipped-products` pins the exact file count and tree sha256. A second floor over the same
+// number would churn on every asset change while proving nothing the first one does not. The named
+// results below are the distinct INVARIANTS; the raw assertion total is reported alongside them so a
+// reader can see both numbers.
+
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.resolve(HERE, "..");
@@ -20,24 +38,58 @@ const serveSource = read("apps/hypervisor/scripts/serve-product-ui.mjs");
 const agentGuide = read("apps/hypervisor/AGENTS.md");
 
 let checks = 0;
-function check(value, message) {
+const results = [];
+
+/** One raw assertion. Throws on failure exactly as before; the census counts what EXECUTED. */
+function assertOne(value, message) {
   assert.ok(value, message);
   checks += 1;
 }
 
+/** One raw assertion that is ALSO a named invariant in the census. */
+function check(value, message, name) {
+  assertOne(value, message);
+  results.push({ name: name ?? message, pass: true });
+}
+
+/**
+ * A sweep over many items recorded as ONE named invariant.
+ *
+ * Every item is still asserted individually — `predicate` failing on any item throws with that
+ * item's own message, so the failure still names the exact file or route. Only the census entry is
+ * singular. See the header for why per-item census entries would duplicate `check:shipped-products`.
+ */
+function checkEvery(items, predicate, message, name) {
+  for (const item of items) assertOne(predicate(item), message(item));
+  results.push({ name, pass: true });
+}
+
 check(record.status === "active_invariant", "seed preservation must be an active invariant");
 check(record.whole_estate_retirement_allowed === false, "whole-estate retirement must remain locked");
-for (const seedRoot of record.seed_roots) check(exists(seedRoot), `required seed root is missing: ${seedRoot}`);
-for (const forbidden of record.forbidden_parallel_replacements) check(!exists(forbidden), `observation-based parallel replacement is present: ${forbidden}`);
+checkEvery(
+  record.seed_roots,
+  (seedRoot) => exists(seedRoot),
+  (seedRoot) => `required seed root is missing: ${seedRoot}`,
+  "every declared seed root is present on disk",
+);
+checkEvery(
+  record.forbidden_parallel_replacements,
+  (forbidden) => !exists(forbidden),
+  (forbidden) => `observation-based parallel replacement is present: ${forbidden}`,
+  "no observation-based parallel replacement has appeared beside the seed",
+);
 check(packageJson.scripts?.["serve:product-ui"] === "node scripts/serve-product-ui.mjs", "ported product serve command is missing");
 check(!Object.hasOwn(packageJson.scripts || {}, "serve:app"), "parallel app serve command must not replace the ported seed");
 check(agentGuide.includes("The ported app UX is the executable product seed"), "repository contributor memory lost the seed invariant");
 
 const manifestFiles = Object.keys(vendorManifest.files || {});
 check(manifestFiles.length >= 383, "owned vendor manifest unexpectedly shrank");
-for (const relative of manifestFiles) {
-  check(exists(path.posix.join("apps/hypervisor/product-ui/owned/public", relative)), `owned ported asset is missing: ${relative}`);
-}
+checkEvery(
+  manifestFiles,
+  (relative) => exists(path.posix.join("apps/hypervisor/product-ui/owned/public", relative)),
+  (relative) => `owned ported asset is missing: ${relative}`,
+  "every asset the owned vendor manifest declares exists on disk",
+);
 
 const protectedClasses = new Set(record.protected_seed_classes);
 const matrixProtected = matrix.seeds
@@ -50,9 +102,12 @@ const matrixProtected = matrix.seeds
   .sort((a, b) => a.slug.localeCompare(b.slug));
 const recordProtected = [...record.protected_routes].sort((a, b) => a.slug.localeCompare(b.slug));
 check(JSON.stringify(recordProtected) === JSON.stringify(matrixProtected), "protected-route record must exactly match the current ported-seed census");
-for (const seed of recordProtected) {
-  check(serveSource.includes(seed.route), `${seed.slug}: ported route is no longer dispatched by the product server`);
-}
+checkEvery(
+  recordProtected,
+  (seed) => serveSource.includes(seed.route),
+  (seed) => `${seed.slug}: ported route is no longer dispatched by the product server`,
+  "every protected ported route is still dispatched by the product server",
+);
 
 function freePort() {
   return new Promise((resolve, reject) => {
@@ -90,14 +145,25 @@ async function runLiveProof() {
   child.stderr.on("data", (chunk) => { output += chunk; });
   try {
     await waitForReady(`http://127.0.0.1:${port}/`, child);
+    // Each served route is asserted on all four properties; the four INVARIANTS are the named
+    // results, so the live census does not scale with how many protected routes exist.
+    const served = [];
     for (const seed of recordProtected) {
       const response = await fetch(`http://127.0.0.1:${port}${seed.route}`, { signal: AbortSignal.timeout(10_000) });
-      const body = await response.text();
-      check(response.status === 200, `${seed.slug}: expected HTTP 200, received ${response.status}`);
-      check((response.headers.get("content-type") || "").includes("text/html"), `${seed.slug}: expected a rendered HTML app`);
-      check(body.length > 1_500, `${seed.slug}: rendered body is too small to be the rich ported UX (${body.length} bytes)`);
-      check(!/RouteRefusalSurface|hypervisor[.]route_retired|route retirement refusal|<title>Route retired/iu.test(body), `${seed.slug}: ported route rendered a retirement/refusal substitute`);
+      served.push({ seed, response, body: await response.text() });
     }
+    checkEvery(served, ({ response }) => response.status === 200,
+      ({ seed, response }) => `${seed.slug}: expected HTTP 200, received ${response.status}`,
+      "live: every protected ported route answers HTTP 200");
+    checkEvery(served, ({ response }) => (response.headers.get("content-type") || "").includes("text/html"),
+      ({ seed }) => `${seed.slug}: expected a rendered HTML app`,
+      "live: every protected ported route renders HTML");
+    checkEvery(served, ({ body }) => body.length > 1_500,
+      ({ seed, body }) => `${seed.slug}: rendered body is too small to be the rich ported UX (${body.length} bytes)`,
+      "live: every protected ported route renders the rich ported body, not a stub");
+    checkEvery(served, ({ body }) => !/RouteRefusalSurface|hypervisor[.]route_retired|route retirement refusal|<title>Route retired/iu.test(body),
+      ({ seed }) => `${seed.slug}: ported route rendered a retirement/refusal substitute`,
+      "live: no protected ported route rendered a retirement/refusal substitute");
   } catch (error) {
     throw new Error(`${error.message}\nserver output:\n${output.slice(-8_000)}`);
   } finally {
@@ -108,5 +174,19 @@ async function runLiveProof() {
   }
 }
 
-if (process.argv.includes("--live")) await runLiveProof();
-console.log(`verify-hypervisor-ported-seed-invariant: ${checks}/${checks} checks passed${process.argv.includes("--live") ? " (live)" : ""}`);
+const live = process.argv.includes("--live");
+if (live) await runLiveProof();
+// The live lane executes MORE named invariants than CI does, so — exactly as
+// check:provider-transport does — it emits no census: one from it would collide with the floor
+// pinned for the lane CI actually runs.
+if (!live) {
+  emitVerifierCensus({
+    verifierId: "ported-seed",
+    sourceUrl: import.meta.url,
+    results,
+  });
+}
+console.log(
+  `verify-hypervisor-ported-seed-invariant: ${results.length}/${results.length} named invariants passed ` +
+    `over ${checks} raw assertions${live ? " (live)" : ""}`,
+);

--- a/apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs
@@ -31,10 +31,39 @@ import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
 import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const failures = [];
 const fail = (msg) => failures.push(msg);
+
+// ---------------------------------------------------------------- positive checkpoints
+//
+// CENSUS SHAPE (next-legs IX Leg 4). This verifier was a typed exclusion from
+// `check:verifier-floors` for a specific reason: it is FAIL-ONLY. It appends to `failures` when
+// something is wrong and records nothing when everything is right, so a green run had nothing to
+// tally and a runtime assertion count would have read zero. The exclusion named the fix — "convert
+// the fail-only walk to positive check records" — and this is it.
+//
+// HOW, AND WHY THIS SHAPE. Not one record per `fail()` site: those live inside per-surface and
+// per-source loops, so the count would scale with the corpus and the floor would churn every time a
+// surface or a seed source was added. Instead each CHECKPOINT marks the end of one logical
+// invariant group and records whether that group added any failure. The 62 checks are untouched —
+// no condition, message, or exit path changed — so this cannot weaken the gate; it only makes a
+// passing run say what it proved. A checkpoint that a later edit deletes drops the count and the
+// floor catches it.
+//
+// WHAT THE `pass` FLAG IS AND IS NOT. A census is emitted ONLY on a green run (see `finish`), so
+// every flag in an emitted census is `true` — the floor consumes the COUNT, and pass/fail is
+// carried by this verifier's exit code and its printed failure list, as it always was. The flag is
+// computed honestly rather than hardcoded so the record stays correct if emission is ever widened,
+// but nothing today reads it, and it should not be cited as evidence that a group passed.
+const results = [];
+let checkpointMark = 0;
+const checkpoint = (name) => {
+  results.push({ name, pass: failures.length === checkpointMark });
+  checkpointMark = failures.length;
+};
 
 const readJson = (rel) => JSON.parse(fs.readFileSync(path.join(appRoot, rel), "utf8"));
 const readText = (rel) => fs.readFileSync(path.join(appRoot, rel), "utf8");
@@ -51,6 +80,9 @@ if (requireReady && !surfaceFilter) {
   console.error("seed-provenance: --require-ready needs --surface <id>");
   process.exit(2);
 }
+
+/// The one mode whose checkpoint set the floor is pinned against.
+const FULL_GATE_MODE = "full tracked gate";
 
 const MANIFEST = "seed-ux-provenance.v1.json";
 const EXPECTED_IDS = [
@@ -72,6 +104,8 @@ const manifest = readJson(MANIFEST);
 if (manifest.schema_version !== "ioi.hypervisor.seed-ux-provenance.v1") {
   fail(`${MANIFEST}: unsupported schema_version ${manifest.schema_version}`);
 }
+
+checkpoint("the provenance manifest declares its registered schema version");
 
 const seenProtected = new Map();
 const seenRetained = new Map();
@@ -112,6 +146,8 @@ if (new Set(ids).size !== ids.length) fail(`${MANIFEST}: duplicate surface ids`)
 if (surfaceFilter && !ids.includes(surfaceFilter)) {
   fail(`--surface ${surfaceFilter}: no such surface`);
 }
+
+checkpoint("the surface census is exactly the twenty expected ids, unique and complete");
 
 const canonicalRoutes = new Set(surfaces.map((s) => s.canonical_route));
 
@@ -239,6 +275,8 @@ for (const surface of surfaces) {
   }
 }
 
+checkpoint("every surface's seed roles, graph status, readiness derivation, and greenfield authorization are internally consistent");
+
 // Exact protected-set equality with ported-seed-preservation.v1.json.
 const preservedRoutes = new Map((preservation.protected_routes ?? []).map((p) => [p.route, p]));
 for (const [route, p] of preservedRoutes) {
@@ -253,6 +291,8 @@ for (const route of seenProtected.keys()) {
   if (!preservedRoutes.has(route)) fail(`protected source ${route} is not in ported-seed-preservation.v1.json — the /__ioi prefix is not a seed namespace`);
 }
 
+checkpoint("the protected-seed set matches ported-seed-preservation.v1.json exactly, both directions");
+
 // Exact retained-set equality with the parity matrix + inventory.
 const matrixSlugs = new Set((parityMatrix.seeds ?? []).map((s) => s.slug));
 for (const slug of matrixSlugs) {
@@ -261,6 +301,8 @@ for (const slug of matrixSlugs) {
 for (const slug of seenRetained.keys()) {
   if (!matrixSlugs.has(slug)) fail(`retained slug ${slug} is not in harvest-app-parity-matrix.json`);
 }
+
+checkpoint("the retained-capture set matches the harvest parity matrix exactly, both directions");
 
 // Exact dormant-set equality with ux-seeds/manifest.json.
 for (const seed of dormant.seeds ?? []) {
@@ -276,6 +318,8 @@ for (const slug of seenDormant.keys()) {
   }
 }
 
+checkpoint("the dormant-reference set matches ux-seeds/manifest.json exactly, both directions");
+
 // Secret-leak gate over the manifest and every graph file.
 if (SECRET.test(readText(MANIFEST))) fail(`${MANIFEST}: secret-shaped token present`);
 const graphDir = path.join(appRoot, "seed-graphs");
@@ -287,6 +331,8 @@ if (fs.existsSync(graphDir)) {
     }
   }
 }
+
+checkpoint("no secret-shaped token appears in the manifest or any seed graph file");
 
 function verifyGraphFile(src, sat, { allowIncomplete = false } = {}) {
   const rel = src.graph_file;
@@ -390,18 +436,33 @@ if (requireReady) {
   }
 }
 
-finish(requireReady ? `require-ready ${surfaceFilter}` : surfaceFilter ? `surface ${surfaceFilter}` : "full tracked gate");
+finish(requireReady ? `require-ready ${surfaceFilter}` : surfaceFilter ? `surface ${surfaceFilter}` : FULL_GATE_MODE);
 
 function finish(mode) {
   if (failures.length > 0) {
     for (const f of failures) console.error(`seed-provenance: ${f}`);
     console.error(`\nseed-provenance FAIL (${mode}) — ${failures.length} failures`);
+    // No census on a failing run — deliberately. The floors gate reads an ABSENT artifact as RED
+    // (`census_missing`), which is the correct reading: a verifier that exited early certifies
+    // nothing. Emitting a partial census here would let a failed run report a count.
     process.exit(1);
   }
   const total = (manifest.surfaces ?? []).reduce((n, s) => n + (s.sources?.length ?? 0), 0);
+  // Only the FULL tracked gate emits a census. `--shared`, `--surface` and `--require-ready` each
+  // execute a different subset of the checkpoints, so their counts would collide with the floor
+  // pinned for the lane CI actually runs — the same reason the provider-transport live lane is
+  // silent.
+  if (mode === FULL_GATE_MODE) {
+    emitVerifierCensus({
+      verifierId: "seed-provenance",
+      sourceUrl: import.meta.url,
+      results,
+    });
+  }
   console.log(
     `seed-provenance OK (${mode}) — ${manifest.surfaces?.length ?? 0} surfaces, ${total} sources ` +
-      `(${seenProtected.size} protected, ${seenRetained.size} retained, ${seenDormant.size} dormant), fail-closed graph gate armed.`,
+      `(${seenProtected.size} protected, ${seenRetained.size} retained, ${seenDormant.size} dormant), ` +
+      `${results.length} invariant checkpoints over ${total} sources, fail-closed graph gate armed.`,
   );
   process.exit(0);
 }

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -2,11 +2,11 @@
   "manifest_version": "ioi.verifier-floors.v1",
   "effective_date": "2026-08-12",
   "governing_check": "apps/hypervisor/scripts/check-verifier-floors.mjs",
-  "purpose": "The floor the verifier family never had. A verifier that asserts less still passes, so deleting assertions from any CI-gated verifier was silently green: the deleted assertion stopped being checked, the survivors passed, and CI reported success. Each row below pins the number of assertions a verifier actually EXECUTED. The count is runtime, never a source grep — a commented-out assertion does not execute, so it does not count, which is precisely the case a grep would miss.",
+  "purpose": "The floor the verifier family never had. A verifier that asserts less still passes, so deleting assertions from any CI-gated verifier was silently green: the deleted assertion stopped being checked, the survivors passed, and CI reported success. Each row below pins the number of assertions a verifier actually EXECUTED. The count is runtime, never a source grep \u2014 a commented-out assertion does not execute, so it does not count, which is precisely the case a grep would miss.",
   "rules": {
-    "closed_world": "The set of verifiers this manifest must cover is re-derived on every run from .github/workflows/ci.yml — every `npm run check:* --workspace=@ioi/hypervisor-app` invocation resolving to a scripts/verify-*.mjs file. A CI-gated verifier with no row here is RED. This is an allowlist derived from the enforcing artifact, not a hand list that can silently omit a verifier.",
+    "closed_world": "The set of verifiers this manifest must cover is re-derived on every run from .github/workflows/ci.yml \u2014 every `npm run check:* --workspace=@ioi/hypervisor-app` invocation resolving to a scripts/verify-*.mjs file. A CI-gated verifier with no row here is RED. This is an allowlist derived from the enforcing artifact, not a hand list that can silently omit a verifier.",
     "reverse_edge": "A pinned floor whose verifier CI does not run is RED. A floor over a verifier that gates nothing is decorative.",
-    "exact_pin": "runtime_assertions is an exact pin, not a minimum. Below it means assertions were deleted. ABOVE it is also RED — the floor is stale and must be raised in the same commit that adds the assertions. Slack is where a later deletion hides.",
+    "exact_pin": "runtime_assertions is an exact pin, not a minimum. Below it means assertions were deleted. ABOVE it is also RED \u2014 the floor is stale and must be raised in the same commit that adds the assertions. Slack is where a later deletion hides.",
     "evidence": "Counts come from the verifier's own completed run via apps/hypervisor/scripts/lib/verifier-census.mjs, which binds the verifier's source sha256. A census never certifies a revision it did not run: an artifact whose digest disagrees with the file on disk is RED.",
     "fail_closed": "A missing census directory, a missing artifact, or a verifier that crashed, exited early, or was BLOCKED is RED, never skip. A false green from a broken probe is the same defect class as a false green from a deleted assertion.",
     "what_this_does_not_prove": "A floor counts assertions; it cannot judge them. Nothing here certifies that an assertion is meaningful, non-decorative, or that a replacement is as strong as what it replaced. assertion_names_sha256 travels with the count so a reviewer can distinguish `replaced` from `renamed`, but that reading is a human's. This gate proves only that the family did not shrink."
@@ -109,21 +109,25 @@
       "source": "apps/hypervisor/scripts/verify-hypervisor-provider-transport.mjs",
       "runtime_assertions": 18,
       "assertion_names_sha256": "888792a93bafb12c6309dd08e2177fdbc5159f0a22977e6b08607a5670d442f7"
+    },
+    {
+      "id": "ported-seed",
+      "npm_script": "check:ported-seed",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-ported-seed-invariant.mjs",
+      "runtime_assertions": 11,
+      "assertion_names_sha256": "64d574c84406ef32ac454b65f990f1be24976155da6c58b71faf4cbaf6d86ccd",
+      "note": "Records named INVARIANTS over a much larger raw assertion total. The per-asset and per-route sweeps assert every item individually but record one named result each: a census scaled to the owned bundle's file COUNT would duplicate check:shipped-products, which already pins that count and the tree sha256, and would churn this floor on every asset change."
+    },
+    {
+      "id": "seed-provenance",
+      "npm_script": "check:seed-provenance",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs",
+      "runtime_assertions": 7,
+      "assertion_names_sha256": "5ea25e9668a35a1658a633ed9370a162e0d49e7e3ff4f34dc50c224cc7ab12ad",
+      "note": "Was fail-only (empty failures array on a green run, so a count read zero). Now records one positive CHECKPOINT per invariant group; the 62 fail sites are untouched. Only the full tracked gate emits a census (--shared/--surface/--require-ready run different subsets), and a FAILING run emits nothing, which this gate reads as RED. The floor consumes the COUNT; pass/fail is carried by the verifier's exit code, so every flag in an emitted census is true by construction and is not evidence on its own."
     }
   ],
   "excluded": [
-    {
-      "npm_script": "check:seed-provenance",
-      "source": "apps/hypervisor/scripts/verify-hypervisor-seed-provenance.mjs",
-      "reason": "Fail-only idiom: it records entries ONLY when something is wrong (62 fail sites, an empty failures array on a green run), so a passing run has nothing to tally and a runtime assertion count would read zero. It is a fail-closed corpus validator over seed-ux-provenance.v1.json rather than an assertion-tallied journey. Bringing it under a floor requires it to record positive checks too.",
-      "residual": "Named residual, not a waiver: convert the fail-only walk to positive check records, then floor it."
-    },
-    {
-      "npm_script": "check:ported-seed",
-      "source": "apps/hypervisor/scripts/verify-hypervisor-ported-seed-invariant.mjs",
-      "reason": "Keeps its own integer `checks` counter and prints N/N checks passed, but builds no named assertion records, so this census has no per-assertion evidence to bind. It is the closest of the three to floorable — the count already exists and only its shape differs.",
-      "residual": "Named residual: emit the census from its existing counter and floor it in the next verifier-family cut."
-    },
     {
       "npm_script": "check:owned-product-ui",
       "source": "apps/hypervisor/scripts/verify-owned-product-ui.mjs",


### PR DESCRIPTION
## What this closes

`check:verifier-floors` shipped with **three typed exclusions**. Two of them named the exact work needed to close them — this does that work. Exclusions go **3 → 1**; the family goes **14 → 16 verifiers, 465 → 477 pinned assertions**.

Only `owned-product-ui` remains, on its standing reason: it throws via `node:assert` and records nothing on success, and a shrink in what it checks is caught where `check:shipped-products` pins the same tree hash.

## `ported-seed` — the counter existed, the *records* did not

Its exclusion read: *"keeps its own integer `checks` counter … but builds no named assertion records, so this census has no per-assertion evidence to bind."*

It now emits a census of **11 named invariants over 413 raw assertions**. Nothing it checks was removed — every assertion still executes and `assert.ok` still throws on the first failure. What changed is **recording granularity**: the per-asset and per-route sweeps record one named result each rather than one per item.

That is deliberate. A census of ~400 per-asset results would pin this floor to the owned bundle's file **count** — and that fact already has an owner: `check:shipped-products` pins the exact count *and* the tree sha256. A second floor over the same number would churn on every asset change while proving nothing the first one does not. The failure message still names the exact file or route.

## `seed-provenance` — fail-only becomes positive, without touching a single check

Its exclusion read: *"records entries ONLY when something is wrong … a passing run has nothing to tally."*

It now records **one positive checkpoint per invariant group**. The **62 fail sites are untouched** — no condition, message, or exit path changed — so this cannot weaken the gate; a checkpoint simply observes whether its group added a failure. Per-fail-site records were rejected for the same reason as above: they sit inside per-surface loops and would churn the floor whenever a surface or seed source was added.

Only the **full tracked gate** emits a census. `--shared`, `--surface` and `--require-ready` each execute a different subset (1 and 7 checkpoints respectively), so their counts would collide with the floor pinned for the lane CI runs — the same reason the provider-transport live lane is silent. Verified: the flag variants leave the full-gate census untouched.

## What the `pass` flag is *not*

A census is emitted only on a green run, so every flag in an emitted census is `true`. The floor consumes the **count**; pass/fail is carried by the exit code, as it always was. The flag is computed honestly rather than hardcoded so the record stays correct if emission is ever widened — but nothing reads it today, and the floor note says so rather than implying it is evidence.

## Five mutations RED

| Mutation | Caught as |
|---|---|
| delete a named invariant (ported-seed) | `assertions_deleted` |
| add one without raising the pin | `floor_stale` |
| abort mid-run so no census is written | `census_missing` |
| inject a real corpus defect into the provenance manifest | fails closed, no census → `census_missing` |
| delete a checkpoint (seed-provenance) | `assertions_deleted` |

In the first of those **the verifier itself still exited 0 reporting "10/10 passed"** — precisely the silent-green hole this floor exists to close.

## Evidence

- **16 CI-gated verifiers pinned at 477 runtime assertions, 1 typed exclusion.**
- All 14 pre-existing pins re-run green at their current counts (provider-transport at master's 18; #276 raises it to 24 on its own branch).
- All bundled gates pass.

**Pre-existing, unrelated:** `check:ported-seed:live` needs a running daemon and fails identically before and after this change (verified against the unmodified file). CI runs only the non-live lane, which is the one floored here.

Independent of #276 — branched from master, touches only the verifier-floor lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)