### PR TITLE
feat(surf-ontology): the governed controls that were neither real nor a named gap

### DIFF
--- a/apps/hypervisor/application-operational-depth.json
+++ b/apps/hypervisor/application-operational-depth.json
@@ -1702,8 +1702,9 @@
           "label": "New → Object type",
           "reference": "Map datasets/models to object types (opens 5-step wizard)",
           "outcome": "governed_receipted_action",
-          "binding": "upsert-object-type (PATCH domain-ontologies) — authority ships but no first-class create-new entry rendered (edit-only form)",
-          "implemented": false
+          "binding": "New -> Object type opens the governed create form (create_new=1) -> PATCH /v1/hypervisor/odk/domain-ontologies/{id} upsert-object-type (ontology_receipt, expected_revision); a duplicate id is refused, never merged",
+          "implemented": true,
+          "reason": "rendered as a first-class create entry by the owned surface (next-legs XII); the daemon authority already shipped, only the entry was missing"
         },
         {
           "id": "new.link-type",
@@ -1711,8 +1712,9 @@
           "label": "New → Link type",
           "reference": "Create relationships between object types",
           "outcome": "governed_receipted_action",
-          "binding": "upsert-link-type — authority ships; create entry not rendered",
-          "implemented": false
+          "binding": "New -> Link type opens the governed create form (create_new=1) -> upsert-link-type; from/to and cardinality are the daemon's own enums; duplicate id refused",
+          "implemented": true,
+          "reason": "rendered as a first-class create entry by the owned surface (next-legs XII); the daemon authority already shipped, only the entry was missing"
         },
         {
           "id": "new.action-type",
@@ -1720,8 +1722,9 @@
           "label": "New → Action type",
           "reference": "Allow writeback to the ontology",
           "outcome": "governed_receipted_action",
-          "binding": "upsert-action-type — declaration authority ships; create entry not rendered (execution stays gapped)",
-          "implemented": false
+          "binding": "New -> Action type opens the governed create form (create_new=1) -> upsert-action-type; kind is the daemon's ACTION_KINDS enum minus function, applies_to required; duplicate id refused",
+          "implemented": true,
+          "reason": "rendered as a first-class create entry by the owned surface (next-legs XII); the daemon authority already shipped, only the entry was missing"
         },
         {
           "id": "new.value-type",
@@ -1729,8 +1732,9 @@
           "label": "New → Value type",
           "reference": "Define property value constraints",
           "outcome": "governed_receipted_action",
-          "binding": "upsert-value-type — authority ships; create entry not rendered",
-          "implemented": false
+          "binding": "New -> Value type opens the governed create form (create_new=1) -> upsert-value-type; base from the daemon vocabulary; duplicate id refused",
+          "implemented": true,
+          "reason": "rendered as a first-class create entry by the owned surface (next-legs XII); the daemon authority already shipped, only the entry was missing"
         },
         {
           "id": "new.function",
@@ -1738,8 +1742,9 @@
           "label": "New → Function",
           "reference": "Define object modifications in code",
           "outcome": "governed_receipted_action",
-          "binding": "upsert-action-type kind=function (declaration) — authority ships; create entry not rendered",
-          "implemented": false
+          "binding": "New -> Function opens the governed create form (create_new=1) -> upsert-action-type kind=function (declaration only); duplicate id refused",
+          "implemented": true,
+          "reason": "rendered as a first-class create entry by the owned surface (next-legs XII); the daemon authority already shipped, only the entry was missing"
         },
         {
           "id": "new.shared-property",
@@ -1972,8 +1977,9 @@
           "label": "New object type (section button)",
           "reference": "section-level create button",
           "outcome": "governed_receipted_action",
-          "binding": "maps to upsert-object-type (create-on-new-id) — authority ships; section-level entry not rendered",
-          "implemented": false
+          "binding": "Section-level New object type -> the same governed create form as New -> Object type (create_new=1, upsert-object-type, ontology_receipt)",
+          "implemented": true,
+          "reason": "rendered as a first-class create entry by the owned surface (next-legs XII); the daemon authority already shipped, only the entry was missing"
         },
         {
           "id": "body.configure-link",
@@ -2000,7 +2006,8 @@
           "reference": "Datasource → Metadata → Properties → Actions → Save location",
           "outcome": "governed_receipted_action",
           "binding": "IOI authority exists (upsert-object-type + upsert-property → ontology_receipt) but no guided wizard / first-class create entry — realized only as inspector edit forms today",
-          "implemented": false
+          "implemented": false,
+          "reason": "the guided 5-step flow is not built; the owned surface renders it as a DISABLED NAMED GAP beside the New forms, which carry the same authority and the same receipt"
         },
         {
           "id": "workflow.datasource-backing-step",
@@ -2130,47 +2137,53 @@
         }
       ],
       "implemented_control_census": [
+        "body.configure-link",
+        "body.definition-row-select",
+        "body.new-object-type-btn",
+        "body.object-explorer-link",
+        "body.object-type-card-select",
+        "body.ontology-switcher",
+        "body.search-form",
+        "config.configure-in-substrate",
+        "config.readout",
+        "global.account",
+        "global.applications",
         "global.home",
         "global.search-cmdj",
-        "global.applications",
-        "global.account",
         "hdr.app-chip",
-        "hdr.search-resources",
         "hdr.branch-main",
         "hdr.new",
-        "rail.discover",
-        "rail.proposals",
-        "rail.history",
-        "rail.object-types",
-        "rail.properties",
-        "rail.shared-properties",
-        "rail.link-types",
-        "rail.action-types",
-        "rail.groups",
-        "rail.interfaces",
-        "rail.value-types",
-        "rail.functions",
-        "rail.health-issues",
-        "rail.cleanup",
-        "rail.ontology-configuration",
-        "body.ontology-switcher",
-        "body.object-type-card-select",
-        "body.definition-row-select",
-        "body.search-form",
-        "body.configure-link",
-        "body.object-explorer-link",
-        "inspector.edit-object-type-form",
+        "hdr.search-resources",
         "inspector.add-property-form",
-        "inspector.edit-value-type-form",
-        "inspector.edit-link-type-form",
         "inspector.edit-action-type-form",
-        "inspector.execute-action",
+        "inspector.edit-link-type-form",
+        "inspector.edit-object-type-form",
+        "inspector.edit-value-type-form",
         "inspector.evaluate-function",
-        "inspector.relationship-browsing",
-        "inspector.open-substrate",
+        "inspector.execute-action",
         "inspector.open-in-cross-app",
-        "config.readout",
-        "config.configure-in-substrate"
+        "inspector.open-substrate",
+        "inspector.relationship-browsing",
+        "new.action-type",
+        "new.function",
+        "new.link-type",
+        "new.object-type",
+        "new.value-type",
+        "rail.action-types",
+        "rail.cleanup",
+        "rail.discover",
+        "rail.functions",
+        "rail.groups",
+        "rail.health-issues",
+        "rail.history",
+        "rail.interfaces",
+        "rail.link-types",
+        "rail.object-types",
+        "rail.ontology-configuration",
+        "rail.properties",
+        "rail.proposals",
+        "rail.shared-properties",
+        "rail.value-types"
       ],
       "existing_daemon": {
         "routes": [

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
@@ -265,6 +265,131 @@ async function run() {
   const reload = await pageText(`/ontology/schema?ontology=${encodeURIComponent(ontId)}`);
   ok("canonical mount re-renders the authored ontology after restart", reload.status === 200 && reload.text.includes(domain), "");
 
+  // ---- the thirteen governed controls: REAL, or a DISABLED NAMED GAP. Never silently absent. ----
+  //
+  // The frozen census puts 13 of the estate's 24 governed_receipted_action controls on this
+  // surface. Six were real (create-ontology + the five inspector EDIT forms). The other seven —
+  // the five New-menu create entries, the section New-object-type button, and the 5-step wizard —
+  // had daemon authority that SHIPPED and module actions that were DECLARED, yet no rendered
+  // gc_entry: with nothing selected the Manager rendered no authoring form at all, and the gaps note
+  // never named them. Silently absent is the one state the read-truth / local-UI-state /
+  // receipted-authority / disabled-named-gap ladder forbids, and no assertion here could see it,
+  // because every authoring assertion drove the action lane directly rather than asking the page
+  // whether a control existed.
+  const gc_CREATE_ENTRIES = [
+    { kind: "object-type", action: "upsert-object-type" },
+    { kind: "link-type", action: "upsert-link-type" },
+    { kind: "action-type", action: "upsert-action-type" },
+    { kind: "value-type", action: "upsert-value-type" },
+    { kind: "function", action: "upsert-action-type" },
+  ];
+  // SUBMIT WHAT THE FORM RENDERS. An assertion that hand-picks field values proves the ACTION works,
+  // never that the FORM does — and a form is what a user has. The first cut asserted exactly that
+  // and stayed green while `New -> Action type` shipped a hidden kind="action" the daemon's enum
+  // refuses on every submit: a control that renders, claims to be real, and can never succeed.
+  // This scrapes each rendered form's own fields (hidden values, first non-empty <option>) and
+  // POSTs that, supplying only the free-text id.
+  const gc_formFields = (html, action) => {
+    const at = html.indexOf(`action="/__ioi/ontology/manager/actions/${action}"`);
+    if (at < 0) return null;
+    const form = html.slice(at, html.indexOf("</form>", at));
+    const data = {};
+    for (const m of form.matchAll(/<input[^>]*name="([^"]+)"[^>]*>/gu)) {
+      if (/type="checkbox"/u.test(m[0])) continue;
+      const v = m[0].match(/value="([^"]*)"/u);
+      data[m[1]] = v ? v[1] : "";
+    }
+    for (const m of form.matchAll(/<select[^>]*name="([^"]+)"[^>]*>([\s\S]*?)<\/select>/gu)) {
+      const opts = [...m[2].matchAll(/<option value="([^"]*)"/gu)].map((o) => o[1]).filter(Boolean);
+      data[m[1]] = opts[0] ?? "";
+    }
+    return data;
+  };
+  const gc_missingEntries = [];
+  const gc_deadEntries = [];
+  for (const gc_entry of gc_CREATE_ENTRIES) {
+    const gc_pane = await pageText(`/ontology/schema?ontology=${encodeURIComponent(ontId)}&section=create&newKind=${gc_entry.kind}`);
+    const gc_fields = gc_formFields(gc_pane.text, gc_entry.action);
+    if (!gc_fields || !("create_new" in gc_fields)) { gc_missingEntries.push(gc_entry.kind); continue; }
+    const gc_sent = { ...gc_fields, ontology: ontId, def_id: `${gc_entry.kind.replace(/-/gu, "_")}_probe`, name: `Probe ${gc_entry.kind}` };
+    const gc_res = await act(gc_entry.action, gc_sent);
+    if (gc_res.q.get("refused") || !gc_res.q.get("receipt")) gc_deadEntries.push(`${gc_entry.kind}:${gc_res.q.get("refused") || "no-receipt"}`);
+  }
+  ok("every New-menu create entry renders a REAL create form, not an absence",
+    gc_missingEntries.length === 0, gc_missingEntries.length ? `missing: ${gc_missingEntries.join(", ")}` : `${gc_CREATE_ENTRIES.length}/5 reachable`);
+  ok("every create entry SUBMITS as rendered — no control that renders but can never succeed",
+    gc_deadEntries.length === 0, gc_deadEntries.length ? `refused as rendered: ${gc_deadEntries.join(", ")}` : `${gc_CREATE_ENTRIES.length}/5 submit`);
+
+  const gc_discover = await pageText(`/ontology/schema?ontology=${encodeURIComponent(ontId)}`);
+  ok("the section-level New object type control is rendered on the surface",
+    /<a[^>]+class="og-newobj"[^>]+href="[^"]*newKind=object-type/.test(gc_discover.text), "anchor + href pinned");
+
+  // The create lane AUTHORS — proven on durable truth, not on the redirect.
+  const gc_beforeCreate = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`);
+  const gc_lnkBefore = ((gc_beforeCreate.body?.ontology?.canonical_object_model || {}).link_types || []).length;
+  const madeLink = await act("upsert-link-type", { ontology: ontId, create_new: "1", def_id: "lnk_journey", name: "Journey link", from: "obj_journey", to: "obj_journey", cardinality: "one_to_many" });
+  const gc_afterCreate = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`);
+  const gc_lnkAfter = ((gc_afterCreate.body?.ontology?.canonical_object_model || {}).link_types || []);
+  ok("a create entry authors a NEW definition with a receipt, readable in durable truth",
+    madeLink.q.get("acted") === "upsert-link-type" && !!madeLink.q.get("receipt")
+      && gc_lnkAfter.length === gc_lnkBefore + 1 && gc_lnkAfter.some((l) => l.id === "lnk_journey"),
+    `${gc_lnkBefore} -> ${gc_lnkAfter.length} receipt ${madeLink.q.get("receipt") ? "yes" : "no"}`);
+
+  // CREATE MEANS CREATE. `upsert-*` merges on an existing id, so without this the create gc_entry
+  // would silently rewrite a definition and still return a receipt.
+  const gc_revBeforeDup = gc_afterCreate.body?.ontology?.revision;
+  const gc_dup = await act("upsert-link-type", { ontology: ontId, create_new: "1", def_id: "lnk_journey", name: "CLOBBERED", from: "obj_journey", to: "obj_journey", cardinality: "one_to_one" });
+  const gc_afterDup = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`);
+  const gc_dupLink = ((gc_afterDup.body?.ontology?.canonical_object_model || {}).link_types || []).find((l) => l.id === "lnk_journey");
+  ok("a create entry REFUSES a duplicate id typed — it never merges over an existing definition",
+    gc_dup.q.get("refused") === "ontology_definition_exists", `refused ${gc_dup.q.get("refused") || "<none>"}`);
+  ok("the refused duplicate changed NOTHING — same revision, original name intact",
+    gc_afterDup.body?.ontology?.revision === gc_revBeforeDup && gc_dupLink?.name === "Journey link",
+    `rev ${gc_revBeforeDup} -> ${gc_afterDup.body?.ontology?.revision}, name ${gc_dupLink?.name}`);
+
+  // The EDIT lane is the other half of the distinction: same id, no create intent, merges.
+  const gc_edited = await act("upsert-link-type", { ontology: ontId, def_id: "lnk_journey", name: "Journey link renamed", from: "obj_journey", to: "obj_journey", cardinality: "one_to_many" });
+  const gc_afterEdit = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`);
+  ok("the EDIT lane still merges onto the same id — create and edit stay distinct governed acts",
+    gc_edited.q.get("acted") === "upsert-link-type"
+      && ((gc_afterEdit.body?.ontology?.canonical_object_model || {}).link_types || []).find((l) => l.id === "lnk_journey")?.name === "Journey link renamed",
+    "renamed in place");
+
+  // THE PROPERTY LANE IS THE ONE LABELLED "Add", AND IT WAS THE ONE THAT STILL CLOBBERED.
+  // A merge-blocking review found the create guard was declared for `upsert-property` but dead:
+  // no create entry existed for properties, and the only property-authoring control — the object
+  // type inspector's "Add a property" form — sent no create intent, so retyping an existing
+  // property id silently changed its value type and returned a receipt for it. The guard is now on
+  // that form; without this assertion, removing it again is invisible (it was: the mutation that
+  // strips it passed 44/44).
+  await act("upsert-object-type", { ontology: ontId, create_new: "1", def_id: "obj_propowner", name: "Prop owner" });
+  await act("upsert-property", { ontology: ontId, create_new: "1", object_type_id: "obj_propowner", def_id: "prop_amount", name: "Amount", value_type: "string" });
+  // DRIVE THE FORM, NOT THE ACTION. Posting `create_new` by hand proves the ACTION refuses a
+  // duplicate; it says nothing about whether the CONTROL sends the create intent. The first version
+  // of this assertion did exactly that and the mutation stripping `create_new` from the rendered
+  // "Add a property" form passed 46/46 — twice. The fields below come from the form itself.
+  const gc_addPane = await pageText(`/ontology/schema?ontology=${encodeURIComponent(ontId)}&section=object-types&definitionKind=object-type&definitionId=obj_propowner`);
+  const gc_addFields = gc_formFields(gc_addPane.text, "upsert-property") || {};
+  const gc_propDup = await act("upsert-property", { ...gc_addFields, ontology: ontId, object_type_id: "obj_propowner", def_id: "prop_amount", name: "Amount", value_type: "integer" });
+  const gc_afterProp = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}`);
+  const gc_prop = (((gc_afterProp.body?.ontology?.canonical_object_model || {}).object_types || [])
+    .find((t) => t.id === "obj_propowner")?.properties || []).find((x) => x.id === "prop_amount");
+  ok("the rendered ADD A PROPERTY form carries the create intent — a duplicate id is refused, never silently retyped",
+    gc_propDup.q.get("refused") === "ontology_definition_exists" && gc_prop?.value_type === "string",
+    `refused ${gc_propDup.q.get("refused") || "<none>"} · value_type ${gc_prop?.value_type}`);
+
+  // The property EDIT lane exists, or making Add create-only would have removed the ability to
+  // change a property at all.
+  const gc_propEdit = await pageText(`/ontology/schema?ontology=${encodeURIComponent(ontId)}&section=object-types&definitionKind=property&definitionId=${encodeURIComponent("obj_propowner.prop_amount")}`);
+  ok("a property EDIT lane is rendered, so create-only Add does not strand the definition",
+    /action="\/__ioi\/ontology\/manager\/actions\/upsert-property"/.test(gc_propEdit.text) && !/name="create_new"[^>]*>\s*<label[^>]*>Property id/.test(gc_propEdit.text),
+    "edit form present");
+
+  // The one control of the thirteen that stays a gap says so where the gaps are named.
+  ok("the 5-step create wizard is a NAMED gap on the surface, not a silent absence",
+    gc_discover.text.includes("5-step create wizard"), "named in the gaps note");
+
+
   // -- G-8 posture matrix (browser) ------------------------------------------
   let pw = null;
   try { pw = await import("playwright"); } catch { pw = null; }

--- a/apps/hypervisor/surfaces/ontology-manager/index.mjs
+++ b/apps/hypervisor/surfaces/ontology-manager/index.mjs
@@ -37,6 +37,7 @@ export function render(model, ctx) {
   return renderOntologyManagerPort(model.overview, model.lists, sel.ontology || "", {
     sel, vocab: model.vocab, embed: ctx.embed,
     q: ctx.url.searchParams.get("q") || "",
+    newKind: ctx.url.searchParams.get("newKind") || "",
     banner: {
       acted: ctx.url.searchParams.get("acted") || "", receipt: ctx.url.searchParams.get("receipt") || "",
       refused: ctx.url.searchParams.get("refused") || "", reason: ctx.url.searchParams.get("reason") || "",
@@ -56,11 +57,11 @@ const mkAction = (id, fields, extra) => ({ id, method: "POST", route: "/actions/
 export const actions = [
   mkAction("create-ontology", ["domain", "version", "description"], { context: [] }),
   mkAction("update-metadata", ["domain", "version", "description"]),
-  mkAction("upsert-value-type", ["def_id", "name", "base", "enum_values"]),
-  mkAction("upsert-object-type", ["def_id", "name", "description", "title_property"]),
-  mkAction("upsert-property", ["object_type_id", "def_id", "name", "value_type", "required"]),
-  mkAction("upsert-link-type", ["def_id", "name", "from", "to", "cardinality"]),
-  mkAction("upsert-action-type", ["def_id", "name", "kind", "applies_to"]),
+  mkAction("upsert-value-type", ["def_id", "name", "base", "enum_values", "create_new"]),
+  mkAction("upsert-object-type", ["def_id", "name", "description", "title_property", "create_new"]),
+  mkAction("upsert-property", ["object_type_id", "def_id", "name", "value_type", "required", "create_new"]),
+  mkAction("upsert-link-type", ["def_id", "name", "from", "to", "cardinality", "create_new"]),
+  mkAction("upsert-action-type", ["def_id", "name", "kind", "applies_to", "create_new"]),
 ];
 
 const bounded = (v, max) => (typeof v === "string" ? v.slice(0, max) : "");
@@ -150,6 +151,21 @@ export async function handleAction({ action, fields, daemonFetch, url }) {
     const com = ont.canonical_object_model || {};
     const id = bounded(fields.def_id || fields.object_type_id, 64).trim();
     if (!/^[a-z][a-z0-9_]*$/.test(action.id === "upsert-property" ? bounded(fields.def_id, 64).trim() : id)) return { kind: "refusal", http: 400, code: "ontology_type_id_invalid", message: "id must match ^[a-z][a-z0-9_]*$" };
+    // CREATE MEANS CREATE. `upsert-*` MERGES onto an existing id, which is right for the edit lane
+    // and wrong for a create entry: reusing an id would silently rewrite someone else's definition
+    // and still hand back a receipt — a governed control doing the opposite of what its label says.
+    // A create intent therefore refuses a duplicate, typed; editing remains the selected-definition
+    // lane. (The id is immutable after creation, so this is the only moment the distinction exists.)
+    if (fields.create_new === "1") {
+      const has = (list, wanted) => (Array.isArray(list) ? list : []).some((x) => x && x.id === wanted);
+      const dup = action.id === "upsert-value-type" ? has(com.value_types, id)
+        : action.id === "upsert-object-type" ? has(com.object_types, id)
+        : action.id === "upsert-link-type" ? has(com.link_types, id)
+        : action.id === "upsert-action-type" ? has(com.action_types, id)
+        : action.id === "upsert-property" ? has((((com.object_types || []).find((t) => t && t.id === bounded(fields.object_type_id, 64).trim())) || {}).properties, id)
+        : false;
+      if (dup) return { kind: "refusal", http: 409, code: "ontology_definition_exists", message: `'${id}' already exists in this ontology — open it to edit it; creating never overwrites` };
+    }
     if (action.id === "upsert-value-type") {
       const e = { id, name: bounded(fields.name, 200), base: bounded(fields.base, 32) || "string" };
       if (e.base === "enum") e.enum_values = bounded(fields.enum_values, 2000).split(",").map((s) => s.trim()).filter(Boolean);
@@ -374,7 +390,22 @@ function renderOntologyManagerPort(ov, lists, selectedId, opts) {
     const crumb = semanticBreadcrumb([{ label: selected.domain || selected.id, href: mHref({ section: "discover" }) }, { label: selD.kind }, { label: selD.id }]);
     if (def.missing) return `<div class="og-inspector" data-testid="og-inspector"><div class="og-ihd"><b>Not found</b></div><div class="og-ibody">${crumb}${ihint(`No ${esc(selD.kind)} <code>${esc(selD.id)}</code> in this ontology — failed closed. <a href="${mHref({ section: "discover" })}">Back to discover</a>.`, true)}</div></div>`;
     let title = selD.id, bodyHtml = "";
-    if (def.ot) {
+    // PROPERTY BEFORE OBJECT TYPE. `resolveDef()` returns `{ot, p}` for a property and `{ot}` for an
+    // object type, so testing `def.ot` first made the property branch below UNREACHABLE: selecting a
+    // property silently rendered its owning object type instead. That was true before this leg and
+    // hid a whole inspector; it started to matter when "Add a property" became create-only, because
+    // the property EDIT form lives in that branch and editing would have been stranded.
+    if (def.p) {
+      const { ot, p } = def; title = p.name || p.id;
+      bodyHtml = [
+        irow("owning object type", `<a href="${defHref("object-type", ot.id, { section: "object-types" })}">${esc(ot.name || ot.id)}</a>`),
+        irow("id · name", `${formatRef(p.id)} · ${esc(p.name || "—")}`),
+        irow("value type", formatRef(p.value_type || "")),
+        irow("posture", `${p.required ? "required" : "optional"}${ot.title_property === p.id ? " · title property" : ""}`),
+        `<h4 class="og-fhd">Edit property</h4>`,
+        aForm("upsert-property", `<input type="hidden" name="object_type_id" value="${esc(ot.id)}"><input type="hidden" name="def_id" value="${esc(p.id)}"><label class="og-fl">Name<input name="name" maxlength="200" value="${esc(p.name || "")}" required></label><label class="og-fl">Value type<select name="value_type" required>${opt([...vocab.base_value_types, ...vts.map((v) => v.id)], p.value_type || "")}</select></label><label class="og-fc"><input type="checkbox" name="required" value="1"${p.required ? " checked" : ""}> required</label>`),
+      ].join("");
+    } else if (def.ot) {
       const t = def.ot; title = t.name || t.id;
       const props = Array.isArray(t.properties) ? t.properties : [];
       const tsets = msets.filter((m) => m.object_type_id === t.id);
@@ -389,17 +420,8 @@ function renderOntologyManagerPort(ov, lists, selectedId, opts) {
         irow("open in", `<a href="${objectTypeLink(oid, t.id)}">Explorer</a> · <a href="${pipelineNodeLink(oid, "mapping")}">Pipeline</a>`),
         `<h4 class="og-fhd">Edit object type</h4>`,
         aForm("upsert-object-type", `<input type="hidden" name="def_id" value="${esc(t.id)}"><label class="og-fl">Name<input name="name" maxlength="200" value="${esc(t.name || "")}" required></label><label class="og-fl">Description<input name="description" maxlength="2000" value="${esc(t.description || "")}"></label><label class="og-fl">Title property<select name="title_property"><option value="">— none —</option>${opt(props.map((p) => p.id), t.title_property || "")}</select></label>`),
-        `<h4 class="og-fhd">Add / edit a property</h4>`,
-        aForm("upsert-property", `<input type="hidden" name="object_type_id" value="${esc(t.id)}"><label class="og-fl">Property id<input name="def_id" maxlength="64" pattern="[a-z][a-z0-9_]*" placeholder="lower_snake" required></label><label class="og-fl">Name<input name="name" maxlength="200" required></label><label class="og-fl">Value type<select name="value_type" required>${opt([...vocab.base_value_types, ...vts.map((v) => v.id)], "")}</select></label><label class="og-fc"><input type="checkbox" name="required" value="1"> required</label>`),
-      ].join("");
-    } else if (def.p) {
-      const { ot, p } = def; title = p.name || p.id;
-      bodyHtml = [
-        irow("owning object type", `<a href="${defHref("object-type", ot.id, { section: "object-types" })}">${esc(ot.name || ot.id)}</a>`),
-        irow("id · name", `${formatRef(p.id)} · ${esc(p.name || "—")}`),
-        irow("value type", formatRef(p.value_type || "")),
-        irow("posture", `${p.required ? "required" : "optional"}${ot.title_property === p.id ? " · title property" : ""}`),
-        irow("mapping usage", (lists.connector_mappings === null) ? "unavailable — daemon did not answer" : (lists.connector_mappings || []).filter((m) => m.ontology_ref === selected.ref && (m.field_mappings || []).some((f) => f.property_id === p.id) || (m.key_mapping && m.key_mapping.property_id === p.id)).length + " mapping(s)"),
+        `<h4 class="og-fhd">Add a property</h4>`,
+        aForm("upsert-property", `<input type="hidden" name="object_type_id" value="${esc(t.id)}"><input type="hidden" name="create_new" value="1"><label class="og-fl">Property id<input name="def_id" maxlength="64" pattern="[a-z][a-z0-9_]*" placeholder="lower_snake" required></label><label class="og-fl">Name<input name="name" maxlength="200" required></label><label class="og-fl">Value type<select name="value_type" required>${opt([...vocab.base_value_types, ...vts.map((v) => v.id)], "")}</select></label><label class="og-fc"><input type="checkbox" name="required" value="1"> required</label>`),
       ].join("");
     } else if (def.v) {
       const v = def.v; title = v.name || v.id;
@@ -470,8 +492,61 @@ function renderOntologyManagerPort(ov, lists, selectedId, opts) {
     }
     return `<div class="og-inspector" data-testid="og-inspector"><div class="og-ihd"><b>${esc(title)}</b><span class="og-ikind">${esc(selD.kind)}</span></div><div class="og-ibody">${crumb}${bodyHtml}${openSubstrate}</div></div>`;
   }
-  // Create-ontology form (section=create) — the one authoring lane without a selected ontology.
-  const createPane = section === "create" ? `<div class="og-inspector" data-testid="og-inspector"><div class="og-ihd"><b>Create ontology</b></div><div class="og-ibody">${ihint("A new DomainOntology draft (revision 1) with a create receipt. Add typed definitions after it exists.")}<form class="og-form" method="post" action="/__ioi/ontology/manager/actions/create-ontology">${sel.embed ? `<input type="hidden" name="embed" value="1">` : ""}<label class="og-fl">Domain<input name="domain" maxlength="120" placeholder="e.g. lending" required></label><label class="og-fl">Version<input name="version" maxlength="60" placeholder="0.1.0"></label><label class="og-fl">Description<input name="description" maxlength="2000"></label><button class="og-save" type="submit">Create</button></form></div></div>` : "";
+  // The New lane (section=create). Realizes the reference's New menu: the ontology create form plus
+  // ONE first-class create entry per definition kind.
+  //
+  // Before this, the daemon authority for all five kinds shipped and the module declared the
+  // actions, but the only rendered authoring forms were the inspector EDIT forms on an
+  // already-selected definition — so seven of this surface's thirteen governed controls were
+  // reachable by no path at all, and were not shown as disabled named gaps either. They were
+  // silently absent, which is the one state the read-truth / local-UI-state / receipted-authority /
+  // disabled-named-gap ladder does not allow.
+  //
+  // Each entry posts the SAME governed action the edit lane uses, with `create_new=1` so a
+  // duplicate id is refused rather than merged over.
+  // The field controls are the SAME vocab-driven selects the edit forms use, deliberately: a create
+  // form that offered a free-text value the daemon's enum refuses would hand the user a placeholder
+  // that fails closed on submit. (It did — the first cut typed `one-to-many` where the daemon
+  // enumerates `one_to_many`, and the live probe refused every create.)
+  const NEW_KINDS = [
+    { k: "object-type", act: "upsert-object-type", label: "Object type", idph: "obj_widget",
+      body: `<label class="og-fl">Name<input name="name" maxlength="200" required></label><label class="og-fl">Description<input name="description" maxlength="2000"></label>` },
+    { k: "link-type", act: "upsert-link-type", label: "Link type", idph: "lnk_owns",
+      needs: "object-types",
+      body: `<label class="og-fl">Name<input name="name" maxlength="200" required></label><label class="og-fl">From<select name="from" required>${opt(otOptions, "")}</select></label><label class="og-fl">To<select name="to" required>${opt(otOptions, "")}</select></label><label class="og-fl">Cardinality<select name="cardinality" required>${opt(vocab.link_cardinalities, "")}</select></label>` },
+    { k: "action-type", act: "upsert-action-type", label: "Action type", idph: "act_approve",
+      // `kind` is the daemon's OWN enum minus `function` (which has its own entry below), never a
+      // hardcoded literal: the first cut sent kind="action", which ACTION_KINDS does not contain,
+      // so every submit refused — the same defect as the `one-to-many` placeholder, re-shipped in
+      // the sibling field. `applies_to` is REQUIRED because the daemon requires it for every
+      // non-function kind, and an empty select value is dropped before it ever reaches the module.
+      needs: "object-types",
+      body: `<label class="og-fl">Name<input name="name" maxlength="200" required></label><label class="og-fl">Kind<select name="kind" required>${opt((vocab.action_kinds || []).filter((k) => k !== "function"), "")}</select></label><label class="og-fl">Applies to<select name="applies_to" required>${opt(otOptions, "")}</select></label>` },
+    { k: "value-type", act: "upsert-value-type", label: "Value type", idph: "val_currency",
+      body: `<label class="og-fl">Name<input name="name" maxlength="200" required></label><label class="og-fl">Base<select name="base">${opt(vocab.base_value_types, "string")}</select></label><label class="og-fl">Enum values (comma-separated, if base=enum)<input name="enum_values" maxlength="2000"></label>` },
+    { k: "function", act: "upsert-action-type", label: "Function", idph: "fn_score",
+      body: `<label class="og-fl">Name<input name="name" maxlength="200" required></label><input type="hidden" name="kind" value="function"><label class="og-fl">Applies to<select name="applies_to"><option value="">— none —</option>${opt(otOptions, "")}</select></label>` },
+  ];
+  const newKind = String(O.newKind || "");
+  const newHref = (k) => ontologyContextQuery("/__ioi/ontology/manager", { ontology: oid, section: "create", ...(sel.embed ? { embed: sel.embed } : {}) }) + `&newKind=${encodeURIComponent(k)}`;
+  const ontologyCreateForm = `<form class="og-form" method="post" action="/__ioi/ontology/manager/actions/create-ontology">${sel.embed ? `<input type="hidden" name="embed" value="1">` : ""}<label class="og-fl">Domain<input name="domain" maxlength="120" placeholder="e.g. lending" required></label><label class="og-fl">Version<input name="version" maxlength="60" placeholder="0.1.0"></label><label class="og-fl">Description<input name="description" maxlength="2000"></label><button class="og-save" type="submit">Create</button></form>`;
+  const chosen = NEW_KINDS.find((n) => n.k === newKind);
+  const newMenu = selected
+    ? `<div class="og-newmenu">${NEW_KINDS.map((n) => `<a class="og-newitem${n.k === newKind ? " on" : ""}" href="${newHref(n.k)}">New ${esc(n.label)}</a>`).join("")}</div>`
+    : "";
+  // An entry whose required select has no options can never be submitted. Advertising it as a live
+  // control would be the "simulated success" the ladder forbids, so it renders as a DISABLED NAMED
+  // GAP naming its own precondition.
+  const kindBlocked = chosen && chosen.needs === "object-types" && otOptions.length === 0;
+  const kindGapPane = kindBlocked
+    ? `<div class="og-inspector" data-testid="og-inspector"><div class="og-ihd"><b>New ${esc(chosen.label)}</b><span class="og-ikind">${esc(chosen.k)}</span></div><div class="og-ibody">${ihint(`A ${esc(chosen.label.toLowerCase())} must name declared object types, and this ontology has none yet.`)}${newMenu}<div class="og-iacts">${disabledSemanticAction({ label: `New ${chosen.label}`, reason: "declare an object type first — this form's required fields resolve only against declared object types" })}</div></div></div>`
+    : "";
+  const kindPane = !kindBlocked && chosen && selected
+    ? `<div class="og-inspector" data-testid="og-inspector"><div class="og-ihd"><b>New ${esc(chosen.label)}</b><span class="og-ikind">${esc(chosen.k)}</span></div><div class="og-ibody">${ihint(`A new ${esc(chosen.label.toLowerCase())} in <b>${domainLabel}</b>, authored through the same governed action the edit form uses (receipted, expected_revision). Ids are immutable and a duplicate is refused, never merged over.`)}${newMenu}<form class="og-form" method="post" action="/__ioi/ontology/manager/actions/${esc(chosen.act)}">${RET}<input type="hidden" name="create_new" value="1"><label class="og-fl">Id<input name="def_id" maxlength="64" pattern="[a-z][a-z0-9_]*" placeholder="${esc(chosen.idph)}" required></label>${chosen.body}<button class="og-save" type="submit">Create</button></form><div class="og-iacts">${disabledSemanticAction({ label: "Guided 5-step wizard", reason: "the guided create flow is not built — this single form carries the same authority and the same receipt" })}</div></div></div>`
+    : "";
+  const createPane = section === "create"
+    ? (kindGapPane || kindPane || `<div class="og-inspector" data-testid="og-inspector"><div class="og-ihd"><b>Create ontology</b></div><div class="og-ibody">${ihint("A new DomainOntology draft (revision 1) with a create receipt. Add typed definitions after it exists.")}${ontologyCreateForm}${selected ? ihint("Or add a typed definition to the selected ontology:") + newMenu : ""}</div></div>`)
+    : "";
   const aside = createPane || (def ? inspectorFor() : "");
 
   // Result banner (#ap-result — the runtime's redirect anchor). Renders only after an action.
@@ -489,6 +564,7 @@ function renderOntologyManagerPort(ov, lists, selectedId, opts) {
           <div class="og-ontolist">${ontologies.length ? ontologies.map((x) => `<a class="og-ontoitem${selected && x.id === selected.id ? " on" : ""}" href="/__ioi/ontology/manager?ontology=${enc(x.id)}">${esc(x.domain || x.id)} <span class="og-dot og-${(x.health || {}).status === "ready" ? "ok" : (x.health || {}).status === "empty" ? "muted" : "warn"}"></span></a>`).join("") : `<div class="og-none">No ontologies yet.</div>`}</div>
         </details>
         <a class="og-explorerlink" href="/__ioi/ontology/explorer" title="Object Explorer — browse object types and materialized object sets (the symmetric #35 surface)">Object Explorer →</a>
+        <a class="og-newobj" href="${newHref("object-type")}" title="Create a new object type in this ontology (governed, receipted)">New object type</a>
         <a class="og-configlink" href="/__ioi/odk/ontologies/${enc(selected.id)}/edit">Configure</a></div>
       ${ots.length ? `<div class="og-cards">${ots.map(cardOf).join("")}</div>` : `<div class="og-none">No object types yet. <a href="/__ioi/odk/ontologies/${enc(selected.id)}/edit">Add typed object types →</a></div>`}
     </section>
@@ -507,7 +583,7 @@ function renderOntologyManagerPort(ov, lists, selectedId, opts) {
       <div class="og-cfgrow"><span>Projections</span><b>${projs.length}</b></div>
       <div class="og-cfgrow"><span>Estate</span><span><span class="om-pill ok">${rollup.ready || 0} ready</span> <span class="om-pill warn">${rollup.incomplete || 0} incomplete</span> <span class="om-pill muted">${rollup.empty || 0} empty</span></span></div>
       <a class="og-editlink" href="/__ioi/odk/ontologies/${enc(selected.id)}/edit">Configure model in substrate →</a>
-      <div class="og-note" style="margin-top:8px">Named gaps (reference-only lanes, no authority contract yet): in-canvas schema editing · Proposals · Shared properties · Groups · Interfaces · Cleanup · action/function execution. Reference: <a href="/__apps/schema" target="_blank" rel="noopener">Ontology Manager ↗</a>.</div>
+      <div class="og-note" style="margin-top:8px">Named gaps (reference-only lanes, no authority contract yet): in-canvas schema editing · the 5-step create wizard (the New forms carry the same authority) · Proposals · Shared properties · Groups · Interfaces · Cleanup · action/function execution. Reference: <a href="/__apps/schema" target="_blank" rel="noopener">Ontology Manager ↗</a>.</div>
     </div></section>
   ` : `<div class="og-none" style="margin:40px auto;max-width:520px">Select or create an ontology to see its schema. <a href="/__ioi/odk/ontologies/new">Create an ontology →</a></div>`}</main>`;
 

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -23,8 +23,8 @@
       "id": "ontology-journey",
       "npm_script": "check:ontology-journey",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs",
-      "runtime_assertions": 36,
-      "assertion_names_sha256": "fdd2711f29b0cf1ec37e4c6082d13deabe48b69c9ae520367f5bd016d2965ae8"
+      "runtime_assertions": 46,
+      "assertion_names_sha256": "ed3903a71c147447131159b4b735f2a4bfc7e6daeb6d1b3a314673811f8092f7"
     },
     {
       "id": "governance-journey",

--- a/docs/architecture/_meta/canon-to-code-delta.md
+++ b/docs/architecture/_meta/canon-to-code-delta.md
@@ -733,6 +733,78 @@ bind address" is not that evidence.**
 |---|---|---|
 | **Every model-route mutation handler authenticates only at the global auth gate, not per-request, because a model route carries no owner.** `handle_model_route_patch`, `_probe`, `_enable`, `_disable`, `_select_default`, `_create`, and `_delete` take `State` + `AxumPath` (+ `Json`) and NO `HeaderMap`; none resolves a caller or an owner scope. The record has no `owner_ref`/`tenant` field at all. Under the default `auto` auth policy the only gate is `daemon_exposed() || request_exposed(headers)`, which is false for the loopback-behind-`serve` topology — so on the estate's documented exposed deployment these mutations are reachable unauthenticated. | Byte-verified at HEAD on `w32/model-route-lease`: the seven handler signatures; `read_record_dir("model-route-registry")` records carry no owner; the adversarial review's finding #1 exploit chain (unauthenticated `PATCH base_url` → `probe` → repoint). The **credential-exfiltration consequence is fenced in the Leg-2 cut above** (destination bound into the invoke grant hash + a credentialed route's config frozen against PATCH), so a bound key cannot be re-aimed. What remains is registry integrity: an unauthenticated party can still repoint an UNCREDENTIALED route, flip enable/disable, or vandalize display fields, and an env-var existence oracle (`credential_binding.env_key_name` → `std::env::var`) is settable the same way. | **Filed OPEN as its own leg, not fixed in Leg 2 (owner-reversible).** Authenticating the whole surface needs a route OWNERSHIP model — capture the owner at `create`, migrate the seed route, and owner-scope every mutation — which is a registry-wide change with its own verifier, well outside a credential-custody cut. Fixing one handler would falsely imply the surface is closed. **Residual named in Leg 2:** even with the destination fenced, a party who repoints an uncredentialed route and then persuades the owner to bind + approve a grant against it exfiltrates on the owner's own approval; the grant facets now NAME the destination, so an owner who inspects them sees the host, but the approval surface decoding those facets is part of this leg. The public "stronger than incumbents" claim stays gated on this and the standing Journeys B/C/D/G bar. |
 
+### Journey verification XII (2026-08-13, next-legs XII — SURF-ontology: the governed controls that were neither real nor named)
+
+| Delta | Evidence | Disposition |
+|---|---|---|
+| **Seven of this surface's thirteen governed controls were reachable by no path at all, and were not shown as disabled named gaps either.** `SURF-ontology` holds 13 of the estate's 24 `governed_receipted_action` controls — the highest concentration of the twenty. Six were real (create-ontology plus five inspector EDIT forms). The other seven — the five New-menu create entries, the section New-object-type button, and the 5-step wizard — had daemon authority that SHIPPED (`upsert-*` creates on a fresh id) and module actions that were DECLARED, but the Manager rendered no authoring form at all unless a definition was already selected, and the gaps note never named them. Silently absent is the one state the read-truth · local-UI-state · receipted-authority · disabled-named-gap ladder does not allow, and no assertion could see it because every authoring assertion drove the action lane directly instead of asking the page whether a control existed. | Live against an isolated daemon + serve throughout. `check:ontology-journey` **46/46** (was 36), floored in the same commit (36 → 46; family 654 → 657). **Eight mutations proven RED-ON-TARGET.** The seed gate was RE-CONFIRMED on ground rather than trusted from its dated row: `--require-ready` green, and both protected graphs replay `complete_interaction_route_graph=true` (schema 32 edges, explorer 3, zero problems). **A merge-blocking adversarial from-source review found a SHIP-BLOCKING defect in the first cut of this very fix** — see the paragraph below — plus six more, all applied. | **Executed and ruled (owner, owner-reversible).** (1) **12 of 13 controls are now REAL**; the 5-step wizard is the one that stays a gap and is rendered as a DISABLED NAMED CONTROL with its reason, not as prose. (2) **CREATE MEANS CREATE.** `upsert-*` merges onto an existing id — correct for the edit lane, catastrophic for a create entry, which would silently rewrite another author's definition and still return a receipt. Create entries carry an explicit intent and refuse a duplicate typed (`ontology_definition_exists`); the edit lane is unchanged. (3) **A CONTROL THAT CANNOT SUCCEED IS NOT REAL.** Entries whose required selects would render empty (a link or action type on an ontology with no object types) render as disabled named gaps naming their own precondition. (4) **The frozen census is updated to match** — 12 of 13 `implemented: true`. Only `implemented` moved; `outcome` describes the REFERENCE control's class and is not ours to rewrite, so the estate total stays 24. |
+
+**THE AUTHORITY RULING, AND WHY THE BRIEF WAS WRONG.** `surfaces/ontology.md` §4 targeted the seven
+authoring actions at "re-plumb through the W0.3 CapabilityLease client (this plane today mutates
+without a wallet challenge)". That target is **withdrawn as stale**. Canon rules ontology authoring
+an ordinary governed mutation, not an authority crossing:
+`domain-ontologies-and-data-recipes.md` — *"Local canonicality is the default. An organization or
+autonomous-system domain may canonically define its own objects, actions, assertions, and
+policies… wallet.network supplies that path when portable delegated authority, secrets, decryption
+leases, external account access, or high-risk approval is required."* Authoring your own ontology is
+none of those. Ruling OQ-1 reached the same conclusion for the sibling object
+(`OntologySurfaceDescriptor`), OQ-11 reaffirmed it and forbade stale contradicting wording, and the
+frozen census binds all 13 of these controls to plain receipted POST/PATCH with **zero** lease
+bindings. The built shape — identity-first (rule E), `expected_revision` CAS,
+`ontology-receipt.v1`, fail-closed on a missing receipt, `acting_principal_ref` per INV-37 — IS the
+target. **Re-plumbing would have invented authority canon does not require and made every schema
+edit demand a wallet approval.** The brief row is corrected in place. Two caveats recorded rather
+than buried: the module already routes through the authority client as a no-lease pass-through, so
+a future 428/403 would be legible without re-plumbing; and canon separately forbids an ontology
+redefining constitutional purpose, prohibitions, authority ceilings or terminal obligations, and
+names constitution-bound roots as protected refs — a GOVERNANCE check that **does not exist on this
+lane** and is named below as a residual.
+
+**THE SHIP-BLOCKING DEFECT THIS RUN SHIPPED INTO ITS OWN FIX, AND WHY THE GATE COULD NOT SEE IT.**
+The first cut's `New → Action type` entry sent a hardcoded `kind="action"`. The daemon enumerates
+`create_object | modify_object | delete_object | function`, so **every submit refused** — a control
+that renders, claims to be real, and can never succeed. It was the SAME defect this cut had already
+made and fixed once (a `one-to-many` placeholder where the daemon enumerates `one_to_many`),
+re-shipped in the sibling field, *under a comment claiming the create forms reuse the edit lane's
+vocab-driven selects*. It survived because **the new assertions hand-picked their field values**:
+they proved the ACTION worked and said nothing about the FORM, so no assertion ever POSTed
+`upsert-action-type` at all. The assertions now **scrape each rendered form's own fields and submit
+that**, which is what made the mutation catchable. The same weakness recurred a third time in the
+property assertion and was caught only because its mutation came back GREEN twice.
+
+**WHAT THE STANDING DISCIPLINE CAUGHT THAT THE REVIEW DID NOT.** Two mutations returned
+GREEN-NOT-CAUGHT and forced repairs. The second of them — stripping the create intent from the one
+form labelled "Add a property" — exposed that **the property inspector branch has been unreachable
+since before this leg**: `resolveDef()` returns `{ot, p}` for a property while the render chain
+tested `if (def.ot)` first, so selecting a property always rendered its owning object type and the
+property inspector had never displayed. That mattered the moment "Add" became create-only, because
+the property EDIT form lives in that branch and editing would have been stranded. Branch order
+fixed; the inspector renders for the first time. Separately,
+`verify-hypervisor-operational-depth.mjs` **crashes on the committed tree and is not CI-gated at
+all** — which is precisely how the depth ledger drifted into claiming "create entry not rendered"
+for controls that render. Both are named as residuals below, not fixed here.
+
+**A FALSE FINDING THIS RUN ALMOST FILED.** The first seed-gate replay reported
+`complete_interaction_route_graph=false` on all three graphs. That was a BROKEN SHARED RUNTIME — a
+`serve` process up with its daemon down — not a broken gate; the isolated recipe replays green. The
+bad run also **overwrote a tracked seed graph**, replacing eight specific per-control problem
+records with two "cannot re-establish node" lines; that churn was reverted. A verification pass must
+not restamp content-addressed artifacts, and a gate is not failing merely because the thing you
+pointed it at was not running.
+
+**SURF-ontology REMAINS OPEN — it is not closed by this cut and must not be read as closed.** ACC-A
+requires create/version/**propose**/read/**search**/**saved-set** journeys to close. Derived from
+the router rather than from guessed URLs: there is **no ontology proposal/branch family** (the only
+`proposal` routes are Foundry qualification and Intelligence improvement), **no** saved
+object-set/exploration family, and **no** object-instance search family (the `instances` matches are
+`managed-worker-instances`, a different plane). Three of the six named journeys have no daemon
+family at all — they are the W3 backend work in the brief's §5 PRs 6–7 — and the per-owner cutover
+with typed 410s is W6.1. **NAMED RESIDUALS (tracked, not waived):** the constitutional-ceiling
+governance check canon requires of ontology evolution does not exist on this lane; the
+operational-depth verifier crashes and gates nothing, so the depth ledger has no machine guard; the
+5-step wizard is a disabled named gap; object-instance execution, proposals, saved sets and search
+remain typed absences; and the legacy `/__ioi/ontology/*` mounts keep serving until that cutover.
+
 ### Journey verification XI (2026-08-13, next-legs XI — W3.3 durable custody: a backup crosses to a fresh daemon, and what was deleted stays deleted)
 
 | Delta | Evidence | Disposition |


### PR DESCRIPTION
`SURF-ontology` holds **13 of the estate's 24 `governed_receipted_action` controls** — the highest authority concentration of the twenty surfaces, and the first rung of the semantic-ladder rehome.

Six of those thirteen were real: `create-ontology` and five inspector **edit** forms. The other seven — the five New-menu create entries, the section New-object-type button, and the 5-step wizard — had daemon authority that **shipped** and module actions that were **declared**, but the Manager rendered no authoring form at all unless a definition was already selected, and the gaps note never named them.

Silently absent is the one state the *read truth · local UI state · receipted authority · disabled named gap* ladder does not allow. No assertion could see it, because every authoring assertion drove the action lane directly instead of asking the page whether a control existed.

## What this cut does

**Twelve of thirteen are now real.** The wizard is the one that stays a gap, rendered as a disabled named control with its reason rather than as prose in a note.

**Create means create.** `upsert-*` merges onto an existing id — correct for the edit lane, catastrophic for a create entry, which would silently rewrite another author's definition *and still return a receipt*. Create entries carry an explicit intent and refuse a duplicate typed (`ontology_definition_exists`); the edit lane is unchanged.

**A control that cannot succeed is not real.** A link or action type on an ontology with no object types would render required selects with no options. Those entries render as disabled named gaps naming their own precondition.

**The property inspector renders for the first time.** `resolveDef()` returns `{ot, p}` for a property while the render chain tested `if (def.ot)` first, so selecting a property always rendered its owning object type — true since before this leg. It began to matter when "Add a property" became create-only, because the property edit form lives in that branch.

## The authority ruling

The brief targeted the seven authoring actions at *"re-plumb through the W0.3 CapabilityLease client (this plane today mutates without a wallet challenge)"*. **That target is withdrawn as stale.** Canon rules ontology authoring an ordinary governed mutation:

> Local canonicality is the default. An organization or autonomous-system domain may canonically define its own objects, actions, assertions, and policies… wallet.network supplies that path when portable delegated authority, secrets, decryption leases, external account access, or high-risk approval is required.

Authoring your own ontology is none of those. OQ-1 reached the same conclusion for the sibling object (`OntologySurfaceDescriptor`), OQ-11 reaffirmed it and forbade stale contradicting wording, and the frozen census binds all 13 controls to plain receipted POST/PATCH with **zero** lease bindings. The built shape — identity-first (rule E), `expected_revision` CAS, `ontology-receipt.v1`, fail-closed on a missing receipt, `acting_principal_ref` per INV-37 — **is** the target. Re-plumbing would have invented authority canon does not require and made every schema edit demand a wallet approval. The adversarial review checked this independently and found it supported, not an overreach.

## Evidence

`check:ontology-journey` **46/46** (was 36) against an isolated live daemon, floored in this commit (36 → 46; family 654 → 657). **Eight mutations RED-ON-TARGET.** The seed gate was re-confirmed on ground rather than trusted from its dated row: `--require-ready` green, both protected graphs replay `complete_interaction_route_graph=true` (schema 32 edges, explorer 3, zero problems). Full verifier family 21/21 green; five bundled gates green; no Rust touched.

## The defect this run shipped into its own fix

The first cut's `New → Action type` sent a hardcoded `kind="action"`. The daemon enumerates `create_object | modify_object | delete_object | function`, so **every submit refused** — a control that renders, claims to be real, and can never succeed. It was the same defect this cut had already made and fixed once (a `one-to-many` placeholder where the daemon enumerates `one_to_many`), re-shipped in the sibling field, under a comment claiming the create forms reuse the edit lane's vocab-driven selects.

It survived because **the new assertions hand-picked their field values** — proving the *action* worked while saying nothing about the *form*, so no assertion ever POSTed `upsert-action-type` at all. A merge-blocking adversarial review found it. The assertions now **scrape each rendered form's own fields and submit that**, which is what made the mutation catchable. The same weakness recurred a third time in the property assertion, caught only because its mutation came back green twice.

## A false finding this run almost filed

The first seed-gate replay reported `complete_interaction_route_graph=false` on all three graphs. That was a **broken shared runtime** — a `serve` up with its daemon down — not a broken gate; the isolated recipe replays green. The bad run also overwrote a tracked seed graph, replacing eight specific per-control problem records with two "cannot re-establish node" lines. That churn was reverted: a verification pass must not restamp content-addressed artifacts.

## SURF-ontology is NOT closed

ACC-A requires create/version/**propose**/read/**search**/**saved-set** journeys to close. Derived from the router rather than from guessed URLs: there is **no** ontology proposal/branch family (the only `proposal` routes are Foundry qualification and Intelligence improvement), **no** saved object-set/exploration family, and **no** object-instance search family (the `instances` matches are `managed-worker-instances`, a different plane). Three of six named journeys have no daemon family at all — the W3 backend work in the brief's §5 PRs 6–7 — and the per-owner cutover with typed 410s is W6.1.

**Named residuals:** the constitutional-ceiling governance check canon requires of ontology evolution does not exist on this lane; `verify-hypervisor-operational-depth.mjs` crashes on the committed tree and is **not CI-gated**, so the depth ledger has no machine guard (which is how it drifted into claiming "create entry not rendered" for controls that render); the wizard is a disabled named gap; proposals, saved sets, search and object-instance execution remain typed absences; legacy `/__ioi/ontology/*` keeps serving until cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
