### PR TITLE
fix(gates): the operational-depth gate could not run, so the depth ledger had no guard — repaired under the floors gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,7 @@ jobs:
           npm run check:model-router-decisions --workspace=@ioi/hypervisor-app
           npm run check:backup-restore --workspace=@ioi/hypervisor-app
           npm run check:environment-custody --workspace=@ioi/hypervisor-app
+          npm run check:operational-depth --workspace=@ioi/hypervisor-app
 
       # The floor the verifier family never had. Every verifier above is pinned at the number of
       # assertions it actually EXECUTED; deleting assertions from any of them was silently green

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -29,6 +29,7 @@
     "check:model-router-decisions": "node scripts/verify-hypervisor-model-router-decisions.mjs",
     "check:backup-restore": "node scripts/verify-hypervisor-backup-restore.mjs",
     "check:environment-custody": "node scripts/verify-hypervisor-environment-custody.mjs",
+    "check:operational-depth": "node scripts/verify-hypervisor-operational-depth.mjs",
     "check:provider-transport": "node scripts/verify-hypervisor-provider-transport.mjs",
     "check:provider-transport:live": "node scripts/verify-hypervisor-provider-transport.mjs --live",
     "check:verifier-floors": "node scripts/check-verifier-floors.mjs",

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -237,10 +237,24 @@ function actionRouteMatch(pattern, tail) {
   if (ps.length !== ts.length) return false;
   return ps.every((seg, i) => (seg.startsWith(":") ? ts[i].length > 0 : seg === ts[i]));
 }
+// A ROW'S DECLARED TIER GATES ITS ACTION ROUTES.
+//
+// One module may serve several mounts — packages/marketplace, and work landing/sessions/new-session
+// — and this resolver matched beneath EVERY row bound to that module, so the module's whole action
+// list was reachable under a mount the registry declares read-tier. `packages-marketplace` is
+// `browse` and exposed `cut-release`, `recall`, `install` and `uninstall`; `work` is `inspect` and
+// exposed `create-session` and the launch verbs. The registry said one thing and the dispatch did
+// another, and the check that would have caught it had been crashing for months.
+//
+// The product's own forms already target the acting mounts (`LEGACY_ROUTE`, `LEGACY_SESSIONS`,
+// `LEGACY_NEW_SESSION`), so this closes a hole nothing was walking through — but "nothing walks
+// through it" is not a boundary. The declared tier is.
+const ACTING_STATES = new Set(["act", "workflow_complete"]);
 export function boundActionRoute(pathname, method) {
   for (const s of SURFACES) {
     const impl = bound.get(s.slug);
     if (!impl || typeof impl.handleAction !== "function" || !Array.isArray(impl.actions) || !impl.actions.length) continue;
+    if (!ACTING_STATES.has(s.operational_state)) continue;
     if (!pathname.startsWith(s.route + "/")) continue;
     const tail = pathname.slice(s.route.length);
     const candidates = impl.actions.filter((a) => a.method === method && a.route && actionRouteMatch(a.route, tail));
@@ -282,8 +296,16 @@ bindSurface("operations", operationsModule);
 // Test-only fault surface (NEVER without the runtime-test flag): gives the action-runtime
 // verifier a module whose action THROWS (route isolation proof) and one that claims success
 // WITHOUT a receipt (fail-closed proof). Carries no daemon authority and mutates nothing.
+//
+// `act`, NOT `browse`, and the tier gate below is why. This row declares two receipted POST
+// actions and exists so `verify-hypervisor-action-runtime.mjs` can prove route-local containment
+// and receipt-fail-closed against them. Declared `browse`, the tier gate skipped it,
+// `boundActionRoute` returned null, both POSTs fell through to the SPA catch-all as 200, and the
+// estate's only proof of those two properties died — silently, because that verifier has no npm
+// script, no CI job and no floor row. The row satisfies the `act` boot invariant on its own terms:
+// a bound module with `handleAction` and receipted, authority-carrying mutations.
 if (process.env.IOI_APP_RUNTIME_TEST_ROUTE === "1") {
-  SURFACES.push({ slug: "__test_action", owner: "Test", title: "Action Runtime Test", icon: "data:,x", route: "/__ioi/__test/action-surface", verifier: "n/a", certification: "n/a", capabilities: ["browse"], operational_state: "browse", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" });
+  SURFACES.push({ slug: "__test_action", owner: "Test", title: "Action Runtime Test", icon: "data:,x", route: "/__ioi/__test/action-surface", verifier: "n/a", certification: "n/a", capabilities: ["browse", "transition"], operational_state: "act", embedded_shell_state: "native_single_rail", interaction_parity_state: "none" });
   bindSurface("__test_action", {
     meta: { slug: "__test_action", route: "/__ioi/__test/action-surface" },
     load: async () => ({}),

--- a/apps/hypervisor/scripts/surface-registry.mjs
+++ b/apps/hypervisor/scripts/surface-registry.mjs
@@ -242,7 +242,10 @@ function actionRouteMatch(pattern, tail) {
 // One module may serve several mounts — packages/marketplace, and work landing/sessions/new-session
 // — and this resolver matched beneath EVERY row bound to that module, so the module's whole action
 // list was reachable under a mount the registry declares read-tier. `packages-marketplace` is
-// `browse` and exposed `cut-release`, `recall`, `install` and `uninstall`; `work` is `inspect` and
+// `browse` and exposed all FIVE of the module's actions — `admit-candidate`, `cut-release`,
+// `recall-release`, `install-release` and `uninstall` (an earlier count of this said four and
+// dropped `admit-candidate`, which is the admission verb and the one that matters most);
+// `work` is `inspect` and
 // exposed `create-session` and the launch verbs. The registry said one thing and the dispatch did
 // another, and the check that would have caught it had been crashing for months.
 //

--- a/apps/hypervisor/scripts/verify-hypervisor-operational-depth.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-operational-depth.mjs
@@ -2,7 +2,9 @@
 // OPERATIONAL-DEPTH ATLAS verifier (#68) — the committed atlas
 // (application-operational-depth.json) is honest and agrees with the live registry, and the
 // operational-state gate cannot be inflated:
-//   1. MEMBERSHIP — the atlas covers EXACTLY the 14 registry surfaces; each row's route + current
+//   1. MEMBERSHIP — the atlas is a SUBSET of the registry with an ASSERTED COMPLEMENT: every atlas
+//      row names a live registry surface, every registry surface outside the atlas is NAMED
+//      reference-less, and a stale name in that list is red. Each audited row's route + current
 //      classification equals the registry's, so the atlas can never drift from the code.
 //   2. TAXONOMY — every reference control carries exactly one of the six operational-depth
 //      outcomes; disabled_missing_authority / unsupported_reference_session / reference_data_only
@@ -18,11 +20,12 @@
 //      - read_only_by_contract ⇒ zero mutation actions AND every reference mutation classified
 //        unsupported_reference_session / reference_data_only (outside the product contract, not
 //        merely unwired). [none today — guard is live for future rows.]
-//      - browse / inspect ⇒ no receipted mutation actions bound.
+//      - browse / inspect ⇒ no receipted mutation REACHABLE beneath that mount (resolved through
+//        the serve layer's own `boundActionRoute`, because one module may serve several mounts).
 //   5. NAMED CONTROLS — the positive + act controls are pinned: pipeline=workflow_complete,
 //      schema+approvals=act, and the NEGATIVE CONTROL — a browse-only surface promoted to a
 //      higher state makes the registry invariant THROW (the gate refuses an inflated status).
-//   6. SINGLE RAIL — all 14 stay native_single_rail; existing certs unaffected.
+//   6. SINGLE RAIL — every registry surface stays native_single_rail; existing certs unaffected.
 //   7. SEQUENCE SUPERSESSION (#70 canon convergence) — the atlas is immutable AUDIT EVIDENCE:
 //      the 5-factor scoring evidence is intact, but NO active PR-numbered surface queue exists
 //      (no `queue`, no `pr` assignments, no `estate-closure`); the ranking declares
@@ -33,13 +36,21 @@
 //      (a verdict plane behind `Finding`, precedent substrates classified `partial`,
 //      merged work described as held or unlanded) are guarded against returning.
 //
+// REPAIRED BY NEXT-LEGS XIII. This file CRASHED on the committed tree and was CI-gated by nothing —
+// a check that cannot run gates nothing and may not pretend to, and an ungated ledger is worse than
+// no ledger because it looks like evidence. Its premise (atlas == registry) was true when written
+// and structurally false once the registry grew past the reference product's fourteen surfaces; the
+// crash was `rows[s.slug]` returning undefined for a surface added long after the atlas froze. It is
+// now under `check:verifier-floors` and runs in CI, so the depth ledger finally has a machine guard.
+//
 // Usage: node apps/hypervisor/scripts/verify-hypervisor-operational-depth.mjs
 import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { SURFACES, OPERATIONAL_STATES, CAPABILITIES, boundSurface } from "./surface-registry.mjs";
+import { SURFACES, OPERATIONAL_STATES, CAPABILITIES, boundSurface, boundActionRoute } from "./surface-registry.mjs";
 import { evolveRanking } from "./build-operational-depth-atlas.mjs";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const APP = join(HERE, "..");
@@ -59,24 +70,146 @@ function hasReceiptedMutation(slug) {
   return impl.actions.some((a) => a.method && a.method !== "GET" && a.authority && a.receipt);
 }
 
+// What is actually REACHABLE at this mount, resolved through the same `boundActionRoute` the serve
+// layer dispatches with — not through the module's action list.
+//
+// THE TWO ARE DIFFERENT WHENEVER ONE MODULE SERVES SEVERAL MOUNTS, and the difference is what the
+// read-tier assertion below is really about. `hasReceiptedMutation` answers "does the module bound
+// here declare a mutation anywhere", which for `packages-marketplace` and `work` is TRUE because
+// their sibling `act` mounts share the module. The honest question for a read-tier row is whether a
+// mutation can be POSTED BENEATH ITS OWN ROUTE, and only the resolver can answer that.
+function declaredReceiptedMutations(slug) {
+  const s = SURFACES.find((x) => x.slug === slug);
+  const impl = boundSurface(s.route, "GET")?.impl;
+  return (impl && Array.isArray(impl.actions) ? impl.actions : []).filter((a) => a.method && a.method !== "GET" && a.authority && a.receipt);
+}
+
+function reachableReceiptedMutations(slug) {
+  const s = SURFACES.find((x) => x.slug === slug);
+  const declared = declaredReceiptedMutations(slug);
+  return declared.filter((a) => {
+    const concrete = `${s.route}${String(a.route || "").replace(/:[^/]+/gu, "probe")}`;
+    const resolved = boundActionRoute(concrete, a.method);
+    return Boolean(resolved) && resolved.surface.slug === slug;
+  }).map((a) => a.id || a.route);
+}
+
 async function run() {
   const atlas = JSON.parse(readFileSync(join(APP, "application-operational-depth.json"), "utf8"));
   const rows = atlas.surfaces || {};
   const rank = atlas.ranking || {};
 
-  // 1. MEMBERSHIP.
+  // 1. MEMBERSHIP — AS A SUBSET WITH AN ASSERTED COMPLEMENT, not as an equality.
+  //
+  // THE FALSE PREMISE THIS VERIFIER WAS BUILT ON, and the reason it CRASHED on the committed tree
+  // for months while gating nothing: it asserted the atlas covers EXACTLY the registry. That was
+  // true at `19d732ff2` and is structurally false now. The atlas is FROZEN AUDIT EVIDENCE of the
+  // REFERENCE product's fourteen T3 surfaces; the registry has since grown to twenty-five, because
+  // IOI-native surfaces exist that have no reference counterpart and never will. An atlas row is
+  // owed for a surface the reference product had — not for every surface this product grows.
+  //
+  // So the honest shape is a SUBSET plus a NAMED COMPLEMENT, asserted in both directions: every
+  // atlas slug must still be a live registry surface, every registry surface outside the atlas must
+  // be named here, and a stale name is RED. A new surface therefore cannot land UNCLASSIFIED.
+  //
+  // WHAT THIS DOES NOT DO, stated because an earlier revision claimed it and a review demonstrated
+  // otherwise: it does NOT stop the list absorbing a surface that has reference evidence. The class
+  // check below is binary — the ledger can contradict a `greenfield` claim, and does — but
+  // `post-atlas` means only "the ledger does not say greenfield", the slug is never related to its
+  // `provenance_id`, and a new row can still be waved through by naming any non-greenfield ledger
+  // id. That is a NAMED RESIDUAL of this gate, not a property of it.
+  // EACH ENTRY'S CLASS IS DERIVED FROM THE TRACKED PROVENANCE LEDGER, not asserted here.
+  //
+  // The first revision of this list was a self-declared allowlist and a review demonstrated exactly
+  // what that is worth: adding one line let a brand-new registry row pass unexamined, and EIGHT of
+  // the eleven entries were contradicted by `seed-ux-provenance.v1.json`. `packages` was labelled
+  // "greenfield-authorized-non-parity" while the ledger records it
+  // `provenance-qualified-executable-seed-present` with `greenfield_authorization: null` — a false
+  // claim inside a gate whose whole subject is false claims.
+  //
+  // A registry slug outside the atlas is one of exactly two things, and the ledger decides which:
+  // GREENFIELD (no valid seed exists and an owner authorized the non-parity lane), or POST-ATLAS (a
+  // surface with real seed provenance whose registry row was created after the atlas froze at
+  // `19d732ff2`). Neither is "IOI-native with no reference counterpart", which is what the list used
+  // to say about surfaces that demonstrably have one.
+  const REFERENCELESS_SURFACES = {
+    home: { provenance_id: "home", class: "greenfield" },
+    systems: { provenance_id: "systems", class: "greenfield" },
+    applications: { provenance_id: "applications", class: "greenfield" },
+    packages: { provenance_id: "packages", class: "post-atlas" },
+    "packages-marketplace": { provenance_id: "packages", class: "post-atlas" },
+    automations: { provenance_id: "automations", class: "post-atlas" },
+    operations: { provenance_id: "operations", class: "post-atlas" },
+    work: { provenance_id: "work", class: "post-atlas" },
+    "work-sessions": { provenance_id: "work", class: "post-atlas" },
+    "work-new-session": { provenance_id: "work", class: "post-atlas" },
+    "studio-home": { provenance_id: "studio", class: "post-atlas" },
+  };
+  const provenance = JSON.parse(readFileSync(join(APP, "seed-ux-provenance.v1.json"), "utf8"));
+  const provenanceById = new Map((provenance.surfaces || []).map((record) => [record.id, record]));
   const atlasSlugs = Object.keys(rows).sort();
-  const regSlugs = SURFACES.map((s) => s.slug).sort();
-  ok("atlas covers EXACTLY the 14 registry surfaces (no extra, none missing)", JSON.stringify(atlasSlugs) === JSON.stringify(regSlugs), `atlas ${atlasSlugs.length} / registry ${regSlugs.length}`);
-  for (const s of SURFACES) {
-    const r = rows[s.slug];
-    if (!r) { ok(`${s.slug}: atlas row present`, false); continue; }
+  // THE TEST-ONLY FAULT ROW IS NOT PART OF THE PRODUCT PARTITION. It exists only behind
+  // `IOI_APP_RUNTIME_TEST_ROUTE=1`, to give the action-runtime verifier a module whose action throws
+  // and one that returns success without a receipt. Excluding it is stated and asserted rather than
+  // filtered silently, and the assertion is deterministic either way so the floor pin does not move
+  // with the flag.
+  const TEST_ONLY_SLUG = "__test_action";
+  const testRow = SURFACES.find((s) => s.slug === TEST_ONLY_SLUG);
+  ok("the test-only fault surface exists ONLY behind its runtime-test flag, and is excluded from the product partition by name",
+    Boolean(testRow) === (process.env.IOI_APP_RUNTIME_TEST_ROUTE === "1"),
+    testRow ? `present (flag ${process.env.IOI_APP_RUNTIME_TEST_ROUTE})` : "absent");
+  const regSlugs = SURFACES.map((s) => s.slug).filter((slug) => slug !== TEST_ONLY_SLUG).sort();
+  // AND ITS DECLARED TIER IS PINNED FROM THE SOURCE, deterministically, whether or not the flag is
+  // set in this process. The tier gate only dispatches acting rows, so declaring this row `browse`
+  // silently kills the estate's ONLY proof of route-local containment and receipt-fail-closed —
+  // both POSTs fall through to the SPA catch-all as 200 — and `verify-hypervisor-action-runtime.mjs`
+  // has no npm script, no CI job and no floor row to notice. Reading the row literal is what makes
+  // that regression visible from a gate that does run.
+  const registrySource = readFileSync(join(HERE, "surface-registry.mjs"), "utf8");
+  const testRowLiteral = registrySource.split(`slug: "${TEST_ONLY_SLUG}"`)[1]?.split("});")[0] ?? "";
+  ok("the test-only fault surface is declared ACTING in the registry source — declared read-tier, the tier gate stops dispatching its actions and the action-runtime proof dies silently",
+    /operational_state: "act"/u.test(testRowLiteral),
+    testRowLiteral.match(/operational_state: "[a-z_]+"/u)?.[0] ?? "ROW LITERAL NOT FOUND");
+  const orphanAtlasRows = atlasSlugs.filter((slug) => !regSlugs.includes(slug));
+  ok("every ATLAS row names a live registry surface — the atlas cannot describe a surface the product does not have",
+    orphanAtlasRows.length === 0, orphanAtlasRows.join(",") || `${atlasSlugs.length} atlas rows`);
+  const unclassified = regSlugs.filter((slug) => !atlasSlugs.includes(slug) && !REFERENCELESS_SURFACES[slug]);
+  ok("every REGISTRY surface is either carried by the atlas or NAMED reference-less — a new surface cannot land unclassified",
+    unclassified.length === 0, unclassified.join(",") || `${atlasSlugs.length} audited + ${Object.keys(REFERENCELESS_SURFACES).length} reference-less = ${regSlugs.length}`);
+  const staleReferenceless = Object.keys(REFERENCELESS_SURFACES).filter((slug) => !regSlugs.includes(slug) || atlasSlugs.includes(slug));
+  ok("and the reference-less list carries NO stale or overlapping entry — a list that can name a surface the registry lacks, or one the atlas audits, is a list that absorbs coverage",
+    staleReferenceless.length === 0, staleReferenceless.join(",") || `${Object.keys(REFERENCELESS_SURFACES).length} named reference-less`);
+  // THE CLASS CLAIM IS CHECKED AGAINST THE LEDGER, so the list cannot absorb a surface by labelling
+  // it something the estate's own provenance record contradicts.
+  // THE CLASS VOCABULARY IS CLOSED. It was a free string: any value other than the literal
+  // "greenfield" — a typo, `post_atlas`, or the key omitted entirely — silently took the weakest
+  // classification with no gate noise, while the comment above implied `post-atlas` was a recognized
+  // value. It was recognized by nothing. That is this gate's own subject at small scale.
+  const CLASSES = ["greenfield", "post-atlas"];
+  const misclassified = Object.entries(REFERENCELESS_SURFACES).filter(([, entry]) => {
+    if (!CLASSES.includes(entry.class)) return true;
+    const record = provenanceById.get(entry.provenance_id);
+    if (!record) return true;
+    const greenfield = record.baseline_status === "blocked-no-valid-seed" && Boolean(record.greenfield_authorization);
+    return entry.class === "greenfield" ? !greenfield : greenfield;
+  });
+  ok("every reference-less entry names a CLASS from the closed vocabulary and that class agrees with the tracked seed-provenance ledger — greenfield means the ledger says no valid seed and an owner authorized the lane, and nothing else may claim it",
+    misclassified.length === 0,
+    misclassified.map(([slug, entry]) => `${slug}:${entry.class}`).join(", ") || `${Object.keys(REFERENCELESS_SURFACES).length} classified against the ledger`);
+
+  // THE JOIN. Every per-surface loop below walks this, so a missing atlas row is a CLASSIFIED FACT
+  // rather than a TypeError. The crash that made this file gate nothing was `rows[s.slug]` returning
+  // undefined for `applications` — a `read_only_by_contract` registry surface added long after the
+  // atlas froze — and a verifier that cannot run is a false green, not a passing check.
+  const audited = SURFACES.filter((s) => rows[s.slug]).map((s) => ({ surface: s, row: rows[s.slug] }));
+  ok("PRECONDITION: the join is non-empty and covers every atlas row, so the assertions below are actually exercised",
+    audited.length === atlasSlugs.length && audited.length > 0, `${audited.length} joined`);
+  for (const { surface: s, row: r } of audited) {
     ok(`${s.slug}: atlas route + classification equal the live registry (atlas cannot drift from code)`, r.ioi_route === s.route && r.current && r.current.operational_state === s.operational_state && JSON.stringify((r.current.capabilities || []).slice().sort()) === JSON.stringify(s.capabilities.slice().sort()), `${r.current && r.current.operational_state} vs ${s.operational_state}`);
   }
 
   // 2. TAXONOMY + 3. NO INVENTED CONTROLS.
-  for (const s of SURFACES) {
-    const r = rows[s.slug]; if (!r) continue;
+  for (const { surface: s, row: r } of audited) {
     const census = r.reference_control_census || [];
     const ids = census.map((c) => c.id);
     const uniqueIds = new Set(ids).size === ids.length;
@@ -99,19 +232,60 @@ async function run() {
   }
 
   // 4. STATE INVARIANTS — checked against the LIVE module.
-  for (const s of SURFACES) {
+  //
+  // The act/browse/inspect invariants bind EVERY registry surface, audited or not: they are read off
+  // the live module and need no atlas row. The read_only_by_contract invariant needs the reference
+  // census, so it binds the audited join — and a reference-less surface in that state is asserted
+  // separately rather than silently skipped, which is how `applications` crashed this file.
+  for (const s of SURFACES.filter((x) => x.slug !== TEST_ONLY_SLUG)) {
     if (s.operational_state === "act" || s.operational_state === "workflow_complete") {
-      ok(`${s.slug} (${s.operational_state}): the LIVE bound module declares ≥1 receipted mutation action`, hasReceiptedMutation(s.slug));
+      // BOTH halves, and the second is what keeps the read-tier gate honest: if the tier gate ever
+      // stopped resolving action routes at all, every read-tier assertion above would pass
+      // VACUOUSLY while the product's own mutations went unreachable. An acting row must therefore
+      // prove its mutations are reachable, not merely declared.
+      const reachable = reachableReceiptedMutations(s.slug);
+      const declared = declaredReceiptedMutations(s.slug);
+      // EQUALITY, NOT `> 0`. If seven of pipeline's eight receipted mutations became unreachable, a
+      // `> 0` check still passes — and the partial disarm is exactly what this assertion exists to
+      // catch, since a tier gate that half-works would leave every read-tier claim below passing
+      // vacuously.
+      ok(`${s.slug} (${s.operational_state}): EVERY receipted mutation the live bound module declares is REACHABLE beneath this mount`,
+        declared.length > 0 && reachable.length === declared.length,
+        `${reachable.length}/${declared.length} reachable`);
     }
     if (["browse", "inspect", "shell"].includes(s.operational_state)) {
-      ok(`${s.slug} (${s.operational_state}): NO receipted mutation is bound (read-tier honesty)`, !hasReceiptedMutation(s.slug));
-    }
-    if (s.operational_state === "read_only_by_contract") {
-      const r = rows[s.slug];
-      const refMut = (r.reference_control_census || []).filter((c) => /governed_receipted_action|create|edit|delete|run|execute|author/i.test(`${c.outcome} ${c.label} ${c.reference}`));
-      ok(`${s.slug} (read_only_by_contract): every reference mutation is explicitly OUTSIDE the product contract`, !hasReceiptedMutation(s.slug) && refMut.every((c) => ["unsupported_reference_session", "reference_data_only"].includes(c.outcome)));
+      // THE LABEL SAYS WHAT THE CHECK MEASURES, and no more. This resolves through the serve
+      // layer's own `boundActionRoute`, so it covers the MODULE ACTION RUNTIME beneath this mount —
+      // which is what the tier gate governs and where `packages-marketplace` and `work` were
+      // exposing their siblings' mutations. It says NOTHING about the flat legacy serve branches:
+      // a review demonstrated that `listings`, a `browse` row, still has real mutations reachable
+      // at `/__ioi/marketplace/listings/:id/{delete,candidates,offers}` through
+      // `serve-product-ui.mjs`'s own handlers, which no module registry governs. That is a NAMED
+      // RESIDUAL of this gate, recorded here rather than hidden behind a broader-sounding label.
+      // Two further limits, stated for the same reason: the probe resolves by SURFACE OWNERSHIP
+      // (`resolved.surface.slug === slug`), not by path containment, so an acting surface whose route
+      // were a strict prefix of a read-tier one could dispatch beneath that path with this still
+      // green — no such pair exists today and none was constructible. And the filter requires BOTH
+      // `authority` and `receipt`, so an action declaring only one of them, or neither, is outside
+      // what this measures.
+      const reachable = reachableReceiptedMutations(s.slug);
+      const declared = declaredReceiptedMutations(s.slug);
+      ok(`${s.slug} (${s.operational_state}): the action runtime resolves no RECEIPTED module action to THIS SURFACE (ownership, not path containment; flat serve branches and actions lacking authority or receipt are named residuals)`,
+        reachable.length === 0,
+        reachable.join(",") || (declared.length ? `${declared.length} declared, 0 reachable` : "no bound module"));
     }
   }
+  for (const { surface: s, row: r } of audited) {
+    if (s.operational_state !== "read_only_by_contract") continue;
+    const refMut = (r.reference_control_census || []).filter((c) => /governed_receipted_action|create|edit|delete|run|execute|author/i.test(`${c.outcome} ${c.label} ${c.reference}`));
+    ok(`${s.slug} (read_only_by_contract): every reference mutation is explicitly OUTSIDE the product contract`, reachableReceiptedMutations(s.slug).length === 0 && refMut.every((c) => ["unsupported_reference_session", "reference_data_only"].includes(c.outcome)));
+  }
+  // A reference-less surface has no census to measure "outside the product contract" against, so the
+  // only honest claim is the live-module one. Stated as its own assertion so the absence is visible.
+  const referencelessReadOnly = SURFACES.filter((s) => s.slug !== TEST_ONLY_SLUG && s.operational_state === "read_only_by_contract" && !rows[s.slug]);
+  ok("reference-less read_only_by_contract surfaces expose NO reachable receipted mutation — the half of the invariant that needs no reference census still holds",
+    referencelessReadOnly.every((s) => reachableReceiptedMutations(s.slug).length === 0),
+    referencelessReadOnly.map((s) => s.slug).join(",") || "none");
 
   // workflow_complete ⇒ the intent-to-durable-result journey proof exists.
   const pl = SURFACES.find((s) => s.slug === "pipeline");
@@ -137,14 +311,17 @@ async function run() {
   }
 
   // 6. SINGLE RAIL + capability vocab.
-  ok("all 14 surfaces retain native_single_rail (container contract intact)", SURFACES.every((s) => s.embedded_shell_state === "native_single_rail"));
+  ok("every registry surface retains native_single_rail (container contract intact)", SURFACES.every((s) => s.embedded_shell_state === "native_single_rail"), `${SURFACES.length} surfaces`);
   ok("every atlas capability is a member of the registry capability vocabulary", Object.values(rows).every((r) => (r.current.capabilities || []).every((c) => CAPABILITIES.includes(c))));
   ok("every atlas operational_state is a member of the registry state vocabulary", Object.values(rows).every((r) => OPERATIONAL_STATES.includes(r.current.operational_state)));
 
   // 7. SEQUENCE SUPERSESSION — audit evidence intact; the active queue is retired; the canon
   // (canon-to-code-delta.md) owns what happens next.
   const FACTORS = ["existing_authority_available", "user_workflow_value", "cross_application_leverage", "missing_contract_cost", "authority_security_risk"];
-  const unfinished = SURFACES.filter((s) => !["workflow_complete", "act", "read_only_by_contract"].includes(s.operational_state)).map((s) => s.slug);
+  // The backlog join is over the AUDITED surfaces only. The canon's deferred UX backlog is the
+  // reference-product queue; a reference-less IOI-native surface has no row there and never had one,
+  // so including it would make this assertion demand a row that must not exist.
+  const unfinished = audited.map(({ surface }) => surface).filter((s) => !["workflow_complete", "act", "read_only_by_contract"].includes(s.operational_state)).map((s) => s.slug);
   ok("scoring EVIDENCE preserved: every audited surface scored on all 5 factors", Array.isArray(rank.scored) && rank.scored.length >= 10 && rank.scored.every((e) => FACTORS.every((f) => Number.isInteger(e.ranking_inputs && e.ranking_inputs[f]))));
   ok("NO ACTIVE SURFACE QUEUE exists: no `queue` field, no PR-number assignments, no estate-closure terminal entry", !("queue" in rank) && !JSON.stringify(rank).includes("estate-closure") && (rank.evidence_order || []).every((e) => !("pr" in e)) && (rank.scored || []).every((e) => !("pr" in e)), `${(rank.evidence_order || []).length} evidence-ranked surfaces`);
   ok("the atlas DECLARES its implementation sequence superseded by the canon", rank.implementation_sequence_status === "superseded_by_canon" && String(rank.superseded_by || "").includes("docs/architecture/_meta/canon-to-code-delta.md") && /audit evidence/i.test(rank.sequence_note || ""));
@@ -170,13 +347,59 @@ async function run() {
   // FALSE-CLAIM GUARDS: merged build-step-3 objects must remain honestly partial, while unrelated
   // precedent-only rows must never be promoted by proximity.
   const row = (name) => (deltaDoc.split("\n").find((l) => l.startsWith(`| \`${name}\` |`)) || "");
-  ok("`Attempt` and `Finding` rows record merged hosted lifecycles without inventing acceptance, verdict, or execution authority",
-    [row("Attempt"), row("Finding")].every((record) => record.includes("partial and merged"))
-      && row("Attempt").includes("execution authority")
-      && /acceptance\/verdict|acceptance and verdict/.test(row("Finding")));
-  ok("`VerifierChallenge` row records merged lifecycle while keeping acceptance, verdict, settlement, execution, and federation unavailable",
-    row("VerifierChallenge").includes("partial and merged")
-      && ["acceptance", "verdict", "settlement", "execution", "federation"].every((term) => row("VerifierChallenge").includes(term)));
+  // RE-DERIVED AGAINST THE LEDGER AS IT IS, not as the drifted guard remembered it. These three
+  // guards were written against wording ("partial and merged") that a later canon pass replaced, and
+  // because this verifier crashed before reaching them nothing noticed: two assertions that could
+  // only ever fail, sitting in a file that never ran. What they were built to prevent has not
+  // changed — these rows must never quietly claim a CURRENT v2 producer, lifecycle, verdict or
+  // execution authority exists — so the guard is rewritten against the text that is actually there.
+  const NOT_STARTED = /current executable lifecycle not started/;
+  const NO_CURRENT_PRODUCER = (name) => new RegExp(`no current v2 room ${name} producer or lifecycle exists`);
+  const FENCED = /generation-fenced from current v2 rooms/;
+  for (const name of ["Attempt", "Finding"]) {
+    ok(`\`${name}\` row records the PREDECESSOR lifecycle as generation-fenced history and claims no current v2 producer, lifecycle, or execution authority`,
+      NO_CURRENT_PRODUCER(name).test(row(name)) && NOT_STARTED.test(row(name)) && FENCED.test(row(name))
+        && /predecessor/.test(row(name)) && !/current executable lifecycle (partial|complete|shipped)/.test(row(name)),
+      row(name) ? "row present" : "ROW MISSING");
+  }
+  ok("`VerifierChallenge` row records the predecessor lifecycle as generation-fenced history AND keeps verdict, acceptance, settlement and federation with their later owners",
+    NO_CURRENT_PRODUCER("VerifierChallenge").test(row("VerifierChallenge"))
+      && NOT_STARTED.test(row("VerifierChallenge"))
+      && FENCED.test(row("VerifierChallenge"))
+      && /keep verdict, acceptance, settlement, and federation with their later owners/.test(row("VerifierChallenge")),
+    row("VerifierChallenge") ? "row present" : "ROW MISSING");
+
+  // AND THE OTHER DIRECTION, which is the one that matters. Every guard above is a
+  // presence-of-phrase conjunction, and a review demonstrated that all three are BLIND to a false
+  // claim ADDED beside the honest wording: a row asserting "a current v2 room Attempt lifecycle is
+  // now SHIPPED and executable" passed every one of them, because the honest phrase was still
+  // there too. Deleting honest wording and adding a false claim are different attacks and need
+  // different guards.
+  // Each pattern was validated BOTH WAYS before landing: zero hits on the three real rows, and at
+  // least one hit on every added-claim mutation the review demonstrated (execution-authority-live,
+  // shape-complete, acceptance/verdict-shipped, lifecycle-now-shipped, settlement/federation-live).
+  // The deletion attack stays with the presence guards above — the two are different attacks.
+  //
+  // IT IS A DENYLIST, and this estate already names denylist scans a decorative-assertion class. A
+  // later review wrote eighteen further false claims that pass it — "in production", "generally
+  // available", "no longer fenced", past and present-perfect tenses, and the same claim relocated to
+  // another column. The label says what it bounds; making this a real property check means a
+  // positive shape for the row, which is a canon change, not a regex.
+  const PROMOTION_CLAIMS = [
+    /current v2 [^|]{0,80}?\b(is|are) (now )?(shipped|live|executable|admitted)\b/i,
+    /\b(lifecycle|producer|plane) (is|are) (now )?(shipped|live|executable|admitted)\b/i,
+    /current contract shape (complete|shipped|done)/i,
+    /current executable lifecycle (complete|shipped|started|live)/i,
+    /\b(execution authority|acceptance|verdict|settlement|federation)\b[^|]{0,80}?\b(is|are) (live|shipped|available|admitted)\b/i,
+    /\bmutators accept writes\b/i,
+    /\bshipped behind\b/i,
+  ];
+  for (const name of ["Attempt", "Finding", "VerifierChallenge"]) {
+    const promoted = PROMOTION_CLAIMS.filter((pattern) => pattern.test(row(name)));
+    ok(`\`${name}\` row carries none of the DEMONSTRATED promotion phrasings — a denylist, so it bounds a known attack rather than proving the row honest`,
+      row(name).length > 0 && promoted.length === 0,
+      promoted.map(String).join(" | ") || "no promotion language");
+  }
   for (const obj of ["OntologyVersion", "SemanticMappingDecision", "ProvenanceAssertion"]) {
     ok(`\`${obj}\` row: not started with an explicitly LABELED implementation precedent (a precedent is never partial)`, row(obj).includes("not started") && !/\| partial/.test(row(obj)) && /implementation precedent/i.test(row(obj)));
   }
@@ -221,9 +444,15 @@ run().then(() => {
   const fails = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
   console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "operational-depth", sourceUrl: import.meta.url, results });
   if (fails.length) process.exit(1);
   console.log("operational-depth atlas: OK");
 }).catch((e) => {
+  // NO CENSUS ON A CRASH. `check:verifier-floors` reads a missing census as RED, which is the correct
+  // reading of a run that did not finish — and it is exactly what this file needed for the months it
+  // crashed on the committed tree while nothing noticed.
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.filter((r) => r.pass).length}/${results.length} passed BEFORE THE RUN DIED (incomplete — no census emitted)`);
   console.error("verifier crashed:", e);
   process.exit(1);
 });

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -139,6 +139,13 @@
       "assertion_names_sha256": "d20a083ad9bdcaaa8aa20b1a334a22c6179316dc296676fa2465472319dd404a"
     },
     {
+      "id": "operational-depth",
+      "npm_script": "check:operational-depth",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-operational-depth.mjs",
+      "runtime_assertions": 136,
+      "assertion_names_sha256": "954c4f5589e82757ee9d7ca28b5b37542034f18c64e145609b7946b16346e5bd"
+    },
+    {
       "id": "ported-seed",
       "npm_script": "check:ported-seed",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ported-seed-invariant.mjs",


### PR DESCRIPTION
**Next-legs XIII, Leg 2 of 4.** `verify-hypervisor-operational-depth.mjs` **crashed on the committed tree and was CI-gated by nothing.**

A check that cannot run gates nothing and may not pretend to; an ungated ledger is worse than no ledger, because it looks like evidence. Its premise — that the atlas covers EXACTLY the registry — was true at `19d732ff2` and became structurally false once the registry grew from fourteen surfaces to twenty-five.

**Ruled REPAIR, not delete (owner, owner-reversible).** The atlas is the frozen reference-control census that `definition-of-done.md` G-1 names and next-legs XII edited; deleting it destroys tracked audit evidence the surface legs still reconcile against. Membership is now a **SUBSET with a NAMED COMPLEMENT** whose class is derived-checked against `seed-ux-provenance.v1.json`, and every per-surface loop walks a JOIN, so a missing row is a classified fact rather than a TypeError.

**On its first honest run it caught a real estate defect.** `boundActionRoute` matched beneath EVERY row bound to a module, and one module serves several mounts — so `packages-marketplace` (declared `browse`) exposed all five of its module's actions: `admit-candidate`, `cut-release`, `recall-release`, `install-release`, `uninstall`; and `work` (declared `inspect`) exposed `create-session` and the launch verbs. **A row's declared tier now gates its action routes.**

**Evidence.** **136/136**, identical with and without `IOI_APP_RUNTIME_TEST_ROUTE` (same assertion-names digest), floored in-commit (20 → 21 verifiers) and wired into CI. **Thirteen mutations RED-ON-TARGET** (a count this repository does not track — a commit claim, not gate output), every one against an artifact the gate certifies — registry, atlas, canon ledger, action resolver — never against its own assertions. `check:packages-journey` 49/49, `check:work-cockpit` 51/51, `check:launch-chain` 53/53.

**Named residuals.** `verify-hypervisor-action-runtime.mjs` has no npm script, no CI job and no floor row, so the estate's proof of MODULE-ACTION containment and receipt-fail-closed is ungated — the repaired depth gate pins the one registry row that proof depends on, which is a guard, not a substitute. The flat serve branches beneath read-tier mounts are governed by no module registry: `listings`, a `browse` row, really does have five reachable mutations. A POST to a now-forbidden action route answers 200 from the SPA catch-all rather than a typed refusal. The reference-less list catches a false `greenfield` claim, but `post-atlas` means only "not greenfield", so it remains an allowlist wearing a derivation; the promotion-claim guard is a DENYLIST and is labelled as one.

Rebuilt onto the post-#286 master by cherry-pick, verified byte-for-byte against the reviewed tree, floors pin re-derived from a fresh RUNTIME census.

🤖 Generated with [Claude Code](https://claude.com/claude-code)