### PR TITLE
feat(odk): the three ontology journeys ACC-A names get a backend — proposals, saved sets, and object-instance search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,7 @@ jobs:
           npm run check:backup-restore --workspace=@ioi/hypervisor-app
           npm run check:environment-custody --workspace=@ioi/hypervisor-app
           npm run check:operational-depth --workspace=@ioi/hypervisor-app
+          npm run check:ontology-backend-families --workspace=@ioi/hypervisor-app
 
       # The floor the verifier family never had. Every verifier above is pinned at the number of
       # assertions it actually EXECUTED; deleting assertions from any of them was silently green

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -30,6 +30,7 @@
     "check:backup-restore": "node scripts/verify-hypervisor-backup-restore.mjs",
     "check:environment-custody": "node scripts/verify-hypervisor-environment-custody.mjs",
     "check:operational-depth": "node scripts/verify-hypervisor-operational-depth.mjs",
+    "check:ontology-backend-families": "node scripts/verify-hypervisor-ontology-backend-families.mjs",
     "check:provider-transport": "node scripts/verify-hypervisor-provider-transport.mjs",
     "check:provider-transport:live": "node scripts/verify-hypervisor-provider-transport.mjs --live",
     "check:verifier-floors": "node scripts/check-verifier-floors.mjs",

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-backend-families.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-backend-families.mjs
@@ -1,0 +1,1183 @@
+#!/usr/bin/env node
+// The three ontology backend families ACC-A names — proposals, saved object sets, object-instance
+// search — driven end to end against a live daemon.
+//
+// WHY THIS EXISTS. Next-legs XII took SURF-ontology to 12 of 13 real governed controls and then said
+// plainly what still blocked closure: it was BACKEND. Derived from the router rather than guessed,
+// there was no ontology proposal/branch family, no saved object-set/exploration family, and no
+// object-instance search family, so three of the six journeys ACC-A names could not close at any
+// depth of UI work. This gate is the proof those three now exist as daemon truth.
+//
+// WHAT IT CHECKS, and why in this shape:
+//   - THE ABSENCE CLAIM IS RE-DERIVED FROM THE ROUTER, both directions: the three families are
+//     registered, and the daemon carries no SECOND writer for an ontology edit. A proposal apply
+//     that re-implemented validation or revision bumping would be a second admission path for one
+//     act, and that mistake has been made twice in this program.
+//   - EVERY MUTATION IS IDENTITY-FIRST. Rule E owes a 401 before a 404 that would otherwise answer
+//     "does this ontology exist" to a caller with no session. Anonymity is built from RAW TRANSPORT.
+//   - CAS IS PROVEN BY DRIFT, not by a happy path: a proposal made against revision N refuses after
+//     the ontology advances, and refuses having changed NOTHING.
+//   - SAVED SETS ARE PER PRINCIPAL, with three real principals all holding `org://local` — the
+//     precondition is asserted, because that tenant is held by everyone and isolates nothing.
+//   - THE TWO EMPTIES ARE DIFFERENT FACTS. "No materialized object set exists here" and "your query
+//     matched nothing" are distinguished, because a surface that cannot tell them apart shows an
+//     empty table and lets a user conclude the wrong one.
+//   - DURABLE TRUTH IS READ FROM DISK and survives a restart. Asking the API whether something
+//     happened is asking the thing under test to grade itself.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import crypto from "node:crypto";
+import http from "node:http";
+import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
+import { mintTestGrant } from "./lib/wallet-authority.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+const code = (j) => j?.code ?? j?.error?.code ?? "";
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const freePort = () => new Promise((resolve, reject) => {
+  const srv = net.createServer();
+  srv.listen(0, "127.0.0.1", () => { const { port } = srv.address(); srv.close(() => resolve(port)); });
+  srv.on("error", reject);
+});
+
+const waitFor = async (url, ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    try { const r = await fetch(url); if (r.status < 500) return; } catch { /* not up */ }
+    await sleep(300);
+  }
+  throw new Error(`timeout waiting for ${url}`);
+};
+
+const daemonBinary = path.resolve(ROOT, process.env.IOI_HYPERVISOR_DAEMON_BINARY ?? "target/debug/hypervisor-daemon");
+try { fs.accessSync(daemonBinary, fs.constants.X_OK); } catch {
+  console.error(`BLOCKED: daemon binary not executable at ${daemonBinary}`);
+  process.exit(2);
+}
+
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "ioi-onto-families-"));
+const dataDir = path.join(scratch, "data");
+fs.mkdirSync(dataDir, { recursive: true });
+
+let DAEMON = "";
+let daemon = null;
+let daemonLog = "";
+const P = { A: { session: "", owner: "", ref: "" }, B: { session: "", owner: "", ref: "" }, C: { session: "", owner: "", ref: "" } };
+
+// ------------------------------------------------------------ the ontology family, watched at RUNTIME
+//
+// THE ENTAILMENT FOR "NO SECOND ONTOLOGY WRITER", and the reason it is not a source census.
+// Five review rounds each defeated a source-derived census with a NEW spelling — a suffixed name, a
+// bare literal, a shadowing const, a raw `fs::write`, a `File::create`, a bare `use super::x;`, a
+// fn-pointer alias, a `use … as` alias, a writer parked on a line carrying a `://` literal so a
+// comment stripper ate it, and an allowlisted module's own exported writer. That is the signal: a
+// WHOLE-PROGRAM property cannot be entailed by regexes over one file, and every round of patching
+// left the label still claiming more than the code checked.
+//
+// So the load-bearing check is BEHAVIOURAL. `odk-domain-ontologies` is not a promoted family
+// (`PROMOTED_DOMAINS` is `["provider-receipts"]`), so its records are plain files. This fingerprints
+// that directory after EVERY request and records which requests changed it. No source spelling can
+// evade it: a second writer anywhere, reached by any name, moves the fingerprint under the request
+// that ran it.
+//
+// WHAT IT DOES NOT PROVE, and the label says so: it is a closed world over the routes THIS JOURNEY
+// DRIVES, not over all code. A route the journey never calls is not covered by it.
+// THIS WATCHES THE LEGACY RECORD DIRECTORY, AND THAT IS ONLY SOUND WHILE THE FAMILY IS NOT
+// PROMOTED. A mutation proved the hazard: `substrate_store::persist_promoted` admits into the
+// multiplexed substrate log at `<data_dir>/substrate/`, so a second writer reached that way would
+// change the ontology's durable truth while this directory sat still. Watching the substrate log
+// too is not the answer — it is shared storage, and `auth/bootstrap` and every scope pin churn it
+// for entirely legitimate reasons, so it reports noise rather than signal.
+//
+// So the PRECONDITION IS ASSERTED INSTEAD OF ASSUMED, below: `PROMOTED_DOMAINS` is pinned, and the
+// ontology family is not in it. Promote this family and that assertion goes red, which is the
+// correct outcome — this observation would need rebuilding against the substrate projection, and it
+// must not go on quietly watching a directory the writes no longer reach.
+const ONTOLOGY_FAMILY_DIR = "odk-domain-ontologies";
+// THE RECEIPT FAMILY IS WATCHED TOO. A review minted fabricated ontology-plane receipts on the
+// WITHDRAW requests — three receipts attesting patches that never happened — and the gate was 81/81,
+// because only the ontology record store was fingerprinted. A second admission path minting
+// ontology-plane RECEIPT truth is a second spine as surely as one minting records.
+const ONTOLOGY_RECEIPT_DIR = "odk-ontology-receipts";
+/** Every ontology record, keyed by id, with its content digest. Walks subdirectories. */
+// ONE READ PRODUCES BOTH THE DIGEST AND THE CONTENT. Taking the digest in one pass and the content
+// in a second left a window where a write landing between them yields a snapshot newer than the
+// digest that selected it.
+const familySnapshot = (rel) => {
+  const root = path.join(dataDir, rel);
+  const out = new Map();
+  const walk = (dir, prefix) => {
+    let entries = [];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      // RECURSE. A one-level read makes a subdirectory throw EISDIR and register as one constant
+      // string, so it is recorded once on creation and never again — a whole subtree that changes
+      // invisibly. Records are flat today; a check that only works while that holds is not a check.
+      if (entry.isDirectory()) { walk(full, `${prefix}${entry.name}/`); continue; }
+      let bytes;
+      try { bytes = fs.readFileSync(full); } catch { out.set(`${prefix}${entry.name}`, { digest: "<unreadable>", record: null }); continue; }
+      let record = null;
+      try { record = JSON.parse(bytes.toString("utf8")); } catch { record = null; }
+      out.set(`${prefix}${entry.name}`, { digest: crypto.createHash("sha256").update(bytes).digest("hex"), record });
+    }
+  };
+  walk(root, "");
+  return out;
+};
+const bothFamilies = () => ({ onto: familySnapshot(ONTOLOGY_FAMILY_DIR), receipts: familySnapshot(ONTOLOGY_RECEIPT_DIR) });
+let ontologyPrint = bothFamilies();
+/** Proposal id -> the `changes` object THE CALLER sent when creating it. Never read from a response. */
+const proposalIntent = new Map();
+/**
+ * Re-baseline the watch after THE CHECKER ITSELF writes a record.
+ *
+ * The observation attributes any change it sees to the request that just ran, which is exactly what
+ * makes it useful — and it means a fixture this file plants out of band would be blamed on the next
+ * request. That happened, and the gate caught it. A fixture is not a daemon write, so it is excluded
+ * EXPLICITLY and audibly here rather than by loosening the rule that noticed it.
+ */
+const resyncOntologyBaseline = () => { ontologyPrint = bothFamilies(); };
+/**
+ * Every request that left the ontology family different than it found it, with the EXACT set of
+ * records it changed and the status it answered.
+ *
+ * KEYED ON THE WRITE, NOT ON THE ROUTE. The first cut of this recorded only `METHOD path` and
+ * allowed three route SHAPES — and a review defeated it live at 78/78 by writing a second ontology
+ * record inside `handle_proposal_apply`, the one handler this gate exists to police. One extra
+ * write under an allowed name is indistinguishable from the allowed write when all you record is
+ * the name. Worse, the write it demonstrated rode a 409-REFUSED apply: a request that refused and
+ * still minted a record, with every assertion green. So what is recorded now is WHICH records moved
+ * and WHAT the request answered, and the assertions below are about the identity of the write.
+ */
+const ontologyMutations = [];
+
+/** `as: null` is ANONYMOUS, built from raw transport — no client object to copy, no bound method. */
+async function jd(method, p, body, { as = "A" } = {}) {
+  const session = as ? P[as].session : "";
+  const headers = {};
+  if (body !== undefined && body !== null) headers["content-type"] = "application/json";
+  if (session) headers.cookie = `ioi_session=${session}`;
+  return fetch(`${DAEMON}${p}`, {
+    method,
+    headers: Object.keys(headers).length ? headers : undefined,
+    body: body !== undefined && body !== null ? JSON.stringify(body) : undefined,
+  }).then(async (r) => {
+    const text = await r.text();
+    let j = null;
+    try { j = JSON.parse(text); } catch { /* non-json */ }
+    return { status: r.status, j, text };
+  }).catch((e) => ({ status: 0, j: { transport_error: String(e) }, text: String(e) })).then((out) => {
+    const before = ontologyPrint;
+    const after = bothFamilies();
+    const diff = (b, a) => {
+      const changed = [];
+      for (const [name, v] of a) if (b.get(name)?.digest !== v.digest) changed.push(name);
+      for (const name of b.keys()) if (!a.has(name)) changed.push(`${name}:REMOVED`);
+      return changed.sort();
+    };
+    const changed = diff(before.onto, after.onto);
+    const receiptsChanged = diff(before.receipts, after.receipts);
+    // THE CALLER'S OWN INTENT — the VALUE is the request's `changes`, which the daemon did not
+    // produce, and that is what makes the check below non-circular. The KEY is the response's
+    // proposal id, which the daemon DID produce; that is stated rather than glossed, and it fails
+    // closed — a key that does not match yields an empty intent and reddens every field.
+    const route = `${method} ${p.split("?")[0]}`;
+    if (/\/odk\/ontology-proposals$/u.test(route) && method === "POST" && out.j?.ontology_proposal?.id) {
+      proposalIntent.set(out.j.ontology_proposal.id, body?.changes ?? {});
+    }
+    if (changed.length || receiptsChanged.length) {
+      ontologyPrint = after;
+      ontologyMutations.push({
+        route, status: out.status, changed, receiptsChanged, body: out.j, request: body ?? null,
+        before: Object.fromEntries(changed.map((n) => [n, before.onto.get(n)?.record ?? null])),
+        after: Object.fromEntries(changed.map((n) => [n, after.onto.get(n)?.record ?? null])),
+        proposalId: /\/ontology-proposals\/([^/]+)\/apply$/u.exec(p)?.[1] ?? null,
+      });
+    }
+    return out;
+  });
+}
+
+function startDaemon(port) {
+  daemon = spawn(daemonBinary, [], {
+    cwd: ROOT,
+      env: {
+      ...process.env,
+      IOI_HYPERVISOR_DAEMON_ADDR: `127.0.0.1:${port}`,
+      IOI_HYPERVISOR_DATA_DIR: dataDir,
+      IOI_HYPERVISOR_MODEL_UPSTREAM: "http://127.0.0.1:1",
+      // The dev signer, so the two wallet crossings in the materialization ladder can be satisfied
+      // by this process. Without it the corpus below cannot be PRODUCT-PRODUCED, and a hand-written
+      // one would be exactly the fixture corpus this estate forbids a checker.
+      IOI_WALLET_TEST_SIGNER: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  daemon.stdout.on("data", (c) => { daemonLog = `${daemonLog}${c}`.slice(-64000); });
+  daemon.stderr.on("data", (c) => { daemonLog = `${daemonLog}${c}`.slice(-64000); });
+}
+const stopDaemon = () => { try { daemon?.kill("SIGTERM"); } catch { /* gone */ } daemon = null; };
+function cleanup() { stopDaemon(); try { fs.rmSync(scratch, { recursive: true, force: true }); } catch { /* best effort */ } }
+
+// ------------------------------------------------------------------- durable-truth readers
+const recordsIn = (dir) => { try { return fs.readdirSync(path.join(dataDir, dir)).filter((f) => f.endsWith(".json")).sort(); } catch { return []; } };
+const readRecord = (dir, id) => { try { return JSON.parse(fs.readFileSync(path.join(dataDir, dir, `${id}.json`), "utf8")); } catch { return null; } };
+
+// ------------------------------------------------------------------- the derived closed world
+const routerSource = () => fs.readFileSync(path.join(ROOT, "crates/node/src/bin/hypervisor-daemon.rs"), "utf8");
+
+/** Every route registered to the ontology-workbench module, with its methods. */
+const workbenchRoutes = () => {
+  const found = [];
+  for (const chunk of routerSource().split(".route(")) {
+    const pathMatch = chunk.match(/^\s*"(\/v1\/hypervisor\/[^"]*)"/u);
+    if (!pathMatch) continue;
+    const body = chunk.slice(0, chunk.indexOf("\n        )"));
+    if (!/ontology_workbench_routes::/u.test(body)) continue;
+    for (const method of ["get", "post", "patch", "put", "delete"]) {
+      if (new RegExp(`(^|[^a-z_])${method}\\(`, "u").test(body)) found.push({ method: method.toUpperCase(), path: pathMatch[1] });
+    }
+  }
+  return found;
+};
+
+async function run() {
+  const port = await freePort();
+  DAEMON = `http://127.0.0.1:${port}`;
+  startDaemon(port);
+  await waitFor(`${DAEMON}/healthz`, 30000);
+
+  // ------------------------------------------------------------ principals
+  const bootToken = daemonLog.match(/ioi_bootstrap_[a-f0-9]{64}/gu)?.at(-1) ?? null;
+  const boot = await jd("POST", "/v1/hypervisor/auth/bootstrap", { token: bootToken, password: "onto-families-a-v1" }, { as: null });
+  P.A.session = boot.j?.session_token ?? "";
+  const whoA = (await jd("GET", "/v1/hypervisor/auth/whoami", null, { as: "A" })).j || {};
+  P.A.owner = (whoA.principal?.tenant_refs || []).find((t) => t === "org://local") || "";
+  P.A.ref = whoA.principal?.principal_ref ?? "";
+  ok("principal A is a REAL authenticated operator session holding the deployment's org tenant",
+    whoA.authenticated === true && P.A.owner === "org://local", `authenticated ${whoA.authenticated} owner ${P.A.owner}`);
+
+  for (const letter of ["B", "C"]) {
+    const email = `onto-families-${letter.toLowerCase()}@ioi.local`;
+    const created = await jd("POST", "/v1/hypervisor/principals", { email, name: `Member ${letter}`, role: "member", password: `onto-families-${letter}-v1` }, { as: "A" });
+    const pid = created.j?.principal?.principal_id ?? "";
+    await jd("POST", `/v1/hypervisor/principals/${pid}/tenant-memberships`, {
+      tenant_ref: "org://local", expected_revision: 0, idempotency_key: `onto-families-grant-${letter}`,
+      reason: "verifier fixture: an ordinary member in the deployment's only organization",
+    }, { as: "A" });
+    const login = await jd("POST", "/v1/hypervisor/auth/login", { email, password: `onto-families-${letter}-v1` }, { as: null });
+    P[letter].session = login.j?.session_token ?? "";
+    const who = (await jd("GET", "/v1/hypervisor/auth/whoami", null, { as: letter })).j || {};
+    P[letter].owner = (who.principal?.tenant_refs || []).find((t) => t === "org://local") || "";
+    P[letter].ref = who.principal?.principal_ref ?? "";
+  }
+  ok("PRECONDITION: all three principals hold the SAME org tenant, so a tenant check would isolate NOTHING",
+    P.A.owner === "org://local" && P.B.owner === "org://local" && P.C.owner === "org://local"
+      && P.A.ref !== P.B.ref && P.B.ref !== P.C.ref, `${P.A.owner}/${P.B.owner}/${P.C.owner}`);
+
+  // ------------------------------------------------------------ the ontology under test
+  const created = await jd("POST", "/v1/hypervisor/odk/domain-ontologies", {
+    domain: "families", version: "1.0.0", description: "the ontology the three families operate on",
+    canonical_object_model: { object_types: [{ id: "widget", name: "Widget", properties: [] }], link_types: [], action_types: [], value_types: [] },
+  }, { as: "A" });
+  const ontologyId = created.j?.ontology?.id ?? "";
+  const ontologyRef = created.j?.ontology?.ref ?? "";
+  ok("PRECONDITION: a real domain ontology is admitted through the product's own route, at revision 1",
+    (created.status === 200 || created.status === 201) && ontologyId.length > 0 && (created.j?.ontology?.revision ?? 0) === 1,
+    `status ${created.status} id ${ontologyId} rev ${created.j?.ontology?.revision}`);
+
+  // ============================================================ FAMILY 1 — proposals
+  const anonPropose = await jd("POST", "/v1/hypervisor/odk/ontology-proposals", { ontology_ref: ontologyRef, title: "x", changes: { description: "y" } }, { as: null });
+  ok("PROPOSE refuses an ANONYMOUS caller — rule E owes a 401 before any record read",
+    anonPropose.status === 401, `status ${anonPropose.status}`);
+  ok("and the refused anonymous propose admitted NO proposal record",
+    recordsIn("odk-ontology-proposals").length === 0, `${recordsIn("odk-ontology-proposals").length} records`);
+
+  const emptyProposal = await jd("POST", "/v1/hypervisor/odk/ontology-proposals", { ontology_ref: ontologyRef, title: "empty", changes: {} }, { as: "A" });
+  ok("a proposal naming NO change is refused typed — an empty proposal proposes nothing",
+    emptyProposal.status === 400 && code(emptyProposal.j) === "ontology_proposal_change_required",
+    `status ${emptyProposal.status} code ${code(emptyProposal.j)}`);
+
+  const unknownOntology = await jd("POST", "/v1/hypervisor/odk/ontology-proposals", { ontology_ref: "domain-ontology://does-not-exist", title: "x", changes: { description: "y" } }, { as: "A" });
+  ok("a proposal against an ontology that does not resolve is refused typed, not silently accepted",
+    unknownOntology.status === 404 && code(unknownOntology.j) === "odk_ontology_not_found",
+    `status ${unknownOntology.status} code ${code(unknownOntology.j)}`);
+
+  const staleBase = await jd("POST", "/v1/hypervisor/odk/ontology-proposals", {
+    ontology_ref: ontologyRef, title: "stale base", expected_revision: 99, changes: { description: "z" },
+  }, { as: "A" });
+  ok("a proposal declaring the WRONG base revision is refused by the same CAS an ordinary edit obeys",
+    staleBase.status === 409 && code(staleBase.j) === "odk_revision_conflict",
+    `status ${staleBase.status} code ${code(staleBase.j)}`);
+
+
+  // PROPOSE AND PATCH MUST AGREE, AND ONLY A LIVE PROBE CAN SAY SO. The static assertions below pin
+  // that one validator exists and both planes call it; they cannot see a SECOND, hand-maintained
+  // pre-check disagreeing with it, which is exactly what a review found — `domain: null` refused at
+  // propose and was a 200 no-op at patch, and `canonical_object_model: null` did the reverse because
+  // the validator disagreed with ITSELF about whether a null is absent.
+  for (const [label, changes, expected] of [
+    // A null string field names nothing on either plane, so there is no shared refusal code to pin —
+    // parity carries that shape alone, and the exception is named where it is applied.
+    ["an explicit null string field", { domain: null }, null],
+    ["an explicit null object model", { canonical_object_model: null }, "odk_field_type_invalid"],
+    ["an empty required field", { domain: "" }, "odk_domain_required"],
+    // The emptiness check TRIMS, and that trim is load-bearing — the module says so itself. Nothing
+    // covered a whitespace-only value, so relaxing `value.trim().is_empty()` to `value.is_empty()`
+    // made `"   "` admissible on BOTH planes and stayed green.
+    ["a whitespace-only required field", { domain: "   " }, "odk_domain_required"],
+    // And the `domain` bound was exercised by nothing at all — raising it to 100000 was silent,
+    // while `version` and `description` were both pinned.
+    ["an over-length domain", { domain: "d".repeat(121) }, "odk_field_too_long"],
+    ["an over-length version", { version: "v".repeat(61) }, "odk_field_too_long"],
+    ["an over-length description", { description: "x".repeat(2001) }, "odk_field_too_long"],
+    ["a non-string field", { domain: 5 }, "odk_field_type_invalid"],
+    ["a model the ontology plane rejects", { canonical_object_model: { object_types: [{ id: "dup", name: "A", properties: [] }, { id: "dup", name: "B", properties: [] }], link_types: [], action_types: [], value_types: [] } }, "ontology_duplicate_id"],
+  ]) {
+    const fresh = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: `parity-${encodeURIComponent(label).slice(0, 12)}`, canonical_object_model: { object_types: [], link_types: [], action_types: [], value_types: [] } }, { as: "A" })).j?.ontology;
+    const patched = await jd("PATCH", `/v1/hypervisor/odk/domain-ontologies/${fresh?.id}`, { expected_revision: fresh?.revision, ...changes }, { as: "A" });
+    const proposed = await jd("POST", "/v1/hypervisor/odk/ontology-proposals", { ontology_ref: fresh?.ref, title: "parity", changes }, { as: "A" });
+    const patchCode = patched.j?.ok === true ? "ACCEPTED" : code(patched.j);
+    const proposeCode = proposed.status === 201 ? "ACCEPTED" : code(proposed.j);
+    // A null names nothing, so patch is a no-op while propose refuses "you proposed nothing" — the
+    // one difference that is a PROPOSAL rule rather than a validation rule, and it is named here
+    // rather than hidden behind a looser comparison.
+    const agree = patchCode === proposeCode
+      || (patchCode === "ACCEPTED" && proposeCode === "ontology_proposal_change_required");
+    ok(`propose and patch agree on ${label} — one validator means one verdict, and a second hand-maintained pre-check is exactly what disagrees`,
+      agree, `patch ${patchCode} / propose ${proposeCode}`);
+    // AND THE ABSOLUTE REFUSAL, because AGREEMENT ALONE IS BLIND BY CONSTRUCTION. A shared validator
+    // preserves parity under ANY weakening — a review deleted one guard key so an empty `domain`
+    // became admissible on BOTH planes, and this journey stayed 63/63 printing "ACCEPTED /
+    // ACCEPTED". Parity can only see a second, non-shared pre-check. What holds the contract is a
+    // per-shape assertion that the estate REFUSES, with the expected code named.
+    if (expected) {
+      // AND THE REFUSAL IS AN ABSENCE OF THE ACT, not a code in a body. A review noted this pinned
+      // the code and never the EFFECT: the writer answers 200 with `ok:false` for a validation
+      // refusal, so "REFUSE" meant only "emitted this string". The ontology is read back and its
+      // revision must be exactly the one the shape was made against — a refusal that still advanced
+      // the revision is not a refusal, whatever it says.
+      const after = await jd("GET", `/v1/hypervisor/odk/domain-ontologies/${fresh?.id}`, null, { as: "A" });
+      ok(`and BOTH planes REFUSE ${label} with \`${expected}\`, propose typed 400, and the ontology STAYS at the revision it was made against — parity is preserved by any weakening of a shared validator, so agreement is not the contract, and a code in a body is not an absence of the act`,
+        patchCode === expected && proposeCode === expected
+          && proposed.status === 400
+          && (after.j?.ontology?.revision ?? -1) === fresh?.revision,
+        `patch ${patchCode} / propose ${proposeCode} (${proposed.status}) rev ${fresh?.revision} -> ${after.j?.ontology?.revision}`);
+    }
+  }
+  ok("and none of those refused proposals was ADMITTED — a refusal that still writes a record is not a refusal",
+    recordsIn("odk-ontology-proposals").length === 0,
+    `${recordsIn("odk-ontology-proposals").length} proposal records`);
+  // AND THE WRITE PATH STORES WHAT IT WAS GIVEN. The extraction once wrote `value.trim()`, silently
+  // rewriting caller data: create stored "  9.9.9  " while patch of the same string stored "9.9.9",
+  // and a proposal's reviewed text stopped being the text that got written.
+  const verbatim = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "verbatim", canonical_object_model: { object_types: [], link_types: [], action_types: [], value_types: [] } }, { as: "A" })).j?.ontology;
+  const spaced = await jd("PATCH", `/v1/hypervisor/odk/domain-ontologies/${verbatim?.id}`, { expected_revision: verbatim?.revision, version: "  9.9.9  " }, { as: "A" });
+  ok("the PATCH write path stores the value VERBATIM — trimming belongs to the emptiness check, never to what is persisted",
+    spaced.j?.ontology?.version === "  9.9.9  ",
+    JSON.stringify(spaced.j?.ontology?.version));
+  // AND SO DOES CREATE, WHICH IT DID NOT. A review found `create` trimming `domain` before storing
+  // while `apply_ontology_change` stored it verbatim — one field's worth of the exact divergence
+  // this module claims to have ended, and the assertion above never saw it because it probes only
+  // PATCH and only `version`. Both routes, and the field that diverged.
+  const paddedCreate = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "  padded-domain  ", canonical_object_model: { object_types: [], link_types: [], action_types: [], value_types: [] } }, { as: "A" })).j?.ontology;
+  ok("and the CREATE write path stores `domain` verbatim too — create and patch may not disagree about what persisting a field means",
+    paddedCreate?.domain === "  padded-domain  " && readRecord("odk-domain-ontologies", paddedCreate?.id ?? "")?.domain === "  padded-domain  ",
+    JSON.stringify(paddedCreate?.domain));
+  // A RECORD WRITTEN BEFORE THIS CAPABILITY LANDED STILL READS THE TRUTH. `health.object_data_note`
+  // is computed at write time and PERSISTED, so an ontology already on disk kept whatever sentence
+  // was true when it was created — a review found three user-facing pages telling readers no
+  // object-instance plane was bound, months after one was, with no backfill anywhere. Prose about
+  // the plane is projected on READ now, and this plants a stale record and reads it back to prove it.
+  const stalePath = path.join(dataDir, "odk-domain-ontologies", `${verbatim?.id}.json`);
+  const staleRecord = JSON.parse(fs.readFileSync(stalePath, "utf8"));
+  staleRecord.health = { ...(staleRecord.health ?? {}), object_data_note: "schema only — no object-instance/projection plane is bound; explorer rows require a real ontology-bound object plane (not built here)" };
+  fs.writeFileSync(stalePath, JSON.stringify(staleRecord, null, 2));
+  resyncOntologyBaseline();   // planted by this file, not by the daemon — see the helper's note
+  const staleGet = await jd("GET", `/v1/hypervisor/odk/domain-ontologies/${verbatim?.id}`, null, { as: "A" });
+  const staleList = await jd("GET", "/v1/hypervisor/odk/domain-ontologies", null, { as: "A" });
+  const staleListed = (staleList.j?.ontologies ?? []).find((o) => o.id === verbatim?.id);
+  ok("an ontology whose PERSISTED health note predates this capability reads back the CURRENT note on both the get and the list path — a sentence about what the estate can do is projected on read, never served from a record written before it was true",
+    !/no object-instance\/projection plane is bound/u.test(JSON.stringify(staleGet.j?.ontology?.health ?? {}))
+      && !/no object-instance\/projection plane is bound/u.test(JSON.stringify(staleListed?.health ?? {}))
+      && /object-instance SEARCH plane/u.test(String(staleGet.j?.ontology?.health?.object_data_note ?? "")),
+    String(staleGet.j?.ontology?.health?.object_data_note ?? "").slice(0, 60));
+
+  // A SUCCESSFUL MODEL PATCH, walked because nothing walked it. The plane recomputes `health` from
+  // the caller's model on every patch, and the caller never names it — so this is the one legitimate
+  // write that tells the caller-intent census apart from a census that has simply never met it.
+  const modelPatch = await jd("PATCH", `/v1/hypervisor/odk/domain-ontologies/${verbatim?.id}`, {
+    expected_revision: spaced.j?.ontology?.revision,
+    canonical_object_model: { object_types: [{ id: "walked", name: "Walked", properties: [] }], link_types: [], action_types: [], value_types: [] },
+  }, { as: "A" });
+  ok("a model patch APPLIES and the plane recomputes health from it — a derived field the caller never names, which is why it is bookkeeping and not a create-only default",
+    modelPatch.status === 200 && modelPatch.j?.ok === true
+      && (modelPatch.j?.ontology?.canonical_object_model?.object_types ?? []).some((t) => t.id === "walked"),
+    `status ${modelPatch.status}`);
+  // AND THE FOURTH WRITER IS WALKED. `DELETE /odk/domain-ontologies/:id` is registered and receipted;
+  // a model of this plane that names three writers is a false statement about it.
+  const doomed = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: "doomed", canonical_object_model: { object_types: [], link_types: [], action_types: [], value_types: [] } }, { as: "A" })).j?.ontology;
+  const deleted = await jd("DELETE", `/v1/hypervisor/odk/domain-ontologies/${doomed?.id}`, null, { as: "A" });
+  ok("the ontology DELETE writer removes its own record and nothing else — the fourth registered writer of this family, walked rather than assumed absent",
+    deleted.status === 200 && readRecord("odk-domain-ontologies", doomed?.id ?? "") === null,
+    `status ${deleted.status}`);
+
+  const proposal = await jd("POST", "/v1/hypervisor/odk/ontology-proposals", {
+    ontology_ref: ontologyRef, title: "describe the widget domain", rationale: "the description was a placeholder",
+    expected_revision: 1, changes: { description: "widgets, their links, and the actions over them" },
+  }, { as: "A" });
+  const proposalId = proposal.j?.ontology_proposal?.id ?? "";
+  ok("A PROPOSAL EXISTS as daemon truth: admitted open, attributed to its proposer, pinned to the revision it was made against",
+    proposal.status === 201
+      && proposal.j?.ontology_proposal?.status === "open"
+      && proposal.j?.ontology_proposal?.based_on_revision === 1
+      && proposal.j?.ontology_proposal?.proposed_by === P.A.ref,
+    `status ${proposal.status} id ${proposalId}`);
+  ok("and it is DURABLE on disk, not just in the response",
+    readRecord("odk-ontology-proposals", proposalId)?.status === "open",
+    recordsIn("odk-ontology-proposals").join(","));
+
+  const listed = await jd("GET", `/v1/hypervisor/odk/ontology-proposals?ontology_ref=${encodeURIComponent(ontologyRef)}&status=open`, null, { as: "B" });
+  ok("the proposal is READABLE by another principal — a proposal is estate truth about a shared ontology, not private working state",
+    listed.status === 200 && (listed.j?.ontology_proposals ?? []).some((p) => p.id === proposalId),
+    `${(listed.j?.ontology_proposals ?? []).length} rows`);
+  const listedAnon = await jd("GET", "/v1/hypervisor/odk/ontology-proposals", null, { as: null });
+  ok("but not by an anonymous one",
+    listedAnon.status === 401, `status ${listedAnon.status}`);
+
+  // THE ONTOLOGY MOVES UNDERNEATH THE PROPOSAL.
+  const drift = await jd("PATCH", `/v1/hypervisor/odk/domain-ontologies/${ontologyId}`, { expected_revision: 1, version: "1.0.1" }, { as: "B" });
+  ok("PRECONDITION: an ordinary edit really does advance the ontology to revision 2",
+    drift.status === 200 && drift.j?.ontology?.revision === 2, `status ${drift.status} rev ${drift.j?.ontology?.revision}`);
+  const staleApply = await jd("POST", `/v1/hypervisor/odk/ontology-proposals/${proposalId}/apply`, null, { as: "A" });
+  ok("APPLYING A STALE PROPOSAL REFUSES, naming both revisions — applying would silently overwrite whatever landed in between",
+    staleApply.status === 409 && code(staleApply.j) === "ontology_proposal_stale"
+      && staleApply.j?.error?.based_on_revision === 1 && staleApply.j?.error?.current_revision === 2,
+    `status ${staleApply.status} code ${code(staleApply.j)}`);
+  const afterStale = await jd("GET", `/v1/hypervisor/odk/domain-ontologies/${ontologyId}`, null, { as: "A" });
+  ok("and the stale apply CHANGED NOTHING — the ontology is still at the revision the drift left it",
+    afterStale.j?.ontology?.revision === 2 && readRecord("odk-ontology-proposals", proposalId)?.status === "open",
+    `rev ${afterStale.j?.ontology?.revision} proposal ${readRecord("odk-ontology-proposals", proposalId)?.status}`);
+
+  // A REBASED PROPOSAL APPLIES, THROUGH THE ONTOLOGY PLANE'S OWN WRITER.
+  const rebased = await jd("POST", "/v1/hypervisor/odk/ontology-proposals", {
+    ontology_ref: ontologyRef, title: "rebased", expected_revision: 2,
+    changes: { description: "widgets, their links, and the actions over them" },
+  }, { as: "A" });
+  const rebasedId = rebased.j?.ontology_proposal?.id ?? "";
+  const receiptsBefore = recordsIn("odk-ontology-receipts").length;
+  const applied = await jd("POST", `/v1/hypervisor/odk/ontology-proposals/${rebasedId}/apply`, null, { as: "C" });
+  ok("A PROPOSAL APPLIES, and the ontology really carries the proposed change at the next revision",
+    applied.status === 200
+      && applied.j?.ontology?.revision === 3
+      && applied.j?.ontology?.description === "widgets, their links, and the actions over them",
+    `status ${applied.status} rev ${applied.j?.ontology?.revision}`);
+  ok("the apply went through the ONTOLOGY PLANE'S OWN WRITER — it emitted that plane's receipt, not a second receipt family of its own",
+    recordsIn("odk-ontology-receipts").length === receiptsBefore + 1
+      && String(applied.j?.ontology_receipt?.schema_version) === "ioi.hypervisor.odk.ontology-receipt.v1"
+      && applied.j?.ontology_receipt?.op === "patched",
+    `${receiptsBefore} -> ${recordsIn("odk-ontology-receipts").length} receipts`);
+  ok("and the ontology's own history carries the applied revision with that receipt — the edit is indistinguishable from an ordinary one, which is the point",
+    (applied.j?.ontology?.history ?? []).some((h) => h.revision === 3 && h.receipt_ref === applied.j?.ontology_receipt?.receipt_ref),
+    `${(applied.j?.ontology?.history ?? []).length} history entries`);
+  ok("the applied proposal records WHO applied it and the revision it produced",
+    readRecord("odk-ontology-proposals", rebasedId)?.status === "applied"
+      && readRecord("odk-ontology-proposals", rebasedId)?.applied?.applied_by === P.C.ref
+      && readRecord("odk-ontology-proposals", rebasedId)?.applied?.resulting_revision === 3,
+    JSON.stringify(readRecord("odk-ontology-proposals", rebasedId)?.applied ?? {}));
+  const reapply = await jd("POST", `/v1/hypervisor/odk/ontology-proposals/${rebasedId}/apply`, null, { as: "C" });
+  const afterReapply = await jd("GET", `/v1/hypervisor/odk/domain-ontologies/${ontologyId}`, null, { as: "A" });
+  ok("RE-APPLYING replays rather than editing twice — the ontology stays at the revision the first apply produced",
+    reapply.status === 200 && reapply.j?.replayed === true && afterReapply.j?.ontology?.revision === 3,
+    `status ${reapply.status} replayed ${reapply.j?.replayed} rev ${afterReapply.j?.ontology?.revision}`);
+
+  const withdrawn = await jd("POST", `/v1/hypervisor/odk/ontology-proposals/${proposalId}/withdraw`, { reason: "superseded by the rebased proposal" }, { as: "A" });
+  ok("an OPEN proposal withdraws, attributed and reasoned",
+    withdrawn.status === 200 && withdrawn.j?.ontology_proposal?.status === "withdrawn"
+      && withdrawn.j?.ontology_proposal?.withdrawn?.withdrawn_by === P.A.ref,
+    `status ${withdrawn.status}`);
+  const applyWithdrawn = await jd("POST", `/v1/hypervisor/odk/ontology-proposals/${proposalId}/apply`, null, { as: "A" });
+  ok("and a withdrawn proposal can never be applied",
+    applyWithdrawn.status === 409 && code(applyWithdrawn.j) === "ontology_proposal_not_open",
+    `status ${applyWithdrawn.status} code ${code(applyWithdrawn.j)}`);
+  const withdrawApplied = await jd("POST", `/v1/hypervisor/odk/ontology-proposals/${rebasedId}/withdraw`, { reason: "too late" }, { as: "A" });
+  ok("nor can an APPLIED proposal be withdrawn — a terminal proposal is history",
+    withdrawApplied.status === 409 && code(withdrawApplied.j) === "ontology_proposal_terminal",
+    `status ${withdrawApplied.status} code ${code(withdrawApplied.j)}`);
+
+  // ============================================================ FAMILY 2 — saved object sets
+  const anonSave = await jd("POST", "/v1/hypervisor/odk/saved-object-sets", { name: "x", ontology_ref: ontologyRef, selection: { q: "a" } }, { as: null });
+  ok("SAVE refuses an anonymous caller",
+    anonSave.status === 401 && recordsIn("odk-saved-object-sets").length === 0,
+    `status ${anonSave.status}`);
+  const emptySelection = await jd("POST", "/v1/hypervisor/odk/saved-object-sets", { name: "empty", ontology_ref: ontologyRef, selection: {} }, { as: "A" });
+  ok("a saved set with an EMPTY selection is refused typed — a set that selects nothing saves nothing",
+    emptySelection.status === 400 && code(emptySelection.j) === "saved_object_set_selection_required",
+    `status ${emptySelection.status} code ${code(emptySelection.j)}`);
+
+  const saved = await jd("POST", "/v1/hypervisor/odk/saved-object-sets", {
+    name: "widgets I care about", description: "the working set", ontology_ref: ontologyRef,
+    selection: { object_type_id: "widget", q: "alpha" },
+  }, { as: "A" });
+  const savedId = saved.j?.saved_object_set?.id ?? "";
+  ok("A SAVED OBJECT SET EXISTS as daemon truth, at revision 1, attributed to the principal who saved it",
+    saved.status === 201 && savedId.startsWith("sos_")
+      && saved.j?.saved_object_set?.revision === 1 && saved.j?.saved_object_set?.saved_by === P.A.ref,
+    `status ${saved.status} id ${savedId}`);
+
+  const bReads = await jd("GET", `/v1/hypervisor/odk/saved-object-sets/${savedId}`, null, { as: "B" });
+  ok("B cannot READ A's saved set — an exploration is one principal's working state, pinned per PRINCIPAL and not by tenant",
+    bReads.status === 403, `status ${bReads.status} code ${code(bReads.j)}`);
+  const bList = await jd("GET", "/v1/hypervisor/odk/saved-object-sets", null, { as: "B" });
+  ok("and B's own list does not contain it — listing derives from the caller's own authorized scope set",
+    bList.status === 200 && (bList.j?.saved_object_sets ?? []).every((s) => s.id !== savedId),
+    `${(bList.j?.saved_object_sets ?? []).length} rows for B`);
+  const aList = await jd("GET", "/v1/hypervisor/odk/saved-object-sets", null, { as: "A" });
+  ok("while A's list does",
+    aList.status === 200 && (aList.j?.saved_object_sets ?? []).some((s) => s.id === savedId),
+    `${(aList.j?.saved_object_sets ?? []).length} rows for A`);
+
+  const bPatch = await jd("PATCH", `/v1/hypervisor/odk/saved-object-sets/${savedId}`, { expected_revision: 1, name: "mine now" }, { as: "B" });
+  ok("B cannot EDIT A's saved set either",
+    bPatch.status === 403 && readRecord("odk-saved-object-sets", savedId)?.name === "widgets I care about",
+    `status ${bPatch.status} name ${readRecord("odk-saved-object-sets", savedId)?.name}`);
+
+  const staleSetPatch = await jd("PATCH", `/v1/hypervisor/odk/saved-object-sets/${savedId}`, { expected_revision: 7, name: "stale" }, { as: "A" });
+  ok("a saved-set edit at the WRONG revision refuses on the same CAS, and changes nothing",
+    staleSetPatch.status === 409 && code(staleSetPatch.j) === "odk_revision_conflict"
+      && readRecord("odk-saved-object-sets", savedId)?.revision === 1,
+    `status ${staleSetPatch.status} code ${code(staleSetPatch.j)}`);
+  const noChange = await jd("PATCH", `/v1/hypervisor/odk/saved-object-sets/${savedId}`, { expected_revision: 1 }, { as: "A" });
+  ok("and a patch naming NO field is refused rather than bumping the revision for nothing",
+    noChange.status === 400 && code(noChange.j) === "saved_object_set_change_required",
+    `status ${noChange.status} code ${code(noChange.j)}`);
+
+  const patched = await jd("PATCH", `/v1/hypervisor/odk/saved-object-sets/${savedId}`, {
+    expected_revision: 1, name: "widgets I really care about", selection: { object_type_id: "widget", q: "beta" },
+  }, { as: "A" });
+  ok("A's own edit applies and advances the revision exactly once",
+    patched.status === 200 && patched.j?.saved_object_set?.revision === 2
+      && patched.j?.saved_object_set?.selection?.q === "beta",
+    `status ${patched.status} rev ${patched.j?.saved_object_set?.revision}`);
+
+  const retired = await jd("POST", `/v1/hypervisor/odk/saved-object-sets/${savedId}/retire`, { reason: "done exploring" }, { as: "A" });
+  ok("RETIRE, NOT DELETE — the record survives as history with its reason and actor, because content deletion belongs to the retention plane",
+    retired.status === 200 && retired.j?.saved_object_set?.status === "retired"
+      && readRecord("odk-saved-object-sets", savedId) !== null,
+    `status ${retired.status}`);
+  const editRetired = await jd("PATCH", `/v1/hypervisor/odk/saved-object-sets/${savedId}`, { expected_revision: 2, name: "back" }, { as: "A" });
+  ok("and a retired set accepts no further edits",
+    editRetired.status === 409 && code(editRetired.j) === "saved_object_set_retired",
+    `status ${editRetired.status} code ${code(editRetired.j)}`);
+  const retireAgain = await jd("POST", `/v1/hypervisor/odk/saved-object-sets/${savedId}/retire`, {}, { as: "A" });
+  ok("retiring twice replays rather than rewriting the retirement",
+    retireAgain.status === 200 && retireAgain.j?.replayed === true,
+    `status ${retireAgain.status}`);
+
+  // ============================================================ FAMILY 3 — object-instance search
+  const anonSearch = await jd("POST", "/v1/hypervisor/odk/object-instance-search", { q: "x" }, { as: null });
+  ok("SEARCH refuses an anonymous caller",
+    anonSearch.status === 401, `status ${anonSearch.status}`);
+
+  const emptyCorpus = await jd("POST", "/v1/hypervisor/odk/object-instance-search", { ontology_ref: ontologyRef, q: "alpha" }, { as: "A" });
+  ok("with NO materialized corpus the answer is a NAMED ABSENCE, not an empty result list — 'nothing has been materialized' and 'your query matched nothing' are different facts",
+    emptyCorpus.status === 200 && (emptyCorpus.j?.results ?? []).length === 0
+      && emptyCorpus.j?.absence?.code === "object_instance_corpus_absent"
+      && emptyCorpus.j?.corpus?.materialized_object_sets_in_scope === 0,
+    `absence ${emptyCorpus.j?.absence?.code}`);
+
+  const badOntology = await jd("POST", "/v1/hypervisor/odk/object-instance-search", { ontology_ref: "domain-ontology://nope", q: "a" }, { as: "A" });
+  ok("a search scoped to an ontology that does not resolve NAMES ITSELF rather than reading as 'no results'",
+    badOntology.status === 404 && code(badOntology.j) === "odk_ontology_not_found",
+    `status ${badOntology.status} code ${code(badOntology.j)}`);
+  const badLimit = await jd("POST", "/v1/hypervisor/odk/object-instance-search", { limit: 0 }, { as: "A" });
+  ok("an out-of-range limit is refused typed, never silently clamped",
+    badLimit.status === 400 && code(badLimit.j) === "object_instance_search_limit_invalid",
+    `status ${badLimit.status} code ${code(badLimit.j)}`);
+
+  // A REAL CORPUS, PRODUCED BY THE PRODUCT'S OWN MATERIALIZATION LADDER. Not written to disk by this
+  // file: this estate forbids a checker its own fixture corpus, and a search gate fed hand-written
+  // rows proves the search code runs, never that it searches what the product actually produces.
+  // Every rung below is the same route the connector-execution plane uses — data source, connector
+  // mapping, policy-bound view, transformation dry-run, projection, lease plan, wallet-gated
+  // materializing run, sealed connector session — ending in a real HTTP fetch of real rows.
+  const SENTINEL = "onto-families-bearer-SENTINEL";
+  const sourceRows = [
+    { id: "L-1", disp: "gold tier loan", amt: 1250.5 },
+    { id: "L-2", disp: "silver tier loan", amt: 90000 },
+    { id: "L-3", disp: "gold tier renewal", amt: 42 },
+  ];
+  let sourceHits = 0;
+  const rowServer = http.createServer((req, res) => {
+    if (req.headers.authorization !== `Bearer ${SENTINEL}`) { res.writeHead(401); return res.end("unauthorized"); }
+    sourceHits += 1;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(sourceRows));
+  });
+  await new Promise((resolve) => rowServer.listen(0, "127.0.0.1", resolve));
+  const rowPort = rowServer.address().port;
+
+  const connector = await jd("POST", "/v1/hypervisor/connectors", { service: "onto-families", base_url: `http://127.0.0.1:${rowPort}`, name: "Ontology families fixture" }, { as: "A" });
+  const connectorId = connector.j?.connector?.connector_id ?? connector.j?.connector_id ?? "";
+  await jd("POST", `/v1/hypervisor/connectors/${connectorId}/credential`, { token: SENTINEL }, { as: "A" });
+
+  const grantFor = (challenge) => mintTestGrant({ policyHash: challenge?.approval?.policy_hash, requestHash: challenge?.approval?.request_hash });
+  const tag = "ontofam";
+  const source = (await jd("POST", "/v1/hypervisor/data-sources", { name: `${tag}-src`, kind: "rest_api", endpoint: `http://127.0.0.1:${rowPort}/rows`, credential_posture: "wallet_credential_lease" }, { as: "A" })).j?.data_source?.source_id;
+  const corpusOntology = (await jd("POST", "/v1/hypervisor/odk/domain-ontologies", { domain: `${tag}-domain`, canonical_object_model: {
+    value_types: [{ id: "money", name: "Money", base: "double" }],
+    object_types: [{ id: "loan", name: "Loan", title_property: "title", properties: [
+      { id: "loan_id", name: "Loan Id", value_type: "string", required: true },
+      { id: "title", name: "Title", value_type: "string" },
+      { id: "amount", name: "Amount", value_type: "money" }] }],
+    action_types: [], link_types: [],
+  } }, { as: "A" })).j?.ontology;
+  const mapping = (await jd("POST", "/v1/hypervisor/odk/connector-mappings", { name: `${tag}-map`, data_source_id: source, ontology_ref: corpusOntology?.ref, object_type_id: "loan",
+    key_mapping: { source_field: "id", property_id: "loan_id", source_type: "string" },
+    title_mapping: { source_field: "disp", property_id: "title", source_type: "string" },
+    field_mappings: [{ source_field: "amt", property_id: "amount", source_type: "double" }] }, { as: "A" })).j?.connector_mapping?.id;
+  const view = (await jd("POST", "/v1/hypervisor/odk/policy-bound-data-views", { connector_mapping_id: mapping, name: `${tag}-gate`, authority_subjects: ["agent://materializer"],
+    allowed_operations: ["read", "transform"], purpose: "analysis", property_scope: ["loan_id", "title", "amount"], retention_posture: "bounded" }, { as: "A" })).j?.policy_bound_data_view?.id;
+  const trun = (await jd("POST", "/v1/hypervisor/odk/transformation-runs", { connector_mapping_id: mapping, policy_view_id: view, name: `${tag}-trun` }, { as: "A" })).j?.transformation_run?.id;
+  await jd("POST", `/v1/hypervisor/odk/transformation-runs/${trun}/dry-run`, null, { as: "A" });
+  const projection = (await jd("POST", "/v1/hypervisor/odk/ontology-projections", { connector_mapping_id: mapping, policy_view_id: view, name: `${tag}-explorer`, visible_properties: ["loan_id", "title", "amount"] }, { as: "A" })).j?.ontology_projection?.id;
+  const plan = (await jd("POST", "/v1/hypervisor/odk/capability-lease-plans", { data_source_id: source, connector_mapping_id: mapping, policy_view_id: view,
+    transformation_run_id: trun, ontology_projection_id: projection, name: `${tag}-plan`, subject: "agent://materializer", ttl_seconds: 900 }, { as: "A" })).j?.capability_lease_plan?.id;
+  const mrun = (await jd("POST", "/v1/hypervisor/odk/materializing-runs", { capability_lease_plan_id: plan, name: `${tag}-mrun` }, { as: "A" })).j?.materializing_run?.id;
+  const leaseChallenge = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, {}, { as: "A" });
+  await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/acquire-lease`, { wallet_approval_grant: await grantFor(leaseChallenge.j) }, { as: "A" });
+  const sessionRes = await jd("POST", "/v1/hypervisor/odk/connector-sessions", { materializing_run_id: mrun, connector_id: connectorId, name: `${tag}-session` }, { as: "A" });
+  const sessionId = sessionRes.j?.connector_session?.id ?? "";
+  const openChallenge = await jd("POST", `/v1/hypervisor/odk/connector-sessions/${sessionId}/open`, {}, { as: "A" });
+  await jd("POST", `/v1/hypervisor/odk/connector-sessions/${sessionId}/open`, { wallet_approval_grant: await grantFor(openChallenge.j) }, { as: "A" });
+  const executed = await jd("POST", `/v1/hypervisor/odk/materializing-runs/${mrun}/execute`, { connector_session_id: sessionId, limit: 10 }, { as: "A" });
+  const corpusOntologyRef = corpusOntology?.ref ?? "";
+
+  // WHERE THE LADDER STOPS IN THIS LANE, AND WHY THAT IS THE HONEST PLACE FOR IT TO STOP.
+  //
+  // Every rung up to the wallet crossing is REAL and built here through the product's own routes.
+  // The crossing itself is not fakeable: `acquire-lease` requires independently resolved, atomically
+  // consumed owner authority (`IOI_HYPERVISOR_AUTHORITY_PRINCIPAL_REF` plus a live principal-authority
+  // resolution), and the estate's only way to satisfy it is a real one-validator wallet.network
+  // fixture that costs MINUTES to stand up. `check:provider-transport` reached the same wall and
+  // ruled it the same way — the credential crossing gets its own opt-in lane rather than a mock,
+  // because a mocked authority crossing proves nothing about authority.
+  //
+  // So this gate proves the ladder is real AND genuinely gated, and stops there.
+  //
+  // AN EARLIER REVISION SHIPPED A `--live-authority` LANE AND CITED IT AS EVIDENCE. It could never
+  // pass: it never started the authority fixture and re-minted a grant from the 501, which carries no
+  // approval — a review ran it and found 4 of its 5 assertions RED and the fifth vacuous. A lane
+  // nobody has demonstrated passing is not evidence, and citing one is the defect this program
+  // exists to catch. It is deleted rather than defended.
+  //
+  // NAMED RESIDUAL, unhedged: search's MATCHING over a product-produced corpus, the provenance on
+  // its rows, its truncation arithmetic and its scope FILTER are proven NOWHERE. Proving them needs
+  // the real one-validator wallet.network principal-authority fixture wired the way
+  // `verify-hypervisor-provider-transport.mjs` wires it — started BEFORE the daemon, since the
+  // authority ref is read at boot, and BLOCKING when unavailable. That is a follow-up packet.
+  ok("the materialization ladder is REAL up to its wallet crossing — every rung admitted through the product's own routes, ending at a run that holds no lease",
+    Boolean(source && corpusOntology?.ref && mapping && view && trun && projection && plan && mrun),
+    `source ${Boolean(source)} map ${Boolean(mapping)} plan ${Boolean(plan)} run ${Boolean(mrun)}`);
+  ok("and the crossing that would PRODUCE a corpus is genuinely wallet-gated — it refuses typed, names the authority it needs, and the estate contacted NO source without it",
+    leaseChallenge.status === 501
+      && String(leaseChallenge.j?.reason ?? "").includes("authority_required")
+      && executed.status === 400 && code(executed.j) === "execution_lease_not_obtained"
+      && sourceHits === 0 && recordsIn("odk-materialized-object-sets").length === 0,
+    `lease ${leaseChallenge.status} execute ${code(executed.j)} source hits ${sourceHits}`);
+  ok("so an unauthorized ladder leaves the corpus EMPTY, and search says exactly that rather than reporting an unmatched query",
+    (await jd("POST", "/v1/hypervisor/odk/object-instance-search", { ontology_ref: corpusOntologyRef, q: "gold" }, { as: "A" })).j?.absence?.code === "object_instance_corpus_absent",
+    "corpus absent");
+
+  // WHAT THIS PROVES AND WHAT IT CANNOT. With no corpus in either scope, "the filter is applied" is
+  // unobservable — both scopes report zero whether the filter runs or is ignored entirely, and a
+  // mutation replacing the whole scope predicate with `true` came back GREEN against an earlier,
+  // broader version of this label. So the label says only what a corpus-free lane can see: the
+  // requested scope is RESOLVED and echoed back. That the filter actually SELECTS is a NAMED
+  // RESIDUAL — unproven anywhere, for the same reason matching is: it needs a materialized corpus.
+  const otherOntology = await jd("POST", "/v1/hypervisor/odk/object-instance-search", { ontology_ref: ontologyRef, q: "gold" }, { as: "A" });
+  ok("a search names the ontology scope it RESOLVED and echoes it back, so a caller can tell which corpus an answer is about",
+    otherOntology.status === 200 && otherOntology.j?.query?.ontology_ref === ontologyRef
+      && otherOntology.j?.corpus?.materialized_object_sets_in_scope === 0,
+    `echo ${otherOntology.j?.query?.ontology_ref}`);
+
+  rowServer.close();
+
+  // ============================================================ RESTART SURVIVAL
+  const pidBefore = daemon?.pid ?? 0;
+  stopDaemon();
+  await sleep(600);
+  startDaemon(port);
+  await waitFor(`${DAEMON}/healthz`, 30000);
+  ok("PRECONDITION: this is a NEW PROCESS over the SAME data directory",
+    pidBefore > 0 && (daemon?.pid ?? 0) > 0 && daemon.pid !== pidBefore, `pid ${pidBefore} -> ${daemon?.pid}`);
+  const proposalAfter = await jd("GET", `/v1/hypervisor/odk/ontology-proposals/${rebasedId}`, null, { as: "A" });
+  const setAfter = await jd("GET", `/v1/hypervisor/odk/saved-object-sets/${savedId}`, null, { as: "A" });
+  const searchAfter = await jd("POST", "/v1/hypervisor/odk/object-instance-search", { ontology_ref: corpusOntologyRef, q: "gold" }, { as: "A" });
+  ok("ACROSS A RESTART all three families read back their durable truth — the applied proposal, the retired set, and a corpus verdict derived from the store rather than from memory",
+    proposalAfter.j?.ontology_proposal?.status === "applied"
+      && setAfter.j?.saved_object_set?.status === "retired"
+      && searchAfter.status === 200
+      && searchAfter.j?.corpus?.materialized_object_sets_in_scope === recordsIn("odk-materialized-object-sets").length,
+    `${proposalAfter.j?.ontology_proposal?.status} / ${setAfter.j?.saved_object_set?.status} / sets ${searchAfter.j?.corpus?.materialized_object_sets_in_scope}`);
+  const setAfterCross = await jd("GET", `/v1/hypervisor/odk/saved-object-sets/${savedId}`, null, { as: "B" });
+  ok("and the per-principal pin survives it — B still cannot read A's saved set",
+    setAfterCross.status === 403, `status ${setAfterCross.status}`);
+
+  // ============================================================ the derived closed world
+  const routes = workbenchRoutes();
+  const FAMILIES = ["/v1/hypervisor/odk/ontology-proposals", "/v1/hypervisor/odk/saved-object-sets", "/v1/hypervisor/odk/object-instance-search"];
+  ok("all THREE families ACC-A names are registered in the router — derived from the router source, not from guessed URLs",
+    FAMILIES.every((family) => routes.some((r) => r.path.startsWith(family))) && routes.length >= 11,
+    `${routes.length} routes: ${routes.map((r) => `${r.method} ${r.path}`).join(", ")}`);
+
+  // EVERY route, not only the mutating ones. Reads leak too — a proposal list or a saved-set read is
+  // estate truth, and an earlier revision of this sweep filtered GETs out entirely, leaving three of
+  // the four read routes never probed anonymously.
+  const anonymousDoors = [];
+  for (const endpoint of routes) {
+    const concrete = endpoint.path.replace(":id", proposalId);
+    const response = await jd(endpoint.method, concrete, endpoint.method === "GET" ? null : {}, { as: null });
+    if (response.status !== 401) anonymousDoors.push(`${endpoint.method} ${endpoint.path} -> ${response.status}`);
+  }
+  ok("EVERY route in all three families — reads included — refuses an anonymous caller, probed from raw transport",
+    anonymousDoors.length === 0 && routes.length >= 11,
+    anonymousDoors.join(", ") || `${routes.length} routes`);
+
+  // NO SECOND SPINE — DERIVED POSITIVELY, because the denylist that stood here was blind to one.
+  //
+  // The first revision scanned the workbench module for the NAMES of the ontology plane's writers.
+  // A review showed the two obvious second spines sail past it: a `persist_record(..., KIND_ONT,
+  // ...)` with its own revision bump, and a locally-named receipt minter. A denylist cannot see a
+  // writer it was not told to look for, and this estate already names denylist scans a decorative
+  // class. So the check is inverted: derive every record family this module writes, and assert the
+  // set is exactly its OWN two. A second spine has to write the ontology family to be one.
+  // ---------------------------------------------------------- the entailment, observed not derived
+  // THE ONLY REQUESTS ALLOWED TO HAVE CHANGED THE ONTOLOGY FAMILY. Three, each justified:
+  //   POST  …/odk/domain-ontologies            — the create route; it mints the ontology
+  //   PATCH …/odk/domain-ontologies/:id        — `apply_ontology_change`, THE one writer
+  //   POST  …/odk/ontology-proposals/:id/apply — which CALLS that same writer, the whole claim
+  // Anything else that moved those bytes is a second spine, whatever it is spelled.
+  // FOUR, NOT THREE. A review drove `DELETE /odk/domain-ontologies/:id` live — a registered,
+  // receipted writer that removes the record — and the three-route model reported a correct
+  // product-produced delete as an unexpected route AND as an unreadable record. A model of the
+  // plane that omits one of its writers is a false statement about the plane, not a strict gate.
+  // NAMED, NOT POSITIONAL. Adding the DELETE writer to a positional list silently re-pointed
+  // `sawApply` at the new entry — the gate caught it, which is the point, but an index into a list
+  // that grows is a coupling waiting to mis-fire.
+  const ONTOLOGY_WRITERS = {
+    create: /^POST \/v1\/hypervisor\/odk\/domain-ontologies$/u,
+    patch: /^PATCH \/v1\/hypervisor\/odk\/domain-ontologies\/[^/]+$/u,
+    delete: /^DELETE \/v1\/hypervisor\/odk\/domain-ontologies\/[^/]+$/u,
+    apply: /^POST \/v1\/hypervisor\/odk\/ontology-proposals\/[^/]+\/apply$/u,
+  };
+  const EXPECTED_ONTOLOGY_MUTATORS = Object.values(ONTOLOGY_WRITERS);
+  const stripRustComments = (src) => {
+    let out = "";
+    for (let i = 0; i < src.length;) {
+      const c = src[i];
+      if (c === "r" && (src[i + 1] === '"' || src[i + 1] === "#")) {
+        let j = i + 1, hashes = 0;
+        while (src[j] === "#") { hashes += 1; j += 1; }
+        if (src[j] === '"') {
+          const close = `"${"#".repeat(hashes)}`;
+          const end = src.indexOf(close, j + 1);
+          const stop = end === -1 ? src.length : end + close.length;
+          out += src.slice(i, stop); i = stop; continue;
+        }
+      }
+      if (c === '"') {
+        let j = i + 1;
+        while (j < src.length) {
+          if (src[j] === "\\") { j += 2; continue; }
+          if (src[j] === '"') { j += 1; break; }
+          j += 1;
+        }
+        out += src.slice(i, j); i = j; continue;
+      }
+      // A CHAR LITERAL CONTAINING A DOUBLE QUOTE — `c == '"'`, `.split('"')`, `matches!(c, '"')`, all
+      // ordinary Rust — flips string parity for the REST OF THE FILE if it is not tracked, which
+      // re-arms the exact `//`-inside-a-literal regression this scanner exists to close. A review
+      // demonstrated it. Lifetimes (`&'a str`) share the tick and have no closing quote, so they are
+      // told apart by looking for the close: `'x'` and `'\x'` are literals, `'a ` is a lifetime.
+      if (c === "'") {
+        let j = i + 1;
+        if (src[i + 1] === "\\") {
+          // AN ESCAPED QUOTE IS THE LITERAL'S CONTENT, NOT ITS CLOSE. Scanning for the next `'`
+          // from i+2 lands ON the escaped quote of `'\\''` and terminates before it starts, leaving
+          // the real closing tick stray — which inverts double-quote parity for the rest of the
+          // file and re-arms the `//`-inside-a-string regression this scanner exists to close. A
+          // review demonstrated exactly that with `matches!(c, '\\''|'"')`.
+          // EACH BRANCH LANDS j ON THE CLOSING QUOTE. The previous cut added an unconditional `j += 1`
+          // after the `\u{..}` branch had already advanced past `}`, overshooting the quote — and a
+          // review showed one line of legal Rust (`matches!(c, '\u{7b}'|'"')`) desynchronising the
+          // scanner and re-arming the `//`-in-a-literal regression it exists to close.
+          if (src[i + 2] === "u" && src[i + 3] === "{") {
+            const close = src.indexOf("}", i + 4);
+            j = close === -1 ? src.length : close + 1;   // the char after `}` — the closing quote
+          } else if (src[i + 2] === "x") { j = i + 5; }  // `\xNN` then the quote
+          else { j = i + 3; }                            // `\n` then the quote
+        } else {
+          // A NON-BMP CHAR LITERAL IS TWO UTF-16 UNITS. `'😀'` closed at i+3, not i+2, so the old
+          // test read it as a LIFETIME, desynchronised, and deleted the rest of a later line — a
+          // review showed it swallowing a real `persist_record(.., KIND_ONT, ..)` while every static
+          // assertion stayed green. It failed OPEN, which is the worst direction for this class.
+          // Scan forward for the closing tick instead of assuming a width.
+          let k = i + 1;
+          while (k < src.length && k <= i + 3 && src[k] !== "'") k += 1;
+          if (src[k] !== "'") { out += c; i += 1; continue; }   // a lifetime, not a literal
+          j = k;
+        }
+        if (src[j] === "'") { out += src.slice(i, j + 1); i = j + 1; continue; }
+        out += c; i += 1; continue;
+      }
+      if (c === "/" && src[i + 1] === "/") { while (i < src.length && src[i] !== "\n") i += 1; continue; }
+      if (c === "/" && src[i + 1] === "*") {
+        let depth = 1; i += 2;
+        while (i < src.length && depth > 0) {
+          if (src[i] === "/" && src[i + 1] === "*") { depth += 1; i += 2; continue; }
+          if (src[i] === "*" && src[i + 1] === "/") { depth -= 1; i += 2; continue; }
+          i += 1;
+        }
+        continue;
+      }
+      out += c; i += 1;
+    }
+    return out;
+  };
+
+  // THE PRECONDITION THE OBSERVATION RESTS ON, asserted rather than assumed. The fingerprint reads
+  // the LEGACY record directory, which is where this family's writes land only while it is not
+  // promoted; a promoted family writes into the substrate log instead and this whole observation
+  // would go quietly blind. Pinned from the substrate module's own source.
+  const substrateSource = fs.readFileSync(path.join(ROOT, "crates/node/src/bin/hypervisor_daemon_routes/substrate_store.rs"), "utf8");
+  // COMMENT-STRIPPED FIRST: an interleaved `// promoted in W3.4` between entries left a split
+  // element that matched no family name, so the assertion passed while the family WAS promoted.
+  const promotedDomains = (stripRustComments(substrateSource).match(/const PROMOTED_DOMAINS: &\[&str\] = &\[([^\]]*)\]/u)?.[1] ?? "")
+    .split(",").map((s) => s.trim().replace(/^"|"$/gu, "")).filter(Boolean);
+  ok("PRECONDITION for the runtime observation below: the ontology family is NOT a promoted substrate family, so its durable writes land in the record directory that observation watches — promote it and this goes red rather than the watch going quietly blind",
+    promotedDomains.length > 0 && !promotedDomains.includes(ONTOLOGY_FAMILY_DIR),
+    `PROMOTED_DOMAINS = [${promotedDomains.join(",")}]`);
+  // A REFUSED REQUEST MUST NOT HAVE WRITTEN, and this is where the route-shaped version died. The
+  // review's mutant wrote a second ontology record on a 409-REFUSED apply and every assertion stayed
+  // green, because a refusal is an ABSENCE OF THE ACT and nothing was checking the act. No status,
+  // no route, no spelling exempts a write from this: if the answer was not 2xx, the family did not
+  // move.
+  // THIS ESTATE'S PRIMARY REFUSAL IS A 200 WITH `ok:false` — `apply_ontology_change` answers
+  // validation refusals that way, and this very journey pins it thirty lines up. Filtering on status
+  // alone exempted the commonest refusal from the assertion whose label reads "a refusal is the
+  // absence of the act".
+  const refusedWrites = ontologyMutations.filter((m) => m.status < 200 || m.status >= 300 || m.body?.ok === false);
+  ok("ON THE JOURNEYS THIS GATE WALKS, no refused request moved an ontology record — a refusal is the absence of the act, so a request answering non-2xx or `ok:false` that still moved a record is admitting truth it declined to admit. Scoped to the traffic below; it does not speak for requests this journey never makes",
+    refusedWrites.length === 0,
+    refusedWrites.length ? `WROTE ON REFUSAL: ${refusedWrites.map((m) => `${m.route} -> ${m.status} changed ${m.changed.join(",")}`).join(" ; ")}` : `${ontologyMutations.length} writing request(s), none refused`);
+  // EVERY WRITE CHANGED EXACTLY ONE RECORD, AND IT IS THE ONE THE RESPONSE NAMES. Route-shape
+  // allowlisting cannot tell "composed over the one writer" from "wrote BESIDE it": a second spine
+  // running in addition to `apply_ontology_change` moves the print exactly once, under an allowed
+  // name. Binding the delta to the ontology id the response reports is what separates them — and it
+  // also catches a write deferred past its own response, which the route-keyed version attributed to
+  // whichever request happened to come next.
+  // BOUND TO THE CALLER'S INTENT, BECAUSE BINDING TO THE RESPONSE WAS CIRCULAR. The previous cut
+  // compared the record on disk to the `ontology` object the response reports — and that object is
+  // the WRITER'S OWN IN-MEMORY PRODUCT. A review defeated it live at 81/81 with a second writer that
+  // injects an object type nobody proposed and then reports the record it wrote: disk and response
+  // agree perfectly, because one produced the other. A check whose reference the subject produces
+  // can only catch a write that ESCAPES the response, never one composed INTO it.
+  //
+  // So the reference is the one thing in this journey the daemon did not make: THE REQUEST. For each
+  // writing request, every field the CALLER named must hold the value the CALLER SENT, every field
+  // the caller did not name must be byte-unchanged from the record before, and the only fields
+  // allowed to move on their own are the plane's declared bookkeeping. An extra object type, an
+  // extra admission block, a silently rewritten description — none of them survive that, whatever
+  // the response says about them.
+  // BOTH SETS WERE WRONG ABOUT THE PLANE, and a review drove each one live.
+  //  - `health` is recomputed from the caller's model on EVERY patch (`odk_routes.rs` recomputes
+  //    `validate_object_model` after applying the change), so it is bookkeeping, not create-only.
+  //    Listing it as create-only made this rule go RED on a legitimate model patch; the journey
+  //    simply never lands one, so the gate was green for the wrong reason.
+  //  - `created_at` is mintable at genesis and immutable after, so it belongs to the create set. In
+  //    bookkeeping it let a patch BACK-DATE a record with nothing objecting.
+  //  - `owner_ref`, `created_by` and `admitted_head` are minted by nothing in this plane. A dead
+  //    entry in a set the label calls closed is a door held open under a name nobody uses.
+  const CREATE_DERIVED = new Set(["id", "ref", "schema_version", "domain", "version", "description", "status", "object", "canonical_object_model", "created_at"]);
+  const BOOKKEEPING = new Set(["revision", "updated_at", "history", "receipt_refs", "health"]);
+  const canonical = (v) => JSON.stringify(v, (_k, val) =>
+    (val && typeof val === "object" && !Array.isArray(val))
+      ? Object.fromEntries(Object.keys(val).sort().map((k) => [k, val[k]]))
+      : val);
+  /** What the CALLER asked this request to change — from the request body, or the proposal it created. */
+  const intentOf = (m) => {
+    if (m.proposalId) return proposalIntent.get(m.proposalId) ?? {};
+    const req = m.request ?? {};
+    return Object.fromEntries(Object.entries(req).filter(([k]) => k !== "expected_revision" && k !== "idempotency_key"));
+  };
+  const unexplained = [];
+  for (const m of ontologyMutations) {
+    if (!m.changed.length) continue;
+    if (m.changed.length !== 1) { unexplained.push(`${m.route} changed ${m.changed.length} records [${m.changed.join(",")}]`); continue; }
+    const name = m.changed[0];
+    // A REMOVAL IS ITS OWN FACT. Folding it in with "unreadable" reported two entirely different
+    // things — a record the plane deleted and a record this checker could not parse — under one
+    // diagnostic, and flagged a correct delete as a defect.
+    if (name.endsWith(":REMOVED")) {
+      const removedId = name.slice(0, -":REMOVED".length).replace(/\.json$/u, "");
+      const pathId = /\/domain-ontologies\/([^/]+)$/u.exec(m.route.split(" ")[1])?.[1] ?? "";
+      if (!m.route.startsWith("DELETE ") || removedId !== pathId) {
+        unexplained.push(`${m.route} removed ${removedId} without being that record's delete route`);
+      }
+      continue;
+    }
+    const prev = m.before[name];
+    const now = m.after[name];
+    if (!now) { unexplained.push(`${m.route} ${name} could not be read back after the write`); continue; }
+    const intent = intentOf(m);
+    for (const key of new Set([...Object.keys(now), ...Object.keys(prev ?? {})])) {
+      if (BOOKKEEPING.has(key)) continue;
+      // A NULL NAMES NOTHING — the plane's own rule, pinned by the parity journey above: an explicit
+      // null is a no-op, not a value. So it does not count as caller-named, and the field falls
+      // through to the stricter test: it must be byte-unchanged.
+      if (key in intent && intent[key] !== null) {
+        if (canonical(now[key]) !== canonical(intent[key])) {
+          unexplained.push(`${m.route} ${name}.${key} is not what the caller sent`);
+        }
+        continue;
+      }
+      // Not named by the caller and not bookkeeping: it must be exactly what it was.
+      // ON A CREATE the plane derives its own defaults, so "unchanged from before" is meaningless.
+      // What IS checkable is that the derived key set is CLOSED: a create may mint these and nothing
+      // else, so a field a second spine adds at genesis is red.
+      if (!prev) { if (!CREATE_DERIVED.has(key)) unexplained.push(`${m.route} ${name}.${key} is neither caller-sent nor a declared create-derived field`); continue; }
+      if (canonical(now[key]) !== canonical(prev[key])) unexplained.push(`${m.route} ${name}.${key} changed without the caller asking`);
+    }
+  }
+  ok("ON THE JOURNEYS THIS GATE WALKS, the ontology truth admitted through the watched path equals what the CALLER REQUESTED — named fields hold the value the request sent, unnamed fields are byte-unchanged, only declared bookkeeping moves on its own. The reference is the request because a response is the writer's own product. THIS IS A JOURNEY-SCOPED FACT, NOT the whole-program property \"no second admission path writes ontology truth\" — that property is filed as a residual and is commissioned to be entailed from module SOURCE, which is the layer it lives at",
+    ontologyMutations.length > 0 && unexplained.length === 0,
+    unexplained.length ? `UNEXPLAINED: ${unexplained.join(" ; ")}` : `${ontologyMutations.length} writing request(s), every field explained by the request that caused it`);
+  // AND A RECEIPT IS MINTED ONLY BESIDE THE WRITE IT ATTESTS. A review minted fabricated ontology
+  // receipts on the WITHDRAW requests — attesting patches that never happened — and nothing saw it,
+  // because only the record store was watched.
+  // THE LABEL CLAIMS CO-OCCURRENCE AND COUNT, WHICH IS WHAT IT CHECKS. It does NOT read receipt
+  // CONTENT, so a receipt minted beside a real write but attesting a different ontology, or a wrong
+  // operation, passes — and a receipt DELETED registers here as one "appearing". A review named
+  // both. Attestation binding is part of the whole-program property filed as a residual, not
+  // something this journey-scoped observation entails.
+  const strayReceipts = ontologyMutations.filter((m) => m.receiptsChanged.length && !m.changed.length);
+  const multiReceipts = ontologyMutations.filter((m) => m.receiptsChanged.length > 1);
+  const removedReceipts = ontologyMutations.filter((m) => m.receiptsChanged.some((n) => n.endsWith(":REMOVED")));
+  ok("and an ontology-plane receipt record APPEARS only in a request that also wrote the ontology, at most one per write, and none is ever removed — co-occurrence and count over the journeys walked; this does not read receipt CONTENT, so what a receipt ATTESTS is not checked here",
+    ontologyMutations.length > 0 && strayReceipts.length === 0 && multiReceipts.length === 0 && removedReceipts.length === 0,
+    strayReceipts.length || multiReceipts.length || removedReceipts.length
+      ? `STRAY: ${[...strayReceipts, ...multiReceipts, ...removedReceipts].map((m) => `${m.route} -> ${m.receiptsChanged.length} receipt(s) [${m.receiptsChanged.join(",")}], ${m.changed.length} record(s)`).join(" ; ")}`
+      : `${ontologyMutations.filter((m) => m.receiptsChanged.length).length} receipt-minting request(s), each beside its own write`);
+  // AND THE WRITING ROUTES ARE STILL A CLOSED SET. Three, each justified:
+  //   POST  …/odk/domain-ontologies            — the create route; it mints the ontology
+  //   PATCH …/odk/domain-ontologies/:id        — `apply_ontology_change`, THE one writer
+  //   POST  …/odk/ontology-proposals/:id/apply — which CALLS that same writer, the whole claim
+  // This is the weakest of the three assertions and is kept because it names the shape; the two
+  // above are what entail the claim. A closed world over the traffic THIS JOURNEY DRIVES.
+  const unexpectedRoutes = [...new Set(ontologyMutations.map((m) => m.route).filter((r) => !EXPECTED_ONTOLOGY_MUTATORS.some((re) => re.test(r))))];
+  const sawApply = ontologyMutations.some((m) => ONTOLOGY_WRITERS.apply.test(m.route));
+  const sawPatch = ontologyMutations.some((m) => ONTOLOGY_WRITERS.patch.test(m.route));
+  ok("and on those same journeys the only routes that moved an ontology record are its four registered writers — create, patch, delete, and the proposal apply that calls the patch writer — a shape claim over observed traffic, standing beside the identity claims above rather than in place of them",
+    unexpectedRoutes.length === 0 && sawApply && sawPatch,
+    unexpectedRoutes.length ? `UNEXPECTED: ${unexpectedRoutes.join(" ; ")}` : `observed: ${[...new Set(ontologyMutations.map((m) => m.route))].join(" ; ")}`);
+
+  const workbenchSource = fs.readFileSync(path.join(ROOT, "crates/node/src/bin/hypervisor_daemon_routes/ontology_workbench_routes.rs"), "utf8");
+  const odkSource = fs.readFileSync(path.join(ROOT, "crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs"), "utf8");
+  // THE CALL-SITE SET, and it must be able to see a write however it is spelled. The previous
+  // revision matched `\b(?:persist_record|remove_record)\(` and a review found three spellings it
+  // still could not see: another module's ontology writer, a raw `std::fs::write` into the family
+  // directory, and `persist_record_durable(` — the estate's NORMAL durable write, whose name this
+  // regex could not match because it is a SUFFIX. Two of those three were named in the comment that
+  // claimed to have closed them.
+  // STRIPPING COMMENTS WITH A REGEX DELETED EXECUTABLE CODE. The previous revision ran
+  // `.replace(/\/\/[^\n]*/gu, "")` over raw Rust, so a `//` INSIDE A STRING LITERAL ate the rest of
+  // the line. It truncated four live lines of this very module — every `org://` and
+  // `ontology-proposal://` literal — and a review demonstrated a second writer parked after a `://`
+  // literal going GREEN here while the code this replaced caught it. The repair was a REGRESSION.
+  // So: a real scanner, which tracks string literals, raw strings and nested block comments.
+  const commentFree = stripRustComments(workbenchSource);
+  // THE `use` DECLARATIONS ARE KEPT, NOT DISCARDED. Stripping them stops an import counting as a
+  // use of the writer — but it also erased `use super::persist_record as mint;`, so the ALIAS that
+  // defeats a name census became invisible while the harmless plain re-import was caught. They are
+  // parsed first, and any alias they bind to a writer joins the set of names counted below.
+  // NOT LINE-ANCHORED. `^[^\S\n]*use\s` required the declaration to start its line, so
+  // `fn shadow(..) { use std::fs as sysfs; sysfs::write(..) }` was seen by NEITHER the import pin
+  // (count still 8) nor the symbol allowlist (it derives no `super::`/`crate::`/`ioi_*` path) — and
+  // the fs denylist misses `sysfs::write` because `\bfs::` finds no word boundary inside it. A
+  // review demonstrated a raw write into the ontology family through exactly that hole.
+  // NOT ANCHORED ON A CHARACTER CLASS EITHER. `[{};\s]` moved the anchor off line-start and a review
+  // walked past it one character over: `#[allow(unused_imports)]use std::fs as sysfs;` — an
+  // attribute's `]` is in neither set, the pin printed "8 declarations, all pinned" with a ninth in
+  // the file, and `sysfs::write` misses the fs denylist because `\bfs::` finds no word boundary
+  // inside it. A NEGATIVE LOOKBEHIND for an identifier character is the anchor that has no gap.
+  const useDecls = [...commentFree.matchAll(/(?<![A-Za-z0-9_])use\s([^;]*);/gu)].map((m) => m[1].replace(/\s+/gu, " ").trim());
+  const executableSource = commentFree.replace(/(?<![A-Za-z0-9_])use\s[^;]*;/gu, " ");
+  const WRITER_BASE = ["persist_record", "remove_record", "persist_promoted", "admit_required"];
+  // EVERY alias in the declaration. A non-global `.match()` registered only the FIRST, so
+  // `use super::{persist_record as mint, persist_record as forge, …}` bound `mint` and left `forge`
+  // an unknown name calling the writer in plain sight. A review demonstrated it.
+  const writerAliases = useDecls.flatMap((decl) =>
+    [...decl.matchAll(new RegExp(`\\b(?:${WRITER_BASE.join("|")})\\w*\\s+as\\s+(\\w+)`, "gu"))].map((m) => m[1]));
+  const writerNames = [...WRITER_BASE, ...writerAliases];
+  const writerPattern = new RegExp(`\\b(?:${writerNames.join("|")})\\w*`, "gu");
+  const writerCallPattern = new RegExp(`\\b(?:${writerNames.join("|")})\\w*\\(\\s*&?[\\w.]+\\s*,\\s*([A-Z_]+)`, "gu");
+  const writeCalls = [...executableSource.matchAll(writerCallPattern)].map((m) => m[1]);
+  // EVERY MENTION, not every call. A `let w: fn(..) = persist_record;` alias writes the family while
+  // the name never appears followed by `(`, so a call-site count silently dropped it — the exact
+  // "cannot read it" case this assertion exists to turn RED. Counting bare mentions makes an alias
+  // unresolvable rather than invisible.
+  const allWriteSites = [...executableSource.matchAll(writerPattern)].length;
+  const OWN_FAMILIES = ["KIND_PROPOSAL", "KIND_SAVED_SET"];
+  ok("every record-writing call site in this module is RESOLVED to a family — a write the derivation cannot read is RED, not silently dropped, and the pattern matches suffixed writers like `persist_record_durable`",
+    allWriteSites > 0 && writeCalls.length === allWriteSites,
+    `${writeCalls.length} resolved of ${allWriteSites} write call sites`);
+  // THE LABEL CLAIMS ONLY WHAT THIS CHECKS, and what it checks is a NAME CENSUS. A review defeated
+  // the previous label — "writes ONLY its own two families" — with a writer this file never names:
+  // `substrate_store::persist_promoted`, in an ALLOWLISTED module, which `persist_record` itself
+  // delegates to. A name census cannot entail "no second writer exists"; the RUNTIME assertion
+  // above is what entails it, and this is the bounded ratchet standing beside it.
+  ok("every record write this module names by any of the KNOWN writer spellings resolves to one of its own two families, and both are named — a NAME CENSUS bounding the spellings it lists, and nothing more: it does not entail that no second writer exists, and neither does the journey observation above",
+    writeCalls.length > 0
+      && writeCalls.every((family) => OWN_FAMILIES.includes(family))
+      && OWN_FAMILIES.every((family) => writeCalls.includes(family)),
+    `writes ${[...new Set(writeCalls)].join(",") || "none"}`);
+  // A `let` IS NOT A `const`. The value pin below counts `const KIND_PROPOSAL` occurrences, so a
+  // `let KIND_PROPOSAL = "odk-domain-ontologies";` shadow type-checks, redirects a write to the
+  // ontology family, and leaves "neither shadowed" green. A review demonstrated exactly that.
+  ok("and neither family constant is REBOUND by a later `let` — the value pin counts `const` declarations, and a `let` shadow would redirect a write while leaving that pin untouched",
+    !new RegExp(`\\b(?:let|static)\\s+(?:mut\\s+)?(?:${OWN_FAMILIES.join("|")})\\b`, "u").test(executableSource),
+    "no let/static shadow of either family constant");
+  ok("and those two constants really point at this module's OWN families — the derivation reads names, so the names are pinned to their values",
+    /const KIND_PROPOSAL: &str = "odk-ontology-proposals";/u.test(workbenchSource)
+      && /const KIND_SAVED_SET: &str = "odk-saved-object-sets";/u.test(workbenchSource)
+      && (workbenchSource.match(/const KIND_PROPOSAL\b/gu) || []).length === 1
+      && (workbenchSource.match(/const KIND_SAVED_SET\b/gu) || []).length === 1,
+    "both constants pinned, neither shadowed");
+  // AND NO RAW FILESYSTEM WRITE AT ALL, which is how a second spine evades any call-site census.
+  // A DENYLIST, and named as one. It covers the filesystem entry points a second spine would
+  // plausibly reach for — a review demonstrated `File::create`, `fs::copy`, `fs::rename`,
+  // `fs::hard_link` and whitespace-separated paths slipping the previous four-name version — but a
+  // denylist cannot entail "no raw write exists", and this label no longer claims that.
+  ok("this module names NONE of the filesystem entry points a second spine would reach for — a denylist bounding a known attack, not a proof that no raw write exists",
+    !/\bfs\s*::\s*(write|create|remove_file|remove_dir|copy|rename|hard_link|OpenOptions|File)/u.test(workbenchSource.replace(/\s*::\s*/gu, "::"))
+      && !/\bFile\s*::\s*create/u.test(workbenchSource),
+    "no denylisted fs entry point");
+  // AND ITS CROSS-MODULE REACH IS A CLOSED SET, because a writer in another module is still a
+  // second spine and no census of THIS file can see one.
+  // Both spellings: `super::x::` in an expression AND a bare `use super::x;` that lets a later call
+  // read `x::write(..)`. `mutation_event_foundation` was allowlisted and never referenced — an
+  // allowlist entry nothing uses is a door held open, and it exports generic writers.
+  // A MODULE ALLOWLIST IS TOO COARSE, and a review proved it with no trick at all: `substrate_store`
+  // was allowlisted for its scope helpers, and it EXPORTS `persist_promoted` — the function
+  // `persist_record` itself delegates to. The same durable write, one name earlier, inside an
+  // allowed module. So the reach is pinned per SYMBOL, derived from the source: every cross-module
+  // name this file actually reaches must be listed, and a new one fails CLOSED until justified.
+  // Also parsed: brace imports (`use super::{a, b};`, which is how `persist_record` arrives today)
+  // and workspace-crate paths, both of which the module-level patterns could not see at all.
+  const braceImports = useDecls.flatMap((decl) => {
+    const m = decl.match(/^super::\{(.+)\}$/u);
+    return m ? m[1].split(",").map((s) => s.trim().split(/\s+as\s+/u)[0]).filter(Boolean) : [];
+  });
+  const crossSymbols = [...new Set([
+    ...[...executableSource.matchAll(/\bsuper::(\w+)::(\w+)/gu)].map((m) => `${m[1]}::${m[2]}`),
+    ...useDecls.flatMap((decl) => {
+      const m = decl.match(/^super::(\w+)::(\w+)/u);
+      return m ? [`${m[1]}::${m[2]}`] : [];
+    }),
+    ...braceImports.map((sym) => `super::${sym}`),
+    ...useDecls.flatMap((decl) => (/^super::(\w+)$/u.test(decl) ? [`super::${decl.slice("super::".length)}`] : [])),
+    ...[...executableSource.matchAll(/\bcrate::([\w:]+)/gu)].map((m) => `crate::${m[1]}`),
+    ...useDecls.flatMap((decl) => {
+      const m = decl.match(/^((?:ioi_|agentgres)\w*)::([\w:]+)/u);
+      return m ? [`${m[1]}::${m[2]}`] : [];
+    }),
+    ...[...executableSource.matchAll(/\b((?:ioi_|agentgres)\w*)::([\w:]+)/gu)].map((m) => `${m[1]}::${m[2]}`),
+  ])].sort();
+  // Every entry is a NON-WRITING symbol: scope binding/authorization, identity resolution, the
+  // record readers, the shared validator, and the ONE ontology writer this module is required to
+  // call rather than reimplement. Nothing here persists a record on this module's behalf except
+  // `odk_routes::apply_ontology_change`, which is the whole point.
+  const ALLOWED_SYMBOLS = [
+    "odk_routes::KIND_ONT", "odk_routes::KIND_ONT_RECEIPT", "odk_routes::apply_ontology_change",
+    "odk_routes::check_expected_revision", "odk_routes::load", "odk_routes::nanos",
+    "odk_routes::odk_scope_refusal", "odk_routes::validate_ontology_change",
+    "substrate_store::authorize_request_resource_scope", "substrate_store::authorized_request_resource_refs",
+    "substrate_store::bind_request_resource_scope", "substrate_store::read_request_scope",
+    "substrate_store::resolve_request_identity", "substrate_store::RequestIdentity",
+    "super::persist_record", "super::read_record_dir",
+    "super::DaemonState", "super::iso_now",
+  ];
+  // AND THE IMPORT SET ITSELF IS CLOSED, because a symbol allowlist derives symbols and two kinds of
+  // reach derive NONE. A review showed both: `use super::*;` matches no `super::x::y`, no
+  // `super::{…}` and no `super::x` pattern, so a parent writer this file never names comes in for
+  // free; and `use std::fs as sys;` then `sys::write(…)` is neither a `super::`/`crate::`/`ioi_*`
+  // path nor the literal `fs::write` the denylist looks for. Pinning the declarations themselves is
+  // the only closed world that covers a reach whose whole point is having no derivable name.
+  const ALLOWED_USE_DECLS = [
+    "std::sync::Arc",
+    "axum::extract::{Path as AxumPath, Query, State}",
+    "axum::http::{HeaderMap, StatusCode}",
+    "axum::Json",
+    "serde_json::{json, Value}",
+    "std::collections::HashMap",
+    "super::odk_routes::{ apply_ontology_change, check_expected_revision, load, nanos, odk_scope_refusal, validate_ontology_change, KIND_ONT, }",
+    "super::{iso_now, persist_record, read_record_dir, DaemonState}",
+  ];
+  const unlistedDecls = useDecls.filter((d) => !ALLOWED_USE_DECLS.includes(d));
+  ok("and this module's IMPORT SET is closed and pinned — a glob (`use super::*;`) and a renamed std path (`use std::fs as sys;`) each derive to NO symbol at all, so a symbol allowlist alone cannot fail closed on them and the declarations themselves are what is pinned",
+    unlistedDecls.length === 0 && useDecls.length === ALLOWED_USE_DECLS.length,
+    unlistedDecls.length ? `UNLISTED IMPORT: ${unlistedDecls.join(" ; ")}` : `${useDecls.length} declarations, all pinned`);
+  const unlistedSymbols = crossSymbols.filter((s) => !ALLOWED_SYMBOLS.includes(s));
+  ok("and this module's cross-module reach is a closed set of NAMED SYMBOLS, not of modules — an allowlisted module that exports a durable writer (`substrate_store::persist_promoted`, which `persist_record` delegates to) is a second spine wearing an approved module name, so a new symbol fails CLOSED",
+    unlistedSymbols.length === 0 && crossSymbols.length > 0,
+    unlistedSymbols.length ? `UNLISTED: ${unlistedSymbols.join(",")}` : `${crossSymbols.length} symbols, all listed`);
+  // COUNTED OVER THE STRIPPED SOURCE, not the raw file: a doc-comment example writing
+  // `apply_ontology_change(...)` would make this 2 and turn the assertion RED on a COMMENT.
+  const applyCalls = (executableSource.match(/apply_ontology_change\(/gu) || []).length;
+  ok("the ontology edit has exactly ONE writer across these two modules, which this one calls rather than reimplements",
+    (odkSource.match(/fn apply_ontology_change\(/gu) || []).length === 1 && applyCalls === 1,
+    `${applyCalls} call(s) to the one writer`);
+  // THE WRITER MUST CALL IT, which is the whole claim. A review found `validate_ontology_change`
+  // was a hand-maintained DUPLICATE that only the proposal plane called, while the writer kept its
+  // own inline copy — two copies nothing held in agreement, and one had already diverged. An
+  // assertion that checks only "the function exists and propose calls it" cannot fail on that.
+  // AND THE WRITER MUST REFUSE ON IT. Replacing its `if let Err(..) { return .. }` with
+  // `let _ = validate_ontology_change(body);` left every static assertion green, because a pinned
+  // call literal matches the discarding form too. The refusing shape is what is pinned, and the
+  // live probe below is what actually holds it.
+  ok("propose and the WRITER run the SAME validator, and the writer REFUSES on it — one definition, called from both, in a form that returns",
+    (odkSource.match(/fn validate_ontology_change\(/gu) || []).length === 1
+      && /if let Err\(\(_status, error\)\) = validate_ontology_change\(body\) \{\s*\n\s*return \(StatusCode::OK, Json\(json!\(\{ "ok": false, "error": error \}\)\)\);/u.test(odkSource)
+      && /validate_ontology_change\(&change\)/u.test(workbenchSource),
+    "one definition, refusing in the writer, called by propose");
+
+  const fails = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.length - fails.length}/${results.length} passed`);
+  emitVerifierCensus({ verifierId: "ontology-backend-families", sourceUrl: import.meta.url, results });
+  cleanup();
+  process.exit(fails.length ? 1 : 0);
+}
+
+run().catch((error) => {
+  // NO CENSUS ON A CRASH: the floors gate reads a missing census as RED, which is the correct
+  // reading of a run that did not finish.
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+  console.log(`\n${results.filter((r) => r.pass).length}/${results.length} passed BEFORE THE RUN DIED (incomplete — no census emitted)`);
+  console.error(`FAIL ontology-backend-families — ${error?.stack || error}`);
+  cleanup();
+  process.exit(1);
+});

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs
@@ -5,8 +5,9 @@
 // processes), the brief §5 acceptance that #219/#222 left open: create /
 // version-discipline / read / search-filter / denial / CAS-conflict-and-
 // recovery / receipt / reload / restart-survival journeys, plus the typed
-// named-gap assertions for the daemon families that do not exist (proposals,
-// saved-set authoring) — absence is asserted, never papered over.
+// presence assertions for the proposal and saved-object-set families, which next-legs XIII landed
+// — the two assertions that used to claim their ABSENCE probed URLs that were never routes and so
+// could never have gone red; see the block at their site.
 //
 // Exit: 0 pass · 1 fail · 2 blocked (daemon binary or product bundle missing).
 //
@@ -218,11 +219,26 @@ async function run() {
   const health = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}/health`);
   ok("health answers for the authored ontology", health.status === 200, `status ${health.status}`);
 
-  // -- named gaps stay typed, never faked ------------------------------------
-  const proposals = await jd(`/v1/hypervisor/odk/domain-ontologies/${ontId}/proposals`);
-  ok("proposal family absent — named gap typed, not simulated", proposals.status === 404 || proposals.status === 405, `status ${proposals.status}`);
-  const savedSet = await jd("/v1/hypervisor/odk/materialized-object-sets", { method: "POST", body: JSON.stringify({ name: "x" }) });
-  ok("saved-set authoring absent — named gap typed, not simulated", savedSet.status === 404 || savedSet.status === 405, `status ${savedSet.status}`);
+  // -- the two families next-legs XIII LANDED, asserted at the routes that actually exist ---------
+  //
+  // THESE TWO ASSERTIONS USED TO CLAIM THESE FAMILIES WERE ABSENT, AND THEY COULD NEVER HAVE FAILED.
+  // They probed `/domain-ontologies/:id/proposals` and `POST /materialized-object-sets` — one was
+  // never a route in any build, the other is registered GET-only — so both answered 404/405 for
+  // reasons that had nothing to do with the subject, and the gate stayed green while the estate's
+  // truth moved underneath it. A merge-blocking audit found them AFTER next-legs XIII landed both
+  // families: CI-wired, floor-pinned, and cited in the ledger as corroborating evidence, with two
+  // false assertion NAMES hashed into the floors digest as certified estate truth. An assertion
+  // whose probe was never real is the purest form of a decorative assertion — it cannot go red on
+  // its own finding in any world.
+  //
+  // They now probe the REAL routes and assert PRESENCE, so this gate fails if either family is
+  // withdrawn — which is what an absence claim was supposed to buy and never did.
+  const proposals = await jd("/v1/hypervisor/odk/ontology-proposals");
+  ok("the ontology PROPOSAL family is REGISTERED at its route and refuses this anonymous probe — this journey sends no session, so what is proven is registration plus an identity-first refusal, not that the family answers; it replaces an assertion that claimed the family was ABSENT while probing a URL that was never a route in any build",
+    proposals.status === 401, `status ${proposals.status}`);
+  const savedSet = await jd("/v1/hypervisor/odk/saved-object-sets");
+  ok("the SAVED-OBJECT-SET family is REGISTERED at its route and refuses this anonymous probe — registration plus an identity-first refusal, not that the family answers; it replaces an assertion that claimed saved-set authoring was ABSENT while probing a GET-only route with a POST",
+    savedSet.status === 401, `status ${savedSet.status}`);
 
   // -- identity gate (W1.1/G-2 finding CLOSED): anonymous authoring refuses typed ----
   // Rule E — the refusal is owed BEFORE any record load: the serve action lane without a

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -24,7 +24,14 @@
       "npm_script": "check:ontology-journey",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-journey.mjs",
       "runtime_assertions": 46,
-      "assertion_names_sha256": "ed3903a71c147447131159b4b735f2a4bfc7e6daeb6d1b3a314673811f8092f7"
+      "assertion_names_sha256": "edd363be3a0c9f3ed364e33530e6b7e0e39ba8dc66f777a5b2ebd877a1957930"
+    },
+    {
+      "id": "ontology-backend-families",
+      "npm_script": "check:ontology-backend-families",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-backend-families.mjs",
+      "runtime_assertions": 86,
+      "assertion_names_sha256": "a6295d669c82fb4c79b1d02d2516cdbde4705f922cf3577c01a4b43498392bc7"
     },
     {
       "id": "governance-journey",

--- a/crates/node/src/bin/hypervisor-daemon.rs
+++ b/crates/node/src/bin/hypervisor-daemon.rs
@@ -122,6 +122,8 @@ mod mutation_event_foundation;
 mod odk_routes;
 #[path = "hypervisor_daemon_routes/ontology_projection_routes.rs"]
 mod ontology_projection_routes;
+#[path = "hypervisor_daemon_routes/ontology_workbench_routes.rs"]
+mod ontology_workbench_routes;
 #[path = "hypervisor_daemon_routes/operability_routes.rs"]
 mod operability_routes;
 #[path = "hypervisor_daemon_routes/operations_support_routes.rs"]
@@ -1601,6 +1603,45 @@ async fn async_main() -> anyhow::Result<()> {
         .route(
             "/v1/hypervisor/odk/domain-ontologies/:id/history",
             get(odk_routes::handle_odk_ontology_history),
+        )
+        // The three ontology backend families ACC-A names and the estate did not have (next-legs
+        // XIII). Ordinary governed mutation, identity-first, `expected_revision` CAS; a proposal
+        // APPLY writes through `odk_routes::apply_ontology_change`, the one writer an ordinary PATCH
+        // uses, so composing over the owner never becomes a second spine beside it.
+        .route(
+            "/v1/hypervisor/odk/ontology-proposals",
+            get(ontology_workbench_routes::handle_proposal_list)
+                .post(ontology_workbench_routes::handle_proposal_create),
+        )
+        .route(
+            "/v1/hypervisor/odk/ontology-proposals/:id",
+            get(ontology_workbench_routes::handle_proposal_get),
+        )
+        .route(
+            "/v1/hypervisor/odk/ontology-proposals/:id/apply",
+            post(ontology_workbench_routes::handle_proposal_apply),
+        )
+        .route(
+            "/v1/hypervisor/odk/ontology-proposals/:id/withdraw",
+            post(ontology_workbench_routes::handle_proposal_withdraw),
+        )
+        .route(
+            "/v1/hypervisor/odk/saved-object-sets",
+            get(ontology_workbench_routes::handle_saved_set_list)
+                .post(ontology_workbench_routes::handle_saved_set_create),
+        )
+        .route(
+            "/v1/hypervisor/odk/saved-object-sets/:id",
+            get(ontology_workbench_routes::handle_saved_set_get)
+                .patch(ontology_workbench_routes::handle_saved_set_patch),
+        )
+        .route(
+            "/v1/hypervisor/odk/saved-object-sets/:id/retire",
+            post(ontology_workbench_routes::handle_saved_set_retire),
+        )
+        .route(
+            "/v1/hypervisor/odk/object-instance-search",
+            post(ontology_workbench_routes::handle_object_instance_search),
         )
         // ConnectorMapping — the first inert authority-crossing brick (declared source fields →
         // typed object properties). No extraction; object_instances stays 0.

--- a/crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/odk_routes.rs
@@ -32,6 +32,9 @@ use std::collections::HashMap;
 use super::{iso_now, persist_record, read_record_dir, remove_record, DaemonState};
 
 pub(crate) const KIND_ONT: &str = "odk-domain-ontologies";
+/// THE ONE SPELLING of the health note. It was written into records at create time and read back
+/// verbatim, so a capability landing could not reach an ontology already on disk.
+const OBJECT_DATA_NOTE: &str = "this health report is derived from the MODEL ALONE — the function that builds it receives no data directory and counts nothing, so the `object_instances` beside it is a structural zero and NOT a materialization count. Ask the object-instance SEARCH plane for that: it is bound as of next-legs XIII (POST /v1/hypervisor/odk/object-instance-search), walks the materialized-set store, and answers a typed corpus-absent when nothing is materialized";
 const KIND_RECIPE: &str = "odk-data-recipes";
 const KIND_MANIFEST: &str = "odk-manifests";
 const KIND_SD: &str = "odk-surface-descriptors";
@@ -84,7 +87,7 @@ const ACTION_KINDS: &[&str] = &[
     "function",
 ];
 /// Receipts for ontology create/patch land here (history is also embedded on the record).
-const KIND_ONT_RECEIPT: &str = "odk-ontology-receipts";
+pub(crate) const KIND_ONT_RECEIPT: &str = "odk-ontology-receipts";
 
 fn safe(seg: &str) -> String {
     seg.replace(
@@ -92,13 +95,13 @@ fn safe(seg: &str) -> String {
         "_",
     )
 }
-fn nanos() -> u128 {
+pub(crate) fn nanos() -> u128 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0)
 }
-fn load(data_dir: &str, kind: &str, id: &str) -> Option<Value> {
+pub(crate) fn load(data_dir: &str, kind: &str, id: &str) -> Option<Value> {
     serde_json::from_slice(
         &std::fs::read(
             Path::new(data_dir)
@@ -748,7 +751,7 @@ fn validate_object_model(com: &Value) -> Result<Value, VErr> {
         },
         "gaps": gaps,
         "object_instances": 0,
-        "object_data_note": "schema only — no object-instance/projection plane is bound; explorer rows require a real ontology-bound object plane (not built here)",
+        "object_data_note": OBJECT_DATA_NOTE,
         "legacy_untyped_names": legacy_untyped
     }))
 }
@@ -835,7 +838,10 @@ fn str_opt_bounded(body: &Value, key: &str, max: usize) -> Result<Option<String>
 /// Optimistic concurrency (#63): when `expected_revision` is supplied it must be an integer that
 /// exactly matches the persisted revision. Malformed → typed invalid refusal; mismatch → typed
 /// conflict. Either refusal changes NOTHING. Legacy callers that omit it are preserved.
-fn check_expected_revision(body: &Value, current: u64) -> Result<(), (StatusCode, String, String)> {
+pub(crate) fn check_expected_revision(
+    body: &Value,
+    current: u64,
+) -> Result<(), (StatusCode, String, String)> {
     match body.get("expected_revision") {
         None | Some(Value::Null) => Ok(()),
         Some(v) => match v.as_u64() {
@@ -848,6 +854,23 @@ fn check_expected_revision(body: &Value, current: u64) -> Result<(), (StatusCode
 
 // ================================ DOMAIN ONTOLOGY ================================================
 
+/// PROSE ABOUT THE PLANE IS PROJECTED ON READ, NEVER SERVED FROM THE RECORD.
+///
+/// `health.object_data_note` describes what this ESTATE can do, and it is computed at write time and
+/// persisted into the record — so every ontology written before a capability lands keeps the old
+/// sentence for ever, and a review found exactly that: three user-facing pages still telling readers
+/// no object-instance plane is bound, months after one was, with no backfill anywhere in the stack.
+/// A stored note is a snapshot of what was true when the record was written; a reader wants what is
+/// true now. So the note is REPROJECTED on every read. The counts and gaps beside it stay stored
+/// truth — they are facts about the model, which is what the record is for.
+fn reproject_object_data_note(record: &mut Value) {
+    if let Some(health) = record.get_mut("health").and_then(Value::as_object_mut) {
+        if health.contains_key("object_data_note") {
+            health.insert("object_data_note".to_string(), json!(OBJECT_DATA_NOTE));
+        }
+    }
+}
+
 pub(crate) async fn handle_odk_ontology_list(
     State(st): State<Arc<DaemonState>>,
     Query(q): Query<HashMap<String, String>>,
@@ -857,6 +880,9 @@ pub(crate) async fn handle_odk_ontology_list(
         items.retain(|o| o.get("domain").and_then(|v| v.as_str()) == Some(domain));
     }
     sort_by_updated(&mut items);
+    for item in items.iter_mut() {
+        reproject_object_data_note(item);
+    }
     Json(json!({ "ok": true, "ontologies": items }))
 }
 
@@ -875,11 +901,13 @@ pub(crate) async fn handle_odk_ontology_create(
         Ok(identity) => identity,
         Err(error) => return odk_scope_refusal(error),
     };
-    let domain = body
-        .get("domain")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
+    // TRIM TO JUDGE, PERSIST WHAT THE CALLER SENT. `apply_ontology_change` stores `domain`
+    // VERBATIM; this route stored it TRIMMED, so create and patch disagreed on the same field —
+    // one field's worth of exactly the divergence this module's own comment claims to have ended,
+    // and silent normalization of persisted data is a defect this run has already paid for once.
+    // The emptiness judgement still uses the trimmed value, which is what the shared validator does.
+    let domain_raw = body.get("domain").and_then(|v| v.as_str());
+    let domain = domain_raw.filter(|s| !s.trim().is_empty());
     let Some(domain) = domain else {
         return bad(
             "odk_domain_required",
@@ -956,7 +984,11 @@ pub(crate) async fn handle_odk_ontology_get(
     State(st): State<Arc<DaemonState>>,
     AxumPath(id): AxumPath<String>,
 ) -> Json<Value> {
-    json_get(&st.data_dir, KIND_ONT, "ontology", &id)
+    let mut out = json_get(&st.data_dir, KIND_ONT, "ontology", &id);
+    if let Some(record) = out.0.get_mut("ontology") {
+        reproject_object_data_note(record);
+    }
+    out
 }
 
 /// PATCH — fail-closed on a malformed model (revision is NOT bumped on rejection); optimistic
@@ -976,7 +1008,81 @@ pub(crate) async fn handle_odk_ontology_patch(
         Ok(identity) => identity,
         Err(error) => return odk_scope_refusal(error),
     };
-    let Some(prev) = load(&st.data_dir, KIND_ONT, &id) else {
+    apply_ontology_change(&st.data_dir, &identity, &id, &body)
+}
+
+/// THE ONE VALIDATOR FOR AN ONTOLOGY CHANGE SET, shared by the edit path and the proposal plane.
+///
+/// A review demonstrated that proposal-time checking was strictly weaker than apply-time: an empty
+/// `domain`, an over-length field, and a duplicate object-type id were all ACCEPTED as proposals and
+/// then refused on apply, leaving permanently unappliable "open" proposals accumulating. That
+/// contradicts the reason a proposal is validated at all — a proposal that could never apply is a
+/// note. Both paths now run this, so "the same rules an ordinary edit obeys" is a shared function
+/// rather than a claim.
+pub(crate) fn validate_ontology_change(body: &Value) -> Result<(), (StatusCode, Value)> {
+    for (key, max) in [("domain", 120usize), ("version", 60), ("description", 2000)] {
+        match str_opt_bounded(body, key, max) {
+            Ok(Some(value)) if key == "domain" && value.trim().is_empty() => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    json!({ "code": "odk_domain_required", "message": "`domain` must stay non-empty" }),
+                ))
+            }
+            Ok(_) => {}
+            Err((code, message)) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    json!({ "code": code, "message": message }),
+                ))
+            }
+        }
+    }
+    // A NULL OBJECT MODEL IS PRESENT AND INVALID, and it stays that way.
+    //
+    // An earlier revision made it "absent" to match how `str_opt_bounded` reads the string fields,
+    // citing a propose/patch divergence. THERE WAS NO DIVERGENCE: both planes already refused it
+    // with `odk_field_type_invalid`. What existed was an inconsistency INSIDE this validator, and
+    // it got resolved by relaxing the STRICTER side — turning a typed refusal on a shipped route
+    // into an accepted no-op that bumped the revision and minted a receipt for nothing. Fail-closed
+    // to fail-open, undeclared. The internal inconsistency is real and is left standing
+    // deliberately: a missing string field and a missing model are different shapes, and between
+    // two ways to make them agree the honest one admits less.
+    if let Some(model) = body.get("canonical_object_model") {
+        if !model.is_object() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                json!({ "code": "odk_field_type_invalid", "message": "`canonical_object_model` must be an object" }),
+            ));
+        }
+        if let Err((code, message)) = validate_object_model(model) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                json!({ "code": code, "message": message }),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// THE ONE WRITER FOR AN ONTOLOGY EDIT.
+///
+/// Extracted from the PATCH handler so the ontology-proposal plane can APPLY a proposal through the
+/// exact path an ordinary edit takes. A proposal apply that re-implemented validation, revision
+/// bumping, health recomputation, receipting or history would be a SECOND ADMISSION PATH for one act
+/// — with its own answer to `expected_revision`, its own idea of what a valid model is, and its own
+/// receipt shape. The estate's standing law is that no surface mints a second spine beside a kernel
+/// owner; this keeps proposals composing over the owner rather than beside it.
+///
+/// Identity is resolved by the CALLER, before this is reached, because rule E owes a 401 before the
+/// record read below is allowed to reveal existence.
+pub(crate) fn apply_ontology_change(
+    data_dir: &str,
+    identity: &super::substrate_store::RequestIdentity,
+    id: &str,
+    body: &Value,
+) -> (StatusCode, Json<Value>) {
+    let st_data_dir = data_dir;
+    let Some(prev) = load(st_data_dir, KIND_ONT, id) else {
         return (
             StatusCode::NOT_FOUND,
             Json(
@@ -985,7 +1091,7 @@ pub(crate) async fn handle_odk_ontology_patch(
         );
     };
     let current_rev = prev.get("revision").and_then(|v| v.as_u64()).unwrap_or(1);
-    if let Err((status, code, msg)) = check_expected_revision(&body, current_rev) {
+    if let Err((status, code, msg)) = check_expected_revision(body, current_rev) {
         return (
             status,
             Json(
@@ -993,52 +1099,30 @@ pub(crate) async fn handle_odk_ontology_patch(
             ),
         );
     }
-    // Hardened (#63): editable fields present-but-wrong-type/oversized are rejected typed.
-    let mut typed_fields: Vec<(&str, Value)> = Vec::new();
-    for (key, max) in [("domain", 120usize), ("version", 60), ("description", 2000)] {
-        match str_opt_bounded(&body, key, max) {
-            Ok(Some(v)) => {
-                if key == "domain" && v.trim().is_empty() {
-                    return (
-                        StatusCode::OK,
-                        Json(
-                            json!({ "ok": false, "error": { "code": "odk_domain_required", "message": "`domain` must stay non-empty" } }),
-                        ),
-                    );
-                }
-                typed_fields.push((key, json!(v)));
-            }
-            Ok(None) => {}
-            Err((code, msg)) => {
-                return (
-                    StatusCode::OK,
-                    Json(json!({ "ok": false, "error": { "code": code, "message": msg } })),
-                )
-            }
-        }
-    }
-    if let Some(new_com) = body.get("canonical_object_model") {
-        if !new_com.is_object() {
-            return (
-                StatusCode::OK,
-                Json(
-                    json!({ "ok": false, "error": { "code": "odk_field_type_invalid", "message": "`canonical_object_model` must be an object" } }),
-                ),
-            );
-        }
-        // Validate the replacement model BEFORE mutating anything — a bad patch changes nothing.
-        if let Err((code, msg)) = validate_object_model(new_com) {
-            return (
-                StatusCode::OK,
-                Json(json!({ "ok": false, "error": { "code": code, "message": msg } })),
-            );
-        }
+    // THE SHARED VALIDATOR, not a second copy of these rules. A review found this path carrying an
+    // inline duplicate of `validate_ontology_change` while the proposal plane called the function —
+    // two copies nothing held in agreement, and one had already diverged (an explicit `null` domain
+    // was accepted here and refused there). One caller, one validator, or "the same rules an
+    // ordinary edit obeys" is a sentence rather than a property.
+    if let Err((_status, error)) = validate_ontology_change(body) {
+        return (StatusCode::OK, Json(json!({ "ok": false, "error": error })));
     }
     let mut o = prev.clone();
     let mut changed: Vec<String> = Vec::new();
-    for (key, v) in typed_fields {
-        o[key] = v;
-        changed.push(key.to_string());
+    for key in ["domain", "version", "description"] {
+        // Validated above by the shared validator; only PRESENT string fields are applied, so an
+        // absent field and an explicit null both leave the record untouched exactly as before.
+        //
+        // AND THE VALUE IS STORED VERBATIM. An earlier revision of this extraction wrote
+        // `value.trim()`, which is an UNDECLARED REWRITE OF CALLER DATA on a shipped write path:
+        // `create` stored `"  9.9.9  "` while `patch` of the same string stored `"9.9.9"`, a
+        // proposal's reviewed text stopped being the text that got written, and the length bound
+        // still measured the raw string while storage was trimmed. Trimming belongs to the
+        // emptiness CHECK in the validator, never to what is persisted.
+        if let Some(value) = body.get(key).and_then(Value::as_str) {
+            o[key] = json!(value);
+            changed.push(key.to_string());
+        }
     }
     if let Some(new_com) = body.get("canonical_object_model") {
         o["canonical_object_model"] = new_com.clone();
@@ -1092,7 +1176,7 @@ pub(crate) async fn handle_odk_ontology_patch(
     refs.push(receipt_ref);
     o["receipt_refs"] = json!(refs);
     if let Err(m) =
-        finalize_ontology_persist(&st.data_dir, &id, Some(&prev), &o, &receipt_id, &receipt)
+        finalize_ontology_persist(st_data_dir, id, Some(&prev), &o, &receipt_id, &receipt)
     {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1628,7 +1712,7 @@ pub(crate) async fn handle_odk_manifest_delete(
 const ODK_NAMESPACE: &str = "hypervisor-odk";
 const ODK_DESCRIPTOR_SCOPE_KIND: &str = "hypervisor-odk-surface-descriptor";
 
-fn odk_scope_refusal(
+pub(crate) fn odk_scope_refusal(
     error: super::substrate_store::RequestScopeRefusal,
 ) -> (StatusCode, Json<Value>) {
     use super::substrate_store::RequestScopeRefusal;

--- a/crates/node/src/bin/hypervisor_daemon_routes/ontology_workbench_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/ontology_workbench_routes.rs
@@ -1,0 +1,1084 @@
+//! The three ontology backend families ACC-A names and the estate did not have.
+//!
+//! Next-legs XII took `SURF-ontology` to 12 of 13 real governed controls and then said plainly what
+//! still blocked closure: it was BACKEND, not surface. Derived from the router rather than from
+//! guessed URLs, there was **no ontology proposal/branch family, no saved object-set/exploration
+//! family, and no object-instance search family**, so three of the six journeys ACC-A names could
+//! not close at any depth of UI work.
+//!
+//! WHAT BINDS THIS MODULE:
+//!
+//!   * **Ordinary governed mutation, NOT an authority crossing.** Ruling OQ-1, its OQ-11
+//!     reaffirmation, and next-legs XII all reached the same place: canon's local-canonicality rule
+//!     makes authoring your own ontology an ordinary governed mutation, and re-plumbing it through
+//!     the CapabilityLease client would invent authority canon does not require and make every
+//!     schema edit demand a wallet approval. Identity-first, `expected_revision` CAS, typed
+//!     receipts, atomic-with-rollback persistence — the same shape `odk_routes` already carries.
+//!
+//!   * **NO SECOND SPINE.** Applying a proposal writes through `odk_routes::apply_ontology_change`,
+//!     the one writer an ordinary PATCH uses. A proposal apply that re-implemented validation,
+//!     revision bumping, health recomputation or receipting would be a second admission path for one
+//!     act, with its own answer to `expected_revision`. That mistake has been made twice in this
+//!     program and both times the substrate had already ruled the question.
+//!
+//!   * **A TYPED ABSENCE IS NOT A GAP TO PAPER OVER.** Object-instance search runs over the
+//!     materialized object sets the connector-execution plane really produces. Where no corpus has
+//!     been materialized the answer is a typed, named empty — never an invented row, and never an
+//!     empty list that reads like "no matches".
+//!
+//!   * **A SAVED SET IS ONE PRINCIPAL'S.** Explorations are per-principal, pinned through the
+//!     substrate's own immutable resource scope — never a record's descriptive `owner_ref` and never
+//!     a tenant check, because `org://local` is the only constructible organization and every
+//!     principal holds it.
+//!
+//! WHAT THIS DOES NOT DO: it does not cut over the legacy `/__ioi/ontology/*` mounts (W6.1, blocked
+//! on OQ-2), and it mints no deletion route — a saved set RETIRES through its own lifecycle
+//! transition, and content deletion belongs to the W1.5 data-retention disposition plane.
+
+use std::sync::Arc;
+
+use axum::extract::{Path as AxumPath, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::Json;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+use super::odk_routes::{
+    apply_ontology_change, check_expected_revision, load, nanos, odk_scope_refusal,
+    validate_ontology_change, KIND_ONT,
+};
+use super::{iso_now, persist_record, read_record_dir, DaemonState};
+
+const KIND_PROPOSAL: &str = "odk-ontology-proposals";
+const KIND_SAVED_SET: &str = "odk-saved-object-sets";
+const PROPOSAL_SCHEMA: &str = "ioi.hypervisor.odk.ontology-proposal.v1";
+const SAVED_SET_SCHEMA: &str = "ioi.hypervisor.odk.saved-object-set.v1";
+const SEARCH_SCHEMA: &str = "ioi.hypervisor.odk.object-instance-search-result.v1";
+const SAVED_SET_SCOPE_KIND: &str = "hypervisor-odk-saved-object-set";
+const MATERIALIZED_SET_DIR: &str = "odk-materialized-object-sets";
+
+const TEXT_MAX: usize = 2000;
+const NAME_MAX: usize = 200;
+const SEARCH_LIMIT_MAX: u64 = 200;
+const SEARCH_LIMIT_DEFAULT: u64 = 50;
+
+type Reply = (StatusCode, Json<Value>);
+
+fn bad(status: StatusCode, code: &str, message: impl Into<String>) -> Reply {
+    (
+        status,
+        Json(json!({ "ok": false, "error": { "code": code, "message": message.into() } })),
+    )
+}
+
+/// Identity FIRST, before any record read — rule E. A 401 is owed before a 404 that would otherwise
+/// answer "does this ontology exist" to a caller with no session.
+// IDENTITY IS RESOLVED THROUGH THE CANONICAL SEAM AT EVERY CALL SITE, NOT THROUGH A LOCAL WRAPPER.
+//
+// A two-line module-local `identity()` helper wrapped `substrate_store::resolve_request_identity`,
+// and `check:admission-evidence` — the estate-wide INV-37 ratchet — reported five of these handlers
+// as having NO in-handler identity call. It was right about what it could see: the canonical name
+// appeared once, in the wrapper, and the handlers named something only this file knows. The audit
+// offers a justified pin for exactly this, and a pin would have been the wrong answer: it would
+// have taken five mutating handlers OUT of an estate-wide census to keep a seam that bought two
+// lines. A convenience that hides the canonical call from a census is the same shape as a name a
+// derivation cannot read, which is the defect this whole leg keeps paying for.
+
+fn bounded_string(body: &Value, key: &str, max: usize, required: bool) -> Result<String, Reply> {
+    match body.get(key) {
+        None | Some(Value::Null) if !required => Ok(String::new()),
+        Some(Value::String(value)) => {
+            let trimmed = value.trim();
+            if required && trimmed.is_empty() {
+                return Err(bad(
+                    StatusCode::BAD_REQUEST,
+                    "odk_field_required",
+                    format!("`{key}` must be a non-empty string"),
+                ));
+            }
+            if trimmed.chars().count() > max {
+                return Err(bad(
+                    StatusCode::BAD_REQUEST,
+                    "odk_field_too_long",
+                    format!("`{key}` exceeds the bounded length ({max} chars)"),
+                ));
+            }
+            Ok(trimmed.to_string())
+        }
+        None | Some(Value::Null) => Err(bad(
+            StatusCode::BAD_REQUEST,
+            "odk_field_required",
+            format!("`{key}` is required"),
+        )),
+        Some(_) => Err(bad(
+            StatusCode::BAD_REQUEST,
+            "odk_field_type_invalid",
+            format!("`{key}` must be a string"),
+        )),
+    }
+}
+
+/// Resolve an ontology by id or by its `ref`, returning the record and its canonical id.
+fn resolve_ontology(data_dir: &str, reference: &str) -> Option<(String, Value)> {
+    if let Some(record) = load(data_dir, KIND_ONT, reference) {
+        let id = record
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or(reference)
+            .to_string();
+        return Some((id, record));
+    }
+    read_record_dir(data_dir, KIND_ONT)
+        .into_iter()
+        .find_map(|record| {
+            let matches = record.get("ref").and_then(Value::as_str) == Some(reference)
+                || record.get("id").and_then(Value::as_str) == Some(reference);
+            matches.then(|| {
+                let id = record
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or(reference)
+                    .to_string();
+                (id, record)
+            })
+        })
+}
+
+// =================================================================================================
+// FAMILY 1 — ontology proposals. The `propose` journey ACC-A names.
+//
+// A proposal is a DECLARED, VALIDATED, REVIEWABLE change against one ontology at one revision. It is
+// deliberately not a branch of the whole model: canon's ontology evolution is revision-based
+// (`expected_revision`), and inventing a parallel branch store would be a second source of truth for
+// what an ontology IS. What a proposal adds over a direct PATCH is the review interval — the change
+// exists, validated and attributable, before anyone applies it.
+// =================================================================================================
+
+/// The change set a proposal carries. Validated AT PROPOSE TIME against the same rules an ordinary
+/// edit obeys, because a proposal that could never apply is not a proposal — it is a note.
+fn proposal_change_set(body: &Value) -> Result<Value, Reply> {
+    let mut change = json!({});
+    let mut named = 0usize;
+    for key in ["domain", "version", "description"] {
+        if let Some(value) = body.get("changes").and_then(|c| c.get(key)) {
+            // NO TYPE CHECK HERE. This was a second, hand-maintained copy of the writer's rules and
+            // it DISAGREED with them: it refused an explicit `null` that the writer reads as an
+            // ABSENT field, so `domain: null` was 400 at propose and a 200 no-op at patch — the very
+            // divergence the shared validator was extracted to end. A null is "not named"; every
+            // other type decision belongs to the shared validator below, which both planes run.
+            if !value.is_null() {
+                change[key] = value.clone();
+                named += 1;
+            }
+        }
+    }
+    if let Some(model) = body
+        .get("changes")
+        .and_then(|c| c.get("canonical_object_model"))
+    {
+        // The model is passed through WHATEVER its shape, null included, so the shared validator
+        // makes the call. Skipping a null here would read it as "not named" while the writer reads
+        // it as present-and-invalid — the two planes disagreeing again, in the other direction.
+        change["canonical_object_model"] = model.clone();
+        named += 1;
+    }
+    if named == 0 {
+        return Err(bad(
+            StatusCode::BAD_REQUEST,
+            "ontology_proposal_change_required",
+            "a proposal must name at least one change — an empty proposal proposes nothing",
+        ));
+    }
+    // THE SAME RULES AN ORDINARY EDIT OBEYS, run through the ontology plane's own validator rather
+    // than approximated here. Checking only JSON types at propose time was strictly weaker than
+    // apply time, so an empty `domain`, an over-length field or a duplicate object-type id was
+    // admitted as an "open" proposal that could never be applied.
+    if let Err((status, error)) = validate_ontology_change(&change) {
+        return Err((status, Json(json!({ "ok": false, "error": error }))));
+    }
+    Ok(change)
+}
+
+/// POST /v1/hypervisor/odk/ontology-proposals
+pub(crate) async fn handle_proposal_create(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Reply {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        Ok(identity) => identity,
+        Err(reply) => return reply,
+    };
+    let ontology_ref = match bounded_string(&body, "ontology_ref", TEXT_MAX, true) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let title = match bounded_string(&body, "title", NAME_MAX, true) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let rationale = match bounded_string(&body, "rationale", TEXT_MAX, false) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let change = match proposal_change_set(&body) {
+        Ok(change) => change,
+        Err(reply) => return reply,
+    };
+    let Some((ontology_id, ontology)) = resolve_ontology(&st.data_dir, &ontology_ref) else {
+        return bad(
+            StatusCode::NOT_FOUND,
+            "odk_ontology_not_found",
+            "no ontology resolves at this ref",
+        );
+    };
+    let current_revision = ontology
+        .get("revision")
+        .and_then(Value::as_u64)
+        .unwrap_or(1);
+    if let Err((status, code, message)) = check_expected_revision(&body, current_revision) {
+        return (
+            status,
+            Json(
+                json!({ "ok": false, "error": { "code": code, "message": message, "current_revision": current_revision } }),
+            ),
+        );
+    }
+    let id = format!("ontp_{:x}", nanos());
+    let record = json!({
+        "schema_version": PROPOSAL_SCHEMA,
+        "id": id,
+        "ref": format!("ontology-proposal://{id}"),
+        "ontology_id": ontology_id,
+        "ontology_ref": ontology.get("ref").cloned().unwrap_or_else(|| json!(ontology_ref)),
+        "based_on_revision": current_revision,
+        "title": title,
+        "rationale": rationale,
+        "changes": change,
+        "status": "open",
+        "proposed_by": identity.principal_ref,
+        "created_at": iso_now(),
+        "applied": Value::Null,
+        "withdrawn": Value::Null,
+    });
+    if persist_record(&st.data_dir, KIND_PROPOSAL, &id, &record).is_err() {
+        return bad(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "ontology_proposal_persistence_failed",
+            "the proposal could not be persisted; nothing was recorded",
+        );
+    }
+    (
+        StatusCode::CREATED,
+        Json(json!({ "ok": true, "ontology_proposal": record })),
+    )
+}
+
+/// GET /v1/hypervisor/odk/ontology-proposals[?ontology_ref=&status=]
+pub(crate) async fn handle_proposal_list(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+) -> Reply {
+    if let Err(reply) = super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        return reply;
+    }
+    let wanted_ontology = query.get("ontology_ref").map(String::as_str);
+    let wanted_status = query.get("status").map(String::as_str);
+    let mut proposals = read_record_dir(&st.data_dir, KIND_PROPOSAL)
+        .into_iter()
+        .filter(|record| {
+            wanted_ontology.is_none_or(|reference| {
+                record.get("ontology_ref").and_then(Value::as_str) == Some(reference)
+                    || record.get("ontology_id").and_then(Value::as_str) == Some(reference)
+            }) && wanted_status
+                .is_none_or(|status| record.get("status").and_then(Value::as_str) == Some(status))
+        })
+        .collect::<Vec<_>>();
+    proposals.sort_by(|a, b| {
+        b.get("created_at")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .cmp(a.get("created_at").and_then(Value::as_str).unwrap_or(""))
+    });
+    (
+        StatusCode::OK,
+        Json(
+            json!({ "ok": true, "schema_version": PROPOSAL_SCHEMA, "ontology_proposals": proposals, "runtimeTruthSource": "daemon-runtime" }),
+        ),
+    )
+}
+
+/// GET /v1/hypervisor/odk/ontology-proposals/:id
+pub(crate) async fn handle_proposal_get(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<String>,
+) -> Reply {
+    if let Err(reply) = super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        return reply;
+    }
+    match load(&st.data_dir, KIND_PROPOSAL, &id) {
+        Some(record) => (
+            StatusCode::OK,
+            Json(json!({ "ok": true, "ontology_proposal": record })),
+        ),
+        None => bad(
+            StatusCode::NOT_FOUND,
+            "ontology_proposal_not_found",
+            "no proposal exists at this id",
+        ),
+    }
+}
+
+/// POST /v1/hypervisor/odk/ontology-proposals/:id/apply
+///
+/// THE WRITE GOES THROUGH THE ONTOLOGY PLANE'S OWN WRITER. This handler decides only whether the
+/// proposal may be applied; what "applying" means is `odk_routes::apply_ontology_change`, the same
+/// function an ordinary PATCH runs.
+pub(crate) async fn handle_proposal_apply(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<String>,
+) -> Reply {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        Ok(identity) => identity,
+        Err(reply) => return reply,
+    };
+    let Some(proposal) = load(&st.data_dir, KIND_PROPOSAL, &id) else {
+        return bad(
+            StatusCode::NOT_FOUND,
+            "ontology_proposal_not_found",
+            "no proposal exists at this id",
+        );
+    };
+    match proposal.get("status").and_then(Value::as_str) {
+        Some("open") => {}
+        Some("applied") => {
+            return (
+                StatusCode::OK,
+                Json(json!({ "ok": true, "replayed": true, "ontology_proposal": proposal })),
+            )
+        }
+        Some(other) => {
+            return bad(
+                StatusCode::CONFLICT,
+                "ontology_proposal_not_open",
+                format!("this proposal is '{other}' and cannot be applied"),
+            )
+        }
+        None => {
+            return bad(
+                StatusCode::CONFLICT,
+                "ontology_proposal_not_open",
+                "this proposal carries no status",
+            )
+        }
+    }
+    let ontology_id = proposal
+        .get("ontology_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let based_on = proposal
+        .get("based_on_revision")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let Some((_, ontology)) = resolve_ontology(&st.data_dir, &ontology_id) else {
+        return bad(
+            StatusCode::CONFLICT,
+            "odk_ontology_not_found",
+            "the ontology this proposal targets no longer resolves",
+        );
+    };
+    let current_revision = ontology
+        .get("revision")
+        .and_then(Value::as_u64)
+        .unwrap_or(1);
+    // A PROPOSAL IS AN OFFER AGAINST ONE REVISION. If the ontology moved underneath it, applying
+    // would silently overwrite whatever landed in between — which is exactly what `upsert-*` merging
+    // did to another author's definition before XII made create mean create. The refusal changes
+    // nothing and names both revisions so the proposer can rebase.
+    if current_revision != based_on {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "ok": false,
+                "error": {
+                    "code": "ontology_proposal_stale",
+                    "message": "the ontology has advanced since this proposal was made; nothing was applied — rebase the proposal onto the current revision",
+                    "based_on_revision": based_on,
+                    "current_revision": current_revision,
+                }
+            })),
+        );
+    }
+    // Carry the CAS through to the one writer, so the revision guard is enforced where the write
+    // happens rather than only where this handler looked.
+    let mut change = proposal
+        .get("changes")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    change["expected_revision"] = json!(current_revision);
+    let (status, Json(applied)) =
+        apply_ontology_change(&st.data_dir, &identity, &ontology_id, &change);
+    if !status.is_success() || applied.get("ok").and_then(Value::as_bool) != Some(true) {
+        return (status, Json(applied));
+    }
+    let mut successor = proposal;
+    successor["status"] = json!("applied");
+    successor["applied"] = json!({
+        "applied_by": identity.principal_ref,
+        "applied_at": iso_now(),
+        "resulting_revision": applied.pointer("/ontology/revision").cloned().unwrap_or(Value::Null),
+        "ontology_receipt_ref": applied.pointer("/ontology_receipt/receipt_ref").cloned().unwrap_or(Value::Null),
+    });
+    if persist_record(&st.data_dir, KIND_PROPOSAL, &id, &successor).is_err() {
+        // The ONTOLOGY edit is durable and receipted; only the proposal's own projection failed.
+        // Saying so exactly is the honest answer — claiming the apply failed would be false, and
+        // claiming it succeeded would hide a proposal stuck reading `open` over an applied change.
+        return bad(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "ontology_proposal_projection_failed",
+            "the ontology edit is applied and receipted, but the proposal's own status could not be persisted; re-read the ontology revision before re-applying",
+        );
+    }
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "ontology_proposal": successor,
+            "ontology": applied.get("ontology").cloned().unwrap_or(Value::Null),
+            "ontology_receipt": applied.get("ontology_receipt").cloned().unwrap_or(Value::Null),
+        })),
+    )
+}
+
+/// POST /v1/hypervisor/odk/ontology-proposals/:id/withdraw
+pub(crate) async fn handle_proposal_withdraw(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<String>,
+    Json(body): Json<Value>,
+) -> Reply {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        Ok(identity) => identity,
+        Err(reply) => return reply,
+    };
+    let reason = match bounded_string(&body, "reason", TEXT_MAX, false) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let Some(proposal) = load(&st.data_dir, KIND_PROPOSAL, &id) else {
+        return bad(
+            StatusCode::NOT_FOUND,
+            "ontology_proposal_not_found",
+            "no proposal exists at this id",
+        );
+    };
+    match proposal.get("status").and_then(Value::as_str) {
+        Some("withdrawn") => {
+            return (
+                StatusCode::OK,
+                Json(json!({ "ok": true, "replayed": true, "ontology_proposal": proposal })),
+            )
+        }
+        Some("open") => {}
+        Some(other) => {
+            return bad(
+                StatusCode::CONFLICT,
+                "ontology_proposal_terminal",
+                format!("this proposal is '{other}'; a terminal proposal cannot be withdrawn"),
+            )
+        }
+        None => {
+            return bad(
+                StatusCode::CONFLICT,
+                "ontology_proposal_terminal",
+                "this proposal carries no status",
+            )
+        }
+    }
+    let mut successor = proposal;
+    successor["status"] = json!("withdrawn");
+    successor["withdrawn"] = json!({
+        "withdrawn_by": identity.principal_ref,
+        "withdrawn_at": iso_now(),
+        "reason": reason,
+    });
+    if persist_record(&st.data_dir, KIND_PROPOSAL, &id, &successor).is_err() {
+        return bad(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "ontology_proposal_persistence_failed",
+            "the withdrawal could not be persisted; the proposal is unchanged",
+        );
+    }
+    (
+        StatusCode::OK,
+        Json(json!({ "ok": true, "ontology_proposal": successor })),
+    )
+}
+
+// =================================================================================================
+// FAMILY 2 — saved object sets. The `saved-set` journey ACC-A names.
+//
+// PER-PRINCIPAL, pinned through the substrate's own immutable scope. A saved exploration is one
+// person's working state, and the estate has exactly one honest way to say that: the resource scope
+// pin. A descriptive `owner_ref` on the record would be a field the record asserts about itself, and
+// a tenant check would isolate nothing at all.
+// =================================================================================================
+
+fn owner_tenant(identity: &super::substrate_store::RequestIdentity) -> Result<String, Reply> {
+    let mut organizations = identity
+        .tenant_refs
+        .iter()
+        .filter(|tenant_ref| tenant_ref.starts_with("org://"));
+    let (Some(owner_ref), None) = (organizations.next(), organizations.next()) else {
+        return Err(bad(
+            StatusCode::FORBIDDEN,
+            "saved_object_set_owner_tenant_unresolved",
+            "ownership binds to exactly one org:// tenant resolved from the caller's own session",
+        ));
+    };
+    Ok(owner_ref.clone())
+}
+
+fn authorize_saved_set(
+    data_dir: &str,
+    identity: &super::substrate_store::RequestIdentity,
+    id: &str,
+) -> Result<Value, Reply> {
+    super::substrate_store::authorize_request_resource_scope(
+        data_dir,
+        identity,
+        SAVED_SET_SCOPE_KIND,
+        id,
+        None,
+    )
+    .map_err(odk_scope_refusal)?;
+    load(data_dir, KIND_SAVED_SET, id).ok_or_else(|| {
+        bad(
+            StatusCode::NOT_FOUND,
+            "saved_object_set_not_found",
+            "the caller holds a scope at this coordinate but no saved set resolves under it",
+        )
+    })
+}
+
+/// The selection a saved set stores. Bounded and typed; never an opaque blob.
+fn saved_set_selection(body: &Value) -> Result<Value, Reply> {
+    let Some(selection) = body.get("selection") else {
+        return Err(bad(
+            StatusCode::BAD_REQUEST,
+            "saved_object_set_selection_required",
+            "`selection` is required — a saved set with no selection saves nothing",
+        ));
+    };
+    if !selection.is_object() {
+        return Err(bad(
+            StatusCode::BAD_REQUEST,
+            "odk_field_type_invalid",
+            "`selection` must be an object",
+        ));
+    }
+    let mut out = json!({});
+    for key in ["object_type_id", "q"] {
+        match selection.get(key) {
+            None | Some(Value::Null) => {}
+            Some(Value::String(value)) => {
+                if value.chars().count() > TEXT_MAX {
+                    return Err(bad(
+                        StatusCode::BAD_REQUEST,
+                        "odk_field_too_long",
+                        format!("`selection.{key}` exceeds the bounded length"),
+                    ));
+                }
+                out[key] = json!(value);
+            }
+            Some(_) => {
+                return Err(bad(
+                    StatusCode::BAD_REQUEST,
+                    "odk_field_type_invalid",
+                    format!("`selection.{key}` must be a string"),
+                ))
+            }
+        }
+    }
+    if out.as_object().is_none_or(|object| object.is_empty()) {
+        return Err(bad(
+            StatusCode::BAD_REQUEST,
+            "saved_object_set_selection_required",
+            "`selection` must carry at least one of `object_type_id` or `q`",
+        ));
+    }
+    Ok(out)
+}
+
+/// POST /v1/hypervisor/odk/saved-object-sets
+pub(crate) async fn handle_saved_set_create(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Reply {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        Ok(identity) => identity,
+        Err(reply) => return reply,
+    };
+    let name = match bounded_string(&body, "name", NAME_MAX, true) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let description = match bounded_string(&body, "description", TEXT_MAX, false) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let ontology_ref = match bounded_string(&body, "ontology_ref", TEXT_MAX, true) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let selection = match saved_set_selection(&body) {
+        Ok(selection) => selection,
+        Err(reply) => return reply,
+    };
+    let Some((ontology_id, ontology)) = resolve_ontology(&st.data_dir, &ontology_ref) else {
+        return bad(
+            StatusCode::NOT_FOUND,
+            "odk_ontology_not_found",
+            "no ontology resolves at this ref",
+        );
+    };
+    let owner_ref = match owner_tenant(&identity) {
+        Ok(owner_ref) => owner_ref,
+        Err(reply) => return reply,
+    };
+    let id = format!("sos_{:x}", nanos());
+    // THE PIN BEFORE THE RECORD. A saved set that existed without an owner pin could be read by
+    // whoever guessed its id, and there would be no coordinate to authorize a later edit against.
+    if let Err(error) = super::substrate_store::bind_request_resource_scope(
+        &st.data_dir,
+        &identity,
+        SAVED_SET_SCOPE_KIND,
+        &id,
+        &owner_ref,
+        &owner_ref,
+        &format!("saved-object-set-owner:{id}"),
+    ) {
+        return odk_scope_refusal(error);
+    }
+    let record = json!({
+        "schema_version": SAVED_SET_SCHEMA,
+        "id": id,
+        "ref": format!("saved-object-set://{id}"),
+        "name": name,
+        "description": description,
+        "ontology_id": ontology_id,
+        "ontology_ref": ontology.get("ref").cloned().unwrap_or_else(|| json!(ontology_ref)),
+        "selection": selection,
+        "status": "active",
+        "revision": 1,
+        "saved_by": identity.principal_ref,
+        "created_at": iso_now(),
+        "updated_at": iso_now(),
+    });
+    if persist_record(&st.data_dir, KIND_SAVED_SET, &id, &record).is_err() {
+        return bad(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "saved_object_set_persistence_failed",
+            "the saved set could not be persisted; nothing was recorded",
+        );
+    }
+    (
+        StatusCode::CREATED,
+        Json(json!({ "ok": true, "saved_object_set": record })),
+    )
+}
+
+/// GET /v1/hypervisor/odk/saved-object-sets — the CALLER'S OWN saved sets.
+pub(crate) async fn handle_saved_set_list(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+) -> Reply {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        Ok(identity) => identity,
+        Err(reply) => return reply,
+    };
+    let authorized = match super::substrate_store::authorized_request_resource_refs(
+        &st.data_dir,
+        &identity,
+        SAVED_SET_SCOPE_KIND,
+    ) {
+        Ok(refs) => refs,
+        Err(error) => return odk_scope_refusal(error),
+    };
+    let mut sets = read_record_dir(&st.data_dir, KIND_SAVED_SET)
+        .into_iter()
+        .filter(|record| {
+            record
+                .get("id")
+                .and_then(Value::as_str)
+                .is_some_and(|id| authorized.contains(id))
+        })
+        .collect::<Vec<_>>();
+    sets.sort_by(|a, b| {
+        b.get("updated_at")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .cmp(a.get("updated_at").and_then(Value::as_str).unwrap_or(""))
+    });
+    (
+        StatusCode::OK,
+        Json(
+            json!({ "ok": true, "schema_version": SAVED_SET_SCHEMA, "saved_object_sets": sets, "runtimeTruthSource": "daemon-runtime" }),
+        ),
+    )
+}
+
+/// GET /v1/hypervisor/odk/saved-object-sets/:id
+pub(crate) async fn handle_saved_set_get(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<String>,
+) -> Reply {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        Ok(identity) => identity,
+        Err(reply) => return reply,
+    };
+    match authorize_saved_set(&st.data_dir, &identity, &id) {
+        Ok(record) => (
+            StatusCode::OK,
+            Json(json!({ "ok": true, "saved_object_set": record })),
+        ),
+        Err(reply) => reply,
+    }
+}
+
+/// PATCH /v1/hypervisor/odk/saved-object-sets/:id — `expected_revision` CAS.
+pub(crate) async fn handle_saved_set_patch(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<String>,
+    Json(body): Json<Value>,
+) -> Reply {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        Ok(identity) => identity,
+        Err(reply) => return reply,
+    };
+    let prev = match authorize_saved_set(&st.data_dir, &identity, &id) {
+        Ok(record) => record,
+        Err(reply) => return reply,
+    };
+    if prev.get("status").and_then(Value::as_str) == Some("retired") {
+        return bad(
+            StatusCode::CONFLICT,
+            "saved_object_set_retired",
+            "this saved set is retired; a retired set is history and does not accept edits",
+        );
+    }
+    let current_revision = prev.get("revision").and_then(Value::as_u64).unwrap_or(1);
+    if let Err((status, code, message)) = check_expected_revision(&body, current_revision) {
+        return (
+            status,
+            Json(
+                json!({ "ok": false, "error": { "code": code, "message": message, "current_revision": current_revision } }),
+            ),
+        );
+    }
+    let mut successor = prev.clone();
+    let mut changed = Vec::new();
+    if body.get("name").is_some() {
+        match bounded_string(&body, "name", NAME_MAX, true) {
+            Ok(value) => {
+                successor["name"] = json!(value);
+                changed.push("name");
+            }
+            Err(reply) => return reply,
+        }
+    }
+    if body.get("description").is_some() {
+        match bounded_string(&body, "description", TEXT_MAX, false) {
+            Ok(value) => {
+                successor["description"] = json!(value);
+                changed.push("description");
+            }
+            Err(reply) => return reply,
+        }
+    }
+    if body.get("selection").is_some() {
+        match saved_set_selection(&body) {
+            Ok(selection) => {
+                successor["selection"] = selection;
+                changed.push("selection");
+            }
+            Err(reply) => return reply,
+        }
+    }
+    if changed.is_empty() {
+        return bad(
+            StatusCode::BAD_REQUEST,
+            "saved_object_set_change_required",
+            "a patch must name at least one of `name`, `description` or `selection`",
+        );
+    }
+    successor["revision"] = json!(current_revision + 1);
+    successor["updated_at"] = json!(iso_now());
+    if persist_record(&st.data_dir, KIND_SAVED_SET, &id, &successor).is_err() {
+        return bad(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "saved_object_set_persistence_failed",
+            "the edit could not be persisted; the saved set is unchanged",
+        );
+    }
+    (
+        StatusCode::OK,
+        Json(json!({ "ok": true, "saved_object_set": successor, "changed": changed })),
+    )
+}
+
+/// POST /v1/hypervisor/odk/saved-object-sets/:id/retire
+///
+/// NOT a delete. This estate has exactly one owner of content deletion — the W1.5 data-retention
+/// disposition plane — and a `DELETE` here would be a second admission path for that act with its
+/// own answer to legal hold. Retiring is a lifecycle transition: the record survives as history.
+pub(crate) async fn handle_saved_set_retire(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    AxumPath(id): AxumPath<String>,
+    Json(body): Json<Value>,
+) -> Reply {
+    let identity = match super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        Ok(identity) => identity,
+        Err(reply) => return reply,
+    };
+    let reason = match bounded_string(&body, "reason", TEXT_MAX, false) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let prev = match authorize_saved_set(&st.data_dir, &identity, &id) {
+        Ok(record) => record,
+        Err(reply) => return reply,
+    };
+    if prev.get("status").and_then(Value::as_str) == Some("retired") {
+        return (
+            StatusCode::OK,
+            Json(json!({ "ok": true, "replayed": true, "saved_object_set": prev })),
+        );
+    }
+    let mut successor = prev;
+    successor["status"] = json!("retired");
+    successor["retired"] = json!({
+        "retired_by": identity.principal_ref,
+        "retired_at": iso_now(),
+        "reason": reason,
+    });
+    successor["updated_at"] = json!(iso_now());
+    if persist_record(&st.data_dir, KIND_SAVED_SET, &id, &successor).is_err() {
+        return bad(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "saved_object_set_persistence_failed",
+            "the retirement could not be persisted; the saved set is unchanged",
+        );
+    }
+    (
+        StatusCode::OK,
+        Json(json!({ "ok": true, "saved_object_set": successor })),
+    )
+}
+
+// =================================================================================================
+// FAMILY 3 — object-instance search. The `search` journey ACC-A names.
+//
+// The corpus is REAL: the connector-execution plane materializes ontology-bound object records into
+// `odk-materialized-object-sets`, each carrying its objects, its object type, its ontology, and the
+// run that produced it. Search reads that and nothing else.
+//
+// WHERE THERE IS NO CORPUS THE ANSWER IS A NAMED EMPTY, not an empty list. "No materialized object
+// set exists for this ontology" and "your query matched nothing" are different facts, and a surface
+// that cannot tell them apart shows a user an empty table and lets them conclude the wrong one.
+// =================================================================================================
+
+fn search_string(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Number(number) => number.to_string(),
+        Value::Bool(flag) => flag.to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// POST /v1/hypervisor/odk/object-instance-search
+pub(crate) async fn handle_object_instance_search(
+    State(st): State<Arc<DaemonState>>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Reply {
+    if let Err(reply) = super::substrate_store::resolve_request_identity(&st.data_dir, &headers)
+        .map_err(odk_scope_refusal)
+    {
+        return reply;
+    }
+    let ontology_ref = match bounded_string(&body, "ontology_ref", TEXT_MAX, false) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let object_type_id = match bounded_string(&body, "object_type_id", TEXT_MAX, false) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let q = match bounded_string(&body, "q", TEXT_MAX, false) {
+        Ok(value) => value,
+        Err(reply) => return reply,
+    };
+    let limit = match body.get("limit") {
+        None | Some(Value::Null) => SEARCH_LIMIT_DEFAULT,
+        Some(Value::Number(number)) => match number.as_u64() {
+            Some(value) if value > 0 && value <= SEARCH_LIMIT_MAX => value,
+            _ => {
+                return bad(
+                    StatusCode::BAD_REQUEST,
+                    "object_instance_search_limit_invalid",
+                    format!("`limit` must be an integer in 1..={SEARCH_LIMIT_MAX}"),
+                )
+            }
+        },
+        Some(_) => {
+            return bad(
+                StatusCode::BAD_REQUEST,
+                "object_instance_search_limit_invalid",
+                "`limit` must be an integer",
+            )
+        }
+    };
+    // The ontology filter is resolved BEFORE the corpus is walked, so a typo names itself rather
+    // than reading as "no results".
+    let resolved_ontology = if ontology_ref.is_empty() {
+        None
+    } else {
+        match resolve_ontology(&st.data_dir, &ontology_ref) {
+            Some((id, record)) => Some((
+                id,
+                record
+                    .get("ref")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            )),
+            None => {
+                return bad(
+                    StatusCode::NOT_FOUND,
+                    "odk_ontology_not_found",
+                    "no ontology resolves at this ref",
+                )
+            }
+        }
+    };
+    let sets = read_record_dir(&st.data_dir, MATERIALIZED_SET_DIR);
+    let in_scope = sets
+        .iter()
+        .filter(|set| {
+            resolved_ontology.as_ref().is_none_or(|(id, reference)| {
+                let set_ref = set
+                    .get("ontology_ref")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                set_ref == reference || set_ref == id
+            }) && (object_type_id.is_empty()
+                || set.get("object_type_id").and_then(Value::as_str)
+                    == Some(object_type_id.as_str()))
+        })
+        .collect::<Vec<_>>();
+    let corpus_objects: usize = in_scope
+        .iter()
+        .map(|set| {
+            set.get("objects")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len)
+        })
+        .sum();
+    let needle = q.to_lowercase();
+    let mut matches = Vec::new();
+    let mut total_matched = 0usize;
+    for set in &in_scope {
+        let set_ref = set.get("ref").cloned().unwrap_or(Value::Null);
+        let run_ref = set
+            .get("materializing_run_ref")
+            .cloned()
+            .unwrap_or(Value::Null);
+        let set_object_type = set.get("object_type_id").cloned().unwrap_or(Value::Null);
+        let set_ontology = set.get("ontology_ref").cloned().unwrap_or(Value::Null);
+        for object in set
+            .get("objects")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let hit = needle.is_empty() || search_string(object).to_lowercase().contains(&needle);
+            if !hit {
+                continue;
+            }
+            total_matched += 1;
+            if matches.len() as u64 >= limit {
+                continue;
+            }
+            matches.push(json!({
+                "object": object,
+                "object_type_id": set_object_type,
+                "ontology_ref": set_ontology,
+                // PROVENANCE TRAVELS WITH EVERY ROW. An instance with no materializing run behind it
+                // is indistinguishable from an invented one.
+                "materialized_object_set_ref": set_ref,
+                "materializing_run_ref": run_ref,
+            }));
+        }
+    }
+    // THE TWO EMPTIES ARE DIFFERENT FACTS and are typed as such.
+    let absence = if in_scope.is_empty() {
+        json!({
+            "code": "object_instance_corpus_absent",
+            "message": "no materialized object set exists in this scope, so there is nothing to search — this is not a query that matched nothing",
+        })
+    } else if total_matched == 0 {
+        json!({
+            "code": "object_instance_query_unmatched",
+            "message": "the corpus was searched and matched nothing",
+        })
+    } else {
+        Value::Null
+    };
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "schema_version": SEARCH_SCHEMA,
+            "query": { "ontology_ref": ontology_ref, "object_type_id": object_type_id, "q": q, "limit": limit },
+            "corpus": {
+                "materialized_object_sets_in_scope": in_scope.len(),
+                "object_instances_in_scope": corpus_objects,
+            },
+            "total_matched": total_matched,
+            "truncated": total_matched > matches.len(),
+            "results": matches,
+            "absence": absence,
+            "runtimeTruthSource": "daemon-runtime",
+        })),
+    )
+}


### PR DESCRIPTION
**Next-legs XIII, Leg 3 of 4.** Three of the six journeys ACC-A names had **no daemon family at all**. XII said plainly that what still blocked SURF-ontology was BACKEND, not surface — derived from the router rather than from guessed URLs.

All three now exist as kernel-owned daemon truth: identity-first (rule E), `expected_revision` CAS, typed receipts, typed absences.

**No second spine.** A proposal APPLY writes through `odk_routes::apply_ontology_change` — the one writer an ordinary PATCH runs — and propose runs `validate_ontology_change`, the same validator that writer runs. A live parity journey drives **nine** input shapes through BOTH planes and asserts, per shape, each plane's ABSOLUTE refusal code, propose's typed 400, and that the ontology's **revision did not advance**. Agreement alone is blind: a shared validator preserves parity under any weakening, and a code in a body is not an absence of the act.

Saved sets are per-PRINCIPAL through the substrate scope pin and **retire rather than delete**, because content deletion belongs to the retention plane. Search types `object_instance_corpus_absent` apart from `object_instance_query_unmatched` — "nothing has been materialized here" and "your query matched nothing" are different facts, and a surface that cannot tell them apart lets a user conclude the wrong one. XII's authority ruling binds and is not re-litigated: ordinary governed mutation, not a CapabilityLease crossing.

### A green gate asserted two of these families did not exist
`check:ontology-journey` carried *"proposal family absent"* and *"saved-set authoring absent"* — probing `/domain-ontologies/:id/proposals`, **never a route in any build**, and `POST /materialized-object-sets`, which is registered GET-only. Neither assertion could go red in any world, and both were floor-pinned, so two **false assertion names were hashed into the floors digest as certified estate truth**. They now probe the registered routes and assert presence; a mutation withdrawing one proves the gate can fail.

### Two daemon defects the reviews found by driving it
- `create` **trimmed** the `domain` it persisted while `apply_ontology_change` stored it verbatim — one field's worth of exactly the divergence this module claims to have ended.
- The health note is computed at write time and **persisted**, so records already on disk kept the sentence that was true when they were written, and three user-facing pages went on saying no object-instance plane was bound. Prose about the plane is **projected on read** now, from one pinned constant.

### What this gate claims — and what it does not
Its observation is **journey-scoped**: on the journeys walked, the ontology truth admitted through the watched path equals **what the caller requested** — named fields hold the value the request sent, unnamed fields are byte-unchanged, only declared bookkeeping moves, no refused request wrote, and a receipt appears only beside the write it attests.

It is **not** the whole-program property *"no second admission path writes ontology truth."* Five review rounds each defeated a proof of that property — route name, file name, response bytes, caller's request — while the code under test stayed correct and green. That is the signature of a claim mis-scoped for its observer: the observer sits inside the system it is bounding. The owner terminated the iteration, the labels are re-scoped, and **the property is filed as a named residual and commissioned as next-legs XIV Leg 3a**, to be entailed from the router/module SOURCE.

**Evidence.** `check:ontology-backend-families` **86/86**, `check:ontology-journey` **46/46**, against a live daemon with three real principals. Floored in-commit (21 → 22 verifiers), both pins re-derived from RUNTIME censuses on this base. **Forty-six mutations RED-ON-TARGET** (a commit claim — this repository tracks no mutation ledger). `cargo test -p ioi-node --bin hypervisor-daemon` 720/720, all five bundled gates green, `cargo fmt --check` clean.

**Residual, unhedged.** Search's MATCHING over a product-produced corpus, its row provenance, its truncation arithmetic and its scope FILTER are proven NOWHERE — producing a corpus requires the wallet-gated materialization crossing. An opt-in lane claiming to prove it was written, could never pass, and was **deleted rather than defended**. Any authenticated principal can WITHDRAW another principal's proposal.

Rebuilt onto the post-#287 master, every payload file byte-verified against the reviewed tree; the floors file resolved wholesale-from-base by textual edit, with only the two intended row changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)