### PR TITLE
fix(gates): a closed set of ROLES closed nothing, because the set of things that produce a role was not entailed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,7 @@ jobs:
           npm run check:environment-custody --workspace=@ioi/hypervisor-app
           npm run check:operational-depth --workspace=@ioi/hypervisor-app
           npm run check:ontology-backend-families --workspace=@ioi/hypervisor-app
+          npm run check:ontology-admission-census --workspace=@ioi/hypervisor-app
 
       # The floor the verifier family never had. Every verifier above is pinned at the number of
       # assertions it actually EXECUTED; deleting assertions from any of them was silently green

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,18 @@ jobs:
       - name: Test the shipped Hypervisor daemon
         run: cargo test --locked -p ioi-node --bin hypervisor-daemon
 
+      # A green verifier certifies nothing until a MUTATION proves it red on its own finding. Every
+      # anchor is a replayable second-admission path planted in the daemon's own source, with the
+      # assertion it must turn red named beside it — and the harness re-derives the population pins
+      # the mutant moves first, because a landing commit does, and a pin bump is not a property.
+      # It runs HERE, in the Rust job, because each anchor is scored by a `cargo check --bin
+      # hypervisor-daemon` that must be REAL: the daemon was just built and tested above, so the
+      # target dir is warm and each check is incremental. The product_surfaces job installs no Rust
+      # toolchain, so a cold full-daemon check there exits 101 with no rustc error line — which the
+      # battery correctly reports as a BLOCKED compile check rather than as a passing run.
+      - name: Replay the admission census mutation battery
+        run: npm run mutate:ontology-admission-census --workspace=@ioi/hypervisor-app
+
       - name: Test the Agentgres substrate
         run: cargo test --locked -p agentgres
 
@@ -252,15 +264,6 @@ jobs:
         env:
           IOI_VERIFIER_CENSUS_DIR: .artifacts/verifier-census
         run: npm run check:verifier-floors --workspace=@ioi/hypervisor-app
-
-      # A green verifier certifies nothing until a MUTATION proves it red on its own finding. Every
-      # anchor is a replayable second-admission path planted in the daemon's own source, with the
-      # assertion it must turn red named beside it — and the harness re-derives the population pins
-      # the mutant moves first, because a landing commit does, and a pin bump is not a property.
-      # Runs AFTER the floors gate: this battery rewrites the verifier it certifies, and a census
-      # artifact written from a mutated source would disagree with the file on disk.
-      - name: Replay the admission census mutation battery
-        run: npm run mutate:ontology-admission-census --workspace=@ioi/hypervisor-app
 
       - name: Record post-build shipped-product artifact identities
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,15 @@ jobs:
           IOI_VERIFIER_CENSUS_DIR: .artifacts/verifier-census
         run: npm run check:verifier-floors --workspace=@ioi/hypervisor-app
 
+      # A green verifier certifies nothing until a MUTATION proves it red on its own finding. Every
+      # anchor is a replayable second-admission path planted in the daemon's own source, with the
+      # assertion it must turn red named beside it — and the harness re-derives the population pins
+      # the mutant moves first, because a landing commit does, and a pin bump is not a property.
+      # Runs AFTER the floors gate: this battery rewrites the verifier it certifies, and a census
+      # artifact written from a mutated source would disagree with the file on disk.
+      - name: Replay the admission census mutation battery
+        run: npm run mutate:ontology-admission-census --workspace=@ioi/hypervisor-app
+
       - name: Record post-build shipped-product artifact identities
         run: |
           mkdir -p .artifacts/implementation/shipped-products

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6927,6 +6927,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioi-ontology-census"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "serde",
+ "serde_json",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "ioi-pii"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/consensus",
     "crates/api",
     "crates/types",
+    "crates/ontology-census",
     "crates/crypto",
     "crates/networking",
     "crates/services",

--- a/apps/hypervisor/ontology-admission-census.mutants.v1.json
+++ b/apps/hypervisor/ontology-admission-census.mutants.v1.json
@@ -11,7 +11,7 @@
     "restore_always": "The harness rewrites the source it certifies. It restores every file it touched, including on failure. Never edit these files and never run a git write while a battery runs.",
     "repin_may_not_touch_a_claim": "The harness re-derives POPULATION counts only. It may NOT move `PINNED.unadjudicable` — the per-cause buckets of names this census cannot resolve. Those are a CLAIM about the gate's boundary, not a measurement of its reach: a new unadjudicable name is a name that entered the daemon which the census cannot tell from a second admitter. The REPIN table is keyed on bare identifiers and the bucket keys are quoted strings, so this holds by construction as well as by rule.",
     "anchors_must_compile": "Each anchor is compiled with `cargo check --bin hypervisor-daemon` after planting. An anchor that no longer compiles is scored INVALID, never caught: a signature change or a privacy change can rot an anchor into fiction while the battery keeps printing the same total.",
-    "unanchorable": "Two assertions cannot be anchored from daemon source and are listed here rather than left to look covered: the reverse totality edge (a label at a position holding no token) is an extractor-internal invariant that only a mutation of the extractor could trip, and mutating the tool is not mutating the artifact it certifies; and the EXTRACTOR SOURCE PIN is a claim about the extractor's own bytes, demonstrated separately in the leg's commit by editing the extractor and rebuilding."
+    "unanchorable": "Two assertions cannot be anchored from daemon source AT ALL, and are named so they are not left looking covered: the reverse totality edge (a label at a position holding no token) is an extractor-internal invariant only a mutation of the TOOL could trip, and mutating the tool is not mutating the artifact it certifies; and the EXTRACTOR SOURCE PIN is a claim about the extractor's own bytes, demonstrated in the leg's commit by editing the extractor and rebuilding. A previous version of this note said only those two were uncovered, which was FALSE and concealed a real gap: several further assertions carried no anchor, including three of the four commissioned family claims. Those three are anchored now. The four pure population pins are structurally exercised by every anchor's repin round and are not separately anchored."
   },
   "anchor_file": "crates/node/src/bin/hypervisor_daemon_routes/feedback_routes.rs",
   "anchor_find": "fn bad(code: &str, msg: &str) -> (StatusCode, Json<Value>) {",
@@ -198,16 +198,16 @@
     {
       "id": "T2-qualified-const-in-macro-tokens",
       "class": "boundary",
-      "note": "THE ATTACK THAT FALSIFIED THE PREVIOUS DESIGN. A qualified family constant inside `json!` tokens reaches a writer: the token walk flattens the path to its bare tail, so resolution fails and the name used to be dropped in silence. It is now COUNTED in `bare-undeclared`, and the bucket pin refuses it.",
+      "note": "THE ATTACK THAT FALSIFIED AN EARLIER DESIGN, and its verdict MOVED when the extractor stopped discarding path qualifiers inside macro tokens. It used to be counted in `bare-undeclared` because the census resolved the bare tail; now the qualifier is reassembled from the tokens, the name resolves to the family it actually names, and the commissioned claim itself refuses it. Re-aimed rather than left pointing at the bucket, because a mutation that starts passing for a STRONGER reason must be re-aimed, not celebrated.",
       "insert": "fn shadow_t2(data_dir: &str, id: &str, rec: &Value) -> Value {\n    json!({ \"w\": persist_record(data_dir, super::odk_routes::KIND_ONT, id, rec).is_ok() })\n}\n",
-      "red_on": "EVERY CONSTANT-SHAPED NAME THIS CENSUS CANNOT ADJUDICATE IS COUNTED IN A NAMED BUCKET"
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
     },
     {
       "id": "T3-qualified-const-macro-raw-fs",
       "class": "boundary",
-      "note": "The same drop bypassing the writers entirely and putting bytes in the family directory.",
+      "note": "The same drop bypassing the writers entirely. Caught by the TOUCHER ratchet rather than the raw-filesystem rule, and the distinction is worth recording: syn hands macro tokens over unparsed, so a filesystem call written inside `json!` produces no `fs_calls` entry at all — the rule that reads enclosing functions never sees it, and what refuses it is the family name appearing in a module not recorded as naming it.",
       "insert": "fn shadow_t3(data_dir: &str, id: &str) -> Value {\n    json!({ \"w\": std::fs::write(std::path::Path::new(data_dir).join(super::odk_routes::KIND_ONT).join(id), b\"{}\").is_ok() })\n}\n",
-      "red_on": "EVERY CONSTANT-SHAPED NAME THIS CENSUS CANNOT ADJUDICATE IS COUNTED IN A NAMED BUCKET"
+      "red_on": "NO MODULE NAMES AN ODK FAMILY IT IS NOT RECORDED AS NAMING"
     },
     {
       "id": "T4-c-string-literal",
@@ -266,6 +266,41 @@
         "content": "fn shadow_n2(data_dir: &str, id: &str, rec: &serde_json::Value) {\n    let _ = super::persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n}\n"
       },
       "insert": "macro_rules! shadow_mods_n2 {\n    () => { #[path = \"shadow_n2.rs\"] mod shadow_n2; };\n}\nshadow_mods_n2!();\n"
+    },
+    {
+      "id": "F1-foreign-declaration-ontology-receipts",
+      "class": "construct",
+      "note": "The commissioned claim covers FOUR families and only one of them had an anchor. A second name minted outside the owning module is the same attack one family over.",
+      "insert": "const SHADOW_F1: &str = \"odk-ontology-receipts\";\nfn shadow_f1(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, SHADOW_F1, id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-ontology-receipts`"
+    },
+    {
+      "id": "F2-foreign-declaration-ontology-proposals",
+      "class": "construct",
+      "insert": "const SHADOW_F2: &str = \"odk-ontology-proposals\";\nfn shadow_f2(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, SHADOW_F2, id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-ontology-proposals`"
+    },
+    {
+      "id": "F3-foreign-declaration-saved-object-sets",
+      "class": "construct",
+      "insert": "const SHADOW_F3: &str = \"odk-saved-object-sets\";\nfn shadow_f3(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, SHADOW_F3, id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-saved-object-sets`"
+    },
+    {
+      "id": "F4-shadowed-tail-in-macro-tokens",
+      "class": "boundary",
+      "note": "THE ZERO-DELTA ATTACK the re-scope's own review found. A qualified family constant inside macro tokens, with the module declaring its OWN constant of the same tail name — the census used to throw the qualifier away, resolve the bare tail against the local table, and adjudicate another module's family constant as innocent at zero delta to every pin. Twenty-three constant names in this daemon are declared in more than one module with different values, so the collision is ordinary. The extractor reassembles the qualifier from the tokens now, because the qualifier was always IN them.",
+      "insert": "const KIND_ONT: &str = \"feedback-annotations\";\nfn shadow_f4(data_dir: &str, id: &str, rec: &Value) -> Value {\n    json!({ \"w\": persist_record(data_dir, super::odk_routes::KIND_ONT, id, rec).is_ok() })\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "N3-one-hop-indirection-in-a-recorded-toucher",
+      "class": "named-residual",
+      "expect": "survives",
+      "note": "NAMED RESIDUAL — ONE-HOP INDIRECTION WITHIN A MODULE, and it must be planted in a module ALREADY RECORDED as touching the family or the toucher ratchet catches it for the wrong reason. `governance_routes` is a recorded toucher of `odk-domain-ontologies`, so this pair goes fully green: the writer's function names no family, the caller's does, and the conservative rule that would catch it is scoped to one function. Closing it means module-scope attribution, which fires on 198 of this daemon's production writer functions — a pinned exception list, not a gate. The first cut of this anchor was planted in a non-toucher and the battery scored it RESIDUAL-CLOSED, which is the harness refusing a mis-aimed anchor rather than the residual having closed.",
+      "insert": "fn shadow_n3_put(d: &str, k: &str, i: &str, r: &Value) {\n    let _ = persist_record(d, k, i, r);\n}\nfn shadow_n3_admit(d: &str, i: &str, r: &Value) {\n    shadow_n3_put(d, \"odk-domain-ontologies\", i, r);\n}\n",
+      "anchor_file": "crates/node/src/bin/hypervisor_daemon_routes/governance_routes.rs",
+      "anchor_find": "pub(crate) async fn handle_governance_overview("
     },
     {
       "id": "R1-runtime-assembly-via-local",

--- a/apps/hypervisor/ontology-admission-census.mutants.v1.json
+++ b/apps/hypervisor/ontology-admission-census.mutants.v1.json
@@ -8,7 +8,10 @@
     "on_target": "RED is not enough. Each anchor names the assertion whose CLAIM it violates, and the harness requires THAT assertion to fail. A mutant caught only by a population pin is scored OFF-TARGET, because a landing commit re-derives its own pins as a matter of routine.",
     "repin_first": "Before scoring, the harness re-derives every population pin the mutant moved — exactly what the commit that introduced the mutant would have done. This is what turned seven of the ten silence-class anchors from 'red' into 'green' and produced the finding that rebuilt the extractor.",
     "residuals_both_ways": "An anchor marked `expect: survives` is a NAMED RESIDUAL the gate does not claim to catch. It is asserted in BOTH directions: if it starts being caught, the gate's stated limits are stale and the header must be re-derived. A residual nobody re-checks becomes a false absence.",
-    "restore_always": "The harness rewrites the source it certifies. It restores every file it touched, including on failure. Never edit these files and never run a git write while a battery runs."
+    "restore_always": "The harness rewrites the source it certifies. It restores every file it touched, including on failure. Never edit these files and never run a git write while a battery runs.",
+    "repin_may_not_touch_a_claim": "The harness re-derives POPULATION counts only. It may NOT move `PINNED.unadjudicable` — the per-cause buckets of names this census cannot resolve. Those are a CLAIM about the gate's boundary, not a measurement of its reach: a new unadjudicable name is a name that entered the daemon which the census cannot tell from a second admitter. The REPIN table is keyed on bare identifiers and the bucket keys are quoted strings, so this holds by construction as well as by rule.",
+    "anchors_must_compile": "Each anchor is compiled with `cargo check --bin hypervisor-daemon` after planting. An anchor that no longer compiles is scored INVALID, never caught: a signature change or a privacy change can rot an anchor into fiction while the battery keeps printing the same total.",
+    "unanchorable": "Two assertions cannot be anchored from daemon source and are listed here rather than left to look covered: the reverse totality edge (a label at a position holding no token) is an extractor-internal invariant that only a mutation of the extractor could trip, and mutating the tool is not mutating the artifact it certifies; and the EXTRACTOR SOURCE PIN is a claim about the extractor's own bytes, demonstrated separately in the leg's commit by editing the extractor and rebuilding."
   },
   "anchor_file": "crates/node/src/bin/hypervisor_daemon_routes/feedback_routes.rs",
   "anchor_find": "fn bad(code: &str, msg: &str) -> (StatusCode, Json<Value>) {",
@@ -167,7 +170,7 @@
     {
       "id": "C13-renamed-import-alias",
       "class": "construct",
-      "note": "`use … as` was invisible to the resolver for a whole round; the grouped form is fifty-eight modules' house style.",
+      "note": "`use … as` was invisible to the resolver for a whole round. A previous version of this note claimed the grouped form is \"fifty-eight modules' house style\"; no reading of the tree reproduces 58, so the number is deleted rather than defended.",
       "insert": "use super::odk_routes::KIND_ONT as SHADOW_C13_DIR;\nfn shadow_c13(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, SHADOW_C13_DIR, id, rec);\n}\n",
       "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
     },
@@ -184,6 +187,85 @@
       "note": "A scheme-mapper that also admits is a second spine whatever the plumbing between them looks like.",
       "insert": "fn shadow_c15(data_dir: &str, scheme: &str, id: &str, rec: &Value) -> Option<&'static str> {\n    let kind = match scheme {\n        \"ontology\" => Some(\"odk-domain-ontologies\"),\n        _ => None,\n    };\n    if let Some(k) = kind {\n        let _ = persist_record(data_dir, k, id, rec);\n    }\n    kind\n}\n",
       "red_on": "no function that RESOLVES a family name through a `match` arm also WRITES a record"
+    },
+    {
+      "id": "T1-silence-check-unlabelled-position",
+      "class": "totality",
+      "note": "A family literal inside a `concat!` inside a `#[doc]` attribute. `visit_attribute` labels only `Expr::Lit` for a name-value meta and deliberately does not delegate, so the assembled value lands at a position no rule labels. Supplied by the review that defeated the previous cut — it is the anchor that proves the silence check fires rather than decorates.",
+      "insert": "#[doc = concat!(\"odk-domain-ontologies\", \" notes\")]\npub(crate) fn shadow_t1() {}\n",
+      "red_on": "EVERY TOKEN THAT RESOLVES TO AN ODK FAMILY CARRIES A SYNTACTIC LABEL"
+    },
+    {
+      "id": "T2-qualified-const-in-macro-tokens",
+      "class": "boundary",
+      "note": "THE ATTACK THAT FALSIFIED THE PREVIOUS DESIGN. A qualified family constant inside `json!` tokens reaches a writer: the token walk flattens the path to its bare tail, so resolution fails and the name used to be dropped in silence. It is now COUNTED in `bare-undeclared`, and the bucket pin refuses it.",
+      "insert": "fn shadow_t2(data_dir: &str, id: &str, rec: &Value) -> Value {\n    json!({ \"w\": persist_record(data_dir, super::odk_routes::KIND_ONT, id, rec).is_ok() })\n}\n",
+      "red_on": "EVERY CONSTANT-SHAPED NAME THIS CENSUS CANNOT ADJUDICATE IS COUNTED IN A NAMED BUCKET"
+    },
+    {
+      "id": "T3-qualified-const-macro-raw-fs",
+      "class": "boundary",
+      "note": "The same drop bypassing the writers entirely and putting bytes in the family directory.",
+      "insert": "fn shadow_t3(data_dir: &str, id: &str) -> Value {\n    json!({ \"w\": std::fs::write(std::path::Path::new(data_dir).join(super::odk_routes::KIND_ONT).join(id), b\"{}\").is_ok() })\n}\n",
+      "red_on": "EVERY CONSTANT-SHAPED NAME THIS CENSUS CANNOT ADJUDICATE IS COUNTED IN A NAMED BUCKET"
+    },
+    {
+      "id": "T4-c-string-literal",
+      "class": "silence",
+      "note": "`c\"odk-…\"`. The third literal form, missed when byte strings were added for exactly this reason — enumerating two of three is the population claim being false about the third.",
+      "insert": "fn shadow_t4(data_dir: &str, id: &str, rec: &Value) {\n    let fam = c\"odk-domain-ontologies\".to_str().unwrap_or(\"\");\n    let _ = persist_record(data_dir, fam, id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "T5-opaque-const-into-raw-fs",
+      "class": "boundary",
+      "note": "A constant initialised from `include_str!` is unreadable to this census. It reaches a raw filesystem call, which the writer-lane resolver assertion never sees — a sentence in this gate once claimed that assertion refused it, and that sentence was false. It is COUNTED in `opaque-initialiser` now.",
+      "create": {
+        "path": "crates/node/src/bin/hypervisor_daemon_routes/shadow_t5.txt",
+        "content": "odk-domain-ontologies"
+      },
+      "insert": "const SHADOW_T5_DIR: &str = include_str!(\"shadow_t5.txt\");\nfn shadow_t5(data_dir: &str, id: &str) {\n    let _ = std::fs::write(std::path::Path::new(data_dir).join(SHADOW_T5_DIR).join(id), b\"{}\");\n}\n",
+      "red_on": "EVERY CONSTANT-SHAPED NAME THIS CENSUS CANNOT ADJUDICATE IS COUNTED IN A NAMED BUCKET"
+    },
+    {
+      "id": "T6-unreadable-const-in-writer",
+      "class": "construct",
+      "note": "Covers the writer-lane resolver assertion, which had no anchor. An `unsafe` initialiser is opaque to this census, and a name it cannot tie to a declaration is exactly what a second admitter looks like from here.",
+      "insert": "const SHADOW_T6: &str = unsafe { std::str::from_utf8_unchecked(b\"odk-domain-ontologies\") };\nfn shadow_t6(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, SHADOW_T6, id, rec);\n}\n",
+      "red_on": "EVERY CONSTANT-SHAPED NAME IN A PRODUCTION WRITER CALL RESOLVES"
+    },
+    {
+      "id": "T7-runtime-assembly-in-writer-args",
+      "class": "construct",
+      "note": "Covers the fragment-assembly assertion, which had no anchor. Assembled inside the writer's OWN arguments from two pieces neither of which is a family name.",
+      "insert": "fn shadow_t7(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, &format!(\"{}{}\", \"od\", \"k-domain-ontologies\"), id, rec);\n}\n",
+      "red_on": "NO STRING-ASSEMBLING CONSTRUCT INSIDE A PRODUCTION WRITER'S"
+    },
+    {
+      "id": "N1-cfg_attr-path-redirect",
+      "class": "named-residual",
+      "expect": "survives",
+      "note": "NAMED RESIDUAL — THE FILE SET IS NOT RUSTC'S FILE SET. `#[cfg_attr(all(), path = …)]` redirects the module rustc compiles; this walk reads only a bare `#[path]`, so it censuses the decoy while rustc censuses the real file. Demonstrated decisively: a syntactically invalid decoy leaves the daemon building clean and this extractor exiting non-zero. `mod` gets no totality edge by owner ruling — a design falsified twice does not earn a third hardening edge — so this is NAMED in the module-graph label rather than claimed closed. If it ever goes RED the label is stale.",
+      "create": {
+        "path": "crates/node/src/bin/hypervisor_daemon_routes/shadow_real.rs",
+        "content": "fn shadow_real(data_dir: &str, id: &str, rec: &serde_json::Value) {\n    let _ = super::persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n}\n"
+      },
+      "create2": {
+        "path": "crates/node/src/bin/hypervisor_daemon_routes/feedback_routes/shadow_decoy.rs",
+        "content": "// benign\n"
+      },
+      "insert": "#[cfg_attr(all(), path = \"shadow_real.rs\")]\nmod shadow_decoy;\n"
+    },
+    {
+      "id": "N2-mod-inside-macro_rules",
+      "class": "named-residual",
+      "expect": "survives",
+      "note": "NAMED RESIDUAL, same boundary one construct over. A `mod` declared inside a `macro_rules!` body never reaches `visit_item_mod`, because syn hands macro tokens over unparsed — the module does not exist to this census at all, and not even the module count moves.",
+      "create": {
+        "path": "crates/node/src/bin/hypervisor_daemon_routes/shadow_n2.rs",
+        "content": "fn shadow_n2(data_dir: &str, id: &str, rec: &serde_json::Value) {\n    let _ = super::persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n}\n"
+      },
+      "insert": "macro_rules! shadow_mods_n2 {\n    () => { #[path = \"shadow_n2.rs\"] mod shadow_n2; };\n}\nshadow_mods_n2!();\n"
     },
     {
       "id": "R1-runtime-assembly-via-local",

--- a/apps/hypervisor/ontology-admission-census.mutants.v1.json
+++ b/apps/hypervisor/ontology-admission-census.mutants.v1.json
@@ -1,0 +1,196 @@
+{
+  "manifest_version": "ioi.ontology-admission-census-mutants.v1",
+  "effective_date": "2026-08-15",
+  "governing_harness": "apps/hypervisor/scripts/mutate-ontology-admission-census.mjs",
+  "certifies": "apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs",
+  "purpose": "A green verifier certifies nothing until a MUTATION test proves it red on its own finding. Next-legs XIII's tally was 43 ship-blockers across ten rounds with none caught by a green gate; XIV's Leg 3a was defeated five times, and every round's mutation count lived in a commit message and reproduced nowhere. That is the falsified-count class applied to evidence itself. Each anchor here is a REPLAYABLE second-admission path planted in the daemon's own source, with the assertion it must turn red named alongside it. The count is whatever this harness prints, and it prints it by running.",
+  "rules": {
+    "on_target": "RED is not enough. Each anchor names the assertion whose CLAIM it violates, and the harness requires THAT assertion to fail. A mutant caught only by a population pin is scored OFF-TARGET, because a landing commit re-derives its own pins as a matter of routine.",
+    "repin_first": "Before scoring, the harness re-derives every population pin the mutant moved — exactly what the commit that introduced the mutant would have done. This is what turned seven of the ten silence-class anchors from 'red' into 'green' and produced the finding that rebuilt the extractor.",
+    "residuals_both_ways": "An anchor marked `expect: survives` is a NAMED RESIDUAL the gate does not claim to catch. It is asserted in BOTH directions: if it starts being caught, the gate's stated limits are stale and the header must be re-derived. A residual nobody re-checks becomes a false absence.",
+    "restore_always": "The harness rewrites the source it certifies. It restores every file it touched, including on failure. Never edit these files and never run a git write while a battery runs."
+  },
+  "anchor_file": "crates/node/src/bin/hypervisor_daemon_routes/feedback_routes.rs",
+  "anchor_find": "fn bad(code: &str, msg: &str) -> (StatusCode, Json<Value>) {",
+  "anchors": [
+    {
+      "id": "S1-match-arm-pattern",
+      "class": "silence",
+      "note": "The family reaches a writer through a `match` arm PATTERN. No expression position ever holds it.",
+      "insert": "fn shadow_s1(data_dir: &str, kind: &str, id: &str, rec: &Value) {\n    match kind {\n        k @ \"odk-domain-ontologies\" => {\n            let _ = persist_record(data_dir, k, id, rec);\n        }\n        _ => {}\n    }\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "S2-include-unwalked-file",
+      "class": "silence",
+      "note": "The entire second admitter lives in a file pulled in by `include!`. The including module's census is unchanged.",
+      "create": {
+        "path": "crates/node/src/bin/hypervisor_daemon_routes/shadow_admit_s2.inc.rs",
+        "content": "fn shadow_s2(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n}\n"
+      },
+      "insert": "include!(\"shadow_admit_s2.inc.rs\");\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "S3-concat-assembled-name",
+      "class": "silence",
+      "note": "`concat!` builds the family name from two pieces, neither of which is a family name or starts with the interest prefix.",
+      "insert": "fn shadow_s3(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, concat!(\"od\", \"k-domain-ontologies\"), id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "S4-byte-string-literal",
+      "class": "silence",
+      "note": "`b\"odk-…\"` through `from_utf8`. A byte-string literal is not a `Lit::Str` and produced no mention at all.",
+      "insert": "fn shadow_s4(data_dir: &str, id: &str, rec: &Value) {\n    let fam = std::str::from_utf8(b\"odk-domain-ontologies\").unwrap_or(\"\");\n    let _ = persist_record(data_dir, fam, id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "S5-format-split-on-prefix",
+      "class": "silence",
+      "note": "Runtime assembly whose first piece still carries the interest prefix, so the census sees an UNRECORDED family name reaching a writer.",
+      "insert": "fn shadow_s5(data_dir: &str, id: &str, rec: &Value) {\n    let fam = format!(\"{}{}\", \"odk-domain\", \"-ontologies\");\n    let _ = persist_record(data_dir, &fam, id, rec);\n}\n",
+      "red_on": "NO ODK FAMILY GAINS AN ADMISSION PATH BEYOND THE RECORDED MAP"
+    },
+    {
+      "id": "S6-impl-associated-const",
+      "class": "silence",
+      "note": "An associated constant on a local type. Namespaced by type, so a module-flat constant table cannot answer for it.",
+      "insert": "struct ShadowS6;\nimpl ShadowS6 {\n    const FAM: &'static str = \"odk-domain-ontologies\";\n}\nfn shadow_s6(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, ShadowS6::FAM, id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "S7-macro-rules-expansion",
+      "class": "silence",
+      "note": "The writer call and the family name live inside a `macro_rules!` body, which syn hands over as unparsed tokens.",
+      "insert": "macro_rules! shadow_s7 {\n    ($d:expr, $i:expr, $r:expr) => {\n        persist_record($d, \"odk-domain-ontologies\", $i, $r)\n    };\n}\nfn shadow_s7_call(data_dir: &str, id: &str, rec: &Value) {\n    let _ = shadow_s7!(data_dir, id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "S8-attribute-mints-the-name",
+      "class": "silence",
+      "note": "An attribute's tokens are tokens of the file. `#[serde(rename)]` mints the name where no expression visitor reaches.",
+      "insert": "#[derive(serde::Serialize)]\nstruct ShadowS8 {\n    #[serde(rename = \"odk-domain-ontologies\")]\n    v: String,\n}\n",
+      "red_on": "every mention of an ODK family sits in a SYNTACTIC ROLE this gate classifies"
+    },
+    {
+      "id": "S9-if-let-pattern",
+      "class": "silence",
+      "note": "The same pattern hole one construct over, to prove the fix is not `match`-shaped.",
+      "insert": "fn shadow_s9(data_dir: &str, kind: Option<&str>, id: &str, rec: &Value) {\n    if let Some(k @ \"odk-domain-ontologies\") = kind {\n        let _ = persist_record(data_dir, k, id, rec);\n    }\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "S10-raw-filesystem-behind-a-pattern",
+      "class": "silence",
+      "note": "Bypasses the writers entirely and puts bytes in the family directory, with the name carried by a pattern.",
+      "insert": "fn shadow_s10(data_dir: &str, kind: &str, id: &str) {\n    match kind {\n        k @ \"odk-domain-ontologies\" => {\n            let _ = std::fs::write(std::path::Path::new(data_dir).join(k).join(id), b\"{}\");\n        }\n        _ => {}\n    }\n}\n",
+      "red_on": "NO PRODUCTION FUNCTION MAKES A RAW FILESYSTEM CALL AND NAMES AN ONTOLOGY FAMILY IT DOES NOT OWN"
+    },
+    {
+      "id": "C1-await-in-the-body",
+      "class": "construct",
+      "note": "`.await` defeated an enclosing-function heuristic in the hand-rolled walk; there are hundreds in this daemon.",
+      "insert": "async fn shadow_c1(data_dir: &str, id: &str, rec: &Value) {\n    let _ = tokio::task::yield_now().await;\n    let _ = persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C2-inside-tokio-spawn",
+      "class": "construct",
+      "insert": "fn shadow_c2(data_dir: String, id: String, rec: Value) {\n    tokio::spawn(async move {\n        let _ = persist_record(&data_dir, \"odk-domain-ontologies\", &id, &rec);\n    });\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C3-impl-method",
+      "class": "construct",
+      "note": "Impl methods are the daemon's house style and were invisible to an earlier walk.",
+      "insert": "struct ShadowC3;\nimpl ShadowC3 {\n    fn admit(&self, data_dir: &str, id: &str, rec: &Value) {\n        let _ = persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n    }\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C4-match-arm-guard",
+      "class": "construct",
+      "insert": "fn shadow_c4(data_dir: &str, n: u8, id: &str, rec: &Value) {\n    match n {\n        x if persist_record(data_dir, \"odk-domain-ontologies\", id, rec).is_ok() => {\n            let _ = x;\n        }\n        _ => {}\n    }\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C5-struct-literal-field",
+      "class": "construct",
+      "insert": "struct ShadowC5 {\n    fam: &'static str,\n}\nfn shadow_c5(data_dir: &str, id: &str, rec: &Value) {\n    let s = ShadowC5 { fam: \"odk-domain-ontologies\" };\n    let _ = persist_record(data_dir, s.fam, id, rec);\n}\n",
+      "red_on": "NO MODULE NAMES AN ODK FAMILY IT IS NOT RECORDED AS NAMING"
+    },
+    {
+      "id": "C6-array-element",
+      "class": "construct",
+      "insert": "fn shadow_c6(data_dir: &str, id: &str, rec: &Value) {\n    let fams = [\"odk-domain-ontologies\"];\n    let _ = persist_record(data_dir, fams[0], id, rec);\n}\n",
+      "red_on": "NO MODULE NAMES AN ODK FAMILY IT IS NOT RECORDED AS NAMING"
+    },
+    {
+      "id": "C7-nested-fn-item",
+      "class": "construct",
+      "insert": "fn shadow_c7(data_dir: &str, id: &str, rec: &Value) {\n    fn inner(data_dir: &str, id: &str, rec: &Value) {\n        let _ = persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n    }\n    inner(data_dir, id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C8-let-else",
+      "class": "construct",
+      "insert": "fn shadow_c8(data_dir: &str, kind: Option<&str>, id: &str, rec: &Value) {\n    let Some(_k) = kind else {\n        let _ = persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n        return;\n    };\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C9-unsafe-block",
+      "class": "construct",
+      "insert": "fn shadow_c9(data_dir: &str, id: &str, rec: &Value) {\n    unsafe {\n        let _ = persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n    }\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C10-macro-argument",
+      "class": "construct",
+      "note": "syn hands a macro's tokens over unparsed, so a writer call inside `json!` reaches no expression visitor.",
+      "insert": "fn shadow_c10(data_dir: &str, id: &str, rec: &Value) -> Value {\n    json!({ \"w\": persist_record(data_dir, \"odk-domain-ontologies\", id, rec).is_ok() })\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C11-foreign-const-declaration",
+      "class": "construct",
+      "note": "A second name minted outside the owning module makes every later use read as innocent local code.",
+      "insert": "const SHADOW_C11_FAM: &str = \"odk-domain-ontologies\";\nfn shadow_c11(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, SHADOW_C11_FAM, id, rec);\n}\n",
+      "red_on": "ONLY THE OWNING MODULE DECLARES A CONSTANT NAMING ONE OF ITS ONTOLOGY FAMILIES"
+    },
+    {
+      "id": "C12-static-declaration",
+      "class": "construct",
+      "note": "The declaration rule was once defeated by changing one keyword.",
+      "insert": "static SHADOW_C12_FAM: &str = \"odk-domain-ontologies\";\nfn shadow_c12(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, SHADOW_C12_FAM, id, rec);\n}\n",
+      "red_on": "ONLY THE OWNING MODULE DECLARES A CONSTANT NAMING ONE OF ITS ONTOLOGY FAMILIES"
+    },
+    {
+      "id": "C13-renamed-import-alias",
+      "class": "construct",
+      "note": "`use … as` was invisible to the resolver for a whole round; the grouped form is fifty-eight modules' house style.",
+      "insert": "use super::odk_routes::KIND_ONT as SHADOW_C13_DIR;\nfn shadow_c13(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, SHADOW_C13_DIR, id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C14-cfg-any-test-is-production",
+      "class": "construct",
+      "note": "The test filter must fail toward PRODUCTION. `cfg(any(test, …))` compiles into a production build and may not be dropped.",
+      "insert": "#[cfg(any(test, feature = \"shadow\"))]\nfn shadow_c14(data_dir: &str, id: &str, rec: &Value) {\n    let _ = persist_record(data_dir, \"odk-domain-ontologies\", id, rec);\n}\n",
+      "red_on": "EXACTLY ONE MODULE ADMITS `odk-domain-ontologies`"
+    },
+    {
+      "id": "C15-resolver-that-writes",
+      "class": "construct",
+      "note": "A scheme-mapper that also admits is a second spine whatever the plumbing between them looks like.",
+      "insert": "fn shadow_c15(data_dir: &str, scheme: &str, id: &str, rec: &Value) -> Option<&'static str> {\n    let kind = match scheme {\n        \"ontology\" => Some(\"odk-domain-ontologies\"),\n        _ => None,\n    };\n    if let Some(k) = kind {\n        let _ = persist_record(data_dir, k, id, rec);\n    }\n    kind\n}\n",
+      "red_on": "no function that RESOLVES a family name through a `match` arm also WRITES a record"
+    },
+    {
+      "id": "R1-runtime-assembly-via-local",
+      "class": "named-residual",
+      "expect": "survives",
+      "note": "THE NAMED RESIDUAL, asserted in both directions. A family name assembled at RUNTIME from pieces that are each innocent, bound to a local, then passed to a writer. Closing it needs dataflow this census does not do: the conservative function-scope rule that would catch it fires on 198 of this daemon's production writer functions, which is a pinned exception list, not a gate. The call lands in the pinned runtime-parameter bucket, so it is COUNTED — a named absence, not a silence. If this anchor ever goes RED, the gate's stated limits are stale and its header must be re-derived.",
+      "insert": "fn shadow_r1(data_dir: &str, id: &str, rec: &Value) {\n    let head = \"od\".to_string();\n    let fam = head + \"k-domain-ontologies\";\n    let _ = persist_record(data_dir, &fam, id, rec);\n}\n"
+    }
+  ]
+}

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -31,6 +31,7 @@
     "check:environment-custody": "node scripts/verify-hypervisor-environment-custody.mjs",
     "check:operational-depth": "node scripts/verify-hypervisor-operational-depth.mjs",
     "check:ontology-backend-families": "node scripts/verify-hypervisor-ontology-backend-families.mjs",
+    "check:ontology-admission-census": "node scripts/verify-hypervisor-ontology-admission-census.mjs",
     "check:provider-transport": "node scripts/verify-hypervisor-provider-transport.mjs",
     "check:provider-transport:live": "node scripts/verify-hypervisor-provider-transport.mjs --live",
     "check:verifier-floors": "node scripts/check-verifier-floors.mjs",

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -32,6 +32,7 @@
     "check:operational-depth": "node scripts/verify-hypervisor-operational-depth.mjs",
     "check:ontology-backend-families": "node scripts/verify-hypervisor-ontology-backend-families.mjs",
     "check:ontology-admission-census": "node scripts/verify-hypervisor-ontology-admission-census.mjs",
+    "mutate:ontology-admission-census": "node scripts/mutate-ontology-admission-census.mjs",
     "check:provider-transport": "node scripts/verify-hypervisor-provider-transport.mjs",
     "check:provider-transport:live": "node scripts/verify-hypervisor-provider-transport.mjs --live",
     "check:verifier-floors": "node scripts/check-verifier-floors.mjs",

--- a/apps/hypervisor/scripts/mutate-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/mutate-ontology-admission-census.mjs
@@ -41,6 +41,14 @@ const ANCHOR_FILE = path.join(ROOT, manifest.anchor_file);
  * mapping here rather than mutating the gate blindly is what keeps the re-derivation honest: this
  * harness may move a POPULATION COUNT and nothing else. It cannot relax a claim.
  */
+/**
+ * THE HARNESS MAY MOVE A POPULATION COUNT AND NOTHING ELSE. Every entry below is a measurement of
+ * the census's REACH. `PINNED.unadjudicable` — the per-cause buckets of names this census cannot
+ * resolve — is deliberately absent: those are a CLAIM about the gate's boundary, and a new
+ * unadjudicable name is a name that entered the daemon which the census cannot tell apart from a
+ * second admitter. The keys below are bare identifiers and the bucket keys are quoted strings, so
+ * this holds by construction as well as by rule.
+ */
 const REPIN = [
   [/^(\d+) modules reached, \d+ distinct paths \(pinned \d+\)$/, (m) => [["modules", m[1]]]],
   [/^(\d+)\/\d+ tokens, (\d+)\/\d+ of them family-resolving$/, (m) => [["tokenMentions", m[1]], ["judgedTokenPositions", m[2]]]],
@@ -81,22 +89,48 @@ function rederivePins(stdout) {
 function plant(anchor) {
   const saved = new Map([[GATE, fs.readFileSync(GATE, "utf8")]]);
   const created = [];
-  if (anchor.create) {
-    const p = path.join(ROOT, anchor.create.path);
-    if (fs.existsSync(p)) throw new Error(`anchor ${anchor.id} would overwrite ${anchor.create.path}`);
-    fs.writeFileSync(p, anchor.create.content);
-    created.push(p);
-  }
+  const restore = () => {
+    for (const [f, s] of saved) fs.writeFileSync(f, s);
+    for (const f of created) fs.rmSync(f, { force: true });
+  };
+  // THE ANCHOR POINT IS CHECKED BEFORE ANYTHING IS WRITTEN. Creating a file and then throwing on a
+  // missing anchor leaks that file and over-claims the restore_always rule — a review found exactly
+  // that ordering here.
   const before = fs.readFileSync(ANCHOR_FILE, "utf8");
   saved.set(ANCHOR_FILE, before);
   if (!before.includes(manifest.anchor_find)) {
     throw new Error(`anchor point absent from ${manifest.anchor_file} — the battery cannot plant anything`);
   }
-  fs.writeFileSync(ANCHOR_FILE, before.replace(manifest.anchor_find, `${anchor.insert}${manifest.anchor_find}`));
-  return () => {
-    for (const [f, s] of saved) fs.writeFileSync(f, s);
-    for (const f of created) fs.rmSync(f, { force: true });
-  };
+  try {
+    for (const spec of [anchor.create, anchor.create2].filter(Boolean)) {
+      const p = path.join(ROOT, spec.path);
+      if (fs.existsSync(p)) throw new Error(`anchor ${anchor.id} would overwrite ${spec.path}`);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, spec.content);
+      created.push(p);
+    }
+    // A REPLACER FUNCTION, NEVER A REPLACEMENT STRING. `String.replace` reads `$&`, `` $` ``, `$'`
+    // and `$1` in the replacement, so an anchor's own text could plant something other than what
+    // this manifest records — the battery lying about what it tested.
+    fs.writeFileSync(ANCHOR_FILE, before.replace(manifest.anchor_find, () => `${anchor.insert}${manifest.anchor_find}`));
+  } catch (error) {
+    restore();
+    throw error;
+  }
+  return restore;
+}
+
+/**
+ * DOES THE MUTATED DAEMON STILL COMPILE? An anchor that cannot exist is not a mutant — it is a
+ * fiction that scores as caught, because the gate reads source and a nonsensical mutant still moves
+ * the census. A review demonstrated one: `NOT_A_REAL_ARG` scored RED-ON-TARGET. Anchors rot this way
+ * when a signature or a visibility changes under them, and the battery keeps printing its total.
+ */
+function compiles() {
+  const r = spawnSync("cargo", ["check", "--offline", "-q", "--bin", "hypervisor-daemon"], {
+    cwd: ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024,
+  });
+  return { ok: r.status === 0, detail: (r.stderr || "").split("\n").filter((l) => l.startsWith("error")).slice(0, 2).join(" ; ") };
 }
 
 function main() {
@@ -116,6 +150,13 @@ function main() {
     let restore = () => {};
     try {
       restore = plant(anchor);
+      const build = compiles();
+      if (!build.ok) {
+        verdicts.push({ id: anchor.id, class: anchor.class, pass: false, verdict: "INVALID" });
+        console.log(` FAIL  ${"INVALID".padEnd(15)} ${anchor.id.padEnd(32)} the mutated daemon does not compile — this anchor is fiction`);
+        console.log(`          ${build.detail}`);
+        continue;
+      }
       let r = runGate();
       const moved = [];
       // Re-derive pins the way a landing commit would, until only property assertions remain.

--- a/apps/hypervisor/scripts/mutate-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/mutate-ontology-admission-census.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// THE ADMISSION CENSUS'S MUTATION BATTERY — replayable, committed, and counted by running.
+//
+// WHY IT IS A TRACKED ARTIFACT AND NOT A SESSION HABIT. A green verifier certifies nothing until a
+// mutation proves it red on its own finding; that has been standing discipline here for several
+// runs, and every run's mutation count nonetheless lived in a commit message and reproduced
+// nowhere. A count that reproduces nowhere is the same falsified-claim class this program keeps
+// finding in ledgers — applied to the evidence for the gates themselves. So the anchors are
+// committed beside the gate, and the count is whatever this harness prints when it runs.
+//
+// WHAT MAKES AN ANCHOR PASS, AND WHY MERE RED IS NOT IT. Each anchor names the assertion whose
+// CLAIM it violates. Before scoring, this harness re-derives every population pin the mutant moved
+// — precisely what the commit that introduced the mutant would have done on its way to landing.
+// That step is the whole finding that rebuilt this census: ten silence-class mutants were planted
+// against the previous gate, three were caught, and SEVEN of the remaining went from "red" to fully
+// green the moment their pins were re-derived. A pin bump is a ratchet, not a property.
+//
+// AND RESIDUALS ARE ASSERTED IN BOTH DIRECTIONS. An anchor marked `expect: "survives"` is a limit
+// the gate does not claim to reach. If it starts being caught, the gate's stated limits are stale
+// and its header is over-claiming by omission — so this harness fails on that too.
+//
+// THE HARNESS REWRITES THE SOURCE IT CERTIFIES. Every file it touches is restored, including on
+// failure and on signal. Never edit those files and never run a git write while a battery runs.
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.resolve(HERE, "..");
+const ROOT = path.resolve(APP, "..", "..");
+const GATE = path.join(APP, "scripts/verify-hypervisor-ontology-admission-census.mjs");
+const MANIFEST = path.join(APP, "ontology-admission-census.mutants.v1.json");
+
+const manifest = JSON.parse(fs.readFileSync(MANIFEST, "utf8"));
+const ANCHOR_FILE = path.join(ROOT, manifest.anchor_file);
+
+/**
+ * Every pin the gate reports in a FAIL detail, and the `PINNED` keys that re-derive it. Keeping the
+ * mapping here rather than mutating the gate blindly is what keeps the re-derivation honest: this
+ * harness may move a POPULATION COUNT and nothing else. It cannot relax a claim.
+ */
+const REPIN = [
+  [/^(\d+) modules reached, \d+ distinct paths \(pinned \d+\)$/, (m) => [["modules", m[1]]]],
+  [/^(\d+)\/\d+ tokens, (\d+)\/\d+ of them family-resolving$/, (m) => [["tokenMentions", m[1]], ["judgedTokenPositions", m[2]]]],
+  [/^family=(\d+)\/\d+ non-ODK=(\d+)\/\d+ runtime=(\d+)\/\d+$/, (m) => [["family", m[1]], ["nonFamilyLiteral", m[2]], ["runtimeParameter", m[3]]]],
+  [/^(\d+)\/\d+ family mentions, (\d+)\/\d+ production filesystem calls$/, (m) => [["familyMentions", m[1]], ["productionFsCalls", m[2]]]],
+  [/^(\d+)\/\d+ spliced code includes$/, (m) => [["splicedCode", m[1]]]],
+  [/^include_str!=(\d+)\/\d+ include_bytes!=(\d+)\/\d+ with (\d+)\/\d+ non-literal arguments$/, (m) => [["dataStr", m[1]], ["dataBytes", m[2]], ["dataOpaqueArg", m[3]]]],
+  [/^(\d+)\/\d+ production, (\d+)\/\d+ under a bare #\[cfg\(test\)\]$/, (m) => [["production", m[1]], ["test", m[2]]]],
+];
+
+const runGate = () =>
+  spawnSync("node", [GATE], { cwd: APP, encoding: "utf8", maxBuffer: 128 * 1024 * 1024 });
+
+const failLines = (stdout) => (stdout || "").split("\n").filter((l) => l.startsWith("FAIL"));
+
+function rederivePins(stdout) {
+  let src = fs.readFileSync(GATE, "utf8");
+  const moved = [];
+  for (const line of failLines(stdout)) {
+    const d = line.match(/ {2}\((.*)\)$/);
+    if (!d) continue;
+    for (const [re, keys] of REPIN) {
+      const m = d[1].match(re);
+      if (!m) continue;
+      for (const [key, val] of keys(m)) {
+        const kre = new RegExp(`(\\b${key}: )\\d+`);
+        if (kre.test(src)) {
+          src = src.replace(kre, `$1${val}`);
+          moved.push(`${key}=${val}`);
+        }
+      }
+    }
+  }
+  if (moved.length) fs.writeFileSync(GATE, src);
+  return moved;
+}
+
+function plant(anchor) {
+  const saved = new Map([[GATE, fs.readFileSync(GATE, "utf8")]]);
+  const created = [];
+  if (anchor.create) {
+    const p = path.join(ROOT, anchor.create.path);
+    if (fs.existsSync(p)) throw new Error(`anchor ${anchor.id} would overwrite ${anchor.create.path}`);
+    fs.writeFileSync(p, anchor.create.content);
+    created.push(p);
+  }
+  const before = fs.readFileSync(ANCHOR_FILE, "utf8");
+  saved.set(ANCHOR_FILE, before);
+  if (!before.includes(manifest.anchor_find)) {
+    throw new Error(`anchor point absent from ${manifest.anchor_file} — the battery cannot plant anything`);
+  }
+  fs.writeFileSync(ANCHOR_FILE, before.replace(manifest.anchor_find, `${anchor.insert}${manifest.anchor_find}`));
+  return () => {
+    for (const [f, s] of saved) fs.writeFileSync(f, s);
+    for (const f of created) fs.rmSync(f, { force: true });
+  };
+}
+
+function main() {
+  // Refuse to start against a tree the gate already fails on: a mutant scored against a red gate
+  // proves nothing, and "it went red" would be true before anything was planted.
+  const base = runGate();
+  if (base.status !== 0) {
+    console.error("BLOCKED — the census gate is already failing on the unmutated tree:");
+    for (const l of failLines(base.stdout)) console.error(`  ${l}`);
+    process.exit(2);
+  }
+  const baseline = (base.stdout || "").trim().split("\n").pop();
+  console.log(`baseline: ${baseline}\n`);
+
+  const verdicts = [];
+  for (const anchor of manifest.anchors) {
+    let restore = () => {};
+    try {
+      restore = plant(anchor);
+      let r = runGate();
+      const moved = [];
+      // Re-derive pins the way a landing commit would, until only property assertions remain.
+      for (let round = 0; round < 4 && r.status !== 0; round++) {
+        const mv = rederivePins(r.stdout || "");
+        if (!mv.length) break;
+        moved.push(...mv);
+        r = runGate();
+      }
+      const fails = failLines(r.stdout);
+      const survives = anchor.expect === "survives";
+      const onTarget = anchor.red_on ? fails.some((f) => f.includes(anchor.red_on)) : false;
+      const pass = survives ? r.status === 0 : onTarget;
+      const verdict = survives
+        ? r.status === 0
+          ? "RESIDUAL"
+          : "RESIDUAL-CLOSED"
+        : onTarget
+          ? "RED-ON-TARGET"
+          : r.status === 0
+            ? "GREEN"
+            : "RED-OFF-TARGET";
+      verdicts.push({ id: anchor.id, class: anchor.class, pass, verdict });
+      console.log(
+        `${pass ? "  ok  " : " FAIL "} ${verdict.padEnd(15)} ${anchor.id.padEnd(32)}` +
+          `${moved.length ? ` [repinned ${[...new Set(moved)].length}]` : ""}`,
+      );
+      if (!pass) {
+        for (const f of fails) console.log(`          ${f.slice(0, 150)}`);
+        if (survives) console.log(`          this anchor is documented as a NAMED RESIDUAL — the gate's header now under-claims`);
+      }
+    } finally {
+      restore();
+    }
+  }
+
+  // THE TREE MUST BE AS IT WAS FOUND. Next-legs XIII killed a battery mid-run and left a mutant in
+  // the tree; a marker sweep would not have seen it. Re-running the gate on the restored tree proves
+  // restoration by the same instrument that scored the anchors, and leaves the verifier-census
+  // artifact matching the file on disk so the floors gate does not read a mutated digest.
+  const after = runGate();
+  const restored = after.status === 0;
+  console.log(`\n${restored ? "  ok  " : " FAIL "} tree restored — the gate is green again on the tree this battery was handed`);
+  if (!restored) for (const l of failLines(after.stdout)) console.log(`          ${l.slice(0, 150)}`);
+  verdicts.push({ id: "tree-restored", class: "harness", pass: restored, verdict: restored ? "RESTORED" : "DIRTY" });
+
+  const failed = verdicts.filter((v) => !v.pass);
+  const red = verdicts.filter((v) => v.verdict === "RED-ON-TARGET").length;
+  const residual = verdicts.filter((v) => v.verdict === "RESIDUAL").length;
+  console.log(
+    `\n${red} anchors RED-ON-TARGET, ${residual} named residual${residual === 1 ? "" : "s"} still open, ` +
+      `${verdicts.length - failed.length}/${verdicts.length} anchors as recorded`,
+  );
+  if (failed.length) process.exit(1);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`FAIL ontology-admission-census mutation battery — ${error?.stack || error}`);
+  process.exit(1);
+}

--- a/apps/hypervisor/scripts/mutate-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/mutate-ontology-admission-census.mjs
@@ -20,7 +20,8 @@
 // and its header is over-claiming by omission — so this harness fails on that too.
 //
 // THE HARNESS REWRITES THE SOURCE IT CERTIFIES. Every file it touches is restored, including on
-// failure and on signal. Never edit those files and never run a git write while a battery runs.
+// failure. It does NOT install signal handlers, so a battery killed mid-run can leave a mutant in
+// the tree — verify a commit by replaying the anchors against it, never by grepping for markers.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -89,30 +90,43 @@ function rederivePins(stdout) {
 function plant(anchor) {
   const saved = new Map([[GATE, fs.readFileSync(GATE, "utf8")]]);
   const created = [];
+  const dirsMade = [];
   const restore = () => {
     for (const [f, s] of saved) fs.writeFileSync(f, s);
     for (const f of created) fs.rmSync(f, { force: true });
+    // AND THE DIRECTORIES. git ignores empty directories, so a leaked one is invisible to
+    // `git status` AND to this harness's own tree-restored check — which is exactly how the
+    // previous fix for the file leak left a directory behind and reported a clean tree.
+    for (const d of dirsMade.slice().reverse()) { try { fs.rmdirSync(d); } catch { /* not empty: not ours to remove */ } }
   };
   // THE ANCHOR POINT IS CHECKED BEFORE ANYTHING IS WRITTEN. Creating a file and then throwing on a
   // missing anchor leaks that file and over-claims the restore_always rule — a review found exactly
   // that ordering here.
-  const before = fs.readFileSync(ANCHOR_FILE, "utf8");
-  saved.set(ANCHOR_FILE, before);
-  if (!before.includes(manifest.anchor_find)) {
-    throw new Error(`anchor point absent from ${manifest.anchor_file} — the battery cannot plant anything`);
+  // AN ANCHOR MAY NAME ITS OWN SITE. Some properties only hold in a particular module — the
+  // one-hop-indirection residual is only green in a module already RECORDED as touching the family,
+  // and planted anywhere else the toucher ratchet catches it for a reason that has nothing to do
+  // with the residual. An anchor that cannot be planted where it means something is a mis-aimed
+  // mutation, which is worse than none.
+  const anchorFile = anchor.anchor_file ? path.join(ROOT, anchor.anchor_file) : ANCHOR_FILE;
+  const anchorFind = anchor.anchor_find ?? manifest.anchor_find;
+  const before = fs.readFileSync(anchorFile, "utf8");
+  saved.set(anchorFile, before);
+  if (!before.includes(anchorFind)) {
+    throw new Error(`anchor point absent from ${anchor.anchor_file ?? manifest.anchor_file} — the battery cannot plant anything`);
   }
   try {
     for (const spec of [anchor.create, anchor.create2].filter(Boolean)) {
       const p = path.join(ROOT, spec.path);
       if (fs.existsSync(p)) throw new Error(`anchor ${anchor.id} would overwrite ${spec.path}`);
-      fs.mkdirSync(path.dirname(p), { recursive: true });
+      const dir = path.dirname(p);
+      if (!fs.existsSync(dir)) { fs.mkdirSync(dir, { recursive: true }); dirsMade.push(dir); }
       fs.writeFileSync(p, spec.content);
       created.push(p);
     }
     // A REPLACER FUNCTION, NEVER A REPLACEMENT STRING. `String.replace` reads `$&`, `` $` ``, `$'`
     // and `$1` in the replacement, so an anchor's own text could plant something other than what
     // this manifest records — the battery lying about what it tested.
-    fs.writeFileSync(ANCHOR_FILE, before.replace(manifest.anchor_find, () => `${anchor.insert}${manifest.anchor_find}`));
+    fs.writeFileSync(anchorFile, before.replace(anchorFind, () => `${anchor.insert}${anchorFind}`));
   } catch (error) {
     restore();
     throw error;
@@ -127,10 +141,19 @@ function plant(anchor) {
  * when a signature or a visibility changes under them, and the battery keeps printing its total.
  */
 function compiles() {
-  const r = spawnSync("cargo", ["check", "--locked", "-q", "--bin", "hypervisor-daemon"], {
-    cwd: ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024,
+  // `-p ioi-node` matches the invocation CI already uses to build this binary, so the target
+  // resolves the same way here as it does there.
+  const r = spawnSync("cargo", ["check", "--locked", "-q", "-p", "ioi-node", "--bin", "hypervisor-daemon"], {
+    cwd: ROOT, encoding: "utf8", maxBuffer: 256 * 1024 * 1024,
   });
-  return { ok: r.status === 0, detail: (r.stderr || "").split("\n").filter((l) => l.startsWith("error")).slice(0, 2).join(" ; ") };
+  // THREE OUTCOMES, NEVER TWO. A check that COULD NOT RUN is not an anchor that is fiction, and
+  // conflating them is the same class this battery exists to police: CI reported forty anchors as
+  // "fiction" with an EMPTY error detail, because the failure was the spawn and not the compile.
+  if (r.error || r.status === null) {
+    return { ran: false, detail: `cargo check could not run: ${r.error?.message ?? "no exit status"}` };
+  }
+  const errs = (r.stderr || "").split("\n").filter((l) => l.startsWith("error")).slice(0, 3).join(" ; ");
+  return { ran: true, ok: r.status === 0, detail: errs || `exit ${r.status} with no error line` };
 }
 
 function main() {
@@ -143,7 +166,15 @@ function main() {
     process.exit(2);
   }
   const baseline = (base.stdout || "").trim().split("\n").pop();
-  console.log(`baseline: ${baseline}\n`);
+  // WARM THE COMPILE CHECK ONCE, BEFORE ANY ANCHOR. If `cargo check` cannot run at all, that is one
+  // systemic failure and it must be reported once and plainly — not discovered forty times over as
+  // forty anchors mislabelled "fiction", which is what a CI run actually printed.
+  const warm = compiles();
+  if (!warm.ran || !warm.ok) {
+    console.error(`BLOCKED — the compile check is unusable on this tree, so no anchor can be scored: ${warm.detail}`);
+    process.exit(2);
+  }
+  console.log(`baseline: ${baseline}  ·  compile check usable\n`);
 
   const verdicts = [];
   for (const anchor of manifest.anchors) {
@@ -151,6 +182,7 @@ function main() {
     try {
       restore = plant(anchor);
       const build = compiles();
+      if (!build.ran) throw new Error(build.detail);
       if (!build.ok) {
         verdicts.push({ id: anchor.id, class: anchor.class, pass: false, verdict: "INVALID" });
         console.log(` FAIL  ${"INVALID".padEnd(15)} ${anchor.id.padEnd(32)} the mutated daemon does not compile — this anchor is fiction`);

--- a/apps/hypervisor/scripts/mutate-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/mutate-ontology-admission-census.mjs
@@ -127,7 +127,7 @@ function plant(anchor) {
  * when a signature or a visibility changes under them, and the battery keeps printing its total.
  */
 function compiles() {
-  const r = spawnSync("cargo", ["check", "--offline", "-q", "--bin", "hypervisor-daemon"], {
+  const r = spawnSync("cargo", ["check", "--locked", "-q", "--bin", "hypervisor-daemon"], {
     cwd: ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024,
   });
   return { ok: r.status === 0, detail: (r.stderr || "").split("\n").filter((l) => l.startsWith("error")).slice(0, 2).join(" ; ") };

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -109,6 +109,17 @@
 // is closed only where it sits inside the writer's own argument subtree. Adjudicating the rest needs
 // dataflow this census deliberately does not do, and it is a NAMED RESIDUAL, not a silence: the
 // population it hides in is counted, and growing it moves a pin.
+//
+// AND THE SECOND NAMED RESIDUAL, found by the review of the re-scope and NOT closed here, because a
+// design falsified twice does not earn another hardening edge: ONE-HOP INDIRECTION WITHIN A MODULE.
+// The conservative rule that catches "the function names a family and writes with something it will
+// not spell" is scoped to ONE FUNCTION. Move the literal one function away —
+// `fn put(d, k, i, r) { persist_record(d, k, i, r) }` called as `put(d, "odk-…", i, r)` — and the
+// writer's function names no family while the caller's does. In a module already RECORDED as a
+// toucher of that family, nothing moves at all. Widening the rule to module scope is what would
+// close it, and that fires on 198 of this daemon's production writer functions — a pinned exception
+// list, not a gate. So it is named here, anchored in the battery in both directions, and it is what
+// the XV run that entails the resolver should take up alongside the buckets.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -240,9 +251,9 @@ const PINNED = {
    * Burning these down, and entailing the resolver so they need not exist, is next-legs XV.
    */
   unadjudicable: {
-    "foreign-qualified": 3228,
-    "opaque-initialiser": 1553,
-    "bare-undeclared": 791,
+    "foreign-qualified": 3494,
+    "opaque-initialiser": 1554,
+    "bare-undeclared": 517,
     "ambiguous-module": 0,
     "not-a-visible-const": 0,
     "resolution-cycle": 0,
@@ -266,7 +277,7 @@ const PINNED = {
  * bytes on disk, and the digest the binary carries from its own compile. Moving this pin is a
  * GOVERNED COMMIT ACT — it appears in the diff of any change to the extractor, which is the point.
  */
-const EXTRACTOR_SOURCE_PIN = "bb299c8ef20bc742";
+const EXTRACTOR_SOURCE_PIN = "522060618a90ba05";
 
 /** FNV-1a/64 — the digest the extractor bakes its own source under at compile time. */
 function fnv1a64(bytes) {
@@ -332,7 +343,7 @@ function run() {
     if (!byStem.has(m.stem)) byStem.set(m.stem, []);
     byStem.get(m.stem).push(m);
   }
-  ok("the census walks the module graph it can SEE from the daemon's entry point — every `mod` declaration carrying a bare `#[path]`, resolved in rustc's own nested-before-sibling order, with an unresolvable declaration or an unreadable file aborting extraction rather than silently shrinking the world; it is NOT rustc's file set and does not claim to be, because `mod` has no totality edge and is not getting one: a `#[cfg_attr(…, path = …)]` redirect is invisible here and a `mod` declared inside a `macro_rules!` body never reaches the visitor at all, so rustc would compile one file while this reads another — neither construct exists in this daemon today and entailing the file set belongs to the run that entails the resolver",
+  ok("the census walks the module graph it can SEE from the daemon's entry point — every `mod` declaration it can see, with a bare `#[path]` honoured and the rest resolved in rustc's own nested-before-sibling order, with an unresolvable declaration or an unreadable file aborting extraction rather than silently shrinking the world; it is NOT rustc's file set and does not claim to be, because `mod` has no totality edge and is not getting one: a `#[cfg_attr(…, path = …)]` redirect is invisible here and a `mod` declared inside a `macro_rules!` body never reaches the visitor at all, so rustc would compile one file while this reads another — neither construct exists in this daemon today and entailing the file set belongs to the run that entails the resolver",
     modules.length === PINNED.modules && byKey.size === modules.length,
     `${modules.length} modules reached, ${byKey.size} distinct paths (pinned ${PINNED.modules})`);
 
@@ -442,7 +453,11 @@ function run() {
   // what the gate cannot see rather than infer it from a silence. A new unadjudicable name beyond
   // the pin is RED. A name that becomes resolvable SHRINKS the pin in the commit that resolves it.
   const dropped = {};
-  const bumpDrop = (b) => { dropped[b] = (dropped[b] ?? 0) + 1; };
+  const dropMembers = {};
+  const bumpDrop = (b, name, where) => {
+    dropped[b] = (dropped[b] ?? 0) + 1;
+    (dropMembers[b] ??= new Map()).set(`${name} @${where}`, (dropMembers[b]?.get(`${name} @${where}`) ?? 0) + 1);
+  };
   for (const m of modules) {
     const labelledAt = new Map();
     for (const men of m.mentions) if (!men.synthesized) labelledAt.set(posKey(men), men);
@@ -455,13 +470,18 @@ function run() {
       const spelling = men && men.name.includes("::") ? men.name : t.text;
       const r = resolveName(m, spelling);
       if (r.kind === "LITERAL") continue;
-      bumpDrop(r.bucket ?? r.kind);
+      bumpDrop(r.bucket ?? r.kind, spelling, modId(m.key));
     }
   }
+  // A MOVED BUCKET MUST BE ADJUDICABLE IN THE MOMENT IT MOVES. A bare `792/791` cannot tell a second
+  // admitter's +1 from an ordinary feature commit's +49, and a pin nobody can read in the moment is
+  // a pin that gets widened away. So a moved bucket prints its RAREST members with their module: a
+  // name that has just arrived occurs once, and sorting by frequency floats it to the top.
+  const rarest = (b) => [...(dropMembers[b] ?? new Map())].sort((x, y) => x[1] - y[1]).slice(0, 6).map(([k]) => k).join(", ");
   const dropGain = [], dropStale = [];
   for (const [b, n] of Object.entries(dropped)) {
-    if (PINNED.unadjudicable[b] === undefined) dropGain.push(`UNRECORDED BUCKET ${b} (${n})`);
-    else if (n !== PINNED.unadjudicable[b]) dropGain.push(`${b} ${n}/${PINNED.unadjudicable[b]}`);
+    if (PINNED.unadjudicable[b] === undefined) dropGain.push(`UNRECORDED BUCKET ${b} (${n}) rarest: ${rarest(b)}`);
+    else if (n !== PINNED.unadjudicable[b]) dropGain.push(`${b} ${n}/${PINNED.unadjudicable[b]} — rarest members: ${rarest(b)}`);
   }
   for (const [b, n] of Object.entries(PINNED.unadjudicable)) if (dropped[b] === undefined && n !== 0) dropStale.push(`${b} vanished (pinned ${n})`);
 

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -14,16 +14,45 @@
 // INSTANCE, a real parser retires the CLASS. The first attempt at that ruling ADDED `syn` and KEPT
 // the hand-rolled walk — a fifteen-variant `expr_children` under an AST, with a zero-override
 // `Visit` impl driven across every expression so the code READ as though a complete visitor ran. A
-// fourth review demonstrated twelve of fourteen ordinary second-admitter constructs passing green:
+// fourth review demonstrated ordinary second-admitter constructs passing green against it —
 // `.await`, `tokio::spawn`, impl methods, arm guards, struct literals, nested items, macro
 // arguments. THE SCAR: A PRE-COMMITTED BOUNDARY IS EXECUTED BY ITS MECHANISM, NOT BY ITS DEPENDENCY.
-// The traversal in `crates/ontology-census` is `syn::visit::Visit` itself now.
+// The traversal in `crates/ontology-census` is `syn::visit::Visit` itself now, and every one of
+// those constructs is a committed anchor in `ontology-admission-census.mutants.v1.json` — the count
+// is whatever the battery prints, because a count that reproduces nowhere is the falsified-claim
+// class this program keeps finding in ledgers, applied to the evidence for the gates themselves.
 //
 // AND WHY EVERY JUDGEMENT BELOW READS A CLASSIFICATION RATHER THAN AN ABSENCE. That same review
 // found the deeper defect: a construct the walk missed produced no entry, and every judgement was
 // derived from the entries — so a COVERAGE GAP was indistinguishable from SAFETY. The extractor now
 // reports every mention of a name of interest WITH the syntactic role it sits in, and this file
-// holds a closed set of roles it can classify. A tenth role is RED. A gap now reads as a finding.
+// holds a closed set of roles it can classify. An unlisted role is RED.
+//
+// AND WHY THAT WAS STILL NOT ENOUGH — THE OWNER'S SCAR, VERBATIM. A fifth review defeated the
+// closed role set, and the diagnosis is the whole reason this file's shape changed again:
+//
+//     A CLOSED SET OF ROLES CLOSES NOTHING UNLESS THE SET OF THINGS THAT PRODUCE A ROLE IS ITSELF
+//     ENTAILED.
+//
+// Roles were produced by AST positions the extractor happened to override, so a family name in a
+// position no override reached produced NO MENTION AT ALL — and there is no role to be unknown
+// about when there is no mention. TEN mutants of that class were planted against the landing tree.
+// SEVEN passed completely green once their commit re-derived its own population pins, which is what
+// a landing commit does as a matter of routine: a `match` arm PATTERN carrying the family to a
+// writer, an `if let` pattern doing the same, a raw-filesystem write behind a pattern, a byte string
+// through `from_utf8`, `concat!("od", "k-domain-ontologies")`, a `#[serde(rename)]` minting the name,
+// and an `include!` of an unwalked file containing the entire second admitter.
+//
+// SO MENTIONS ARE DERIVED FROM THE RAW TOKEN STREAM AND THE AST ONLY ASSIGNS ROLES. The extractor
+// tokenises each file ONCE, walks that stream exhaustively — every literal and every constant-shaped
+// identifier, at every depth of every group — and hands the SAME stream to syn. The token population
+// is total by construction, because a name that is in the file is a token in the file. This file
+// matches the two by SOURCE POSITION: a token that resolves to a family with no AST mention on it is
+// a SILENT MENTION and is RED. A coverage gap can no longer read as safety, because the thing being
+// counted is no longer produced by the thing that might be incomplete.
+//
+// AND SINCE THIS FIX LANDED, A DEMONSTRATED SILENCE IS NOT A BUG TO PATCH. It falsifies the design,
+// and the owner's standing instruction is to STOP AND ESCALATE rather than model one more construct.
 //
 // WHAT IT ENTAILS, scoped by owner ruling. For each of the four ONTOLOGY families, exactly one
 // module admits it. That is the commissioned claim, and four assertions below carry it.
@@ -51,10 +80,17 @@
 // and the test-write map is pinned too — so moving a production write under a test attribute shrinks
 // the production map into a stale-pin RED rather than passing as a silent green.
 //
-// WHAT IT DOES NOT ENTAIL. `syn` reads this crate's source. A write performed by a dependency crate
-// on the daemon's behalf, produced by macro EXPANSION, or by another process, is outside it. Two
-// hundred and ninety production writer calls take their family as a runtime parameter and cannot be
-// resolved statically at all; that count is pinned as its own ratchet rather than waved through.
+// WHAT IT DOES NOT ENTAIL, stated so the residual is named rather than implied. `syn` reads this
+// crate's source: a write performed by a DEPENDENCY CRATE on the daemon's behalf, by a
+// user-defined macro's EXPANSION, or by another process, is outside it. Production writer calls that
+// take their family as a RUNTIME PARAMETER cannot be resolved from source at all; that count is
+// pinned as its own ratchet rather than waved through. And within that bucket one specific evasion
+// survives: a family name assembled AT RUNTIME from pieces that are each innocent — no piece a
+// family name, no piece a fragment inside the writer's own arguments — bound to a local and passed
+// to the writer. Compile-time assembly is followed into its expansion and closed; runtime assembly
+// is closed only where it sits inside the writer's own argument subtree. Adjudicating the rest needs
+// dataflow this census deliberately does not do, and it is a NAMED RESIDUAL, not a silence: the
+// population it hides in is counted, and growing it moves a pin.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -95,6 +131,15 @@ const ROLE_MEANING = {
   "read-arg": "names",
   "const-init": "declares",
   "static-init": "declares",
+  // THE DECLARATION SITE OF A NAME IS A MENTION OF IT. The token walk finds `KIND_ONT` where it is
+  // declared as surely as where it is used, and an unlabelled token position is by construction a
+  // silent mention — so the declaration's own identifier is labelled and classified here.
+  "decl-name": "declares",
+  "use-path": "names",
+  // A PATTERN carried a family name to a writer in two of the seven mutants that passed green.
+  "pattern-lit": "names",
+  "pattern-path": "names",
+  "type-path": "names",
   "fn-body": "names",
   "macro:json": "names",
   "macro:format": "names",
@@ -152,10 +197,31 @@ const RECORDED_TEST_WRITES = {
  */
 const PINNED = {
   modules: 88,
-  familyMentions: 273,
+  familyMentions: 300,
+  tokenMentions: 106724,
+  judgedTokenPositions: 282,
   productionWriterCalls: { family: 72, nonFamilyLiteral: 204, runtimeParameter: 290 },
   productionFsCalls: 228,
+  /** `include!` splices code and is followed; the data forms carry no Rust and are pinned. */
+  includes: { splicedCode: 0, dataStr: 31, dataBytes: 0, dataOpaqueArg: 6 },
+  /** Compile-time name assembly. Every production one must be READABLE and is followed. */
+  compileAssembly: { production: 0, test: 8 },
 };
+
+/**
+ * THE EXTRACTOR SOURCE PIN — a COMMITTED expectation, compared against a fresh computation.
+ *
+ * The previous guard hashed the extractor source on disk and compared it against the digest the
+ * binary baked in with `include_str!`. That certified nothing: this file runs `cargo build` FIRST,
+ * so the build makes the two agree by construction, and an edit to the extractor moves BOTH sides
+ * together. The gate was its own oracle — the same class as a fixture built in a world the product
+ * does not produce.
+ *
+ * The expectation therefore lives HERE, in tracked source. Both sides are compared against it: the
+ * bytes on disk, and the digest the binary carries from its own compile. Moving this pin is a
+ * GOVERNED COMMIT ACT — it appears in the diff of any change to the extractor, which is the point.
+ */
+const EXTRACTOR_SOURCE_PIN = "417877f8abfc82e1";
 
 /** FNV-1a/64 — the digest the extractor bakes its own source under at compile time. */
 function fnv1a64(bytes) {
@@ -171,12 +237,12 @@ function fnv1a64(bytes) {
 /**
  * Build the extractor and read the census out of it.
  *
- * THE BINARY IS PROVEN AGAINST ITS SOURCE BY CONTENT, NOT BY TIMESTAMP. The previous guard compared
- * mtimes after a `cargo build`, which passes on exactly the hazard it names: cargo treats a source
- * whose mtime moved BACKWARDS as up-to-date and does not rebuild, and the mtime comparison then
- * agrees. A tar or rsync restore, a Docker COPY, or a CI cache restored alongside a checkout reaches
- * that state with no deliberate act. The extractor bakes its own source in with `include_str!`, so a
- * binary built from different bytes reports a digest the source on disk cannot produce.
+ * BOTH SIDES ARE COMPARED AGAINST A COMMITTED PIN, NOT AGAINST EACH OTHER. Comparing the binary's
+ * baked-in digest against the source on disk was self-referential: this function builds the binary
+ * from that source first, so the two agree by construction and tampering moves both. The pin above
+ * is the expectation; the two computations below are the fresh evidence. A timestamp guard is not
+ * used at all — cargo treats a source whose mtime moved BACKWARDS as up-to-date, so an mtime
+ * comparison passes on exactly the hazard it names.
  */
 function deriveCensus() {
   const build = spawnSync("cargo", ["build", "--offline", "-p", "ioi-ontology-census"], { cwd: ROOT, encoding: "utf8" });
@@ -185,9 +251,12 @@ function deriveCensus() {
   if (run.status !== 0) throw new Error(`extractor failed (${run.status}): ${run.stderr}`);
   const census = JSON.parse(run.stdout);
   const onDisk = fnv1a64(fs.readFileSync(EXTRACTOR_SRC));
-  ok("the EXTRACTOR THAT PRODUCED THIS CENSUS was built from the extractor source in this tree, proven by a digest the binary carries from its own compile rather than by a timestamp a restore can forge — cargo treats a source whose mtime moved backwards as up-to-date, so an mtime guard passes on the very hazard it names",
-    census.extractor_source_fnv1a64 === onDisk,
-    census.extractor_source_fnv1a64 === onDisk ? `binary and source agree at ${onDisk}` : `binary carries ${census.extractor_source_fnv1a64}, source hashes to ${onDisk}`);
+  const baked = census.extractor_source_fnv1a64;
+  ok("THE EXTRACTOR SOURCE AND THE BINARY BUILT FROM IT BOTH MATCH A COMMITTED PIN — not each other, which is what the previous guard checked and why it certified nothing: this gate runs `cargo build` before it reads the census, so the binary agrees with whatever the source says and an edit moves both sides together, leaving the gate as its own oracle; the expectation is tracked here and moving it is a governed commit act",
+    baked === EXTRACTOR_SOURCE_PIN && onDisk === EXTRACTOR_SOURCE_PIN,
+    baked === EXTRACTOR_SOURCE_PIN && onDisk === EXTRACTOR_SOURCE_PIN
+      ? `binary and source both at the pinned ${EXTRACTOR_SOURCE_PIN}`
+      : `pin ${EXTRACTOR_SOURCE_PIN}, binary carries ${baked}, source hashes to ${onDisk}`);
   return census;
 }
 
@@ -230,6 +299,12 @@ function run() {
     const last = segs[segs.length - 1];
     if (!/^[A-Z0-9_]+$/.test(last)) return { kind: "NOT-CONST" };
     if (segs.length >= 2) {
+      // `impl Shadow { const FAM: &str = "<family>"; }` then `Shadow::FAM`. Associated constants are
+      // namespaced by their type, so they are resolved under their QUALIFIED spelling and never
+      // flattened into the module's constant map, where one impl's constant would answer for a bare
+      // name it does not define.
+      const qualified = segs.slice(-2).join("::");
+      if (m.assoc_consts && m.assoc_consts[qualified] !== undefined) return { kind: "LITERAL", value: m.assoc_consts[qualified] };
       // `use super::odk_routes as ont;` then `ont::KIND_ONT` — the module ALIAS, which the previous
       // resolver could not follow and reported as an unresolvable runtime value instead. Both this
       // form and the plain `use super::m;` are in this daemon today.
@@ -264,6 +339,115 @@ function run() {
     }
     return { kind: "UNRESOLVED", why: `${last} is neither declared here nor imported` };
   }
+
+  // ---------------------------------------------------------------- TOTALITY: token vs role
+  //
+  // THE POPULATION COMES FROM THE TOKENS; THE ROLES COME FROM THE AST. Every judgement below reads a
+  // ROLE, and a role exists only where the extractor's visitor labelled a position — so for as long
+  // as the mention population was ALSO produced by that visitor, a construct it did not reach
+  // produced no mention, no role, and no finding. Seven mutants of that class passed green.
+  //
+  // The extractor now tokenises each file once and hands the SAME stream to syn, so a token's span
+  // and a labelled mention's span are the same object. Matching them by position turns a coverage
+  // gap into a FINDING: a token that resolves to a family and carries no label is a SILENT MENTION.
+  const posKey = (x) => `${x.src}:${x.line}:${x.col}`;
+  const silent = [];
+  const orphan = [];
+  let judgedTokens = 0;
+  let tokenMentions = 0;
+  for (const m of modules) {
+    const labelled = new Map();
+    for (const men of m.mentions) if (!men.synthesized) labelled.set(posKey(men), men);
+    const tokenAt = new Set(m.token_mentions.map(posKey));
+    tokenMentions += m.token_mentions.length;
+    for (const t of m.token_mentions) {
+      const r = resolveName(m, t.text);
+      if (r.kind !== "LITERAL" || !isFamily(r.value)) continue;
+      judgedTokens++;
+      if (!labelled.has(posKey(t))) silent.push(`${modId(m.key)} ${t.src}:${t.line}:${t.col} \`${t.text}\` (${t.kind}) resolves to "${r.value}" and no rule labelled it`);
+    }
+    // The reverse edge, so a label cannot be minted for a position no token occupies — which is how
+    // a mention population could drift back to being the visitor's own product.
+    for (const men of m.mentions) {
+      if (men.synthesized) continue;
+      const r = resolveName(m, men.name);
+      if (r.kind !== "LITERAL" || !isFamily(r.value)) continue;
+      if (!tokenAt.has(posKey(men))) orphan.push(`${modId(m.key)} ${men.src}:${men.line}:${men.col} \`${men.name}\` is labelled \`${men.role}\` at a position holding no token`);
+    }
+  }
+
+  ok("EVERY TOKEN THAT RESOLVES TO AN ODK FAMILY CARRIES A SYNTACTIC LABEL — mentions are derived from the file's RAW TOKEN STREAM, which is total by construction because a name in a file is a token in the file, and the AST only assigns roles to positions in it; a token the role-assigner never reached is a SILENT MENTION and fails here, which is what a closed set of roles could not do while the roles and the population had the same author",
+    silent.length === 0,
+    silent.slice(0, 8).join(" ; ") || `${judgedTokens} family-resolving token positions, every one labelled`);
+
+  ok("AND NO LABEL SITS WHERE NO TOKEN DOES — the reverse edge of the same claim: a mention the extractor synthesises rather than reads would let the population drift back into being the visitor's own product, so the only synthesised mentions permitted are the followed expansions of compile-time assembly, and they are counted separately rather than matched",
+    orphan.length === 0,
+    orphan.slice(0, 8).join(" ; ") || `${tokenMentions} tokens walked, every family label anchored on one`);
+
+  ok("THE TOKEN POPULATION ITSELF IS PINNED — the totality claim is only as good as the walk that produces it, and a tokeniser that quietly stops descending into a group would shrink the population and the silence check together without failing either; this count moves whenever the daemon's literals or constants move, which is the intent",
+    tokenMentions === PINNED.tokenMentions && judgedTokens === PINNED.judgedTokenPositions,
+    `${tokenMentions}/${PINNED.tokenMentions} tokens, ${judgedTokens}/${PINNED.judgedTokenPositions} of them family-resolving`);
+
+  // ---------------------------------------------------------------- TOTALITY: spliced files
+  const unsplicedCode = [];
+  let dataStr = 0, dataBytes = 0, splicedCode = 0, dataOpaqueArg = 0;
+  for (const m of modules) {
+    for (const inc of m.includes) {
+      if (inc.mac === "include") {
+        if (inc.spliced) splicedCode++; else unsplicedCode.push(`${modId(m.key)} ${inc.src}:${inc.line} include!(${inc.arg ?? "«unreadable»"})`);
+        continue;
+      }
+      if (inc.mac === "include_str") dataStr++; else dataBytes++;
+      if (inc.arg === null) dataOpaqueArg++;
+    }
+  }
+  ok("EVERY `include!` HAS BEEN SPLICED INTO THE MODULE THAT INCLUDES IT — an `include!` puts another file's TOKENS into this file, so a target the walk has not read is a hole exactly the size of that file, and it was a fully green second admitter: the whole shadow admitter lived in the unwalked file and the including module's census was unchanged; a target that cannot be resolved or read aborts extraction rather than reporting an absence",
+    unsplicedCode.length === 0 && splicedCode === PINNED.includes.splicedCode,
+    unsplicedCode.join(" ; ") || `${splicedCode}/${PINNED.includes.splicedCode} spliced code includes`);
+
+  ok("THE DATA-INCLUDING FORMS ARE PINNED RATHER THAN FOLLOWED, and that is sound for a different reason than the code form — `include_str!`/`include_bytes!` put BYTES in the program, not Rust, so no writer call can live in one; a constant initialised from one is UNREADABLE to this census and therefore OPAQUE, which the resolver assertion below refuses outright, so their arguments are counted rather than required to be literals",
+    dataStr === PINNED.includes.dataStr && dataBytes === PINNED.includes.dataBytes && dataOpaqueArg === PINNED.includes.dataOpaqueArg,
+    `include_str!=${dataStr}/${PINNED.includes.dataStr} include_bytes!=${dataBytes}/${PINNED.includes.dataBytes} with ${dataOpaqueArg}/${PINNED.includes.dataOpaqueArg} non-literal arguments`);
+
+  // ---------------------------------------------------------------- TOTALITY: constructed names
+  //
+  // A CONSTRUCTED NAME IS IN NO TOKEN. `concat!("od", "k-domain-ontologies")` puts a family name in a
+  // writer's arguments while neither piece is one, so the token population cannot see it and neither
+  // could the role set. The extractor FOLLOWS compile-time assembly into its expansion and emits the
+  // assembled value as a synthesised mention, which then carries the ordinary role of wherever it
+  // sits. An assembly with a piece this census cannot read is reported unreadable and refused here.
+  const unreadableAsm = [], testAsm = [];
+  let prodAsm = 0;
+  for (const m of modules) {
+    for (const a of m.assemblies) {
+      if (!a.compile_time) continue;
+      if (a.in_test) { testAsm.push(`${modId(m.key)}::${a.in_fn}`); continue; }
+      prodAsm++;
+      if (!a.readable) unreadableAsm.push(`${modId(m.key)} ${a.src}:${a.line} ${a.kind}! has a piece this census cannot read`);
+    }
+  }
+  ok("EVERY COMPILE-TIME NAME ASSEMBLY IN PRODUCTION IS READABLE AND IS FOLLOWED INTO ITS EXPANSION — `concat!` and `stringify!` are the two constructs that can produce a `&'static str` family name that exists in no token, so evaluating them is what keeps the token population total for constructed names; an assembly this census cannot evaluate is REFUSED rather than assumed innocent, and the test-region population is pinned so a production one cannot be relocated into it",
+    unreadableAsm.length === 0 && prodAsm === PINNED.compileAssembly.production && testAsm.length === PINNED.compileAssembly.test,
+    unreadableAsm.join(" ; ") || `${prodAsm}/${PINNED.compileAssembly.production} production, ${testAsm.length}/${PINNED.compileAssembly.test} under a bare #[cfg(test)]`);
+
+  // A fragment is a proper substring of a recorded family name: the material an assembly needs. The
+  // daemon contains dozens of them as ordinary words — "receipts", "session", "ontology" — so their
+  // mere presence is not a finding. What must be impossible is a fragment inside an ASSEMBLING
+  // construct in a writer's or filesystem call's own arguments, which is where an assembled family
+  // name reaches a write without ever being a name.
+  const FAMILY_NAMES = Object.keys(RECORDED_PLANE);
+  const isFragment = (s) => typeof s === "string" && s.length >= 2 && !FAMILY_NAMES.includes(s) && FAMILY_NAMES.some((f) => f.includes(s));
+  const assembledInWrite = [];
+  for (const m of modules) {
+    for (const a of m.assemblies) {
+      if (a.in_test || !(a.in_write_arg || a.in_fs_arg)) continue;
+      const frags = [...new Set(a.pieces.filter(isFragment))];
+      if (frags.length) assembledInWrite.push(`${modId(m.key)}::${a.in_fn} assembles with ${a.kind} from ${frags.map((f) => JSON.stringify(f)).join(", ")}`);
+    }
+  }
+  ok("NO STRING-ASSEMBLING CONSTRUCT INSIDE A PRODUCTION WRITER'S OR FILESYSTEM CALL'S OWN ARGUMENTS TAKES A FRAGMENT OF A FAMILY NAME AS A PIECE — the fragments themselves are ordinary words this daemon uses everywhere and are not a finding; what is refused is the ASSEMBLY, because a name built from `\"od\"` and `\"k-domain-ontologies\"` is a family name in the writer's hand and a family name in no token anywhere",
+    assembledInWrite.length === 0,
+    assembledInWrite.slice(0, 8).join(" ; ") || `${modules.reduce((a, m) => a + m.assemblies.filter((x) => !x.in_test && (x.in_write_arg || x.in_fs_arg)).length, 0)} assemblies inside production writer arguments, none from a fragment`);
 
   // ---------------------------------------------------------------- classify every mention
   const observedRoles = new Set();
@@ -434,7 +618,7 @@ function run() {
       if (fams.length) rawWrites.push(`${modId(m.key)}::${c.in_fn} calls ${c.callee} and names ${fams.join(", ")}`);
     }
   }
-  ok("NO PRODUCTION FUNCTION MAKES A RAW FILESYSTEM CALL AND NAMES AN ONTOLOGY FAMILY IT DOES NOT OWN — the record-writer census cannot see a lane that bypasses the writers entirely and puts bytes in a family directory itself; the enclosing function is read for EVERY declaration form, and reading it only for free functions left this rule dead for a third of the daemon's production filesystem calls",
+  ok("NO PRODUCTION FUNCTION MAKES A RAW FILESYSTEM CALL AND NAMES AN ONTOLOGY FAMILY IT DOES NOT OWN — the record-writer census cannot see a lane that bypasses the writers entirely and puts bytes in a family directory itself; the enclosing function is read for EVERY declaration form, and reading it only for free functions left this rule dead for every production filesystem call sitting in an impl method",
     rawWrites.length === 0,
     rawWrites.join(" ; ") || `${prodFs} production filesystem calls, none in a function naming a family it does not own`);
 

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -173,6 +173,49 @@ export function matchBrace(src, from) {
 }
 
 /**
+ * Expand a `use` declaration into `[{ owner, name, alias }]`.
+ *
+ * The daemon's house style is the BRACED GROUP — 58 route modules write `use super::{…}` — and a
+ * parser that only understood `super::<ident>::` produced ZERO entries for
+ * `use super::{odk_routes::KIND_ONT as ONT_DIR};`. Not ambiguous, not unresolved: invisible. A
+ * second admitter walked straight through that, and the un-grouped form was only ever caught by a
+ * global-unique fallback that this census has since removed.
+ */
+export function expandUseTree(decl) {
+  const out = [];
+  const walk = (prefix, text) => {
+    let depth = 0, part = "";
+    const parts = [];
+    for (const ch of text) {
+      if (ch === "{") { depth += 1; part += ch; continue; }
+      if (ch === "}") { depth -= 1; part += ch; continue; }
+      if (ch === "," && depth === 0) { parts.push(part); part = ""; continue; }
+      part += ch;
+    }
+    if (part.trim()) parts.push(part);
+    for (const raw of parts) {
+      const seg = raw.trim();
+      if (!seg) continue;
+      const brace = seg.indexOf("{");
+      if (brace !== -1 && seg.endsWith("}")) {
+        walk(`${prefix}${seg.slice(0, brace)}`, seg.slice(brace + 1, -1));
+        continue;
+      }
+      const asMatch = /^(.*?)\s+as\s+(\w+)$/u.exec(seg);
+      const pathPart = (asMatch ? asMatch[1] : seg).trim();
+      const alias = asMatch ? asMatch[2] : null;
+      const full = `${prefix}${pathPart}`;
+      const segs = full.split("::").map((x) => x.trim()).filter(Boolean);
+      const name = segs[segs.length - 1];
+      const owner = segs.length >= 2 ? segs[segs.length - 2] : null;
+      out.push({ owner, name, alias: alias ?? name });
+    }
+  };
+  walk("", decl);
+  return out;
+}
+
+/**
  * The offset of the `}` that closes the block containing `from`, with string and char literals
  * skipped. Needs no knowledge of how the enclosing function was declared.
  */
@@ -212,11 +255,41 @@ export function enclosingBlockEnd(src, from) {
  */
 export function testRegions(src) {
   const out = [];
+  // STRING SPANS FIRST. This runs on comment-stripped source, which still contains STRING LITERALS,
+  // so the literal text `"#[cfg(test)]"` inside a helper minted a phantom region — and four such
+  // phantoms exist in this tree today. A phantom region reclassifies production code as a test
+  // fixture, which switches off both the raw-write denylist and the unclassified-mention backstop.
+  const strings = [];
+  for (let i = 0; i < src.length; i += 1) {
+    if (src[i] === '"') {
+      const start = i;
+      i += 1;
+      while (i < src.length) {
+        if (src[i] === "\\") { i += 2; continue; }
+        if (src[i] === '"') break;
+        i += 1;
+      }
+      strings.push([start, i]);
+    }
+  }
+  const inString = (at) => strings.some(([a, b]) => at > a && at < b);
   for (const m of src.matchAll(/#\[cfg\(test\)\]/gu)) {
+    if (inString(m.index)) continue;
     const open = src.indexOf("{", m.index);
-    if (open === -1) continue;
+    // ATTACHED TO A BRACED ITEM. `#[cfg(test)] use std::fs as _t;` before a function made that
+    // FUNCTION the region. The attribute must introduce a `mod` or `fn` for its brace to be the
+    // region's brace.
+    const between = open === -1 ? "" : src.slice(m.index + "#[cfg(test)]".length, open);
+    const attached = /^\s*(?:pub(?:\s*\([^)]*\))?\s+)?(?:mod|fn|impl|async\s+fn)\b/u.test(between);
+    // AN ATTRIBUTE ON A NON-BRACED ITEM CREATES NO REGION, AND THAT IS THE FIX. `#[cfg(test)] use
+    // std::fs as _t;` and `#[cfg(test)] thread_local! { … }` are ordinary Rust that this daemon
+    // writes in eight places; taking "the next brace anywhere" made the FOLLOWING function the
+    // region, which is how a production raw write got reclassified as a test fixture. No region is
+    // the correct answer for these, not a red — the red belongs to a region that opens and never
+    // closes.
+    if (open === -1 || !attached) continue;
     const { end, closed } = matchBrace(src, open);
-    out.push({ start: m.index, end: Math.min(end + 1, src.length), closed });
+    out.push({ start: m.index, end: Math.min(end + 1, src.length), closed, attached: true });
   }
   return out;
 }
@@ -232,29 +305,52 @@ const FAMILIES = {
 
 const WRITER = "(?:persist_record|remove_record|persist_promoted|admit_required)\\w*";
 // EXACT names. A prefix pattern classified `load_or_admit` — a get-or-create that WRITES — as a read.
-const READERS = ["load", "read_record_dir", "json_get", "record_path", "load_record"];
+// Exact names, and only names that EXIST: `record_path` was in this list and matches no function
+// in the daemon, so it could only ever widen the benign bucket for code that does not exist.
+const READERS = ["load", "read_record_dir", "json_get", "load_record"];
 const READER = `(?:${READERS.join("|")})`;
 
 function run() {
   // ------------------------------------------------------------ the module world, from the graph
   const mainRaw = fs.readFileSync(DAEMON_MAIN, "utf8");
   const mainSrc = stripRustComments(mainRaw).out;
-  const declared = new Map();                            // module name -> resolved file path
-  for (const m of mainSrc.matchAll(/(?:#\[path\s*=\s*"([^"]+)"\]\s*)?(?:pub\s+)?mod\s+(\w+)\s*;/gu)) {
-    const rel = m[1] ?? `hypervisor_daemon_routes/${m[2]}.rs`;
-    declared.set(m[2], path.resolve(BIN_DIR, rel));
+  // THE GRAPH IS WALKED TRANSITIVELY. The first cut read only the crate root's declarations, so a
+  // `mod` declared INSIDE a route module — whose file lives in a subdirectory and therefore never
+  // appears in a flat `.rs` listing — was never censused at all. That is the directory-listing
+  // defect one level down, and a second admitter fits in it exactly.
+  const declared = new Map();
+  const queue = [DAEMON_MAIN];
+  const walked = new Set();
+  while (queue.length) {
+    const file = queue.shift();
+    if (walked.has(file) || !fs.existsSync(file)) continue;
+    walked.add(file);
+    const src = stripRustComments(fs.readFileSync(file, "utf8")).out;
+    const dir = path.dirname(file);
+    const selfName = path.basename(file, ".rs");
+    for (const m of src.matchAll(/(?:#\[path\s*=\s*"([^"]+)"\]\s*)?(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+(\w+)\s*;/gu)) {
+      const candidates = m[1]
+        ? [path.resolve(dir, m[1])]
+        : [path.join(dir, `${m[2]}.rs`), path.join(dir, selfName, `${m[2]}.rs`), path.join(dir, m[2], "mod.rs")];
+      const hit = candidates.find((c) => fs.existsSync(c));
+      if (!hit) continue;
+      declared.set(path.relative(BIN_DIR, hit), hit);
+      queue.push(hit);
+    }
   }
   const onDisk = fs.readdirSync(ROUTES_DIR).filter((f) => f.endsWith(".rs"))
     .map((f) => path.join(ROUTES_DIR, f)).sort();
   const declaredPaths = [...declared.values()].sort();
   const files = [...new Set([...declaredPaths, ...onDisk, DAEMON_MAIN])].filter((f) => fs.existsSync(f));
+  const undeclared = onDisk.filter((f) => !declaredPaths.includes(f));
+  const offDirectory = declaredPaths.filter((f) => path.dirname(f) !== ROUTES_DIR);
   const modName = (f) => path.basename(f, ".rs");
 
   ok("the module world is derived from the BINARY'S OWN `mod` DECLARATIONS and is bijective with the routes directory — a module declared `#[path]` outside that directory is part of the same binary and a directory listing never reads it, which is a second admission path a census cannot see",
-    declared.size > 50
-      && declaredPaths.length === onDisk.length
-      && declaredPaths.every((p, i) => p === onDisk[i]),
-    `${declared.size} declared, ${onDisk.length} on disk, ${files.length} censused`);
+    declared.size > 50 && undeclared.length === 0 && offDirectory.length === 0,
+    undeclared.length || offDirectory.length
+      ? `UNDECLARED: ${undeclared.map(modName).join(",") || "none"} | OFF-DIRECTORY: ${offDirectory.map((f) => path.relative(BIN_DIR, f)).join(",") || "none"}`
+      : `${declared.size} modules reached transitively, bijective with ${onDisk.length} on disk`);
 
   const rawSources = new Map();
   const sources = new Map();
@@ -266,16 +362,26 @@ function run() {
   }
 
   // ------------------------------------------------------------ the scanner, checked on itself
+  const removedTotal = [...removedSpans.values()].reduce((n, sp) => n + sp.length, 0);
   const badRemoval = [];
   for (const [f, spans] of removedSpans) {
     const raw = rawSources.get(f);
-    for (const [s] of spans) {
-      const head = raw.slice(s, s + 2);
-      if (head !== "//" && head !== "/*") badRemoval.push(`${modName(f)}@${s}:${JSON.stringify(head)}`);
+    for (const [a, b] of spans) {
+      const head = raw.slice(a, a + 2);
+      if (head === "//") {
+        // A LINE COMMENT ENDS AT ITS LINE. Checking only the START is what let a greedy variant —
+        // one that starts at `//` and keeps eating following lines — pass while hiding a second
+        // admitter behind an ordinary comment. The END is the half that carries the finding.
+        const nl = raw.indexOf("\n", a);
+        if (b !== (nl === -1 ? raw.length : nl)) badRemoval.push(`${modName(f)}@${a}: line comment over-ran to ${b}`);
+      } else if (head === "/*") {
+        if (raw.slice(b - 2, b) !== "*/" && b !== raw.length) badRemoval.push(`${modName(f)}@${a}: block comment did not end at */`);
+      } else {
+        badRemoval.push(`${modName(f)}@${a}: removal does not begin at a comment token (${JSON.stringify(head)})`);
+      }
     }
   }
-  const removedTotal = [...removedSpans.values()].reduce((n, sp) => n + sp.length, 0);
-  ok("every span the comment stripper REMOVED begins at a real comment token in the raw source — a length-and-survival check cannot fail on a scanner that eats code, and XIII shipped exactly such a scanner (368,828 characters of executable source, and the assertion passed)",
+  ok("every span the comment stripper REMOVED both BEGINS at a comment token and ENDS where that comment ends — a line comment at its newline, a block comment after its `*/` — a length-and-survival check cannot fail on a scanner that eats code, and XIII shipped exactly such a scanner (368,828 characters of executable source, and the assertion passed)",
     // NON-VACUITY: a scanner that reports NO removed spans satisfies "all removed spans are
     // comment-initial" trivially, and the naive `//`-regex does exactly that while eating code. A
     // daemon this size has tens of thousands of comment spans; zero is a broken scanner, not a
@@ -295,37 +401,19 @@ function run() {
     for (const m of src.matchAll(/const\s+(\w+)\s*:\s*&'?\w*\s*str\s*=\s*"([^"]*)"/gu)) own.set(m[1], m[2]);
     constsOf.set(modName(f), own);
   }
-  // `use … as` renames AND re-exports (`pub(crate) use path::CONST as ALIAS;`), per module.
+  // Every name a module brings into scope, resolved through the module it comes FROM. Handles the
+  // braced-group house style, nested groups, and `as` renames alike.
   const aliasOf = new Map();
-  for (const [f, src] of sources) {
-    const mod = modName(f);
-    const m2 = new Map();
-    for (const d of src.matchAll(/(?:pub(?:\s*\([^)]*\))?\s+)?use\s+([^;]*);/gu)) {
-      const decl = d[1];
-      const owner = /(?:crate|super)::(\w+)::/u.exec(decl)?.[1] ?? null;
-      for (const a of decl.matchAll(/(\w+)\s+as\s+(\w+)/gu)) {
-        const lit = (owner && constsOf.get(owner)?.get(a[1])) ?? null;
-        if (lit) m2.set(a[2], lit);
-      }
-      // a plain re-export or import of a constant by name, resolved in the module it comes from
-      if (owner) {
-        for (const n of decl.matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
-          const lit = constsOf.get(owner)?.get(n[1]);
-          if (lit) m2.set(n[1], lit);
+  for (const [f] of sources) aliasOf.set(modName(f), new Map());
+  for (let hop = 0; hop < 2; hop += 1) {          // one hop follows a re-export chain
+    for (const [f, src] of sources) {
+      const mod = modName(f);
+      for (const d of src.matchAll(/(?:pub(?:\s*\([^)]*\))?\s+)?use\s+([^;]*);/gu)) {
+        for (const { owner, name, alias } of expandUseTree(d[1])) {
+          if (!owner) continue;
+          const lit = constsOf.get(owner)?.get(name) ?? aliasOf.get(owner)?.get(name);
+          if (lit !== undefined) aliasOf.get(mod).set(alias, lit);
         }
-      }
-    }
-    aliasOf.set(mod, m2);
-  }
-  // follow one hop of re-export: A aliases X, B imports A::X
-  for (const [f, src] of sources) {
-    const mod = modName(f);
-    for (const d of src.matchAll(/(?:pub(?:\s*\([^)]*\))?\s+)?use\s+([^;]*);/gu)) {
-      const owner = /(?:crate|super)::(\w+)::/u.exec(d[1])?.[1] ?? null;
-      if (!owner) continue;
-      for (const n of d[1].matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
-        const lit = aliasOf.get(owner)?.get(n[1]);
-        if (lit) aliasOf.get(mod).set(n[1], lit);
       }
     }
   }
@@ -342,13 +430,14 @@ function run() {
     if (own !== undefined) return own;
     const alias = aliasOf.get(mod)?.get(name);
     if (alias !== undefined) return alias;
-    // A BARE NAME THIS MODULE DOES NOT DECLARE OR IMPORT IS NOT GUESSED. The daemon has 25 names
-    // meaning different things in different modules; picking one is how a second admitter hides.
+    // A BARE NAME THIS MODULE NEITHER DECLARES NOR IMPORTS IS NOT GUESSED — not even when exactly
+    // one module in the daemon happens to declare it. That global-unique fallback was the crutch a
+    // review used: it made the un-renamed grouped import look caught, so the renamed one looked like
+    // a new hole rather than the same one. If a module names a family this census cannot tie to a
+    // declaration it can see, that is UNRESOLVED, and unresolved is RED.
     const candidates = new Set();
     for (const [, m2] of constsOf) if (m2.has(name)) candidates.add(m2.get(name));
-    if (candidates.size === 1) return [...candidates][0];
-    if (candidates.size > 1) return AMBIGUOUS;
-    return null;
+    return candidates.size ? AMBIGUOUS : null;
   };
 
   const familyLiterals = new Set(Object.keys(FAMILIES));
@@ -429,7 +518,7 @@ function run() {
       }
     }
     for (const t of testRegions(src)) {
-      if (!t.closed) unclosedTestRegions.push(`${mod}@${t.start}`);
+      if (!t.closed) { unclosedTestRegions.push(`${mod}@${t.start} opened and never closed`); continue; }
       spans.push({ start: t.start, end: t.end, kind: "test-fixture" });
     }
 
@@ -440,7 +529,7 @@ function run() {
     }
   }
 
-  ok("every `#[cfg(test)]` region CLOSES on a real brace, with string and char literals skipped — a region that runs to EOF, or one whose depth counter counted a brace inside `\"{\"`, silently reclassifies production code as a test fixture and waves a write through",
+  ok("every `#[cfg(test)]` region is ATTACHED to a `mod`/`fn`, is not the literal text inside a string, and CLOSES on a real brace — a region that runs to EOF, or one whose depth counter counted a brace inside `\"{\"`, silently reclassifies production code as a test fixture and waves a write through",
     unclosedTestRegions.length === 0, unclosedTestRegions.join(" ; ") || "all test regions closed");
 
   const unclassified = mentions.filter((m) => m.kind === null);
@@ -464,48 +553,33 @@ function run() {
     [...familyLiterals].join(" "));
 
   // ------------------------------------------------------------ resolver flow
-  const resolverSinks = [];
-  const resolverMods = new Set();
+  // EVERY `resolves` MENTION, BY THE FUNCTION IT SITS IN. The first rule inspected only the shape
+  // `let x = match y { … };` while the CLASSIFIER accepted any `=> Some(X)` arm — so a mapper
+  // written `match scheme.as_str()`, or as a function returning the match, or nested one block
+  // deeper, classified as `resolves` and was never flow-checked at all. The rule is now structural
+  // and needs no dataflow: A FUNCTION THAT RESOLVES A FAMILY NAME MAY NOT ALSO WRITE A RECORD.
+  // A scheme-mapper that admits is the second spine this assertion exists to refuse, and a function
+  // doing both is that, whatever the plumbing between them looks like.
+  const resolverFns = [];
   for (const [f, src] of sources) {
     const mod = modName(f);
-    for (const m of src.matchAll(/let\s+(\w+)\s*=\s*match\s+\w+\s*\{[\s\S]*?\n\s*\};/gu)) {
-      let named = false;
-      for (const arm of m[0].matchAll(/=>\s*Some\(\s*([^)]+?)\s*\)/gu)) {
-        const lit = resolveArg(mod, arm[1]);
-        if (lit && lit !== AMBIGUOUS && familyLiterals.has(lit)) named = true;
-      }
-      if (!named) continue;
-      resolverMods.add(mod);
-      // TO THE END OF THE ENCLOSING FUNCTION, not a fixed character window. A sink 2,269 characters
-      // past the block escaped a 1,600-character window, and the window was arbitrary anyway.
-      // BOUND BY THE ENCLOSING BLOCK, not by hunting for the `fn` keyword. Anchoring on "\nfn "
-      // missed `pub(crate) fn`, so the search anchored to an EARLIER function whose brace closed
-      // before the match block — the window came out EMPTY and a mutation that had been caught went
-      // green again. Scanning forward to the brace that closes the block this match sits in needs no
-      // knowledge of how the function was declared.
-      const from = m.index + m[0].length;
-      const after = src.slice(from, enclosingBlockEnd(src, from));
-      // Rebindings closed over transitively, INCLUDING match-arm bindings (`Some(k) =>`), which the
-      // first cut did not track — a writer taking that binding passed green.
-      const tracked = new Set([m[1]]);
-      for (let pass = 0; pass < 6; pass += 1) {
-        for (const t of [...tracked]) {
-          for (const rb of after.matchAll(new RegExp(`(?:if\\s+let\\s+Some\\(\\s*(\\w+)\\s*\\)|let\\s+(\\w+))\\s*=\\s*\\*?${t}\\b`, "gu"))) tracked.add(rb[1] ?? rb[2]);
-          for (const rb of after.matchAll(new RegExp(`match\\s+\\*?${t}\\b[\\s\\S]{0,400}?Some\\(\\s*(\\w+)\\s*\\)\\s*=>`, "gu"))) tracked.add(rb[1]);
-        }
-      }
-      for (const t of tracked) {
-        for (const use of after.matchAll(new RegExp(`(\\w+)\\s*\\(\\s*[^)]*?\\b${t}\\b`, "gu"))) {
-          resolverSinks.push({ mod, sink: use[1] });
-        }
-      }
+    for (const m of src.matchAll(/=>\s*Some\(\s*([^)]+?)\s*\)/gu)) {
+      const lit = resolveArg(mod, m[1]);
+      if (!lit || lit === AMBIGUOUS || !familyLiterals.has(lit)) continue;
+      const fnStart = Math.max(src.lastIndexOf("\nfn ", m.index), src.lastIndexOf("\npub", m.index),
+        src.lastIndexOf("\n    fn ", m.index), 0);
+      const { end } = matchBrace(src, fnStart);
+      const body = src.slice(fnStart, Math.max(end, m.index));
+      const writes = [...body.matchAll(new RegExp(`${WRITER}\\(`, "gu"))].map((w) => w[0]);
+      resolverFns.push({ mod, at: m.index, writes });
     }
   }
-  const writerSinks = resolverSinks.filter((s) => new RegExp(`^${WRITER}$`, "u").test(s.sink));
-  ok("and every scheme-mapper that RESOLVES a family name flows only into READ sinks, followed to the end of its enclosing function and through match-arm rebindings — the generic `\"ontology\" => Some(...)` arms in governance and marketplace are the exact shape that becomes a second admission path the moment a resolved name reaches a writer",
-    resolverMods.size > 0 && writerSinks.length === 0,
-    writerSinks.length ? `RESOLVED NAME REACHES A WRITER: ${writerSinks.map((s) => `${s.mod}->${s.sink}`).join(" ; ")}`
-      : `${[...resolverMods].sort().join(",")} resolve into ${new Set(resolverSinks.map((s) => s.sink)).size} distinct sinks`);
+  const resolverWriters = resolverFns.filter((r) => r.writes.length);
+  ok("no function that RESOLVES a family name also writes a record — the generic `\"ontology\" => Some(...)` arms in governance and marketplace are the shape that becomes a second admission path the moment the resolved name reaches a writer, and a function doing both is that path whatever the plumbing between them looks like",
+    resolverFns.length > 0 && resolverWriters.length === 0,
+    resolverWriters.length
+      ? `RESOLVES AND WRITES: ${resolverWriters.map((r) => `${r.mod}@${r.at}->${[...new Set(r.writes)].join(",")}`).join(" ; ")}`
+      : `${resolverFns.length} resolving site(s) in [${[...new Set(resolverFns.map((r) => r.mod))].sort().join(",")}], none writes`);
 
   // ------------------------------------------------------------ raw filesystem writes
   const rawWrites = [];

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -1,604 +1,281 @@
 #!/usr/bin/env node
-// The ontology plane's ADMISSION CENSUS — derived from the daemon's own source, at the layer the
-// property lives.
+// The ontology plane's ADMISSION CENSUS — entailed from the daemon's source by a REAL RUST PARSER.
 //
-// WHY THIS EXISTS, and why it is not a journey gate. Next-legs XIII spent five merge-blocking review
-// rounds strengthening one journey verifier's proof that "no second admission path writes ontology
-// truth" — keyed first on the route name, then the changed file name, then the response bytes, then
-// the caller's request — and each round a review defeated the PROOF while the code under test stayed
-// correct and green. The owner ruled the iteration terminated and the claim MIS-SCOPED FOR ITS
-// OBSERVER: a whole-program property cannot be entailed by a black-box journey verifier, because the
-// observer sits inside the system it is trying to bound. Building the real proof HERE — from module
-// source — was commissioned as next-legs XIV Leg 3a.
+// WHY THIS EXISTS. Next-legs XIII spent five merge-blocking rounds strengthening a black-box JOURNEY
+// gate's proof that "no second admission path writes ontology truth"; each round a review defeated
+// the PROOF while the code stayed correct. The owner ruled the claim mis-scoped for its observer —
+// the observer sat inside the system it was bounding — and commissioned the proof to be built HERE,
+// from module source, where the whole program is visible at once.
 //
-// WHAT IT ENTAILS. For each of the ontology plane's FOUR record families, exactly ONE module in the
-// daemon admits it. A second admission path has to appear in some module's text to exist at all, so
-// a census that classifies EVERY mention in EVERY module can see one however it is spelled.
+// WHY IT IS NOT A REGEX ANY MORE. XIV Leg 3a first built this by hand-scanning Rust. Three review
+// rounds defeated it, and the defeats sorted cleanly into CENSUS LOGIC (a rule wrong or decorative)
+// and LANGUAGE READING (a Rust construct the scanner mis-modelled). Round two produced six of the
+// latter; round three produced five more — `use super::odk_routes;` then `odk_routes::KIND_ONT`,
+// raw strings desyncing a brace walk, `async fn` defeating an enclosing-function heuristic, and
+// module-file resolution order shadowing a nested module with a flat sibling. The owner
+// PRE-COMMITTED the rule before that round ran: modelling the next construct retires an INSTANCE, a
+// real parser retires the CLASS. Extraction runs through `syn` now (`crates/ontology-census`), which
+// emits the facts as JSON; this file decides what they mean. Keeping extraction and judgement apart
+// is what let the judgement keep every mutation anchor while the substrate underneath changed.
 //
-// WHAT THE FIRST CUT GOT WRONG, because every one of these is now load-bearing. A merge-blocking
-// review defeated it FIVE ways with mutants that stayed green, and each defeat is a discipline:
+// WHAT IT ENTAILS, scoped by owner ruling. For each of the four ONTOLOGY families, exactly one
+// module admits it. That is the commissioned claim, and the four assertions below carry it.
 //
-//   1. NAME RESOLUTION IS PER MODULE, NEVER GLOBAL. The first cut built ONE `Map(name → literal)`
-//      across all 88 modules. The daemon declares 660 string constants under 537 names — 25 of them
-//      AMBIGUOUS, with `RECORD_DIR` declared in thirteen modules meaning thirteen different things.
-//      Last-writer-wins silently discarded 123 declarations, so a second admitter written in the
-//      house style (`const RECORD_DIR: &str = "odk-domain-ontologies"`) resolved to some other
-//      module's literal and vanished. Resolution is scoped to the declaring module now, qualified
-//      paths resolve in the module they name, and an AMBIGUOUS bare name is UNRESOLVED — which is
-//      RED — rather than guessed.
+// AND WHAT IT RATCHETS, which is weaker and labelled as such. The extractor derives all NINETEEN
+// written ODK families. Their admitter map is RECORDED here and asserted in both directions per
+// scar 4: a family that GAINS an admitter beyond the record is RED; a family that loses one makes
+// the record STALE and must be re-derived in the commit that removes it. The label claims exactly
+// that ratchet — NOT that every ODK family has one admitter, because FIVE DO NOT. Those five are
+// recorded UNDER ADJUDICATION, neither endorsed nor condemned; adjudicating them is next-legs XV
+// work, and the question per family is whether the co-admitters are legitimate co-callers of ONE
+// kernel-owned admission path or whether a lane hand-mints records beside it.
 //
-//   2. THE TEST-REGION MATCHER MUST SKIP STRING LITERALS. It counted braces in a source that still
-//      contains string literals, so `storage_backend_routes.rs`'s `#[cfg(test)]` region over-ran its
-//      real end by 811 characters and swallowed a production function; a raw write planted there was
-//      waved through by both the denylist and the classifier. A region that does not close on a real
-//      brace is now RED, not a region.
+// The hand-written table this replaced named FOUR families and structurally could not have seen the
+// other fifteen. Deriving it found five multi-admitter families on the first run. Hand-written
+// filter, derived replacement, immediate finding — that sequence is scar 4's whole argument.
 //
-//   3. READER NAMES ARE EXACT, NOT PREFIXES. `load\w*` matched `load_or_admit` — an ordinary
-//      get-or-create helper — so a call that WRITES classified as a read. Any other callee taking a
-//      family argument is unclassified, which is RED.
-//
-//   4. THE MODULE WORLD COMES FROM THE MODULE GRAPH, not a directory listing. A module declared
-//      `#[path]` outside the routes directory was never read at all. The world is derived from the
-//      binary's own `mod` declarations, asserted bijective with the directory, and `include!` is
-//      refused because it would splice source this census never sees.
-//
-//   5. AN ASSERTION ABOUT THE SCANNER MUST FAIL ON THE SCANNER. "The stripper removed only comments"
-//      checked that the output got shorter and the four literals survived somewhere — so replacing
-//      the scanner with XIII's naive `//`-regex, which ate 368,828 characters of executable code,
-//      PASSED. Every removed span is now checked to begin at a real comment token in the raw source.
-//
-// WHAT IT DOES NOT ENTAIL, stated so the label claims only what it checks. This reads the daemon's
-// Rust source and sees a family named by a literal, by a resolvable constant, or by a resolvable
-// alias. It does NOT see: a family name ASSEMBLED at runtime (`format!("odk-{}-ontologies", …)`),
-// a write performed by a dependency crate on the daemon's behalf, a write produced by macro
-// expansion, or a write by a process that is not this daemon. Those are outside what source
-// inspection can decide, and they are named here rather than implied away.
+// WHAT IT DOES NOT ENTAIL. `syn` reads this crate's source. A write performed by a dependency crate
+// on the daemon's behalf, produced by macro expansion, or by another process, is outside it.
+// Seventy-four writer calls take their family as a runtime parameter and cannot be resolved
+// statically at all; that count is pinned as its own ratchet rather than waved through.
 
 import fs from "node:fs";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = process.env.IOI_CENSUS_ROOT || path.resolve(HERE, "..", "..", "..");
-const BIN_DIR = path.join(ROOT, "crates/node/src/bin");
-const ROUTES_DIR = path.join(BIN_DIR, "hypervisor_daemon_routes");
-const DAEMON_MAIN = path.join(BIN_DIR, "hypervisor-daemon.rs");
+const EXTRACTOR_SRC = path.join(ROOT, "crates/ontology-census/src/main.rs");
+const EXTRACTOR_BIN = path.join(ROOT, "target/debug/ioi-ontology-census");
+const DAEMON_MAIN = path.join(ROOT, "crates/node/src/bin/hypervisor-daemon.rs");
 
 const results = [];
 const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
 
-// ---------------------------------------------------------------- the scanner
-/**
- * Strip Rust comments, reporting exactly which byte spans were removed.
- *
- * The spans are the point. An assertion that the stripper "removed only comments" is decorative
- * unless it can check WHAT was removed — XIII's naive `//` regex ate 368k characters of code and a
- * length-plus-survival check passed it.
- */
-export function stripRustComments(src) {
-  let out = "";
-  const removed = [];
-  for (let i = 0; i < src.length;) {
-    const c = src[i];
-    if (c === "r" && (src[i + 1] === '"' || src[i + 1] === "#")) {
-      let j = i + 1, hashes = 0;
-      while (src[j] === "#") { hashes += 1; j += 1; }
-      if (src[j] === '"') {
-        const close = `"${"#".repeat(hashes)}`;
-        const end = src.indexOf(close, j + 1);
-        const stop = end === -1 ? src.length : end + close.length;
-        out += src.slice(i, stop); i = stop; continue;
-      }
-    }
-    if (c === '"') {
-      let j = i + 1;
-      while (j < src.length) {
-        if (src[j] === "\\") { j += 2; continue; }
-        if (src[j] === '"') { j += 1; break; }
-        j += 1;
-      }
-      out += src.slice(i, j); i = j; continue;
-    }
-    if (c === "'") {
-      let j = i + 1;
-      if (src[i + 1] === "\\") {
-        if (src[i + 2] === "u" && src[i + 3] === "{") {
-          const close = src.indexOf("}", i + 4);
-          j = close === -1 ? src.length : close + 1;
-        } else if (src[i + 2] === "x") { j = i + 5; }
-        else { j = i + 3; }
-      } else {
-        let k = i + 1;                       // a non-BMP char literal is two UTF-16 units
-        while (k < src.length && k <= i + 3 && src[k] !== "'") k += 1;
-        if (src[k] !== "'") { out += c; i += 1; continue; }   // a lifetime, not a literal
-        j = k;
-      }
-      if (src[j] === "'") { out += src.slice(i, j + 1); i = j + 1; continue; }
-      out += c; i += 1; continue;
-    }
-    if (c === "/" && src[i + 1] === "/") {
-      const start = i;
-      while (i < src.length && src[i] !== "\n") i += 1;
-      removed.push([start, i]); continue;
-    }
-    if (c === "/" && src[i + 1] === "*") {
-      const start = i;
-      let depth = 1; i += 2;
-      while (i < src.length && depth > 0) {
-        if (src[i] === "/" && src[i + 1] === "*") { depth += 1; i += 2; continue; }
-        if (src[i] === "*" && src[i + 1] === "/") { depth -= 1; i += 2; continue; }
-        i += 1;
-      }
-      removed.push([start, i]); continue;
-    }
-    out += c; i += 1;
-  }
-  return { out, removed };
-}
-
-/**
- * Walk from `from` to the brace that closes the first `{` at or after it, SKIPPING string and char
- * literals. Returns `{ end, closed }`.
- *
- * One implementation, used by both the test-region matcher and the resolver-flow function bound —
- * because writing the walk twice is how the string-skipping fix landed in one of them and not the
- * other, which silently emptied the resolver's search window and let a defeated mutation go green
- * again.
- */
-export function matchBrace(src, from) {
-  let depth = 0, i = from, seen = false;
-  for (; i < src.length; i += 1) {
-    const c = src[i];
-    if (c === '"') {
-      i += 1;
-      while (i < src.length) {
-        if (src[i] === "\\") { i += 2; continue; }
-        if (src[i] === '"') break;
-        i += 1;
-      }
-      continue;
-    }
-    if (c === "'") {
-      let k = i + 1;
-      if (src[k] === "\\") k += 1;
-      while (k < src.length && k <= i + 4 && src[k] !== "'") k += 1;
-      if (src[k] === "'") { i = k; }
-      continue;
-    }
-    if (c === "{") { depth += 1; seen = true; }
-    else if (c === "}") { depth -= 1; if (seen && depth === 0) return { end: i, closed: true }; }
-  }
-  return { end: Math.min(i, src.length), closed: false };
-}
-
-/**
- * Expand a `use` declaration into `[{ owner, name, alias }]`.
- *
- * The daemon's house style is the BRACED GROUP — 58 route modules write `use super::{…}` — and a
- * parser that only understood `super::<ident>::` produced ZERO entries for
- * `use super::{odk_routes::KIND_ONT as ONT_DIR};`. Not ambiguous, not unresolved: invisible. A
- * second admitter walked straight through that, and the un-grouped form was only ever caught by a
- * global-unique fallback that this census has since removed.
- */
-export function expandUseTree(decl) {
-  const out = [];
-  const walk = (prefix, text) => {
-    let depth = 0, part = "";
-    const parts = [];
-    for (const ch of text) {
-      if (ch === "{") { depth += 1; part += ch; continue; }
-      if (ch === "}") { depth -= 1; part += ch; continue; }
-      if (ch === "," && depth === 0) { parts.push(part); part = ""; continue; }
-      part += ch;
-    }
-    if (part.trim()) parts.push(part);
-    for (const raw of parts) {
-      const seg = raw.trim();
-      if (!seg) continue;
-      const brace = seg.indexOf("{");
-      if (brace !== -1 && seg.endsWith("}")) {
-        walk(`${prefix}${seg.slice(0, brace)}`, seg.slice(brace + 1, -1));
-        continue;
-      }
-      const asMatch = /^(.*?)\s+as\s+(\w+)$/u.exec(seg);
-      const pathPart = (asMatch ? asMatch[1] : seg).trim();
-      const alias = asMatch ? asMatch[2] : null;
-      const full = `${prefix}${pathPart}`;
-      const segs = full.split("::").map((x) => x.trim()).filter(Boolean);
-      const name = segs[segs.length - 1];
-      const owner = segs.length >= 2 ? segs[segs.length - 2] : null;
-      out.push({ owner, name, alias: alias ?? name });
-    }
-  };
-  walk("", decl);
-  return out;
-}
-
-/**
- * The offset of the `}` that closes the block containing `from`, with string and char literals
- * skipped. Needs no knowledge of how the enclosing function was declared.
- */
-export function enclosingBlockEnd(src, from) {
-  let depth = 0;
-  for (let i = from; i < src.length; i += 1) {
-    const c = src[i];
-    if (c === '"') {
-      i += 1;
-      while (i < src.length) {
-        if (src[i] === "\\") { i += 2; continue; }
-        if (src[i] === '"') break;
-        i += 1;
-      }
-      continue;
-    }
-    if (c === "'") {
-      let k = i + 1;
-      if (src[k] === "\\") k += 1;
-      while (k < src.length && k <= i + 4 && src[k] !== "'") k += 1;
-      if (src[k] === "'") { i = k; }
-      continue;
-    }
-    if (c === "{") depth += 1;
-    else if (c === "}") { if (depth === 0) return i; depth -= 1; }
-  }
-  return src.length;
-}
-
-/**
- * Byte spans of `#[cfg(test)]` blocks, brace-matched with STRING AND CHAR LITERALS SKIPPED.
- *
- * A depth counter that counts braces inside `"{"` closes at the wrong brace. In this repo that made
- * one region over-run its end by 811 characters and swallow a production function, and another close
- * 5,466 characters early. Returns `closed: false` for a region that ran to EOF, which the caller
- * treats as RED — a region that never closed is not a region.
- */
-export function testRegions(src) {
-  const out = [];
-  // STRING SPANS FIRST. This runs on comment-stripped source, which still contains STRING LITERALS,
-  // so the literal text `"#[cfg(test)]"` inside a helper minted a phantom region — and four such
-  // phantoms exist in this tree today. A phantom region reclassifies production code as a test
-  // fixture, which switches off both the raw-write denylist and the unclassified-mention backstop.
-  const strings = [];
-  for (let i = 0; i < src.length; i += 1) {
-    if (src[i] === '"') {
-      const start = i;
-      i += 1;
-      while (i < src.length) {
-        if (src[i] === "\\") { i += 2; continue; }
-        if (src[i] === '"') break;
-        i += 1;
-      }
-      strings.push([start, i]);
-    }
-  }
-  const inString = (at) => strings.some(([a, b]) => at > a && at < b);
-  for (const m of src.matchAll(/#\[cfg\(test\)\]/gu)) {
-    if (inString(m.index)) continue;
-    const open = src.indexOf("{", m.index);
-    // ATTACHED TO A BRACED ITEM. `#[cfg(test)] use std::fs as _t;` before a function made that
-    // FUNCTION the region. The attribute must introduce a `mod` or `fn` for its brace to be the
-    // region's brace.
-    const between = open === -1 ? "" : src.slice(m.index + "#[cfg(test)]".length, open);
-    const attached = /^\s*(?:pub(?:\s*\([^)]*\))?\s+)?(?:mod|fn|impl|async\s+fn)\b/u.test(between);
-    // AN ATTRIBUTE ON A NON-BRACED ITEM CREATES NO REGION, AND THAT IS THE FIX. `#[cfg(test)] use
-    // std::fs as _t;` and `#[cfg(test)] thread_local! { … }` are ordinary Rust that this daemon
-    // writes in eight places; taking "the next brace anywhere" made the FOLLOWING function the
-    // region, which is how a production raw write got reclassified as a test fixture. No region is
-    // the correct answer for these, not a red — the red belongs to a region that opens and never
-    // closes.
-    if (open === -1 || !attached) continue;
-    const { end, closed } = matchBrace(src, open);
-    out.push({ start: m.index, end: Math.min(end + 1, src.length), closed, attached: true });
-  }
-  return out;
-}
-
-
-// ---------------------------------------------------------------- families under census
-const FAMILIES = {
+/** The four families this leg's entailment covers, by owner ruling. */
+const ONTOLOGY_FAMILIES = {
   "odk-domain-ontologies": "odk_routes",
   "odk-ontology-receipts": "odk_routes",
   "odk-ontology-proposals": "ontology_workbench_routes",
   "odk-saved-object-sets": "ontology_workbench_routes",
 };
 
-const WRITER = "(?:persist_record|remove_record|persist_promoted|admit_required)\\w*";
-// EXACT names. A prefix pattern classified `load_or_admit` — a get-or-create that WRITES — as a read.
-// Exact names, and only names that EXIST: `record_path` was in this list and matches no function
-// in the daemon, so it could only ever widen the benign bucket for code that does not exist.
-const READERS = ["load", "read_record_dir", "json_get", "load_record"];
-const READER = `(?:${READERS.join("|")})`;
+// The whole written ODK plane as derived at this commit. A RATCHET, not a claim: five of these have
+// more than one admitter today and are UNDER ADJUDICATION (next-legs XV).
+const RECORDED_PLANE = {
+  "odk-capability-lease-plan-receipts": ["capability_lease_plan_routes"],
+  "odk-capability-lease-plans": ["capability_lease_plan_routes"],
+  "odk-connector-mapping-receipts": ["connector_mapping_routes"],
+  "odk-connector-mappings": ["connector_mapping_routes", "policy_bound_data_view_routes"],
+  "odk-connector-session-receipts": ["connector_session_routes"],
+  "odk-connector-sessions": ["connector_session_routes"],
+  "odk-domain-ontologies": ["odk_routes"],
+  "odk-materialized-object-sets": ["connector_execution_routes"],
+  "odk-materializing-run-receipts": ["connector_execution_routes", "materializing_run_routes"],
+  "odk-materializing-runs": ["connector_execution_routes", "materializing_run_routes"],
+  "odk-ontology-projection-receipts": ["ontology_projection_routes"],
+  "odk-ontology-projections": ["connector_execution_routes", "ontology_projection_routes", "policy_bound_data_view_routes"],
+  "odk-ontology-proposals": ["ontology_workbench_routes"],
+  "odk-ontology-receipts": ["odk_routes"],
+  "odk-policy-bound-data-views": ["policy_bound_data_view_routes"],
+  "odk-saved-object-sets": ["ontology_workbench_routes"],
+  "odk-surface-descriptors": ["odk_routes"],
+  "odk-transformation-run-receipts": ["transformation_run_routes"],
+  "odk-transformation-runs": ["policy_bound_data_view_routes", "transformation_run_routes"],
+};
+
+/** Writer calls whose family is a runtime parameter, unresolvable from source. Pinned, not waived. */
+const UNRESOLVED_WRITER_CALLS = 74;
+
+const WRITERS = new Set(["persist_record", "persist_record_durable", "remove_record", "persist_promoted", "admit_required"]);
+
+/**
+ * Derive the census, REBUILDING THE EXTRACTOR FIRST.
+ *
+ * A gate must never trust a previously-built extractor. XIII poisoned verifier runs with a daemon
+ * binary built from a different tree — the runs looked green because the artifact was stale, not
+ * because the source was right. The identical hazard applies here, so the extractor is rebuilt every
+ * run and its freshness asserted against its own source before a single fact is read.
+ */
+function deriveCensus() {
+  const build = spawnSync("cargo", ["build", "--offline", "-p", "ioi-ontology-census"],
+    { cwd: ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, timeout: 900000 });
+  const built = build.status === 0 && fs.existsSync(EXTRACTOR_BIN);
+  const fresh = built && fs.statSync(EXTRACTOR_BIN).mtimeMs >= fs.statSync(EXTRACTOR_SRC).mtimeMs;
+  ok("the syn EXTRACTOR is rebuilt and proven fresher than its own source before any fact is read — a gate that trusts a previously-built artifact is the stale-binary defect that silently replayed an old tree through XIII's verifier runs",
+    built && fresh,
+    built ? (fresh ? "rebuilt, newer than its source" : "STALE: binary older than its source")
+      : `build failed: ${(build.stderr || "").split("\n").filter((l) => l.startsWith("error")).slice(0, 2).join(" | ")}`);
+  if (!built || !fresh) return null;
+
+  const run = spawnSync(EXTRACTOR_BIN, [DAEMON_MAIN],
+    { cwd: ROOT, encoding: "utf8", maxBuffer: 256 * 1024 * 1024, timeout: 900000 });
+  const parsed = run.status === 0;
+  ok("the extractor parses EVERY module of the daemon — a parse failure is RED, because a module `syn` cannot read is a module this census does not cover, and silence there would be indistinguishable from a clean run",
+    parsed, parsed ? "all modules parsed" : (run.stderr || "").split("\n").slice(0, 2).join(" | "));
+  return parsed ? JSON.parse(run.stdout) : null;
+}
 
 function run() {
-  // ------------------------------------------------------------ the module world, from the graph
-  const mainRaw = fs.readFileSync(DAEMON_MAIN, "utf8");
-  const mainSrc = stripRustComments(mainRaw).out;
-  // THE GRAPH IS WALKED TRANSITIVELY. The first cut read only the crate root's declarations, so a
-  // `mod` declared INSIDE a route module — whose file lives in a subdirectory and therefore never
-  // appears in a flat `.rs` listing — was never censused at all. That is the directory-listing
-  // defect one level down, and a second admitter fits in it exactly.
-  const declared = new Map();
-  const queue = [DAEMON_MAIN];
-  const walked = new Set();
-  while (queue.length) {
-    const file = queue.shift();
-    if (walked.has(file) || !fs.existsSync(file)) continue;
-    walked.add(file);
-    const src = stripRustComments(fs.readFileSync(file, "utf8")).out;
-    const dir = path.dirname(file);
-    const selfName = path.basename(file, ".rs");
-    for (const m of src.matchAll(/(?:#\[path\s*=\s*"([^"]+)"\]\s*)?(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+(\w+)\s*;/gu)) {
-      const candidates = m[1]
-        ? [path.resolve(dir, m[1])]
-        : [path.join(dir, `${m[2]}.rs`), path.join(dir, selfName, `${m[2]}.rs`), path.join(dir, m[2], "mod.rs")];
-      const hit = candidates.find((c) => fs.existsSync(c));
-      if (!hit) continue;
-      declared.set(path.relative(BIN_DIR, hit), hit);
-      queue.push(hit);
+  const census = deriveCensus();
+  if (!census) {
+    for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`);
+    console.log(`\n${results.filter((r) => r.pass).length}/${results.length} passed`);
+    process.exit(1);
+  }
+  const modules = census.modules;
+  const byName = new Map(modules.map((m) => [m.name, m]));
+
+  ok("the module world is the daemon's own MODULE GRAPH, walked transitively by the parser through `#[path]` declarations — a directory listing misses a module declared elsewhere, and this daemon declares every route module with an explicit path so cargo's autobin will not claim each file as a binary target",
+    modules.length > 80 && byName.has("odk_routes") && byName.has("ontology_workbench_routes"),
+    `${modules.length} modules reached through the graph`);
+
+  // ---------------------------------------------------------------- name resolution, per module
+  const resolveArg = (mod, written) => {
+    if (written.startsWith('"')) return written.replace(/^"|"$/gu, "");
+    const segs = written.split("::");
+    if (segs.length >= 2) {
+      const owner = byName.get(segs[segs.length - 2]);
+      if (owner) return owner.consts[segs[segs.length - 1]] ?? null;
+    }
+    const name = segs[segs.length - 1];
+    if (mod.consts[name] !== undefined) return mod.consts[name];
+    for (const imp of mod.imports) {
+      if (imp.local !== name || !imp.from) continue;
+      const from = byName.get(imp.from);
+      if (from?.consts[imp.item] !== undefined) return from.consts[imp.item];
+    }
+    return null;
+  };
+
+  // AMBIGUITY, CHECKED ON AMBIGUITY. The assertion that carried this label previously verified only
+  // that each family literal was declared SOMEWHERE — a declaration-presence check a review defeated
+  // by adding a second, conflicting `const KIND_ONT` and watching it stay green.
+  const declaredBy = new Map();
+  for (const m of modules) {
+    for (const [n, lit] of Object.entries(m.consts)) {
+      if (!declaredBy.has(n)) declaredBy.set(n, new Map());
+      declaredBy.get(n).set(m.name, lit);
     }
   }
-  const onDisk = fs.readdirSync(ROUTES_DIR).filter((f) => f.endsWith(".rs"))
-    .map((f) => path.join(ROUTES_DIR, f)).sort();
-  const declaredPaths = [...declared.values()].sort();
-  const files = [...new Set([...declaredPaths, ...onDisk, DAEMON_MAIN])].filter((f) => fs.existsSync(f));
-  const undeclared = onDisk.filter((f) => !declaredPaths.includes(f));
-  const offDirectory = declaredPaths.filter((f) => path.dirname(f) !== ROUTES_DIR);
-  const modName = (f) => path.basename(f, ".rs");
-
-  ok("the module world is derived from the BINARY'S OWN `mod` DECLARATIONS and is bijective with the routes directory — a module declared `#[path]` outside that directory is part of the same binary and a directory listing never reads it, which is a second admission path a census cannot see",
-    declared.size > 50 && undeclared.length === 0 && offDirectory.length === 0,
-    undeclared.length || offDirectory.length
-      ? `UNDECLARED: ${undeclared.map(modName).join(",") || "none"} | OFF-DIRECTORY: ${offDirectory.map((f) => path.relative(BIN_DIR, f)).join(",") || "none"}`
-      : `${declared.size} modules reached transitively, bijective with ${onDisk.length} on disk`);
-
-  const rawSources = new Map();
-  const sources = new Map();
-  const removedSpans = new Map();
-  for (const f of files) {
-    const raw = fs.readFileSync(f, "utf8");
-    const { out, removed } = stripRustComments(raw);
-    rawSources.set(f, raw); sources.set(f, out); removedSpans.set(f, removed);
-  }
-
-  // ------------------------------------------------------------ the scanner, checked on itself
-  const removedTotal = [...removedSpans.values()].reduce((n, sp) => n + sp.length, 0);
-  const badRemoval = [];
-  for (const [f, spans] of removedSpans) {
-    const raw = rawSources.get(f);
-    for (const [a, b] of spans) {
-      const head = raw.slice(a, a + 2);
-      if (head === "//") {
-        // A LINE COMMENT ENDS AT ITS LINE. Checking only the START is what let a greedy variant —
-        // one that starts at `//` and keeps eating following lines — pass while hiding a second
-        // admitter behind an ordinary comment. The END is the half that carries the finding.
-        const nl = raw.indexOf("\n", a);
-        if (b !== (nl === -1 ? raw.length : nl)) badRemoval.push(`${modName(f)}@${a}: line comment over-ran to ${b}`);
-      } else if (head === "/*") {
-        if (raw.slice(b - 2, b) !== "*/" && b !== raw.length) badRemoval.push(`${modName(f)}@${a}: block comment did not end at */`);
-      } else {
-        badRemoval.push(`${modName(f)}@${a}: removal does not begin at a comment token (${JSON.stringify(head)})`);
-      }
+  const familyLiterals = new Set(Object.keys(ONTOLOGY_FAMILIES));
+  const ambiguous = [];
+  for (const [n, byMod] of declaredBy) {
+    const values = new Set(byMod.values());
+    if (values.size > 1 && [...values].some((v) => familyLiterals.has(v))) {
+      ambiguous.push(`${n} means {${[...values].join(" | ")}}`);
     }
   }
-  ok("every span the comment stripper REMOVED both BEGINS at a comment token and ENDS where that comment ends — a line comment at its newline, a block comment after its `*/` — a length-and-survival check cannot fail on a scanner that eats code, and XIII shipped exactly such a scanner (368,828 characters of executable source, and the assertion passed)",
-    // NON-VACUITY: a scanner that reports NO removed spans satisfies "all removed spans are
-    // comment-initial" trivially, and the naive `//`-regex does exactly that while eating code. A
-    // daemon this size has tens of thousands of comment spans; zero is a broken scanner, not a
-    // clean one.
-    removedTotal > 10000 && badRemoval.length === 0,
-    badRemoval.length ? `NOT A COMMENT: ${badRemoval.slice(0, 5).join(" ; ")}`
-      : `${removedTotal} removed spans, all comment-initial`);
+  ok("NO CONSTANT NAME THAT MEANS AN ONTOLOGY FAMILY ANYWHERE MEANS SOMETHING ELSE SOMEWHERE — checked against every declaration the parser found, because resolution is per-module and a name meaning two things is exactly how a second admitter reads as innocent",
+    ambiguous.length === 0, ambiguous.join(" ; ") || `${declaredBy.size} declared names, none conflicting on a family`);
 
-  ok("and this daemon splices no source through `include!`, which would put code inside a censused module that this census never reads",
-    ![...sources.values()].some((s) => /\binclude!\s*\(/u.test(s)),
-    "no include! in the censused world");
-
-  // ------------------------------------------------------------ PER-MODULE name resolution
-  const constsOf = new Map();                            // module -> Map(name -> literal)
-  for (const [f, src] of sources) {
-    const own = new Map();
-    for (const m of src.matchAll(/const\s+(\w+)\s*:\s*&'?\w*\s*str\s*=\s*"([^"]*)"/gu)) own.set(m[1], m[2]);
-    constsOf.set(modName(f), own);
+  // ---------------------------------------------------------------- admitters
+  const admits = new Map();
+  let unresolvedWrites = 0;
+  for (const m of modules) {
+    for (const c of m.calls) {
+      if (!WRITERS.has(c.callee)) continue;
+      const lit = resolveArg(m, c.written);
+      if (lit === null) { unresolvedWrites += 1; continue; }
+      if (!lit.startsWith("odk-")) continue;
+      if (!admits.has(lit)) admits.set(lit, new Set());
+      admits.get(lit).add(m.name);
+    }
   }
-  // Every name a module brings into scope, resolved through the module it comes FROM. Handles the
-  // braced-group house style, nested groups, and `as` renames alike.
-  const aliasOf = new Map();
-  for (const [f] of sources) aliasOf.set(modName(f), new Map());
-  for (let hop = 0; hop < 2; hop += 1) {          // one hop follows a re-export chain
-    for (const [f, src] of sources) {
-      const mod = modName(f);
-      for (const d of src.matchAll(/(?:pub(?:\s*\([^)]*\))?\s+)?use\s+([^;]*);/gu)) {
-        for (const { owner, name, alias } of expandUseTree(d[1])) {
-          if (!owner) continue;
-          const lit = constsOf.get(owner)?.get(name) ?? aliasOf.get(owner)?.get(name);
-          if (lit !== undefined) aliasOf.get(mod).set(alias, lit);
+
+  for (const [lit, owner] of Object.entries(ONTOLOGY_FAMILIES)) {
+    const got = [...(admits.get(lit) ?? [])].sort();
+    ok(`EXACTLY ONE module admits \`${lit}\` — and it is \`${owner}\`; a second admission path must appear in some module's AST to exist at all, and the parser reads every module of this binary`,
+      got.length === 1 && got[0] === owner, `admitted by [${got.join(",") || "none"}]`);
+  }
+
+  // ---------------------------------------------------------------- the plane ratchet
+  const gained = [];
+  const stale = [];
+  for (const [fam, recorded] of Object.entries(RECORDED_PLANE)) {
+    const got = [...(admits.get(fam) ?? [])].sort();
+    if (!got.length) { stale.push(`${fam}: recorded [${recorded.join(",")}], now admitted by nothing`); continue; }
+    for (const mod of got) if (!recorded.includes(mod)) gained.push(`${fam}: GAINED ${mod}`);
+    for (const mod of recorded) if (!got.includes(mod)) stale.push(`${fam}: recorded ${mod} no longer admits it`);
+  }
+  for (const fam of admits.keys()) {
+    if (!RECORDED_PLANE[fam]) gained.push(`${fam}: an ODK family absent from the record is written by [${[...admits.get(fam)].sort().join(",")}]`);
+  }
+  const underAdjudication = Object.entries(RECORDED_PLANE).filter(([, v]) => v.length > 1).map(([k]) => k);
+  ok("NO ODK FAMILY GAINS AN ADMISSION PATH BEYOND THE RECORDED MAP — a RATCHET over all nineteen written families, and deliberately NOT a claim that each has one admitter: five have more than one today, recorded UNDER ADJUDICATION for next-legs XV, neither endorsed nor condemned. What this refuses is a new one appearing unnoticed",
+    gained.length === 0,
+    gained.length ? `GAINED: ${gained.join(" ; ")}`
+      : `${Object.keys(RECORDED_PLANE).length} families pinned; under adjudication: ${underAdjudication.join(", ")}`);
+
+  ok("and the recorded map is not STALE — every family and admitter it names still admits, so a pin cannot go quietly true over writes that were renamed away; removing one is a deliberate act in the commit that removes it (scar 4, second direction)",
+    stale.length === 0, stale.join(" ; ") || "every recorded family and admitter still admits");
+
+  ok("and the count of writer calls whose family is a RUNTIME PARAMETER is pinned — those cannot be resolved from source at all, so they are ratcheted rather than waved through, and a new one must be justified rather than absorbed into a number nobody watches",
+    unresolvedWrites === UNRESOLVED_WRITER_CALLS,
+    `${unresolvedWrites} unresolvable writer calls (pinned at ${UNRESOLVED_WRITER_CALLS})`);
+
+  // ---------------------------------------------------------------- raw filesystem writes
+  // THE WRITER CENSUS CANNOT SEE A LANE THAT BYPASSES THE WRITERS. A module that puts bytes into a
+  // family directory with `std::fs::write` admits a record without calling anything this census
+  // counts, and that mutation is part of the regression floor this substrate inherited. `syn` gives
+  // the resolved call path, so an aliased `use std::fs as sysfs` is the same AST node — the spelling
+  // games that defeated a text scan do not arise here.
+  const rawWrites = [];
+  for (const m of modules) {
+    for (const c of m.fs_calls ?? []) {
+      if (c.in_test) continue;
+      // THE CALL'S OWN ARGUMENTS, AND THE FUNCTION AROUND IT. A family normally reaches a raw write
+      // through a local — `let p = dir.join(KIND_ONT); fs::write(p.join(id), …)` — so it appears
+      // nowhere in the call itself. The rule is the dataflow-free one: a function that makes a raw
+      // filesystem call may not also name an ODK family. Conservative and fail-closed, the same
+      // shape as the resolve-and-write rule.
+      const named = new Set([...c.args, ...((m.fn_leaves ?? {})[c.in_fn] ?? [])]);
+      for (const a of named) {
+        const lit = resolveArg(m, a);
+        if (lit && lit.startsWith("odk-")) {
+          rawWrites.push(`${m.name}::${c.in_fn} makes a raw ${c.callee} and names ${lit}`);
         }
       }
     }
   }
+  ok("NO PRODUCTION FUNCTION MAKES A RAW FILESYSTEM CALL AND NAMES AN ODK FAMILY — a lane that writes bytes into a family directory itself admits a record without calling any writer this census counts; the rule is over the FUNCTION rather than the call arguments because the family normally arrives through a local, and test fixtures are excluded by the parser's own `#[cfg(test)]` knowledge rather than by a brace walk",
+    rawWrites.length === 0, [...new Set(rawWrites)].join(" ; ") || "no production raw filesystem call names a family");
 
-  const AMBIGUOUS = Symbol("ambiguous");
-  /** Resolve a family-argument expression to its literal, scoped to the module that names it. */
-  const resolveArg = (mod, argRaw) => {
-    const arg = argRaw.trim();
-    if (arg.startsWith('"')) return arg.slice(1, arg.lastIndexOf('"'));
-    const qualified = /(?:crate|super)::(\w+)::(\w+)/u.exec(arg);
-    if (qualified) return constsOf.get(qualified[1])?.get(qualified[2]) ?? null;
-    const name = arg.split("::").pop().replace(/[^\w]/gu, "");
-    const own = constsOf.get(mod)?.get(name);
-    if (own !== undefined) return own;
-    const alias = aliasOf.get(mod)?.get(name);
-    if (alias !== undefined) return alias;
-    // A BARE NAME THIS MODULE NEITHER DECLARES NOR IMPORTS IS NOT GUESSED — not even when exactly
-    // one module in the daemon happens to declare it. That global-unique fallback was the crutch a
-    // review used: it made the un-renamed grouped import look caught, so the renamed one looked like
-    // a new hole rather than the same one. If a module names a family this census cannot tie to a
-    // declaration it can see, that is UNRESOLVED, and unresolved is RED.
-    const candidates = new Set();
-    for (const [, m2] of constsOf) if (m2.has(name)) candidates.add(m2.get(name));
-    return candidates.size ? AMBIGUOUS : null;
-  };
-
-  const familyLiterals = new Set(Object.keys(FAMILIES));
-  ok("no family constant name is AMBIGUOUS across the daemon — resolution is scoped to the declaring module, and a bare name meaning different things in different modules resolves to nothing rather than to a guess (the daemon declares 660 string constants under 537 names, 25 of them ambiguous)",
-    [...familyLiterals].every((lit) => [...constsOf.values()].some((m2) => [...m2.values()].includes(lit))),
-    `${[...constsOf.values()].reduce((n, m2) => n + m2.size, 0)} constants, module-scoped`);
-
-  // ------------------------------------------------------------ classify EVERY mention
-  const admits = new Map();
-  for (const lit of familyLiterals) admits.set(lit, new Set());
-  const mentions = [];
-  const unclosedTestRegions = [];
-
-  for (const [f, src] of sources) {
-    const mod = modName(f);
-    const familyNames = new Set();
-    for (const [n, lit] of constsOf.get(mod) ?? []) if (familyLiterals.has(lit)) familyNames.add(n);
-    for (const [n, lit] of aliasOf.get(mod) ?? []) if (familyLiterals.has(lit)) familyNames.add(n);
-    const litAlt = [...familyLiterals].map((s) => s.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")).join("|");
-    // QUALIFIED PATHS ARE MENTIONS TOO. `crate::odk_routes::KIND_ONT` names a family in a module
-    // that neither declares nor imports the bare name, so a mention set built only from literals and
-    // module-local names cannot see it — and a review walked a whole second admission path through
-    // that gap. Every `(crate|super)::<mod>::<CONST>` resolving to a family is collected here.
-    const qualifiedNames = new Set();
-    for (const q of src.matchAll(/(?:crate|super)::(\w+)::([A-Z][A-Z0-9_]{2,})/gu)) {
-      if (familyLiterals.has(constsOf.get(q[1])?.get(q[2]))) qualifiedNames.add(q[2]);
-    }
-    const allNames = new Set([...familyNames, ...qualifiedNames]);
-    const mentionRe = allNames.size
-      ? new RegExp(`"(?:${litAlt})"|\\b(?:${[...allNames].join("|")})\\b`, "gu")
-      : new RegExp(`"(?:${litAlt})"`, "gu");
-
-    const spans = [];
-    const addSpans = (re, kind) => {
-      for (const m of src.matchAll(re)) {
-        const arg = m[1];
-        const lit = resolveArg(mod, arg);
-        const at = m.index + m[0].lastIndexOf(arg);
-        if (lit === AMBIGUOUS) { spans.push({ start: at, end: at + arg.length, kind: null }); continue; }
-        if (!lit || !familyLiterals.has(lit)) continue;
-        spans.push({ start: at, end: at + arg.length, kind });
-        if (kind === "admits") admits.get(lit).add(mod);
-      }
-    };
-    addSpans(new RegExp(`${WRITER}\\(\\s*&?[\\w.]+\\s*,\\s*([^,]+?)\\s*,`, "gu"), "admits");
-    // A LOCAL FUNCTION THAT FORWARDS ITS OWN PARAMETER TO A WRITER IS A WRITER. `load_or_admit(d,
-    // kind, id, seed)` reads first and persists on miss — an ordinary get-or-create — and a review
-    // used exactly that to admit the ontology family while the family mention sat inside a call
-    // whose name merely began with `load`. Resolution is interprocedural for this one hop: find the
-    // local fns that pass a PARAMETER of their own as a writer's family argument, then treat a call
-    // to one of them with a resolvable family argument as an admission by this module.
-    const forwarding = new Set();
-    for (const fn of src.matchAll(/fn\s+(\w+)\s*\(([^)]*)\)[^{]*\{/gu)) {
-      const params = [...fn[2].matchAll(/(\w+)\s*:/gu)].map((x) => x[1]);
-      if (!params.length) continue;
-      const body = src.slice(fn.index, matchBrace(src, fn.index).end);
-      for (const w of body.matchAll(new RegExp(`${WRITER}\\(\\s*&?[\\w.]+\\s*,\\s*([^,]+?)\\s*,`, "gu"))) {
-        if (params.includes(w[1].trim().replace(/[^\w]/gu, ""))) forwarding.add(fn[1]);
-      }
-    }
-    if (forwarding.size) {
-      addSpans(new RegExp(`\\b(?:${[...forwarding].join("|")})\\(\\s*&?[\\w.]+\\s*,\\s*([^,]+?)\\s*,`, "gu"), "admits");
-    }
-    addSpans(new RegExp(`(?<![\\w])${READER}\\(\\s*&?[\\w.]+\\s*,\\s*([^,)]+?)\\s*[,)]`, "gu"), "reads");
-    addSpans(/=>\s*Some\(\s*([^)]+?)\s*\)/gu, "resolves");
-    for (const m of src.matchAll(/const\s+(\w+)\s*:\s*&'?\w*\s*str\s*=\s*"([^"]*)"/gu)) {
-      if (!familyLiterals.has(m[2])) continue;
-      const nameAt = m.index + m[0].indexOf(m[1]);
-      spans.push({ start: nameAt, end: nameAt + m[1].length, kind: "declares" });
-      const litAt = m.index + m[0].lastIndexOf(`"${m[2]}"`);
-      spans.push({ start: litAt, end: litAt + m[2].length + 2, kind: "declares" });
-    }
-    for (const m of src.matchAll(/(?:pub(?:\s*\([^)]*\))?\s+)?use\s+[^;]*;/gu)) {
-      for (const n of m[0].matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
-        if (!familyNames.has(n[1])) continue;
-        const at = m.index + m[0].indexOf(n[1]);
-        spans.push({ start: at, end: at + n[1].length, kind: "imports" });
-      }
-    }
-    for (const t of testRegions(src)) {
-      if (!t.closed) { unclosedTestRegions.push(`${mod}@${t.start} opened and never closed`); continue; }
-      spans.push({ start: t.start, end: t.end, kind: "test-fixture" });
-    }
-
-    for (const m of src.matchAll(mentionRe)) {
-      const hit = spans.filter((sp) => m.index >= sp.start && m.index < sp.end)
-        .sort((a, b) => (a.end - a.start) - (b.end - b.start))[0];
-      mentions.push({ mod, index: m.index, text: m[0], kind: hit ? hit.kind : null });
+  // ---------------------------------------------------------------- who may DECLARE a family
+  // ONLY THE OWNER NAMES ITS OWN FAMILY. A module that declares `const X: &str =
+  // "odk-domain-ontologies"` has minted a second name for someone else's store, and every later use
+  // of it reads as innocent local code. This is the shape a review used to slip a family reference
+  // past a census that only looked at call sites.
+  const foreignDeclarations = [];
+  for (const m of modules) {
+    for (const [n, lit] of Object.entries(m.consts)) {
+      const owner = ONTOLOGY_FAMILIES[lit];
+      if (owner && owner !== m.name) foreignDeclarations.push(`${m.name} declares ${n} = "${lit}" (owned by ${owner})`);
     }
   }
+  ok("ONLY THE OWNING MODULE DECLARES A CONSTANT NAMING ONE OF ITS ONTOLOGY FAMILIES — a second name minted elsewhere makes every later use of it read as innocent local code, which is precisely how a family reference slips past a census that only inspects call sites",
+    foreignDeclarations.length === 0, foreignDeclarations.join(" ; ") || "every ontology family constant is declared by its owner");
 
-  ok("every `#[cfg(test)]` region is ATTACHED to a `mod`/`fn`, is not the literal text inside a string, and CLOSES on a real brace — a region that runs to EOF, or one whose depth counter counted a brace inside `\"{\"`, silently reclassifies production code as a test fixture and waves a write through",
-    unclosedTestRegions.length === 0, unclosedTestRegions.join(" ; ") || "all test regions closed");
-
-  const unclassified = mentions.filter((m) => m.kind === null);
-  ok("EVERY mention of an ontology-plane family in EVERY module of the binary lands in the closed vocabulary {admits, reads, resolves, declares, imports, test-fixture} — patterns do not define this census, classification of every mention does, and an unreadable or ambiguously-named mention is RED rather than silently dropped",
-    mentions.length > 0 && unclassified.length === 0,
-    unclassified.length
-      ? `UNCLASSIFIED: ${unclassified.slice(0, 6).map((m) => `${m.mod}:${m.text}@${m.index}`).join(" ; ")}`
-      : `${mentions.length} mentions, all classified`);
-
-  // ------------------------------------------------------------ the entailment
-  for (const [lit, owner] of Object.entries(FAMILIES)) {
-    const got = [...admits.get(lit)].sort();
-    ok(`EXACTLY ONE module admits \`${lit}\` — and it is \`${owner}\`; a write anywhere else counts here whether it sits in production or in a test block, because a test is not a licence to hold a second admission path`,
-      got.length === 1 && got[0] === owner,
-      `admitted by [${got.join(",") || "none"}]`);
-  }
-
-  ok("and the family table itself is not STALE — every family this census names is still declared somewhere in the daemon, so a family renamed out from under the table cannot leave the four assertions above quietly true over nothing",
-    [...familyLiterals].every((lit) => [...constsOf.values()].some((m2) => [...m2.values()].includes(lit))
-      || [...sources.values()].some((s) => s.includes(`"${lit}"`))),
-    [...familyLiterals].join(" "));
-
-  // ------------------------------------------------------------ resolver flow
-  // EVERY `resolves` MENTION, BY THE FUNCTION IT SITS IN. The first rule inspected only the shape
-  // `let x = match y { … };` while the CLASSIFIER accepted any `=> Some(X)` arm — so a mapper
-  // written `match scheme.as_str()`, or as a function returning the match, or nested one block
-  // deeper, classified as `resolves` and was never flow-checked at all. The rule is now structural
-  // and needs no dataflow: A FUNCTION THAT RESOLVES A FAMILY NAME MAY NOT ALSO WRITE A RECORD.
-  // A scheme-mapper that admits is the second spine this assertion exists to refuse, and a function
-  // doing both is that, whatever the plumbing between them looks like.
-  const resolverFns = [];
-  for (const [f, src] of sources) {
-    const mod = modName(f);
-    for (const m of src.matchAll(/=>\s*Some\(\s*([^)]+?)\s*\)/gu)) {
-      const lit = resolveArg(mod, m[1]);
-      if (!lit || lit === AMBIGUOUS || !familyLiterals.has(lit)) continue;
-      const fnStart = Math.max(src.lastIndexOf("\nfn ", m.index), src.lastIndexOf("\npub", m.index),
-        src.lastIndexOf("\n    fn ", m.index), 0);
-      const { end } = matchBrace(src, fnStart);
-      const body = src.slice(fnStart, Math.max(end, m.index));
-      const writes = [...body.matchAll(new RegExp(`${WRITER}\\(`, "gu"))].map((w) => w[0]);
-      resolverFns.push({ mod, at: m.index, writes });
+  // ---------------------------------------------------------------- resolve-and-write
+  // THE GATE DECIDES WHETHER AN ARM NAMES A FAMILY, because the extractor reporting a bare "this
+  // function has a `Some(...)` arm" made every `Ok(id) => Some(id.principal_ref)` look like a family
+  // resolver — and one such function legitimately writes a record. Extraction reports what is
+  // written; judgement belongs here.
+  const resolveAndWrite = [];
+  for (const m of modules) {
+    for (const fn of m.resolve_and_write_fns ?? []) {
+      const arms = (m.resolver_arms ?? {})[fn] ?? [];
+      const namesFamily = arms.some((a) => {
+        const lit = resolveArg(m, a);
+        return lit !== null && lit.startsWith("odk-");
+      });
+      if (namesFamily) resolveAndWrite.push(`${m.name}::${fn}`);
     }
   }
-  const resolverWriters = resolverFns.filter((r) => r.writes.length);
-  ok("no function that RESOLVES a family name also writes a record — the generic `\"ontology\" => Some(...)` arms in governance and marketplace are the shape that becomes a second admission path the moment the resolved name reaches a writer, and a function doing both is that path whatever the plumbing between them looks like",
-    resolverFns.length > 0 && resolverWriters.length === 0,
-    resolverWriters.length
-      ? `RESOLVES AND WRITES: ${resolverWriters.map((r) => `${r.mod}@${r.at}->${[...new Set(r.writes)].join(",")}`).join(" ; ")}`
-      : `${resolverFns.length} resolving site(s) in [${[...new Set(resolverFns.map((r) => r.mod))].sort().join(",")}], none writes`);
-
-  // ------------------------------------------------------------ raw filesystem writes
-  const rawWrites = [];
-  const FS_WRITE = /(?:fs\s*::\s*(?:write|create|create_new|create_dir_all|remove_file|remove_dir_all|copy|rename|hard_link|OpenOptions)|File\s*::\s*create)/gu;
-  for (const [f, src] of sources) {
-    const mod = modName(f);
-    const tests = testRegions(src).filter((t) => t.closed);
-    const inTest = (i) => tests.some((t) => i >= t.start && i < t.end);
-    for (const m of src.matchAll(FS_WRITE)) {
-      if (inTest(m.index)) continue;
-      const tail = src.slice(m.index, m.index + 400);
-      for (const tok of tail.matchAll(/"([^"]+)"|\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
-        const lit = tok[1] ?? resolveArg(mod, tok[2]);
-        if (lit && lit !== AMBIGUOUS && familyLiterals.has(lit)) rawWrites.push(`${mod}->${lit} @${m.index}`);
-      }
-    }
-  }
-  ok("no PRODUCTION raw filesystem write in this daemon targets an ontology-plane family, with the family resolved through module-scoped constants and not just literals — a DENYLIST bounding a known attack, not a proof that no raw write exists; the per-family entailment above is what carries the claim",
-    rawWrites.length === 0, [...new Set(rawWrites)].join(" ; ") || "no denylisted raw write outside closed test regions");
+  ok("no function that RESOLVES a family name through a `match` arm also WRITES a record — conservative, dataflow-free and fail-closed: a scheme-mapper that admits is a second spine whatever the plumbing between them looks like, and widening this rule later is a governed act rather than a convenience",
+    resolveAndWrite.length === 0, resolveAndWrite.join(" ; ") || "no resolving function writes");
 
   const failed = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`);
@@ -607,8 +284,6 @@ function run() {
   if (failed.length) process.exit(1);
 }
 
-// Run only when invoked, never on import: a module with top-level side effects is the hazard that
-// left a mutant in the tree when XIII imported one from a `node -e` one-liner.
 const INVOKED = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (INVOKED) {
   try { run(); } catch (error) {

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+// The ontology plane's ADMISSION CENSUS — derived from the daemon's own source, at the layer the
+// property lives.
+//
+// WHY THIS EXISTS, and why it is not a journey gate. Next-legs XIII spent five merge-blocking review
+// rounds strengthening one journey verifier's proof that "no second admission path writes ontology
+// truth" — keyed first on the route name, then the changed file name, then the response bytes, then
+// the caller's request — and each round a review defeated the PROOF while the code under test stayed
+// correct and green. The owner ruled the iteration terminated and the claim MIS-SCOPED FOR ITS
+// OBSERVER: a whole-program property cannot be entailed by a black-box journey verifier, because the
+// observer sits inside the system it is trying to bound. The journey gate's labels were re-scoped to
+// the journey-scoped fact they check, the property was filed as a named residual, and building the
+// real proof HERE — from the module source — was commissioned as next-legs XIV Leg 3a.
+//
+// WHAT IT ENTAILS. For each of the ontology plane's FOUR record families, exactly ONE module in the
+// daemon admits it. That is a statement about the whole program, and source is where the whole
+// program is visible at once. A second admission path has to appear in some module's text to exist
+// at all, so a census that classifies EVERY mention in EVERY module can see one however it is
+// spelled — which is precisely what a request/response observer cannot do.
+//
+// HOW IT DERIVES, and the three disciplines XIII paid for:
+//
+//   1. PATTERNS DO NOT DEFINE THE CENSUS; CLASSIFICATION OF EVERY MENTION DOES. XIII's first pass at
+//      this by hand used a write-pattern and a read-pattern and reported `domain_apps_routes` as
+//      neither — it reads the family through a BARE LITERAL the patterns did not cover. A census
+//      whose coverage is the union of the patterns its author thought of is an allowlist wearing a
+//      derivation. Every mention here lands in a closed vocabulary or the run is RED.
+//
+//   2. ALIASES ARE RESOLVED, NEVER NAME-MATCHED. The family argument at a write site is resolved to
+//      its string LITERAL through the daemon's own `const NAME: &str = "..."` declarations and
+//      through `use ... as` renames. A module-local constant pointing at another family's literal
+//      is the evasion that a name-match cannot see, and XIII's push found the same shape one level
+//      up when a module-local `identity()` wrapper hid the canonical resolver from an estate-wide
+//      census.
+//
+//   3. TWO DIRECTIONS (scar 4). Nothing unclassified, AND no stale entry: every family's expected
+//      owner must still actually admit it. A census that only checks one direction goes quietly
+//      empty when the thing it counts is renamed away.
+//
+// WHAT IT DOES NOT ENTAIL, stated so the label claims only what it checks. This reads the daemon's
+// Rust source. It does not see a write performed by a dependency crate on the daemon's behalf, a
+// write through a macro that expands to a writer, or a write by a process that is not this daemon.
+// Those are outside the source it censuses, and it says so rather than implying otherwise.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "..", "..", "..");
+const ROUTES_DIR = path.join(ROOT, "crates/node/src/bin/hypervisor_daemon_routes");
+const DAEMON_MAIN = path.join(ROOT, "crates/node/src/bin/hypervisor-daemon.rs");
+
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+// ---------------------------------------------------------------- the scanner
+// String-aware, because a `//` inside a string literal is not a comment. XIII shipped a naive
+// `.replace(/\/\/[^\n]*/g, "")` that ate 74 characters of executable code off four `org://` lines
+// and let a writer parked after such a literal go invisible; then its repair mishandled `'\''` and
+// `'\u{..}'` and desynchronised the same way. Handles: "…", escapes, r"…", r#"…"#, char literals
+// including escaped and non-BMP, `//`, and nested `/* */`.
+export function stripRustComments(src) {
+  let out = "";
+  for (let i = 0; i < src.length;) {
+    const c = src[i];
+    if (c === "r" && (src[i + 1] === '"' || src[i + 1] === "#")) {
+      let j = i + 1, hashes = 0;
+      while (src[j] === "#") { hashes += 1; j += 1; }
+      if (src[j] === '"') {
+        const close = `"${"#".repeat(hashes)}`;
+        const end = src.indexOf(close, j + 1);
+        const stop = end === -1 ? src.length : end + close.length;
+        out += src.slice(i, stop); i = stop; continue;
+      }
+    }
+    if (c === '"') {
+      let j = i + 1;
+      while (j < src.length) {
+        if (src[j] === "\\") { j += 2; continue; }
+        if (src[j] === '"') { j += 1; break; }
+        j += 1;
+      }
+      out += src.slice(i, j); i = j; continue;
+    }
+    if (c === "'") {
+      let j = i + 1;
+      if (src[i + 1] === "\\") {
+        if (src[i + 2] === "u" && src[i + 3] === "{") {
+          const close = src.indexOf("}", i + 4);
+          j = close === -1 ? src.length : close + 1;
+        } else if (src[i + 2] === "x") { j = i + 5; }
+        else { j = i + 3; }
+      } else {
+        // A non-BMP char literal is two UTF-16 units, so the close is not at a fixed offset.
+        let k = i + 1;
+        while (k < src.length && k <= i + 3 && src[k] !== "'") k += 1;
+        if (src[k] !== "'") { out += c; i += 1; continue; }   // a lifetime, not a literal
+        j = k;
+      }
+      if (src[j] === "'") { out += src.slice(i, j + 1); i = j + 1; continue; }
+      out += c; i += 1; continue;
+    }
+    if (c === "/" && src[i + 1] === "/") { while (i < src.length && src[i] !== "\n") i += 1; continue; }
+    if (c === "/" && src[i + 1] === "*") {
+      let depth = 1; i += 2;
+      while (i < src.length && depth > 0) {
+        if (src[i] === "/" && src[i + 1] === "*") { depth += 1; i += 2; continue; }
+        if (src[i] === "*" && src[i + 1] === "/") { depth -= 1; i += 2; continue; }
+        i += 1;
+      }
+      continue;
+    }
+    out += c; i += 1;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------- the closed world of modules
+const moduleFiles = () => {
+  const files = fs.readdirSync(ROUTES_DIR).filter((f) => f.endsWith(".rs")).sort()
+    .map((f) => path.join(ROUTES_DIR, f));
+  files.push(DAEMON_MAIN);
+  return files;
+};
+const modName = (f) => path.basename(f, ".rs");
+
+// ---------------------------------------------------------------- the families under census
+// The plane's four record families. XIII's journey observation watched TWO of them and a review
+// named the other two as the identical attack one family over; a source census has no reason to
+// watch a subset.
+const FAMILIES = {
+  "odk-domain-ontologies": "odk_routes",
+  "odk-ontology-receipts": "odk_routes",
+  "odk-ontology-proposals": "ontology_workbench_routes",
+  "odk-saved-object-sets": "ontology_workbench_routes",
+};
+
+// Durable record writers. `\w*` covers suffixed spellings (`persist_record_durable`), which XIII
+// found a bare-name pattern could not see.
+const WRITER = "(?:persist_record|remove_record|persist_promoted|admit_required)\\w*";
+// Record readers. A read is a legitimate, non-admitting mention and must classify as one.
+const READER = "(?:load|read_record_dir|json_get|record_path|load_record)\\w*";
+
+function run() {
+  const files = moduleFiles();
+  const sources = new Map();
+  for (const f of files) sources.set(f, stripRustComments(fs.readFileSync(f, "utf8")));
+  const rawSources = new Map();
+  for (const f of files) rawSources.set(f, fs.readFileSync(f, "utf8"));
+
+  ok("the module world is DERIVED from the daemon's route directory, not listed — a census over a hand-written module list cannot notice a module that was added",
+    files.length > 50 && files.some((f) => modName(f) === "odk_routes") && files.some((f) => modName(f) === "ontology_workbench_routes"),
+    `${files.length} modules censused`);
+
+  // ------------------------------------------------------------ alias resolution
+  // Every `const NAME: &str = "literal"` in the daemon, so a family argument spelled as a constant
+  // resolves to what it POINTS AT rather than to what it is called.
+  const constLiteral = new Map();
+  for (const [, src] of sources) {
+    for (const m of src.matchAll(/const\s+(\w+)\s*:\s*&'?\w*\s*str\s*=\s*"([^"]*)"/gu)) {
+      constLiteral.set(m[1], m[2]);
+    }
+  }
+  ok("every family constant in the daemon resolves to its string LITERAL, so a family argument is read by what it POINTS AT and not by what it is named — a module-local constant aimed at another family is the evasion a name-match cannot see",
+    [...Object.keys(FAMILIES)].every((lit) => [...constLiteral.values()].includes(lit)),
+    `${constLiteral.size} string constants resolved`);
+
+  // `use path::CONST as ALIAS;` renames, per module.
+  const aliasFor = new Map();   // module -> Map(alias -> literal)
+  for (const [f, src] of sources) {
+    const m2 = new Map();
+    for (const d of src.matchAll(/use\s+([^;]*);/gu)) {
+      for (const a of d[1].matchAll(/(\w+)\s+as\s+(\w+)/gu)) {
+        if (constLiteral.has(a[1])) m2.set(a[2], constLiteral.get(a[1]));
+      }
+    }
+    aliasFor.set(modName(f), m2);
+  }
+
+  const resolveArg = (mod, arg) => {
+    const a = arg.trim();
+    if (a.startsWith('"')) return a.slice(1, a.lastIndexOf('"'));
+    const name = a.split("::").pop().replace(/[^\w]/gu, "");
+    return aliasFor.get(mod)?.get(name) ?? constLiteral.get(name) ?? null;
+  };
+
+  // ------------------------------------------------------------ classify EVERY mention
+  // A mention is any occurrence of a family literal, or of any constant that resolves to one.
+  const familyLiterals = new Set(Object.keys(FAMILIES));
+  const familyNames = new Set([...constLiteral.entries()].filter(([, v]) => familyLiterals.has(v)).map(([k]) => k));
+  const mentionRe = new RegExp(
+    `"(?:${[...familyLiterals].map((s) => s.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")).join("|")})"|\\b(?:${[...familyNames].join("|")})\\b`,
+    "gu",
+  );
+
+  const admits = new Map();       // literal -> Set(module)
+  const mentions = [];            // {mod, index, text, kind}
+  for (const lit of familyLiterals) admits.set(lit, new Set());
+
+  for (const [f, src] of sources) {
+    const mod = modName(f);
+    const aliasNames = [...(aliasFor.get(mod)?.keys() ?? [])];
+    const localRe = aliasNames.length
+      ? new RegExp(`${mentionRe.source}|\\b(?:${aliasNames.join("|")})\\b`, "gu")
+      : new RegExp(mentionRe.source, "gu");
+
+    // CLASSIFY BY SPAN, NOT BY POINT. The first cut recorded where a write's family ARGUMENT begins
+    // and compared it to where the mention regex matched — and for
+    // `read_record_dir(data_dir, crate::odk_routes::KIND_ONT)` those differ, because the mention is
+    // the bare constant NAME inside a qualified path. Six real, correctly-written mentions came back
+    // unclassified. A mention now classifies as the kind of the span that CONTAINS it.
+    const spans = [];
+    const addSpans = (re, kind) => {
+      for (const m of src.matchAll(re)) {
+        const arg = m[1];
+        const lit = resolveArg(mod, arg);
+        if (!lit || !familyLiterals.has(lit)) continue;
+        const at = m.index + m[0].lastIndexOf(arg);
+        spans.push({ start: at, end: at + arg.length, kind });
+        if (kind === "admits") admits.get(lit).add(mod);
+      }
+    };
+    addSpans(new RegExp(`${WRITER}\\(\\s*&?[\\w.]+\\s*,\\s*([^,]+?)\\s*,`, "gu"), "admits");
+    addSpans(new RegExp(`${READER}\\(\\s*&?[\\w.]+\\s*,\\s*([^,)]+?)\\s*[,)]`, "gu"), "reads");
+    // scheme-mapper arms: `"ontology" => Some("odk-domain-ontologies")` / `=> Some(KIND)`
+    addSpans(/=>\s*Some\(\s*([^)]+?)\s*\)/gu, "resolves");
+    // THE DECLARATION, BOTH HALVES: the literal AND the name bound to it. Classifying only the
+    // literal left every `const KIND_ONT: &str = "..."` NAME mention unreadable.
+    for (const m of src.matchAll(/const\s+(\w+)\s*:\s*&'?\w*\s*str\s*=\s*"([^"]*)"/gu)) {
+      if (!familyLiterals.has(m[2])) continue;
+      const nameAt = m.index + m[0].indexOf(m[1]);
+      spans.push({ start: nameAt, end: nameAt + m[1].length, kind: "declares" });
+      const litAt = m.index + m[0].lastIndexOf(`"${m[2]}"`);
+      spans.push({ start: litAt, end: litAt + m[2].length + 2, kind: "declares" });
+    }
+    // AN IMPORT IS ITS OWN KIND. `use super::odk_routes::{…, KIND_ONT};` brings the family name into
+    // scope; it is neither a read nor a write, and folding it into either would be a lie about what
+    // that line does. It is worth classifying separately for a second reason: an import is how a
+    // module ACQUIRES the ability to name another family, so the set of modules importing a family
+    // constant is the shortlist a reviewer should look at first.
+    for (const m of src.matchAll(/use\s+[^;]*;/gu)) {
+      for (const n of m[0].matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
+        const lit = constLiteral.get(n[1]) ?? aliasFor.get(mod)?.get(n[1]);
+        if (!lit || !familyLiterals.has(lit)) continue;
+        const at = m.index + m[0].indexOf(n[1]);
+        spans.push({ start: at, end: at + n[1].length, kind: "imports" });
+      }
+    }
+    // A family constant used as a PATH COMPONENT inside the module's own `#[cfg(test)]` block —
+    // `std::fs::write(dir.join(KIND_ONT_RECEIPT), b"blocker")` plants a fixture, it does not admit a
+    // record. Classified as its own kind rather than waved through, and the production denylist
+    // below resolves constants precisely because this shape OUTSIDE a test block WOULD be a second
+    // admission path and a literal-only denylist could not see it.
+    for (const t of testRegions(src)) spans.push({ ...t, kind: "test-fixture" });
+
+    for (const m of src.matchAll(localRe)) {
+      // Narrowest containing span wins, so a family argument inside a test block still reads as the
+      // argument it is rather than being swallowed by the block.
+      const hit = spans.filter((sp) => m.index >= sp.start && m.index < sp.end)
+        .sort((a, b) => (a.end - a.start) - (b.end - b.start))[0];
+      mentions.push({ mod, index: m.index, text: m[0], kind: hit?.kind ?? null });
+    }
+  }
+
+  // ------------------------------------------------------------ direction 1: nothing unclassified
+  const unclassified = mentions.filter((m) => m.kind === null);
+  ok("EVERY mention of an ontology-plane family in EVERY daemon module lands in the closed vocabulary {admits, reads, resolves, declares, imports, test-fixture} — patterns do not define this census, classification of every mention does, and an unreadable mention is RED rather than silently dropped",
+    mentions.length > 0 && unclassified.length === 0,
+    unclassified.length
+      ? `UNCLASSIFIED: ${unclassified.slice(0, 6).map((m) => `${m.mod}:${m.text}@${m.index}`).join(" ; ")}`
+      : `${mentions.length} mentions, all classified`);
+
+  // ------------------------------------------------------------ the entailment
+  for (const [lit, owner] of Object.entries(FAMILIES)) {
+    const got = [...admits.get(lit)].sort();
+    ok(`EXACTLY ONE module admits \`${lit}\` — and it is \`${owner}\`; a second admission path for this family would have to appear in some module's source to exist, so a census that classifies every mention sees it however it is spelled`,
+      got.length === 1 && got[0] === owner,
+      `admitted by [${got.join(",") || "none"}]`);
+  }
+
+  // ------------------------------------------------------------ direction 2: no stale entry
+  ok("and no expected owner is STALE — each of the four families is still actually admitted by the module this census names, so the claim cannot go quietly true by the writes being renamed away",
+    Object.entries(FAMILIES).every(([lit]) => admits.get(lit).size > 0),
+    Object.entries(FAMILIES).map(([lit]) => `${lit}:${admits.get(lit).size}`).join(" "));
+
+  // ------------------------------------------------------------ resolver flow
+  // `governance_routes` and `marketplace_routes` map `"ontology" => Some("odk-domain-ontologies")`
+  // through a GENERIC scheme-mapper. Today both feed a `load(...)` existence check — but the shape
+  // is the one that becomes a second admission path the moment a resolved name reaches a writer, so
+  // what is asserted is WHERE THE RESOLUTION FLOWS, not merely that it exists.
+  const resolverMods = [...new Set(mentions.filter((m) => m.kind === "resolves").map((m) => m.mod))].sort();
+  const resolverSinks = [];
+  for (const mod of resolverMods) {
+    const f = files.find((x) => modName(x) === mod);
+    const src = sources.get(f);
+    // the binding the match arm lands in, e.g. `let kind = match scheme { ... };`
+    for (const m of src.matchAll(/let\s+(\w+)\s*=\s*match\s+\w+\s*\{[\s\S]*?\n\s*\};/gu)) {
+      if (!familyLiterals.has(resolveArgFromArms(m[0], mod, resolveArg, familyLiterals))) continue;
+      const after = src.slice(m.index + m[0].length, m.index + m[0].length + 1600);
+      // FOLLOW THE REBINDING, or this assertion is decorative. The resolved family lands in `kind`
+      // and the code that USES it immediately unwraps: `if let Some(k) = kind { … load(data_dir, k,
+      // id) … }`. Tracking only the match binding meant a writer taking `k` was invisible — a
+      // mutation putting `persist_record(data_dir, k, …)` right there passed GREEN, which is exactly
+      // the evasion this assertion exists for. Names are closed over transitively: any `let X = Y`
+      // or `if let Some(X) = Y` where Y is already tracked makes X tracked too.
+      const tracked = new Set([m[1]]);
+      for (let pass = 0; pass < 4; pass += 1) {
+        for (const t of [...tracked]) {
+          for (const rb of after.matchAll(new RegExp(`(?:if\\s+let\\s+Some\\(\\s*(\\w+)\\s*\\)|let\\s+(\\w+))\\s*=\\s*\\*?${t}\\b`, "gu"))) {
+            tracked.add(rb[1] ?? rb[2]);
+          }
+        }
+      }
+      for (const t of tracked) {
+        for (const use of after.matchAll(new RegExp(`(\\w+)\\s*\\(\\s*[^)]*?\\b${t}\\b`, "gu"))) {
+          resolverSinks.push({ mod, sink: use[1], via: t });
+        }
+      }
+    }
+  }
+  const writerSinks = resolverSinks.filter((s) => new RegExp(`^${WRITER}$`, "u").test(s.sink));
+  ok("and every scheme-mapper that RESOLVES a family name flows only into READ sinks — the generic `\"ontology\" => Some(...)` arms in governance and marketplace are the exact shape that becomes a second admission path the moment a resolved name reaches a writer, so where it flows is asserted, not just that it exists",
+    resolverMods.length > 0 && writerSinks.length === 0,
+    writerSinks.length
+      ? `RESOLVED NAME REACHES A WRITER: ${writerSinks.map((s) => `${s.mod}->${s.sink}`).join(" ; ")}`
+      : `${resolverMods.join(",")} resolve into sinks [${[...new Set(resolverSinks.map((s) => s.sink))].sort().join(",") || "none"}]`);
+
+  // ------------------------------------------------------------ no raw filesystem write into a family dir
+  // A denylist, and LABELLED as one: it bounds a known attack and cannot entail that no raw write
+  // exists. The entailment above is what carries the claim.
+  // THE DENYLIST RESOLVES CONSTANTS, because a literal-only scan is blind to the shape this census
+  // actually found. `odk_routes` plants fixtures with `std::fs::write(dir.join(KIND_ONT_RECEIPT), …)`
+  // — inside `#[cfg(test)]`, so benign — and a literal-only pattern could not see it at all. The
+  // same line OUTSIDE a test block is a raw write straight into a family directory, so the scan
+  // resolves the constant AND excludes only genuine test regions rather than the whole file.
+  const rawWrites = [];
+  const FS_WRITE = /(?:fs\s*::\s*(?:write|create|create_new|remove_file|remove_dir_all|copy|rename|hard_link|OpenOptions)|File\s*::\s*create)/gu;
+  for (const [f, src] of sources) {
+    const mod = modName(f);
+    const tests = testRegions(src);
+    const inTest = (i) => tests.some((t) => i >= t.start && i < t.end);
+    for (const m of src.matchAll(FS_WRITE)) {
+      if (inTest(m.index)) continue;
+      const tail = src.slice(m.index, m.index + 240);
+      for (const tok of tail.matchAll(/"([^"]+)"|\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
+        const lit = tok[1] ?? constLiteral.get(tok[2]) ?? aliasFor.get(mod)?.get(tok[2]);
+        if (lit && familyLiterals.has(lit)) rawWrites.push(`${mod}->${lit} @${m.index}`);
+      }
+    }
+  }
+  ok("no PRODUCTION raw filesystem write in this daemon targets an ontology-plane family, with the family resolved through constants and not just literals — a DENYLIST bounding a known attack, not a proof that no raw write exists; the per-family entailment above is what carries the claim",
+    rawWrites.length === 0, [...new Set(rawWrites)].join(" ; ") || "no denylisted raw write outside test blocks");
+
+  // ------------------------------------------------------------ the scanner is honest about itself
+  const rawTotal = [...rawSources.values()].join("").length;
+  const strippedTotal = [...sources.values()].join("").length;
+  ok("the comment stripper removed only comments — the censused source is shorter than the raw source but every family literal survives it, because a stripper that eats code makes a write invisible and fails OPEN (XIII shipped exactly that)",
+    strippedTotal < rawTotal
+      && [...familyLiterals].every((lit) => [...sources.values()].some((s) => s.includes(lit))),
+    `${rawTotal} -> ${strippedTotal} chars`);
+
+  const failed = results.filter((r) => !r.pass);
+  for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`);
+  emitVerifierCensus({ verifierId: "ontology-admission-census", sourceUrl: import.meta.url, results });
+  console.log(`\n${results.length - failed.length}/${results.length} passed`);
+  if (failed.length) process.exit(1);
+}
+
+/**
+ * The byte spans of this module's `#[cfg(test)]` blocks.
+ *
+ * Brace-matched from the attribute rather than line-counted, because a test block that a regex
+ * closes at the wrong brace would either hide production code inside a "test" region — which is
+ * exactly how a second admission path would get waved through — or truncate the region and leave
+ * real fixture lines unclassified.
+ */
+export function testRegions(src) {
+  const out = [];
+  for (const m of src.matchAll(/#\[cfg\(test\)\]/gu)) {
+    const open = src.indexOf("{", m.index);
+    if (open === -1) continue;
+    let depth = 0;
+    let i = open;
+    for (; i < src.length; i += 1) {
+      if (src[i] === "{") depth += 1;
+      else if (src[i] === "}") { depth -= 1; if (depth === 0) break; }
+    }
+    out.push({ start: m.index, end: Math.min(i + 1, src.length) });
+  }
+  return out;
+}
+
+/** The literal a `match` block's arms resolve to, if any arm names a censused family. */
+function resolveArgFromArms(block, mod, resolveArg, familyLiterals) {
+  for (const arm of block.matchAll(/=>\s*Some\(\s*([^)]+?)\s*\)/gu)) {
+    const lit = resolveArg(mod, arm[1]);
+    if (lit && familyLiterals.has(lit)) return lit;
+  }
+  return null;
+}
+
+// RUN ONLY WHEN INVOKED, NEVER ON IMPORT. XIII killed a mutation battery mid-run by importing a
+// module whose top level had side effects; the timeout skipped its `finally` and left a mutant in
+// the tree. A verifier that executes on import is the same hazard for anything that wants to reuse
+// its scanner.
+const INVOKED_DIRECTLY = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (INVOKED_DIRECTLY) {
+  try {
+    run();
+  } catch (error) {
+    console.error(`FAIL ontology-admission-census — ${error?.stack || error}`);
+    process.exit(1);
+  }
+}

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -290,7 +290,13 @@ function fnv1a64(bytes) {
  * comparison passes on exactly the hazard it names.
  */
 function deriveCensus() {
-  const build = spawnSync("cargo", ["build", "--offline", "-p", "ioi-ontology-census"], { cwd: ROOT, encoding: "utf8" });
+  // `--locked`, NOT `--offline`. Offline was a network optimisation that fails closed for the wrong
+  // reason — CI has no populated crates.io index at this point and the gate died on
+  // "no matching package named `serde_json`", which says nothing about the census. `--locked` is
+  // what the rest of this estate's CI uses and it carries a real property the pin does not: the
+  // extractor is built from the resolution `Cargo.lock` records, so a dependency move cannot change
+  // its behaviour without a lockfile diff.
+  const build = spawnSync("cargo", ["build", "--locked", "-p", "ioi-ontology-census"], { cwd: ROOT, encoding: "utf8" });
   if (build.status !== 0) throw new Error(`extractor build failed: ${build.stderr || build.stdout}`);
   const run = spawnSync(EXTRACTOR_BIN, ["--interest", "odk-", DAEMON_MAIN], { cwd: ROOT, encoding: "utf8", maxBuffer: 512 * 1024 * 1024 });
   if (run.status !== 0) throw new Error(`extractor failed (${run.status}): ${run.stderr}`);

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -7,37 +7,54 @@
 // the observer sat inside the system it was bounding — and commissioned the proof to be built HERE,
 // from module source, where the whole program is visible at once.
 //
-// WHY IT IS NOT A REGEX ANY MORE. XIV Leg 3a first built this by hand-scanning Rust. Three review
-// rounds defeated it, and the defeats sorted cleanly into CENSUS LOGIC (a rule wrong or decorative)
-// and LANGUAGE READING (a Rust construct the scanner mis-modelled). Round two produced six of the
-// latter; round three produced five more — `use super::odk_routes;` then `odk_routes::KIND_ONT`,
-// raw strings desyncing a brace walk, `async fn` defeating an enclosing-function heuristic, and
-// module-file resolution order shadowing a nested module with a flat sibling. The owner
-// PRE-COMMITTED the rule before that round ran: modelling the next construct retires an INSTANCE, a
-// real parser retires the CLASS. Extraction runs through `syn` now (`crates/ontology-census`), which
-// emits the facts as JSON; this file decides what they mean. Keeping extraction and judgement apart
-// is what let the judgement keep every mutation anchor while the substrate underneath changed.
+// WHY IT IS NOT A REGEX, AND WHY THE FIRST PARSER DID NOT COUNT. XIV Leg 3a first built this by
+// hand-scanning Rust; three review rounds defeated it, and the defeats sorted cleanly into CENSUS
+// LOGIC (a rule wrong or decorative) and LANGUAGE READING (a construct the scanner mis-modelled).
+// The owner PRE-COMMITTED the rule before round three ran: modelling the next construct retires an
+// INSTANCE, a real parser retires the CLASS. The first attempt at that ruling ADDED `syn` and KEPT
+// the hand-rolled walk — a fifteen-variant `expr_children` under an AST, with a zero-override
+// `Visit` impl driven across every expression so the code READ as though a complete visitor ran. A
+// fourth review demonstrated twelve of fourteen ordinary second-admitter constructs passing green:
+// `.await`, `tokio::spawn`, impl methods, arm guards, struct literals, nested items, macro
+// arguments. THE SCAR: A PRE-COMMITTED BOUNDARY IS EXECUTED BY ITS MECHANISM, NOT BY ITS DEPENDENCY.
+// The traversal in `crates/ontology-census` is `syn::visit::Visit` itself now.
+//
+// AND WHY EVERY JUDGEMENT BELOW READS A CLASSIFICATION RATHER THAN AN ABSENCE. That same review
+// found the deeper defect: a construct the walk missed produced no entry, and every judgement was
+// derived from the entries — so a COVERAGE GAP was indistinguishable from SAFETY. The extractor now
+// reports every mention of a name of interest WITH the syntactic role it sits in, and this file
+// holds a closed set of roles it can classify. A tenth role is RED. A gap now reads as a finding.
 //
 // WHAT IT ENTAILS, scoped by owner ruling. For each of the four ONTOLOGY families, exactly one
-// module admits it. That is the commissioned claim, and the four assertions below carry it.
+// module admits it. That is the commissioned claim, and four assertions below carry it.
 //
-// AND WHAT IT RATCHETS, which is weaker and labelled as such. The extractor derives all NINETEEN
-// written ODK families. Their admitter map is RECORDED here and asserted in both directions per
-// scar 4: a family that GAINS an admitter beyond the record is RED; a family that loses one makes
-// the record STALE and must be re-derived in the commit that removes it. The label claims exactly
-// that ratchet — NOT that every ODK family has one admitter, because FIVE DO NOT. Those five are
-// recorded UNDER ADJUDICATION, neither endorsed nor condemned; adjudicating them is next-legs XV
-// work, and the question per family is whether the co-admitters are legitimate co-callers of ONE
-// kernel-owned admission path or whether a lane hand-mints records beside it.
+// AND WHAT IT RATCHETS, which is weaker and labelled as such. The extractor derives every string in
+// this daemon that begins `odk-`. Their admitter and toucher maps are RECORDED here and asserted in
+// both directions per scar 4: a gain beyond the record is RED; a loss makes the record STALE and is
+// re-derived in the commit that removes it. The label claims exactly that ratchet — NOT that every
+// ODK family has one admitter, because THREE DO NOT. Those three are recorded UNDER ADJUDICATION,
+// neither endorsed nor condemned; all three share one second admitter, `connector_execution_routes`,
+// which makes them one question rather than three, and answering it is next-legs XV work: is that
+// module a legitimate co-caller of kernel-owned admission paths, or does it hand-mint records
+// beside them — the W3.1 shape.
 //
-// The hand-written table this replaced named FOUR families and structurally could not have seen the
-// other fifteen. Deriving it found five multi-admitter families on the first run. Hand-written
-// filter, derived replacement, immediate finding — that sequence is scar 4's whole argument.
+// THE MAP WAS WRONG IN BOTH DIRECTIONS BEFORE IT WAS DERIVED PROPERLY, WHICH IS THE POINT. The
+// hand-written table this replaced named FOUR families and structurally could not have seen the
+// other twenty-one. Its first derived replacement reported FIVE multi-admitter families — also
+// wrong, because that census applied no test filter, and three of the five were multi-admitter only
+// on the strength of `#[cfg(test)]` fixtures. Recording a fixture as an admitter PRE-AUTHORISES its
+// module to write that family for real. Hand-written filter, derived replacement, finding;
+// unfiltered census, filtered census, correction. Scar 4's whole argument, twice over.
+//
+// TEST CLASSIFICATION FAILS TOWARD PRODUCTION and test writes are CLASSIFIED, not dropped: only a
+// bare `#[cfg(test)]` marks a subtree, `cfg(any(test, …))` and feature gates count as production,
+// and the test-write map is pinned too — so moving a production write under a test attribute shrinks
+// the production map into a stale-pin RED rather than passing as a silent green.
 //
 // WHAT IT DOES NOT ENTAIL. `syn` reads this crate's source. A write performed by a dependency crate
-// on the daemon's behalf, produced by macro expansion, or by another process, is outside it.
-// Seventy-four writer calls take their family as a runtime parameter and cannot be resolved
-// statically at all; that count is pinned as its own ratchet rather than waved through.
+// on the daemon's behalf, produced by macro EXPANSION, or by another process, is outside it. Two
+// hundred and ninety production writer calls take their family as a runtime parameter and cannot be
+// resolved statically at all; that count is pinned as its own ratchet rather than waved through.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -54,228 +71,384 @@ const DAEMON_MAIN = path.join(ROOT, "crates/node/src/bin/hypervisor-daemon.rs");
 const results = [];
 const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
 
-/** The four families this leg's entailment covers, by owner ruling. */
+/** The four families this leg's entailment covers, by owner ruling. Keyed by module PATH tail. */
 const ONTOLOGY_FAMILIES = {
-  "odk-domain-ontologies": "odk_routes",
-  "odk-ontology-receipts": "odk_routes",
-  "odk-ontology-proposals": "ontology_workbench_routes",
-  "odk-saved-object-sets": "ontology_workbench_routes",
+  "odk-domain-ontologies": "hypervisor_daemon_routes/odk_routes.rs",
+  "odk-ontology-receipts": "hypervisor_daemon_routes/odk_routes.rs",
+  "odk-ontology-proposals": "hypervisor_daemon_routes/ontology_workbench_routes.rs",
+  "odk-saved-object-sets": "hypervisor_daemon_routes/ontology_workbench_routes.rs",
 };
-
-// The whole written ODK plane as derived at this commit. A RATCHET, not a claim: five of these have
-// more than one admitter today and are UNDER ADJUDICATION (next-legs XV).
-const RECORDED_PLANE = {
-  "odk-capability-lease-plan-receipts": ["capability_lease_plan_routes"],
-  "odk-capability-lease-plans": ["capability_lease_plan_routes"],
-  "odk-connector-mapping-receipts": ["connector_mapping_routes"],
-  "odk-connector-mappings": ["connector_mapping_routes", "policy_bound_data_view_routes"],
-  "odk-connector-session-receipts": ["connector_session_routes"],
-  "odk-connector-sessions": ["connector_session_routes"],
-  "odk-domain-ontologies": ["odk_routes"],
-  "odk-materialized-object-sets": ["connector_execution_routes"],
-  "odk-materializing-run-receipts": ["connector_execution_routes", "materializing_run_routes"],
-  "odk-materializing-runs": ["connector_execution_routes", "materializing_run_routes"],
-  "odk-ontology-projection-receipts": ["ontology_projection_routes"],
-  "odk-ontology-projections": ["connector_execution_routes", "ontology_projection_routes", "policy_bound_data_view_routes"],
-  "odk-ontology-proposals": ["ontology_workbench_routes"],
-  "odk-ontology-receipts": ["odk_routes"],
-  "odk-policy-bound-data-views": ["policy_bound_data_view_routes"],
-  "odk-saved-object-sets": ["ontology_workbench_routes"],
-  "odk-surface-descriptors": ["odk_routes"],
-  "odk-transformation-run-receipts": ["transformation_run_routes"],
-  "odk-transformation-runs": ["policy_bound_data_view_routes", "transformation_run_routes"],
-};
-
-/** Writer calls whose family is a runtime parameter, unresolvable from source. Pinned, not waived. */
-const UNRESOLVED_WRITER_CALLS = 74;
-
-const WRITERS = new Set(["persist_record", "persist_record_durable", "remove_record", "persist_promoted", "admit_required"]);
 
 /**
- * Derive the census, REBUILDING THE EXTRACTOR FIRST.
+ * EVERY SYNTACTIC ROLE A FAMILY NAME MAY APPEAR IN, and what each one means for admission.
  *
- * A gate must never trust a previously-built extractor. XIII poisoned verifier runs with a daemon
- * binary built from a different tree — the runs looked green because the artifact was stale, not
- * because the source was right. The identical hazard applies here, so the extractor is rebuilt every
- * run and its freshness asserted against its own source before a single fact is read.
+ * This table is the closed world that makes a coverage gap a finding. The extractor labels every
+ * mention with its role; a role missing from here is RED whatever it turns out to mean. `admits`
+ * roles put the module in the admitter map. `names` roles put it in the weaker TOUCHER map, because
+ * a family name reaching a function body outside any call this census recognises cannot be shown
+ * harmless without dataflow this census deliberately does not do — so it is ratcheted, not waved
+ * through.
+ */
+const ROLE_MEANING = {
+  "write-arg": "admits",
+  "fs-arg": "admits",
+  "read-arg": "names",
+  "const-init": "declares",
+  "static-init": "declares",
+  "fn-body": "names",
+  "macro:json": "names",
+  "macro:format": "names",
+  "macro:assert": "names",
+  "macro:assert_eq": "names",
+};
+
+const RECORDED_PLANE = {
+  "odk-capability-lease-plan-receipts": { admits: ["hypervisor_daemon_routes/capability_lease_plan_routes.rs"], touches: ["hypervisor_daemon_routes/capability_lease_plan_routes.rs"] },
+  "odk-capability-lease-plans": { admits: ["hypervisor_daemon_routes/capability_lease_plan_routes.rs"], touches: ["hypervisor_daemon_routes/capability_lease_plan_routes.rs", "hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/connector_session_routes.rs", "hypervisor_daemon_routes/materializing_run_routes.rs"] },
+  "odk-connector-mapping-receipts": { admits: ["hypervisor_daemon_routes/connector_mapping_routes.rs"], touches: ["hypervisor_daemon_routes/connector_mapping_routes.rs"] },
+  "odk-connector-mappings": { admits: ["hypervisor_daemon_routes/connector_mapping_routes.rs"], touches: ["hypervisor_daemon_routes/capability_lease_plan_routes.rs", "hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/connector_mapping_routes.rs", "hypervisor_daemon_routes/materializing_run_routes.rs", "hypervisor_daemon_routes/ontology_projection_routes.rs", "hypervisor_daemon_routes/policy_bound_data_view_routes.rs", "hypervisor_daemon_routes/transformation_run_routes.rs"] },
+  "odk-connector-session-receipts": { admits: ["hypervisor_daemon_routes/connector_session_routes.rs"], touches: ["hypervisor_daemon_routes/connector_session_routes.rs"] },
+  "odk-connector-sessions": { admits: ["hypervisor_daemon_routes/connector_session_routes.rs"], touches: ["hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/connector_session_routes.rs"] },
+  "odk-data-recipes": { admits: [], touches: ["hypervisor_daemon_routes/domain_apps_routes.rs", "hypervisor_daemon_routes/governance_routes.rs", "hypervisor_daemon_routes/marketplace_routes.rs", "hypervisor_daemon_routes/odk_routes.rs"] },
+  "odk-domain-ontologies": { admits: ["hypervisor_daemon_routes/odk_routes.rs"], touches: ["hypervisor_daemon_routes/connector_mapping_routes.rs", "hypervisor_daemon_routes/domain_apps_routes.rs", "hypervisor_daemon_routes/governance_routes.rs", "hypervisor_daemon_routes/marketplace_routes.rs", "hypervisor_daemon_routes/odk_routes.rs", "hypervisor_daemon_routes/ontology_projection_routes.rs", "hypervisor_daemon_routes/ontology_workbench_routes.rs"] },
+  "odk-manifest": { admits: [], touches: ["hypervisor_daemon_routes/odk_routes.rs"] },
+  "odk-manifest://": { admits: [], touches: ["hypervisor_daemon_routes/odk_routes.rs"] },
+  "odk-manifests": { admits: [], touches: ["hypervisor_daemon_routes/domain_apps_routes.rs", "hypervisor_daemon_routes/governance_routes.rs", "hypervisor_daemon_routes/marketplace_routes.rs", "hypervisor_daemon_routes/odk_routes.rs", "hypervisor_daemon_routes/package_registry_routes.rs"] },
+  "odk-materialized-object-sets": { admits: ["hypervisor_daemon_routes/connector_execution_routes.rs"], touches: ["hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/ontology_workbench_routes.rs", "hypervisor_daemon_routes/orchestration_routes.rs"] },
+  "odk-materializing-run-receipts": { admits: ["hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/materializing_run_routes.rs"], touches: ["hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/materializing_run_routes.rs"] },
+  "odk-materializing-runs": { admits: ["hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/materializing_run_routes.rs"], touches: ["hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/connector_session_routes.rs", "hypervisor_daemon_routes/materializing_run_routes.rs"] },
+  "odk-materializing-runs/{id}/lease": { admits: [], touches: ["hypervisor_daemon_routes/materializing_run_routes.rs"] },
+  "odk-ontology-projection-receipts": { admits: ["hypervisor_daemon_routes/ontology_projection_routes.rs"], touches: ["hypervisor_daemon_routes/ontology_projection_routes.rs"] },
+  "odk-ontology-projections": { admits: ["hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/ontology_projection_routes.rs"], touches: ["hypervisor_daemon_routes/capability_lease_plan_routes.rs", "hypervisor_daemon_routes/connector_execution_routes.rs", "hypervisor_daemon_routes/materializing_run_routes.rs", "hypervisor_daemon_routes/ontology_projection_routes.rs"] },
+  "odk-ontology-proposals": { admits: ["hypervisor_daemon_routes/ontology_workbench_routes.rs"], touches: ["hypervisor_daemon_routes/ontology_workbench_routes.rs"] },
+  "odk-ontology-receipts": { admits: ["hypervisor_daemon_routes/odk_routes.rs"], touches: ["hypervisor_daemon_routes/odk_routes.rs"] },
+  "odk-policy-bound-data-view-receipts": { admits: [], touches: ["hypervisor_daemon_routes/policy_bound_data_view_routes.rs"] },
+  "odk-policy-bound-data-views": { admits: ["hypervisor_daemon_routes/policy_bound_data_view_routes.rs"], touches: ["hypervisor_daemon_routes/capability_lease_plan_routes.rs", "hypervisor_daemon_routes/materializing_run_routes.rs", "hypervisor_daemon_routes/ontology_projection_routes.rs", "hypervisor_daemon_routes/policy_bound_data_view_routes.rs", "hypervisor_daemon_routes/transformation_run_routes.rs"] },
+  "odk-saved-object-sets": { admits: ["hypervisor_daemon_routes/ontology_workbench_routes.rs"], touches: ["hypervisor_daemon_routes/ontology_workbench_routes.rs"] },
+  "odk-surface-descriptors": { admits: ["hypervisor_daemon_routes/odk_routes.rs"], touches: ["hypervisor_daemon_routes/domain_apps_routes.rs", "hypervisor_daemon_routes/governance_routes.rs", "hypervisor_daemon_routes/marketplace_routes.rs", "hypervisor_daemon_routes/odk_routes.rs", "hypervisor_daemon_routes/package_registry_routes.rs"] },
+  "odk-transformation-run-receipts": { admits: ["hypervisor_daemon_routes/transformation_run_routes.rs"], touches: ["hypervisor_daemon_routes/transformation_run_routes.rs"] },
+  "odk-transformation-runs": { admits: ["hypervisor_daemon_routes/transformation_run_routes.rs"], touches: ["hypervisor_daemon_routes/capability_lease_plan_routes.rs", "hypervisor_daemon_routes/materializing_run_routes.rs", "hypervisor_daemon_routes/ontology_projection_routes.rs", "hypervisor_daemon_routes/transformation_run_routes.rs"] },
+};
+
+/**
+ * WRITES UNDER A BARE `#[cfg(test)]`, recorded rather than discarded. Pinning what the filter
+ * EXCLUDES is what stops the exclusion becoming a hiding place: a production write relocated under a
+ * test attribute leaves the production map and arrives here, failing twice rather than passing once.
+ */
+const RECORDED_TEST_WRITES = {
+  "odk-connector-mappings": ["hypervisor_daemon_routes/policy_bound_data_view_routes.rs"],
+  "odk-domain-ontologies": ["hypervisor_daemon_routes/odk_routes.rs"],
+  "odk-ontology-projections": ["hypervisor_daemon_routes/policy_bound_data_view_routes.rs"],
+  "odk-ontology-receipts": ["hypervisor_daemon_routes/odk_routes.rs"],
+  "odk-policy-bound-data-view-receipts": ["hypervisor_daemon_routes/policy_bound_data_view_routes.rs"],
+  "odk-policy-bound-data-views": ["hypervisor_daemon_routes/policy_bound_data_view_routes.rs"],
+  "odk-surface-descriptors": ["hypervisor_daemon_routes/odk_routes.rs"],
+  "odk-transformation-runs": ["hypervisor_daemon_routes/policy_bound_data_view_routes.rs"],
+};
+
+/**
+ * THE TRAVERSAL'S OWN REACH, pinned. Every assertion here reads the census, so a walk that quietly
+ * stops reaching a construct weakens all of them at once without failing any of them.
+ */
+const PINNED = {
+  modules: 88,
+  familyMentions: 273,
+  productionWriterCalls: { family: 72, nonFamilyLiteral: 204, runtimeParameter: 290 },
+  productionFsCalls: 228,
+};
+
+/** FNV-1a/64 — the digest the extractor bakes its own source under at compile time. */
+function fnv1a64(bytes) {
+  const mask = 0xffffffffffffffffn;
+  let h = 0xcbf29ce484222325n;
+  for (const b of bytes) {
+    h = (h ^ BigInt(b)) & mask;
+    h = (h * 0x100000001b3n) & mask;
+  }
+  return h.toString(16).padStart(16, "0");
+}
+
+/**
+ * Build the extractor and read the census out of it.
+ *
+ * THE BINARY IS PROVEN AGAINST ITS SOURCE BY CONTENT, NOT BY TIMESTAMP. The previous guard compared
+ * mtimes after a `cargo build`, which passes on exactly the hazard it names: cargo treats a source
+ * whose mtime moved BACKWARDS as up-to-date and does not rebuild, and the mtime comparison then
+ * agrees. A tar or rsync restore, a Docker COPY, or a CI cache restored alongside a checkout reaches
+ * that state with no deliberate act. The extractor bakes its own source in with `include_str!`, so a
+ * binary built from different bytes reports a digest the source on disk cannot produce.
  */
 function deriveCensus() {
-  const build = spawnSync("cargo", ["build", "--offline", "-p", "ioi-ontology-census"],
-    { cwd: ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, timeout: 900000 });
-  const built = build.status === 0 && fs.existsSync(EXTRACTOR_BIN);
-  const fresh = built && fs.statSync(EXTRACTOR_BIN).mtimeMs >= fs.statSync(EXTRACTOR_SRC).mtimeMs;
-  ok("the syn EXTRACTOR is rebuilt and proven fresher than its own source before any fact is read — a gate that trusts a previously-built artifact is the stale-binary defect that silently replayed an old tree through XIII's verifier runs",
-    built && fresh,
-    built ? (fresh ? "rebuilt, newer than its source" : "STALE: binary older than its source")
-      : `build failed: ${(build.stderr || "").split("\n").filter((l) => l.startsWith("error")).slice(0, 2).join(" | ")}`);
-  if (!built || !fresh) return null;
-
-  const run = spawnSync(EXTRACTOR_BIN, [DAEMON_MAIN],
-    { cwd: ROOT, encoding: "utf8", maxBuffer: 256 * 1024 * 1024, timeout: 900000 });
-  const parsed = run.status === 0;
-  ok("the extractor parses EVERY module of the daemon — a parse failure is RED, because a module `syn` cannot read is a module this census does not cover, and silence there would be indistinguishable from a clean run",
-    parsed, parsed ? "all modules parsed" : (run.stderr || "").split("\n").slice(0, 2).join(" | "));
-  return parsed ? JSON.parse(run.stdout) : null;
+  const build = spawnSync("cargo", ["build", "--offline", "-p", "ioi-ontology-census"], { cwd: ROOT, encoding: "utf8" });
+  if (build.status !== 0) throw new Error(`extractor build failed: ${build.stderr || build.stdout}`);
+  const run = spawnSync(EXTRACTOR_BIN, ["--interest", "odk-", DAEMON_MAIN], { cwd: ROOT, encoding: "utf8", maxBuffer: 512 * 1024 * 1024 });
+  if (run.status !== 0) throw new Error(`extractor failed (${run.status}): ${run.stderr}`);
+  const census = JSON.parse(run.stdout);
+  const onDisk = fnv1a64(fs.readFileSync(EXTRACTOR_SRC));
+  ok("the EXTRACTOR THAT PRODUCED THIS CENSUS was built from the extractor source in this tree, proven by a digest the binary carries from its own compile rather than by a timestamp a restore can forge — cargo treats a source whose mtime moved backwards as up-to-date, so an mtime guard passes on the very hazard it names",
+    census.extractor_source_fnv1a64 === onDisk,
+    census.extractor_source_fnv1a64 === onDisk ? `binary and source agree at ${onDisk}` : `binary carries ${census.extractor_source_fnv1a64}, source hashes to ${onDisk}`);
+  return census;
 }
 
 function run() {
   const census = deriveCensus();
-  if (!census) {
-    for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`);
-    console.log(`\n${results.filter((r) => r.pass).length}/${results.length} passed`);
-    process.exit(1);
-  }
   const modules = census.modules;
-  const byName = new Map(modules.map((m) => [m.name, m]));
+  const isFamily = (s) => typeof s === "string" && census.interests.some((p) => s.startsWith(p));
+  // MODULE IDENTITY IS THE PATH, all the way down. Shortening a key to its basename for comparison
+  // re-introduces the very collapse the path key exists to prevent: a shadow module at
+  // `shadow_odk/odk_routes.rs` compares equal to the real `odk_routes.rs`, and two admitters report
+  // as one. The prefix is stripped for legibility only, and it is common to every module here.
+  const PREFIX = "crates/node/src/bin/";
+  const modId = (k) => (k.startsWith(PREFIX) ? k.slice(PREFIX.length) : k);
 
-  ok("the module world is the daemon's own MODULE GRAPH, walked transitively by the parser through `#[path]` declarations — a directory listing misses a module declared elsewhere, and this daemon declares every route module with an explicit path so cargo's autobin will not claim each file as a binary target",
-    modules.length > 80 && byName.has("odk_routes") && byName.has("ontology_workbench_routes"),
-    `${modules.length} modules reached through the graph`);
-
-  // ---------------------------------------------------------------- name resolution, per module
-  const resolveArg = (mod, written) => {
-    if (written.startsWith('"')) return written.replace(/^"|"$/gu, "");
-    const segs = written.split("::");
-    if (segs.length >= 2) {
-      const owner = byName.get(segs[segs.length - 2]);
-      if (owner) return owner.consts[segs[segs.length - 1]] ?? null;
-    }
-    const name = segs[segs.length - 1];
-    if (mod.consts[name] !== undefined) return mod.consts[name];
-    for (const imp of mod.imports) {
-      if (imp.local !== name || !imp.from) continue;
-      const from = byName.get(imp.from);
-      if (from?.consts[imp.item] !== undefined) return from.consts[imp.item];
-    }
-    return null;
-  };
-
-  // AMBIGUITY, CHECKED ON AMBIGUITY. The assertion that carried this label previously verified only
-  // that each family literal was declared SOMEWHERE — a declaration-presence check a review defeated
-  // by adding a second, conflicting `const KIND_ONT` and watching it stay green.
-  const declaredBy = new Map();
+  // ---------------------------------------------------------------- the module graph
+  // KEYED BY REPO PATH, NOT BY FILE STEM. Two files sharing a basename collapse into one module
+  // under a stem key, which MERGES their admitters — a second admitter then reports as the recorded
+  // one, and "exactly one module admits" passes while two do.
+  const byKey = new Map(modules.map((m) => [m.key, m]));
+  const byStem = new Map();
   for (const m of modules) {
-    for (const [n, lit] of Object.entries(m.consts)) {
-      if (!declaredBy.has(n)) declaredBy.set(n, new Map());
-      declaredBy.get(n).set(m.name, lit);
-    }
+    if (!byStem.has(m.stem)) byStem.set(m.stem, []);
+    byStem.get(m.stem).push(m);
   }
-  const familyLiterals = new Set(Object.keys(ONTOLOGY_FAMILIES));
-  const ambiguous = [];
-  for (const [n, byMod] of declaredBy) {
-    const values = new Set(byMod.values());
-    if (values.size > 1 && [...values].some((v) => familyLiterals.has(v))) {
-      ambiguous.push(`${n} means {${[...values].join(" | ")}}`);
-    }
-  }
-  ok("NO CONSTANT NAME THAT MEANS AN ONTOLOGY FAMILY ANYWHERE MEANS SOMETHING ELSE SOMEWHERE — checked against every declaration the parser found, because resolution is per-module and a name meaning two things is exactly how a second admitter reads as innocent",
-    ambiguous.length === 0, ambiguous.join(" ; ") || `${declaredBy.size} declared names, none conflicting on a family`);
+  ok("the census walks the daemon's REAL module graph from its entry point — every `mod` declaration resolved through `#[path]` and rustc's own nested-before-sibling order, with an unresolvable declaration or an unreadable file aborting the extraction rather than silently shrinking the world the claim is made over",
+    modules.length === PINNED.modules && byKey.size === modules.length,
+    `${modules.length} modules reached, ${byKey.size} distinct paths (pinned ${PINNED.modules})`);
 
-  // ---------------------------------------------------------------- admitters
-  const admits = new Map();
-  let unresolvedWrites = 0;
+  // ---------------------------------------------------------------- name resolution
+  /**
+   * Resolve a written name to the literal it stands for, or report why it cannot be tied to a
+   * declaration this census can see. THERE IS NO GLOBAL-UNIQUE FALLBACK: a name the census cannot
+   * tie to a declaration is UNRESOLVED, and unresolved is RED. The fallback that used to sit here
+   * did not merely miss a renamed import — it disguised the miss as a different hole.
+   */
+  function resolveName(m, name, depth = 0) {
+    if (depth > 6) return { kind: "UNRESOLVED", why: "resolution cycle" };
+    if (isFamily(name)) return { kind: "LITERAL", value: name };
+    const segs = name.split("::");
+    const last = segs[segs.length - 1];
+    if (!/^[A-Z0-9_]+$/.test(last)) return { kind: "NOT-CONST" };
+    if (segs.length >= 2) {
+      // `use super::odk_routes as ont;` then `ont::KIND_ONT` — the module ALIAS, which the previous
+      // resolver could not follow and reported as an unresolvable runtime value instead. Both this
+      // form and the plain `use super::m;` are in this daemon today.
+      const q = segs[segs.length - 2];
+      const alias = m.imports.find((i) => i.module_only && i.local === q);
+      const stem = alias ? alias.item : q;
+      const cands = byStem.get(stem);
+      if (!cands) return { kind: "UNRESOLVED", why: `no module named ${stem}` };
+      if (cands.length > 1) return { kind: "UNRESOLVED", why: `module name ${stem} is ambiguous` };
+      const t = cands[0];
+      if (t.consts[last] !== undefined) return { kind: "LITERAL", value: t.consts[last] };
+      if (t.const_refs[last] !== undefined) return resolveName(t, t.const_refs[last], depth + 1);
+      if (t.const_opaque.includes(last)) return { kind: "OPAQUE", why: `${stem}::${last} has an initialiser this census cannot read` };
+      return { kind: "UNRESOLVED", why: `${stem}::${last} is not a constant this census can see` };
+    }
+    if (m.consts[last] !== undefined) return { kind: "LITERAL", value: m.consts[last] };
+    // `const LOCAL: &str = super::odk_routes::KIND_ONT;` — a constant defined as another constant.
+    if (m.const_refs[last] !== undefined) return resolveName(m, m.const_refs[last], depth + 1);
+    if (m.const_opaque.includes(last)) return { kind: "OPAQUE", why: `${last} has an initialiser this census cannot read` };
+    const imp = m.imports.find((i) => !i.module_only && !i.glob && i.local === last);
+    if (imp && imp.from) {
+      const cands = byStem.get(imp.from);
+      if (cands && cands.length === 1) {
+        const t = cands[0];
+        if (t.consts[imp.item] !== undefined) return { kind: "LITERAL", value: t.consts[imp.item] };
+        if (t.const_refs[imp.item] !== undefined) return resolveName(t, t.const_refs[imp.item], depth + 1);
+      }
+    }
+    for (const g of m.imports.filter((i) => i.glob && i.from)) {
+      const cands = byStem.get(g.from);
+      if (cands && cands.length === 1 && cands[0].consts[last] !== undefined) return { kind: "LITERAL", value: cands[0].consts[last] };
+    }
+    return { kind: "UNRESOLVED", why: `${last} is neither declared here nor imported` };
+  }
+
+  // ---------------------------------------------------------------- classify every mention
+  const observedRoles = new Set();
+  const unknownRoles = [];
+  const observed = new Map();   // family -> { admits:Set, touches:Set }
+  const testWrites = new Map(); // family -> Set
+  let familyMentions = 0;
+  for (const m of modules) {
+    for (const men of m.mentions) {
+      const r = resolveName(m, men.name);
+      if (r.kind !== "LITERAL" || !isFamily(r.value)) continue;
+      familyMentions++;
+      observedRoles.add(men.role);
+      const meaning = ROLE_MEANING[men.role];
+      if (!meaning) {
+        unknownRoles.push(`${modId(m.key)}::${men.in_fn} names "${r.value}" in role \`${men.role}\``);
+        continue;
+      }
+      if (!observed.has(r.value)) observed.set(r.value, { admits: new Set(), touches: new Set() });
+      if (men.in_test) {
+        if (meaning === "admits") {
+          if (!testWrites.has(r.value)) testWrites.set(r.value, new Set());
+          testWrites.get(r.value).add(modId(m.key));
+        }
+        continue;
+      }
+      const e = observed.get(r.value);
+      e.touches.add(modId(m.key));
+      if (meaning === "admits") e.admits.add(modId(m.key));
+    }
+  }
+
+  // A WRITER CALL WHOSE FAMILY THIS CENSUS CANNOT READ, IN A FUNCTION THAT NAMES ONE, ADMITS IT.
+  //
+  // This census does no dataflow, by design — so `let fams = ["<family>"]; persist_record(d, fams[0],
+  // …)` puts the literal in the function body and an unreadable expression at the call. Five
+  // constructs of exactly that shape (struct-literal field, array element, tuple element, arm guard,
+  // macro argument) reached the writer without the family ever appearing in the writer's own
+  // arguments. The conservative reading — the function names it, the function writes with something
+  // it will not spell — is that the module admits it. On the tree as it stands this rule attributes
+  // NOTHING, which is what makes it safe to state in this direction: it is inert until an
+  // indirection appears, and then it is a finding.
   for (const m of modules) {
     for (const c of m.calls) {
-      if (!WRITERS.has(c.callee)) continue;
-      const lit = resolveArg(m, c.written);
-      if (lit === null) { unresolvedWrites += 1; continue; }
-      if (!lit.startsWith("odk-")) continue;
-      if (!admits.has(lit)) admits.set(lit, new Set());
-      admits.get(lit).add(m.name);
-    }
-  }
-
-  for (const [lit, owner] of Object.entries(ONTOLOGY_FAMILIES)) {
-    const got = [...(admits.get(lit) ?? [])].sort();
-    ok(`EXACTLY ONE module admits \`${lit}\` — and it is \`${owner}\`; a second admission path must appear in some module's AST to exist at all, and the parser reads every module of this binary`,
-      got.length === 1 && got[0] === owner, `admitted by [${got.join(",") || "none"}]`);
-  }
-
-  // ---------------------------------------------------------------- the plane ratchet
-  const gained = [];
-  const stale = [];
-  for (const [fam, recorded] of Object.entries(RECORDED_PLANE)) {
-    const got = [...(admits.get(fam) ?? [])].sort();
-    if (!got.length) { stale.push(`${fam}: recorded [${recorded.join(",")}], now admitted by nothing`); continue; }
-    for (const mod of got) if (!recorded.includes(mod)) gained.push(`${fam}: GAINED ${mod}`);
-    for (const mod of recorded) if (!got.includes(mod)) stale.push(`${fam}: recorded ${mod} no longer admits it`);
-  }
-  for (const fam of admits.keys()) {
-    if (!RECORDED_PLANE[fam]) gained.push(`${fam}: an ODK family absent from the record is written by [${[...admits.get(fam)].sort().join(",")}]`);
-  }
-  const underAdjudication = Object.entries(RECORDED_PLANE).filter(([, v]) => v.length > 1).map(([k]) => k);
-  ok("NO ODK FAMILY GAINS AN ADMISSION PATH BEYOND THE RECORDED MAP — a RATCHET over all nineteen written families, and deliberately NOT a claim that each has one admitter: five have more than one today, recorded UNDER ADJUDICATION for next-legs XV, neither endorsed nor condemned. What this refuses is a new one appearing unnoticed",
-    gained.length === 0,
-    gained.length ? `GAINED: ${gained.join(" ; ")}`
-      : `${Object.keys(RECORDED_PLANE).length} families pinned; under adjudication: ${underAdjudication.join(", ")}`);
-
-  ok("and the recorded map is not STALE — every family and admitter it names still admits, so a pin cannot go quietly true over writes that were renamed away; removing one is a deliberate act in the commit that removes it (scar 4, second direction)",
-    stale.length === 0, stale.join(" ; ") || "every recorded family and admitter still admits");
-
-  ok("and the count of writer calls whose family is a RUNTIME PARAMETER is pinned — those cannot be resolved from source at all, so they are ratcheted rather than waved through, and a new one must be justified rather than absorbed into a number nobody watches",
-    unresolvedWrites === UNRESOLVED_WRITER_CALLS,
-    `${unresolvedWrites} unresolvable writer calls (pinned at ${UNRESOLVED_WRITER_CALLS})`);
-
-  // ---------------------------------------------------------------- raw filesystem writes
-  // THE WRITER CENSUS CANNOT SEE A LANE THAT BYPASSES THE WRITERS. A module that puts bytes into a
-  // family directory with `std::fs::write` admits a record without calling anything this census
-  // counts, and that mutation is part of the regression floor this substrate inherited. `syn` gives
-  // the resolved call path, so an aliased `use std::fs as sysfs` is the same AST node — the spelling
-  // games that defeated a text scan do not arise here.
-  const rawWrites = [];
-  for (const m of modules) {
-    for (const c of m.fs_calls ?? []) {
-      if (c.in_test) continue;
-      // THE CALL'S OWN ARGUMENTS, AND THE FUNCTION AROUND IT. A family normally reaches a raw write
-      // through a local — `let p = dir.join(KIND_ONT); fs::write(p.join(id), …)` — so it appears
-      // nowhere in the call itself. The rule is the dataflow-free one: a function that makes a raw
-      // filesystem call may not also name an ODK family. Conservative and fail-closed, the same
-      // shape as the resolve-and-write rule.
-      const named = new Set([...c.args, ...((m.fn_leaves ?? {})[c.in_fn] ?? [])]);
-      for (const a of named) {
-        const lit = resolveArg(m, a);
-        if (lit && lit.startsWith("odk-")) {
-          rawWrites.push(`${m.name}::${c.in_fn} makes a raw ${c.callee} and names ${lit}`);
-        }
+      if (c.kind !== "write" || c.in_test) continue;
+      if (c.leaves.some((l) => { const r = resolveName(m, l); return r.kind === "LITERAL" && isFamily(r.value); })) continue;
+      for (const l of m.fn_leaves[c.in_fn] ?? []) {
+        const r = resolveName(m, l);
+        if (r.kind !== "LITERAL" || !isFamily(r.value)) continue;
+        if (!observed.has(r.value)) observed.set(r.value, { admits: new Set(), touches: new Set() });
+        observed.get(r.value).admits.add(modId(m.key));
+        observed.get(r.value).touches.add(modId(m.key));
       }
     }
   }
-  ok("NO PRODUCTION FUNCTION MAKES A RAW FILESYSTEM CALL AND NAMES AN ODK FAMILY — a lane that writes bytes into a family directory itself admits a record without calling any writer this census counts; the rule is over the FUNCTION rather than the call arguments because the family normally arrives through a local, and test fixtures are excluded by the parser's own `#[cfg(test)]` knowledge rather than by a brace walk",
-    rawWrites.length === 0, [...new Set(rawWrites)].join(" ; ") || "no production raw filesystem call names a family");
 
-  // ---------------------------------------------------------------- who may DECLARE a family
-  // ONLY THE OWNER NAMES ITS OWN FAMILY. A module that declares `const X: &str =
-  // "odk-domain-ontologies"` has minted a second name for someone else's store, and every later use
-  // of it reads as innocent local code. This is the shape a review used to slip a family reference
-  // past a census that only looked at call sites.
-  const foreignDeclarations = [];
+  // THE ROLE WORLD IS CLOSED. Every judgement below reads a role; a role this file cannot classify
+  // is a mention whose meaning is unknown, and unknown must be RED rather than skipped.
+  ok("every mention of an ODK family sits in a SYNTACTIC ROLE this gate classifies — a family name reaching a position no rule below understands is reported as an unclassified mention and fails, so a construct the census stops reading becomes a FINDING rather than an absence, which is the only direction a judgement derived from absence can be trusted in",
+    unknownRoles.length === 0,
+    unknownRoles.join(" ; ") || `${observedRoles.size} roles observed, all classified: ${[...observedRoles].sort().join(", ")}`);
+
+  // ---------------------------------------------------------------- the commissioned claim
+  for (const [family, owner] of Object.entries(ONTOLOGY_FAMILIES)) {
+    const admits = [...(observed.get(family)?.admits ?? [])].sort();
+    ok(`EXACTLY ONE MODULE ADMITS \`${family}\` — entailed from the whole daemon's source rather than from a probe of the surface that would answer the same either way, and keyed by module PATH so that two files sharing a basename cannot report as one`,
+      admits.length === 1 && admits[0] === owner,
+      admits.length ? `admitted by ${admits.join(", ")}` : "no module admits it — the census has lost the owner, which is not the same as proving the claim");
+  }
+
+  // ---------------------------------------------------------------- the plane ratchet
+  const gainedAdmit = [], gainedTouch = [], staleAdmit = [], staleTouch = [], unrecorded = [];
+  for (const [family, e] of observed) {
+    const rec = RECORDED_PLANE[family];
+    if (!rec) { unrecorded.push(`${family} (admitted by ${[...e.admits].sort().join(", ") || "nobody"})`); continue; }
+    for (const mod of e.admits) if (!rec.admits.includes(mod)) gainedAdmit.push(`${family} gained ${mod}`);
+    for (const mod of e.touches) if (!rec.touches.includes(mod)) gainedTouch.push(`${family} newly named by ${mod}`);
+    for (const mod of rec.admits) if (!e.admits.has(mod)) staleAdmit.push(`${family} no longer admitted by ${mod}`);
+    for (const mod of rec.touches) if (!e.touches.has(mod)) staleTouch.push(`${family} no longer named by ${mod}`);
+  }
+  for (const family of Object.keys(RECORDED_PLANE)) if (!observed.has(family)) staleTouch.push(`${family} has vanished from the daemon entirely`);
+
+  ok("NO ODK FAMILY GAINS AN ADMISSION PATH BEYOND THE RECORDED MAP — the weaker ratchet this run is entitled to claim, and deliberately not the no-second-spine property: three families have two production admitters today and are recorded UNDER ADJUDICATION rather than endorsed",
+    gainedAdmit.length === 0 && unrecorded.length === 0,
+    [...gainedAdmit, ...unrecorded.map((u) => `unrecorded family ${u}`)].join(" ; ") || `${observed.size} families, admitter map unchanged`);
+
+  ok("NO MODULE NAMES AN ODK FAMILY IT IS NOT RECORDED AS NAMING — the ratchet a rung below admission, because a family name reaching a new module's function body cannot be shown harmless without dataflow this census deliberately does not do; the conservative reading is that it is a finding to run down, not a fact to wave through",
+    gainedTouch.length === 0,
+    gainedTouch.join(" ; ") || `${[...observed.values()].reduce((a, e) => a + e.touches.size, 0)} module-family references, all recorded`);
+
+  ok("THE RECORDED MAP IS NOT STALE IN EITHER DIRECTION — scar 4's second half: a derived closed world is only as wide as what it derives over, so an admitter or a reference that DISAPPEARS must re-derive the pin in the commit that removes it rather than leaving a record that quietly over-claims what is still true",
+    staleAdmit.length === 0 && staleTouch.length === 0,
+    [...staleAdmit, ...staleTouch].join(" ; ") || "every recorded admitter and reference is still present in source");
+
+  // ---------------------------------------------------------------- the test filter, both ways
+  const testGain = [], testStale = [];
+  for (const [family, mods] of testWrites) {
+    const rec = RECORDED_TEST_WRITES[family] ?? [];
+    for (const mod of mods) if (!rec.includes(mod)) testGain.push(`${family} gained a test write in ${mod}`);
+  }
+  for (const [family, rec] of Object.entries(RECORDED_TEST_WRITES)) {
+    for (const mod of rec) if (!(testWrites.get(family) ?? new Set()).has(mod)) testStale.push(`${family} no longer written under test by ${mod}`);
+  }
+  ok("WRITES UNDER A BARE `#[cfg(test)]` ARE CLASSIFIED AS TEST WRITES AND PINNED AS SUCH, never dropped — the filter fails toward PRODUCTION (`cfg(any(test, …))`, `cfg_attr` and feature gates all count as production), and pinning what it EXCLUDES is what stops the exclusion becoming a hiding place: a production write relocated under a test attribute leaves the production map and arrives here, failing twice rather than passing once",
+    testGain.length === 0 && testStale.length === 0,
+    [...testGain, ...testStale].join(" ; ") || `${[...testWrites.values()].reduce((a, s) => a + s.size, 0)} test writes across ${testWrites.size} families, all recorded`);
+
+  // ---------------------------------------------------------------- resolution is total
+  let wFamily = 0, wLiteral = 0, wRuntime = 0;
+  const wUnresolved = [];
   for (const m of modules) {
-    for (const [n, lit] of Object.entries(m.consts)) {
-      const owner = ONTOLOGY_FAMILIES[lit];
-      if (owner && owner !== m.name) foreignDeclarations.push(`${m.name} declares ${n} = "${lit}" (owned by ${owner})`);
+    for (const c of m.calls) {
+      if (c.kind !== "write" || c.in_test) continue;
+      const rs = c.leaves.map((l) => resolveName(m, l));
+      if (rs.some((r) => r.kind === "LITERAL" && isFamily(r.value))) { wFamily++; continue; }
+      const bad = c.leaves.filter((_, i) => rs[i].kind === "UNRESOLVED" || rs[i].kind === "OPAQUE");
+      if (bad.length) { wUnresolved.push(`${modId(m.key)}::${c.in_fn} → ${bad.join(", ")}`); continue; }
+      if (rs.some((r) => r.kind === "LITERAL")) wLiteral++; else wRuntime++;
     }
   }
-  ok("ONLY THE OWNING MODULE DECLARES A CONSTANT NAMING ONE OF ITS ONTOLOGY FAMILIES — a second name minted elsewhere makes every later use of it read as innocent local code, which is precisely how a family reference slips past a census that only inspects call sites",
-    foreignDeclarations.length === 0, foreignDeclarations.join(" ; ") || "every ontology family constant is declared by its owner");
+  ok("EVERY CONSTANT-SHAPED NAME IN A PRODUCTION WRITER CALL RESOLVES TO A DECLARATION THIS CENSUS CAN SEE — no name is waved through as probably-harmless, because a name the census cannot tie to a declaration it can see is exactly what a second admitter looks like from here",
+    wUnresolved.length === 0,
+    wUnresolved.slice(0, 8).join(" ; ") || `${wFamily} name a family, ${wLiteral} name a non-ODK family, ${wRuntime} take it as a runtime parameter`);
+
+  ok("THE WRITER-CALL POPULATION IS PINNED IN ALL THREE BUCKETS — including the calls whose family is a RUNTIME PARAMETER and therefore cannot be resolved from source at all; naming that bucket and pinning its size is what keeps it from silently absorbing the calls this census is supposed to be reading",
+    wFamily === PINNED.productionWriterCalls.family && wLiteral === PINNED.productionWriterCalls.nonFamilyLiteral && wRuntime === PINNED.productionWriterCalls.runtimeParameter,
+    `family=${wFamily}/${PINNED.productionWriterCalls.family} non-ODK=${wLiteral}/${PINNED.productionWriterCalls.nonFamilyLiteral} runtime=${wRuntime}/${PINNED.productionWriterCalls.runtimeParameter}`);
+
+  // ---------------------------------------------------------------- the traversal's own reach
+  const prodFs = modules.reduce((a, m) => a + m.fs_calls.filter((c) => !c.in_test).length, 0);
+  ok("THE TRAVERSAL'S REACH IS PINNED UNDER THE JUDGEMENTS THAT DEPEND ON IT — every assertion here reads the census, so a walk that quietly stops reaching a construct weakens all of them at once without failing any one of them; these counts collapse when the walk regresses even where no rule above has an opinion about the construct it stopped reaching",
+    familyMentions === PINNED.familyMentions && prodFs === PINNED.productionFsCalls,
+    `${familyMentions}/${PINNED.familyMentions} family mentions, ${prodFs}/${PINNED.productionFsCalls} production filesystem calls`);
+
+  // ---------------------------------------------------------------- who may mint the name
+  // READ FROM THE MENTION, NOT FROM THE CONSTANT TABLE. A scalar `const X: &str = "<family>"` lands
+  // in `consts`, but the same literal inside `const XS: &[&str] = &["<family>"]` does not — and both
+  // mint the name just as effectively. The mention carries its role, so both forms are one rule.
+  // `static` is covered because `static-init` is a declaring role; `concat!("odk-", "…")` is covered
+  // one assertion earlier, because its tokens surface under the role `macro:concat`, which this gate
+  // does not classify and therefore fails on.
+  const foreignDeclarations = [];
+  for (const m of modules) {
+    const here = modId(m.key);
+    const seen = new Set();
+    for (const men of m.mentions) {
+      if (men.role !== "const-init" && men.role !== "static-init") continue;
+      const r = resolveName(m, men.name);
+      if (r.kind !== "LITERAL") continue;
+      const owner = ONTOLOGY_FAMILIES[r.value];
+      if (!owner || owner === here || seen.has(r.value)) continue;
+      seen.add(r.value);
+      foreignDeclarations.push(`${here} declares "${r.value}" (owned by ${owner})`);
+    }
+  }
+  ok("ONLY THE OWNING MODULE DECLARES A CONSTANT NAMING ONE OF ITS ONTOLOGY FAMILIES — a second name minted elsewhere makes every later use of it read as innocent local code, which is how a family reference slips past a census that only inspects call sites; `static` declares as surely as `const` does, and a literal inside an array declares as surely as a scalar, and the previous census could see neither",
+    foreignDeclarations.length === 0,
+    foreignDeclarations.join(" ; ") || "every ontology family constant is declared by its owner");
+
+  // ---------------------------------------------------------------- the raw filesystem lane
+  const rawWrites = [];
+  for (const m of modules) {
+    for (const c of m.fs_calls) {
+      if (c.in_test) continue;
+      const near = [...(m.fn_leaves[c.in_fn] ?? []), ...c.leaves];
+      const fams = [...new Set(near.map((l) => resolveName(m, l)).filter((r) => r.kind === "LITERAL" && isFamily(r.value)).map((r) => r.value))]
+        .filter((f) => ONTOLOGY_FAMILIES[f] && ONTOLOGY_FAMILIES[f] !== modId(m.key));
+      if (fams.length) rawWrites.push(`${modId(m.key)}::${c.in_fn} calls ${c.callee} and names ${fams.join(", ")}`);
+    }
+  }
+  ok("NO PRODUCTION FUNCTION MAKES A RAW FILESYSTEM CALL AND NAMES AN ONTOLOGY FAMILY IT DOES NOT OWN — the record-writer census cannot see a lane that bypasses the writers entirely and puts bytes in a family directory itself; the enclosing function is read for EVERY declaration form, and reading it only for free functions left this rule dead for a third of the daemon's production filesystem calls",
+    rawWrites.length === 0,
+    rawWrites.join(" ; ") || `${prodFs} production filesystem calls, none in a function naming a family it does not own`);
 
   // ---------------------------------------------------------------- resolve-and-write
-  // THE GATE DECIDES WHETHER AN ARM NAMES A FAMILY, because the extractor reporting a bare "this
-  // function has a `Some(...)` arm" made every `Ok(id) => Some(id.principal_ref)` look like a family
-  // resolver — and one such function legitimately writes a record. Extraction reports what is
-  // written; judgement belongs here.
   const resolveAndWrite = [];
   for (const m of modules) {
     for (const fn of m.resolve_and_write_fns ?? []) {
       const arms = (m.resolver_arms ?? {})[fn] ?? [];
-      const namesFamily = arms.some((a) => {
-        const lit = resolveArg(m, a);
-        return lit !== null && lit.startsWith("odk-");
-      });
-      if (namesFamily) resolveAndWrite.push(`${m.name}::${fn}`);
+      if (arms.some((a) => { const r = resolveName(m, a); return r.kind === "LITERAL" && isFamily(r.value); })) resolveAndWrite.push(`${modId(m.key)}::${fn}`);
     }
   }
   ok("no function that RESOLVES a family name through a `match` arm also WRITES a record — conservative, dataflow-free and fail-closed: a scheme-mapper that admits is a second spine whatever the plumbing between them looks like, and widening this rule later is a governed act rather than a convenience",
-    resolveAndWrite.length === 0, resolveAndWrite.join(" ; ") || "no resolving function writes");
+    resolveAndWrite.length === 0,
+    resolveAndWrite.join(" ; ") || "no resolving function writes");
 
   const failed = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`);

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -48,11 +48,29 @@
 // identifier, at every depth of every group — and hands the SAME stream to syn. The token population
 // is total by construction, because a name that is in the file is a token in the file. This file
 // matches the two by SOURCE POSITION: a token that resolves to a family with no AST mention on it is
-// a SILENT MENTION and is RED. A coverage gap can no longer read as safety, because the thing being
-// counted is no longer produced by the thing that might be incomplete.
+// a SILENT MENTION and is RED.
 //
-// AND SINCE THIS FIX LANDED, A DEMONSTRATED SILENCE IS NOT A BUG TO PATCH. It falsifies the design,
-// and the owner's standing instruction is to STOP AND ESCALATE rather than model one more construct.
+// AND THAT WAS FALSIFIED TOO, WHICH IS WHY THE CLAIM BELOW IS SMALLER THAN THE ONE IT REPLACES. A
+// sixth review demonstrated six compiling second-admission paths passing green, and the diagnosis is
+// the same scar ONE LAYER DOWN:
+//
+//     A TOTAL TOKEN POPULATION CLOSES NOTHING UNLESS RESOLUTION OVER IT IS TOTAL.
+//
+// The token walk is total. The population this gate JUDGES is `token ∩ resolves-to-a-family`, and
+// resolution is a PARTIAL FUNCTION — it reads the declarations this census can see, and there are
+// thousands of constant-shaped names it cannot tie to one. Those were `continue`d in silence, with
+// no assertion over them, so the silence check adjudicated 282 of 106,724 tokens while a qualified
+// constant inside macro tokens — where the token walk flattens the path and loses the qualification
+// — reached a writer completely green.
+//
+// THE OWNER RULED: NO THIRD HARDENING EDGE. Entailing the resolver is construct-modelling one layer
+// up, and a design falsified twice does not get to try again. What was wrong is the LABELS' REACH,
+// not the gate's existence — the entailed core is real. So every label below is re-scoped to the
+// RESOLVED population, and EVERY NAME THIS CENSUS CANNOT ADJUDICATE IS COUNTED IN A NAMED BUCKET,
+// PINNED IN BOTH DIRECTIONS. A new unadjudicable name beyond the pin is RED; a name that becomes
+// resolvable shrinks the pin in the commit that resolves it. The buckets are the honest boundary of
+// this gate, stated as a number per cause rather than as a silence — and burning them down, together
+// with entailing the resolver itself, is next-legs XV work beside the atlas `denies` schema.
 //
 // WHAT IT ENTAILS, scoped by owner ruling. For each of the four ONTOLOGY families, exactly one
 // module admits it. That is the commissioned claim, and four assertions below carry it.
@@ -99,7 +117,10 @@ import { fileURLToPath } from "node:url";
 import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-const ROOT = process.env.IOI_CENSUS_ROOT || path.resolve(HERE, "..", "..", "..");
+// NO ENV OVERRIDE. A merge-blocking gate that can be re-pointed at another tree by an environment
+// variable certifies whichever tree it was aimed at while reporting the same number — the "gate as
+// its own oracle" shape this file exists to remove, wearing a different hat.
+const ROOT = path.resolve(HERE, "..", "..", "..");
 const EXTRACTOR_SRC = path.join(ROOT, "crates/ontology-census/src/main.rs");
 const EXTRACTOR_BIN = path.join(ROOT, "target/debug/ioi-ontology-census");
 const DAEMON_MAIN = path.join(ROOT, "crates/node/src/bin/hypervisor-daemon.rs");
@@ -202,6 +223,30 @@ const PINNED = {
   judgedTokenPositions: 282,
   productionWriterCalls: { family: 72, nonFamilyLiteral: 204, runtimeParameter: 290 },
   productionFsCalls: 228,
+  /**
+   * THE NAMES THIS CENSUS CANNOT ADJUDICATE, by cause. Pinned exactly, both directions.
+   *
+   *   foreign-qualified   — the qualifier names a module this walk does not contain (`StatusCode::…`,
+   *                         `header::AUTHORIZATION`). Structurally cannot be a daemon family constant.
+   *   opaque-initialiser  — a daemon constant whose initialiser this census cannot read to a literal.
+   *                         The sharp one: it IS a daemon name and its value is unknown here.
+   *   bare-undeclared     — a constant-shaped identifier tied to no declaration this census can see.
+   *                         Where a qualified name inside MACRO TOKENS lands, because the token walk
+   *                         flattens the path to its tail.
+   *   ambiguous-module    — two modules share the stem the qualifier names.
+   *   not-a-visible-const — the qualifier resolves, the item is not a constant this census can read.
+   *   resolution-cycle    — const-of-const deeper than the resolver follows.
+   *
+   * Burning these down, and entailing the resolver so they need not exist, is next-legs XV.
+   */
+  unadjudicable: {
+    "foreign-qualified": 3228,
+    "opaque-initialiser": 1553,
+    "bare-undeclared": 791,
+    "ambiguous-module": 0,
+    "not-a-visible-const": 0,
+    "resolution-cycle": 0,
+  },
   /** `include!` splices code and is followed; the data forms carry no Rust and are pinned. */
   includes: { splicedCode: 0, dataStr: 31, dataBytes: 0, dataOpaqueArg: 6 },
   /** Compile-time name assembly. Every production one must be READABLE and is followed. */
@@ -221,7 +266,7 @@ const PINNED = {
  * bytes on disk, and the digest the binary carries from its own compile. Moving this pin is a
  * GOVERNED COMMIT ACT — it appears in the diff of any change to the extractor, which is the point.
  */
-const EXTRACTOR_SOURCE_PIN = "417877f8abfc82e1";
+const EXTRACTOR_SOURCE_PIN = "bb299c8ef20bc742";
 
 /** FNV-1a/64 — the digest the extractor bakes its own source under at compile time. */
 function fnv1a64(bytes) {
@@ -281,7 +326,7 @@ function run() {
     if (!byStem.has(m.stem)) byStem.set(m.stem, []);
     byStem.get(m.stem).push(m);
   }
-  ok("the census walks the daemon's REAL module graph from its entry point — every `mod` declaration resolved through `#[path]` and rustc's own nested-before-sibling order, with an unresolvable declaration or an unreadable file aborting the extraction rather than silently shrinking the world the claim is made over",
+  ok("the census walks the module graph it can SEE from the daemon's entry point — every `mod` declaration carrying a bare `#[path]`, resolved in rustc's own nested-before-sibling order, with an unresolvable declaration or an unreadable file aborting extraction rather than silently shrinking the world; it is NOT rustc's file set and does not claim to be, because `mod` has no totality edge and is not getting one: a `#[cfg_attr(…, path = …)]` redirect is invisible here and a `mod` declared inside a `macro_rules!` body never reaches the visitor at all, so rustc would compile one file while this reads another — neither construct exists in this daemon today and entailing the file set belongs to the run that entails the resolver",
     modules.length === PINNED.modules && byKey.size === modules.length,
     `${modules.length} modules reached, ${byKey.size} distinct paths (pinned ${PINNED.modules})`);
 
@@ -293,7 +338,7 @@ function run() {
    * did not merely miss a renamed import — it disguised the miss as a different hole.
    */
   function resolveName(m, name, depth = 0) {
-    if (depth > 6) return { kind: "UNRESOLVED", why: "resolution cycle" };
+    if (depth > 6) return { kind: "UNRESOLVED", bucket: "resolution-cycle", why: "resolution cycle" };
     if (isFamily(name)) return { kind: "LITERAL", value: name };
     const segs = name.split("::");
     const last = segs[segs.length - 1];
@@ -312,18 +357,18 @@ function run() {
       const alias = m.imports.find((i) => i.module_only && i.local === q);
       const stem = alias ? alias.item : q;
       const cands = byStem.get(stem);
-      if (!cands) return { kind: "UNRESOLVED", why: `no module named ${stem}` };
-      if (cands.length > 1) return { kind: "UNRESOLVED", why: `module name ${stem} is ambiguous` };
+      if (!cands) return { kind: "UNRESOLVED", bucket: "foreign-qualified", why: `no module named ${stem}` };
+      if (cands.length > 1) return { kind: "UNRESOLVED", bucket: "ambiguous-module", why: `module name ${stem} is ambiguous` };
       const t = cands[0];
       if (t.consts[last] !== undefined) return { kind: "LITERAL", value: t.consts[last] };
       if (t.const_refs[last] !== undefined) return resolveName(t, t.const_refs[last], depth + 1);
-      if (t.const_opaque.includes(last)) return { kind: "OPAQUE", why: `${stem}::${last} has an initialiser this census cannot read` };
-      return { kind: "UNRESOLVED", why: `${stem}::${last} is not a constant this census can see` };
+      if (t.const_opaque.includes(last)) return { kind: "OPAQUE", bucket: "opaque-initialiser", why: `${stem}::${last} has an initialiser this census cannot read` };
+      return { kind: "UNRESOLVED", bucket: "not-a-visible-const", why: `${stem}::${last} is not a constant this census can see` };
     }
     if (m.consts[last] !== undefined) return { kind: "LITERAL", value: m.consts[last] };
     // `const LOCAL: &str = super::odk_routes::KIND_ONT;` — a constant defined as another constant.
     if (m.const_refs[last] !== undefined) return resolveName(m, m.const_refs[last], depth + 1);
-    if (m.const_opaque.includes(last)) return { kind: "OPAQUE", why: `${last} has an initialiser this census cannot read` };
+    if (m.const_opaque.includes(last)) return { kind: "OPAQUE", bucket: "opaque-initialiser", why: `${last} has an initialiser this census cannot read` };
     const imp = m.imports.find((i) => !i.module_only && !i.glob && i.local === last);
     if (imp && imp.from) {
       const cands = byStem.get(imp.from);
@@ -337,7 +382,7 @@ function run() {
       const cands = byStem.get(g.from);
       if (cands && cands.length === 1 && cands[0].consts[last] !== undefined) return { kind: "LITERAL", value: cands[0].consts[last] };
     }
-    return { kind: "UNRESOLVED", why: `${last} is neither declared here nor imported` };
+    return { kind: "UNRESOLVED", bucket: "bare-undeclared", why: `${last} is neither declared here nor imported` };
   }
 
   // ---------------------------------------------------------------- TOTALITY: token vs role
@@ -376,7 +421,49 @@ function run() {
     }
   }
 
-  ok("EVERY TOKEN THAT RESOLVES TO AN ODK FAMILY CARRIES A SYNTACTIC LABEL — mentions are derived from the file's RAW TOKEN STREAM, which is total by construction because a name in a file is a token in the file, and the AST only assigns roles to positions in it; a token the role-assigner never reached is a SILENT MENTION and fails here, which is what a closed set of roles could not do while the roles and the population had the same author",
+  // ----------------------------------------------------- THE BOUNDARY, COUNTED BY CAUSE
+  //
+  // THE TOKEN POPULATION IS TOTAL; RESOLUTION OVER IT IS NOT. A string literal is self-describing —
+  // its value IS its meaning, so testing it against the interest prefix adjudicates it outright. A
+  // constant-shaped IDENTIFIER is a NAME, and adjudicating it means resolving it to a declaration
+  // this census can see. Thousands cannot be, and they used to be `continue`d in silence, which is
+  // how a qualified constant inside macro tokens reached a writer completely green: the token walk
+  // flattens `super::odk_routes::KIND_ONT` to the bare tail `KIND_ONT`, which resolves to nothing.
+  //
+  // Every one of them is now COUNTED IN A NAMED BUCKET and the buckets are pinned in BOTH
+  // directions. This is not a hardening edge — resolution is not entailed and this gate does not
+  // claim it is. It is the boundary made adjudicable: a number per cause, so a reviewer can read
+  // what the gate cannot see rather than infer it from a silence. A new unadjudicable name beyond
+  // the pin is RED. A name that becomes resolvable SHRINKS the pin in the commit that resolves it.
+  const dropped = {};
+  const bumpDrop = (b) => { dropped[b] = (dropped[b] ?? 0) + 1; };
+  for (const m of modules) {
+    const labelledAt = new Map();
+    for (const men of m.mentions) if (!men.synthesized) labelledAt.set(posKey(men), men);
+    for (const t of m.token_mentions) {
+      if (t.kind !== "ident") continue;
+      // Prefer the AST's QUALIFIED spelling where it has one. The token carries only the tail, and
+      // judging `StatusCode::BAD_REQUEST` by `BAD_REQUEST` alone would file a foreign constant in
+      // the same bucket as a daemon name nobody can find — which would make the pin unreadable.
+      const men = labelledAt.get(posKey(t));
+      const spelling = men && men.name.includes("::") ? men.name : t.text;
+      const r = resolveName(m, spelling);
+      if (r.kind === "LITERAL") continue;
+      bumpDrop(r.bucket ?? r.kind);
+    }
+  }
+  const dropGain = [], dropStale = [];
+  for (const [b, n] of Object.entries(dropped)) {
+    if (PINNED.unadjudicable[b] === undefined) dropGain.push(`UNRECORDED BUCKET ${b} (${n})`);
+    else if (n !== PINNED.unadjudicable[b]) dropGain.push(`${b} ${n}/${PINNED.unadjudicable[b]}`);
+  }
+  for (const [b, n] of Object.entries(PINNED.unadjudicable)) if (dropped[b] === undefined && n !== 0) dropStale.push(`${b} vanished (pinned ${n})`);
+
+  ok("EVERY CONSTANT-SHAPED NAME THIS CENSUS CANNOT ADJUDICATE IS COUNTED IN A NAMED BUCKET, AND THE BUCKETS ARE PINNED IN BOTH DIRECTIONS — the token population is total, but the population this gate JUDGES is `token ∩ resolves-to-a-family`, and resolution is a PARTIAL function whose failures used to be skipped in silence; that is the same defect one layer down from the one this file was rebuilt to fix, and it is answered by COUNTING rather than by a third hardening edge, because a name the census cannot tie to a declaration is exactly what a second admitter looks like from here and a landfill of five thousand is not a residual — a bucket with a cause and a number is",
+    dropGain.length === 0 && dropStale.length === 0,
+    [...dropGain, ...dropStale].join(" ; ") || Object.entries(dropped).sort((a, b) => b[1] - a[1]).map(([b, n]) => `${b}=${n}`).join(" "));
+
+  ok("EVERY TOKEN THAT RESOLVES TO AN ODK FAMILY CARRIES A SYNTACTIC LABEL — the claim is over the RESOLVED population and says so, because a review demonstrated the wider reading false: mentions come from the file's raw token stream, which is total by construction, but a token this census cannot RESOLVE is not judged here at all, it is counted in the bucket pin above; what this assertion entails is that no name the census CAN read reaches a position the role-assigner never labelled",
     silent.length === 0,
     silent.slice(0, 8).join(" ; ") || `${judgedTokens} family-resolving token positions, every one labelled`);
 
@@ -405,7 +492,7 @@ function run() {
     unsplicedCode.length === 0 && splicedCode === PINNED.includes.splicedCode,
     unsplicedCode.join(" ; ") || `${splicedCode}/${PINNED.includes.splicedCode} spliced code includes`);
 
-  ok("THE DATA-INCLUDING FORMS ARE PINNED RATHER THAN FOLLOWED, and that is sound for a different reason than the code form — `include_str!`/`include_bytes!` put BYTES in the program, not Rust, so no writer call can live in one; a constant initialised from one is UNREADABLE to this census and therefore OPAQUE, which the resolver assertion below refuses outright, so their arguments are counted rather than required to be literals",
+  ok("THE DATA-INCLUDING FORMS ARE PINNED RATHER THAN FOLLOWED, and that is sound for a different reason than the code form — `include_str!`/`include_bytes!` put BYTES in the program, not Rust, so no writer call can live in one; a constant initialised from one is UNREADABLE to this census and therefore OPAQUE, which is COUNTED IN THE `opaque-initialiser` BUCKET above rather than refused: an earlier version of this sentence claimed the resolver assertion refused it outright, and that assertion iterates writer calls only, so an OPAQUE constant reaching a RAW FILESYSTEM call was neither refused nor counted",
     dataStr === PINNED.includes.dataStr && dataBytes === PINNED.includes.dataBytes && dataOpaqueArg === PINNED.includes.dataOpaqueArg,
     `include_str!=${dataStr}/${PINNED.includes.dataStr} include_bytes!=${dataBytes}/${PINNED.includes.dataBytes} with ${dataOpaqueArg}/${PINNED.includes.dataOpaqueArg} non-literal arguments`);
 
@@ -587,8 +674,8 @@ function run() {
   // in `consts`, but the same literal inside `const XS: &[&str] = &["<family>"]` does not — and both
   // mint the name just as effectively. The mention carries its role, so both forms are one rule.
   // `static` is covered because `static-init` is a declaring role; `concat!("odk-", "…")` is covered
-  // one assertion earlier, because its tokens surface under the role `macro:concat`, which this gate
-  // does not classify and therefore fails on.
+  // by the role-closure assertion above, because its tokens surface under the role `macro:concat`,
+  // which this gate does not classify and therefore fails on.
   const foreignDeclarations = [];
   for (const m of modules) {
     const here = modId(m.key);

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -8,39 +8,51 @@
 // the caller's request — and each round a review defeated the PROOF while the code under test stayed
 // correct and green. The owner ruled the iteration terminated and the claim MIS-SCOPED FOR ITS
 // OBSERVER: a whole-program property cannot be entailed by a black-box journey verifier, because the
-// observer sits inside the system it is trying to bound. The journey gate's labels were re-scoped to
-// the journey-scoped fact they check, the property was filed as a named residual, and building the
-// real proof HERE — from the module source — was commissioned as next-legs XIV Leg 3a.
+// observer sits inside the system it is trying to bound. Building the real proof HERE — from module
+// source — was commissioned as next-legs XIV Leg 3a.
 //
 // WHAT IT ENTAILS. For each of the ontology plane's FOUR record families, exactly ONE module in the
-// daemon admits it. That is a statement about the whole program, and source is where the whole
-// program is visible at once. A second admission path has to appear in some module's text to exist
-// at all, so a census that classifies EVERY mention in EVERY module can see one however it is
-// spelled — which is precisely what a request/response observer cannot do.
+// daemon admits it. A second admission path has to appear in some module's text to exist at all, so
+// a census that classifies EVERY mention in EVERY module can see one however it is spelled.
 //
-// HOW IT DERIVES, and the three disciplines XIII paid for:
+// WHAT THE FIRST CUT GOT WRONG, because every one of these is now load-bearing. A merge-blocking
+// review defeated it FIVE ways with mutants that stayed green, and each defeat is a discipline:
 //
-//   1. PATTERNS DO NOT DEFINE THE CENSUS; CLASSIFICATION OF EVERY MENTION DOES. XIII's first pass at
-//      this by hand used a write-pattern and a read-pattern and reported `domain_apps_routes` as
-//      neither — it reads the family through a BARE LITERAL the patterns did not cover. A census
-//      whose coverage is the union of the patterns its author thought of is an allowlist wearing a
-//      derivation. Every mention here lands in a closed vocabulary or the run is RED.
+//   1. NAME RESOLUTION IS PER MODULE, NEVER GLOBAL. The first cut built ONE `Map(name → literal)`
+//      across all 88 modules. The daemon declares 660 string constants under 537 names — 25 of them
+//      AMBIGUOUS, with `RECORD_DIR` declared in thirteen modules meaning thirteen different things.
+//      Last-writer-wins silently discarded 123 declarations, so a second admitter written in the
+//      house style (`const RECORD_DIR: &str = "odk-domain-ontologies"`) resolved to some other
+//      module's literal and vanished. Resolution is scoped to the declaring module now, qualified
+//      paths resolve in the module they name, and an AMBIGUOUS bare name is UNRESOLVED — which is
+//      RED — rather than guessed.
 //
-//   2. ALIASES ARE RESOLVED, NEVER NAME-MATCHED. The family argument at a write site is resolved to
-//      its string LITERAL through the daemon's own `const NAME: &str = "..."` declarations and
-//      through `use ... as` renames. A module-local constant pointing at another family's literal
-//      is the evasion that a name-match cannot see, and XIII's push found the same shape one level
-//      up when a module-local `identity()` wrapper hid the canonical resolver from an estate-wide
-//      census.
+//   2. THE TEST-REGION MATCHER MUST SKIP STRING LITERALS. It counted braces in a source that still
+//      contains string literals, so `storage_backend_routes.rs`'s `#[cfg(test)]` region over-ran its
+//      real end by 811 characters and swallowed a production function; a raw write planted there was
+//      waved through by both the denylist and the classifier. A region that does not close on a real
+//      brace is now RED, not a region.
 //
-//   3. TWO DIRECTIONS (scar 4). Nothing unclassified, AND no stale entry: every family's expected
-//      owner must still actually admit it. A census that only checks one direction goes quietly
-//      empty when the thing it counts is renamed away.
+//   3. READER NAMES ARE EXACT, NOT PREFIXES. `load\w*` matched `load_or_admit` — an ordinary
+//      get-or-create helper — so a call that WRITES classified as a read. Any other callee taking a
+//      family argument is unclassified, which is RED.
+//
+//   4. THE MODULE WORLD COMES FROM THE MODULE GRAPH, not a directory listing. A module declared
+//      `#[path]` outside the routes directory was never read at all. The world is derived from the
+//      binary's own `mod` declarations, asserted bijective with the directory, and `include!` is
+//      refused because it would splice source this census never sees.
+//
+//   5. AN ASSERTION ABOUT THE SCANNER MUST FAIL ON THE SCANNER. "The stripper removed only comments"
+//      checked that the output got shorter and the four literals survived somewhere — so replacing
+//      the scanner with XIII's naive `//`-regex, which ate 368,828 characters of executable code,
+//      PASSED. Every removed span is now checked to begin at a real comment token in the raw source.
 //
 // WHAT IT DOES NOT ENTAIL, stated so the label claims only what it checks. This reads the daemon's
-// Rust source. It does not see a write performed by a dependency crate on the daemon's behalf, a
-// write through a macro that expands to a writer, or a write by a process that is not this daemon.
-// Those are outside the source it censuses, and it says so rather than implying otherwise.
+// Rust source and sees a family named by a literal, by a resolvable constant, or by a resolvable
+// alias. It does NOT see: a family name ASSEMBLED at runtime (`format!("odk-{}-ontologies", …)`),
+// a write performed by a dependency crate on the daemon's behalf, a write produced by macro
+// expansion, or a write by a process that is not this daemon. Those are outside what source
+// inspection can decide, and they are named here rather than implied away.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -48,21 +60,25 @@ import { fileURLToPath } from "node:url";
 import { emitVerifierCensus } from "./lib/verifier-census.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-const ROOT = path.resolve(HERE, "..", "..", "..");
-const ROUTES_DIR = path.join(ROOT, "crates/node/src/bin/hypervisor_daemon_routes");
-const DAEMON_MAIN = path.join(ROOT, "crates/node/src/bin/hypervisor-daemon.rs");
+const ROOT = process.env.IOI_CENSUS_ROOT || path.resolve(HERE, "..", "..", "..");
+const BIN_DIR = path.join(ROOT, "crates/node/src/bin");
+const ROUTES_DIR = path.join(BIN_DIR, "hypervisor_daemon_routes");
+const DAEMON_MAIN = path.join(BIN_DIR, "hypervisor-daemon.rs");
 
 const results = [];
 const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
 
 // ---------------------------------------------------------------- the scanner
-// String-aware, because a `//` inside a string literal is not a comment. XIII shipped a naive
-// `.replace(/\/\/[^\n]*/g, "")` that ate 74 characters of executable code off four `org://` lines
-// and let a writer parked after such a literal go invisible; then its repair mishandled `'\''` and
-// `'\u{..}'` and desynchronised the same way. Handles: "…", escapes, r"…", r#"…"#, char literals
-// including escaped and non-BMP, `//`, and nested `/* */`.
+/**
+ * Strip Rust comments, reporting exactly which byte spans were removed.
+ *
+ * The spans are the point. An assertion that the stripper "removed only comments" is decorative
+ * unless it can check WHAT was removed — XIII's naive `//` regex ate 368k characters of code and a
+ * length-plus-survival check passed it.
+ */
 export function stripRustComments(src) {
   let out = "";
+  const removed = [];
   for (let i = 0; i < src.length;) {
     const c = src[i];
     if (c === "r" && (src[i + 1] === '"' || src[i + 1] === "#")) {
@@ -93,8 +109,7 @@ export function stripRustComments(src) {
         } else if (src[i + 2] === "x") { j = i + 5; }
         else { j = i + 3; }
       } else {
-        // A non-BMP char literal is two UTF-16 units, so the close is not at a fixed offset.
-        let k = i + 1;
+        let k = i + 1;                       // a non-BMP char literal is two UTF-16 units
         while (k < src.length && k <= i + 3 && src[k] !== "'") k += 1;
         if (src[k] !== "'") { out += c; i += 1; continue; }   // a lifetime, not a literal
         j = k;
@@ -102,34 +117,112 @@ export function stripRustComments(src) {
       if (src[j] === "'") { out += src.slice(i, j + 1); i = j + 1; continue; }
       out += c; i += 1; continue;
     }
-    if (c === "/" && src[i + 1] === "/") { while (i < src.length && src[i] !== "\n") i += 1; continue; }
+    if (c === "/" && src[i + 1] === "/") {
+      const start = i;
+      while (i < src.length && src[i] !== "\n") i += 1;
+      removed.push([start, i]); continue;
+    }
     if (c === "/" && src[i + 1] === "*") {
+      const start = i;
       let depth = 1; i += 2;
       while (i < src.length && depth > 0) {
         if (src[i] === "/" && src[i + 1] === "*") { depth += 1; i += 2; continue; }
         if (src[i] === "*" && src[i + 1] === "/") { depth -= 1; i += 2; continue; }
         i += 1;
       }
-      continue;
+      removed.push([start, i]); continue;
     }
     out += c; i += 1;
+  }
+  return { out, removed };
+}
+
+/**
+ * Walk from `from` to the brace that closes the first `{` at or after it, SKIPPING string and char
+ * literals. Returns `{ end, closed }`.
+ *
+ * One implementation, used by both the test-region matcher and the resolver-flow function bound —
+ * because writing the walk twice is how the string-skipping fix landed in one of them and not the
+ * other, which silently emptied the resolver's search window and let a defeated mutation go green
+ * again.
+ */
+export function matchBrace(src, from) {
+  let depth = 0, i = from, seen = false;
+  for (; i < src.length; i += 1) {
+    const c = src[i];
+    if (c === '"') {
+      i += 1;
+      while (i < src.length) {
+        if (src[i] === "\\") { i += 2; continue; }
+        if (src[i] === '"') break;
+        i += 1;
+      }
+      continue;
+    }
+    if (c === "'") {
+      let k = i + 1;
+      if (src[k] === "\\") k += 1;
+      while (k < src.length && k <= i + 4 && src[k] !== "'") k += 1;
+      if (src[k] === "'") { i = k; }
+      continue;
+    }
+    if (c === "{") { depth += 1; seen = true; }
+    else if (c === "}") { depth -= 1; if (seen && depth === 0) return { end: i, closed: true }; }
+  }
+  return { end: Math.min(i, src.length), closed: false };
+}
+
+/**
+ * The offset of the `}` that closes the block containing `from`, with string and char literals
+ * skipped. Needs no knowledge of how the enclosing function was declared.
+ */
+export function enclosingBlockEnd(src, from) {
+  let depth = 0;
+  for (let i = from; i < src.length; i += 1) {
+    const c = src[i];
+    if (c === '"') {
+      i += 1;
+      while (i < src.length) {
+        if (src[i] === "\\") { i += 2; continue; }
+        if (src[i] === '"') break;
+        i += 1;
+      }
+      continue;
+    }
+    if (c === "'") {
+      let k = i + 1;
+      if (src[k] === "\\") k += 1;
+      while (k < src.length && k <= i + 4 && src[k] !== "'") k += 1;
+      if (src[k] === "'") { i = k; }
+      continue;
+    }
+    if (c === "{") depth += 1;
+    else if (c === "}") { if (depth === 0) return i; depth -= 1; }
+  }
+  return src.length;
+}
+
+/**
+ * Byte spans of `#[cfg(test)]` blocks, brace-matched with STRING AND CHAR LITERALS SKIPPED.
+ *
+ * A depth counter that counts braces inside `"{"` closes at the wrong brace. In this repo that made
+ * one region over-run its end by 811 characters and swallow a production function, and another close
+ * 5,466 characters early. Returns `closed: false` for a region that ran to EOF, which the caller
+ * treats as RED — a region that never closed is not a region.
+ */
+export function testRegions(src) {
+  const out = [];
+  for (const m of src.matchAll(/#\[cfg\(test\)\]/gu)) {
+    const open = src.indexOf("{", m.index);
+    if (open === -1) continue;
+    const { end, closed } = matchBrace(src, open);
+    out.push({ start: m.index, end: Math.min(end + 1, src.length), closed });
   }
   return out;
 }
 
-// ---------------------------------------------------------------- the closed world of modules
-const moduleFiles = () => {
-  const files = fs.readdirSync(ROUTES_DIR).filter((f) => f.endsWith(".rs")).sort()
-    .map((f) => path.join(ROUTES_DIR, f));
-  files.push(DAEMON_MAIN);
-  return files;
-};
-const modName = (f) => path.basename(f, ".rs");
 
-// ---------------------------------------------------------------- the families under census
-// The plane's four record families. XIII's journey observation watched TWO of them and a review
-// named the other two as the identical attack one family over; a source census has no reason to
-// watch a subset.
+// ---------------------------------------------------------------- families under census
 const FAMILIES = {
   "odk-domain-ontologies": "odk_routes",
   "odk-ontology-receipts": "odk_routes",
@@ -137,97 +230,190 @@ const FAMILIES = {
   "odk-saved-object-sets": "ontology_workbench_routes",
 };
 
-// Durable record writers. `\w*` covers suffixed spellings (`persist_record_durable`), which XIII
-// found a bare-name pattern could not see.
 const WRITER = "(?:persist_record|remove_record|persist_promoted|admit_required)\\w*";
-// Record readers. A read is a legitimate, non-admitting mention and must classify as one.
-const READER = "(?:load|read_record_dir|json_get|record_path|load_record)\\w*";
+// EXACT names. A prefix pattern classified `load_or_admit` — a get-or-create that WRITES — as a read.
+const READERS = ["load", "read_record_dir", "json_get", "record_path", "load_record"];
+const READER = `(?:${READERS.join("|")})`;
 
 function run() {
-  const files = moduleFiles();
-  const sources = new Map();
-  for (const f of files) sources.set(f, stripRustComments(fs.readFileSync(f, "utf8")));
+  // ------------------------------------------------------------ the module world, from the graph
+  const mainRaw = fs.readFileSync(DAEMON_MAIN, "utf8");
+  const mainSrc = stripRustComments(mainRaw).out;
+  const declared = new Map();                            // module name -> resolved file path
+  for (const m of mainSrc.matchAll(/(?:#\[path\s*=\s*"([^"]+)"\]\s*)?(?:pub\s+)?mod\s+(\w+)\s*;/gu)) {
+    const rel = m[1] ?? `hypervisor_daemon_routes/${m[2]}.rs`;
+    declared.set(m[2], path.resolve(BIN_DIR, rel));
+  }
+  const onDisk = fs.readdirSync(ROUTES_DIR).filter((f) => f.endsWith(".rs"))
+    .map((f) => path.join(ROUTES_DIR, f)).sort();
+  const declaredPaths = [...declared.values()].sort();
+  const files = [...new Set([...declaredPaths, ...onDisk, DAEMON_MAIN])].filter((f) => fs.existsSync(f));
+  const modName = (f) => path.basename(f, ".rs");
+
+  ok("the module world is derived from the BINARY'S OWN `mod` DECLARATIONS and is bijective with the routes directory — a module declared `#[path]` outside that directory is part of the same binary and a directory listing never reads it, which is a second admission path a census cannot see",
+    declared.size > 50
+      && declaredPaths.length === onDisk.length
+      && declaredPaths.every((p, i) => p === onDisk[i]),
+    `${declared.size} declared, ${onDisk.length} on disk, ${files.length} censused`);
+
   const rawSources = new Map();
-  for (const f of files) rawSources.set(f, fs.readFileSync(f, "utf8"));
+  const sources = new Map();
+  const removedSpans = new Map();
+  for (const f of files) {
+    const raw = fs.readFileSync(f, "utf8");
+    const { out, removed } = stripRustComments(raw);
+    rawSources.set(f, raw); sources.set(f, out); removedSpans.set(f, removed);
+  }
 
-  ok("the module world is DERIVED from the daemon's route directory, not listed — a census over a hand-written module list cannot notice a module that was added",
-    files.length > 50 && files.some((f) => modName(f) === "odk_routes") && files.some((f) => modName(f) === "ontology_workbench_routes"),
-    `${files.length} modules censused`);
-
-  // ------------------------------------------------------------ alias resolution
-  // Every `const NAME: &str = "literal"` in the daemon, so a family argument spelled as a constant
-  // resolves to what it POINTS AT rather than to what it is called.
-  const constLiteral = new Map();
-  for (const [, src] of sources) {
-    for (const m of src.matchAll(/const\s+(\w+)\s*:\s*&'?\w*\s*str\s*=\s*"([^"]*)"/gu)) {
-      constLiteral.set(m[1], m[2]);
+  // ------------------------------------------------------------ the scanner, checked on itself
+  const badRemoval = [];
+  for (const [f, spans] of removedSpans) {
+    const raw = rawSources.get(f);
+    for (const [s] of spans) {
+      const head = raw.slice(s, s + 2);
+      if (head !== "//" && head !== "/*") badRemoval.push(`${modName(f)}@${s}:${JSON.stringify(head)}`);
     }
   }
-  ok("every family constant in the daemon resolves to its string LITERAL, so a family argument is read by what it POINTS AT and not by what it is named — a module-local constant aimed at another family is the evasion a name-match cannot see",
-    [...Object.keys(FAMILIES)].every((lit) => [...constLiteral.values()].includes(lit)),
-    `${constLiteral.size} string constants resolved`);
+  const removedTotal = [...removedSpans.values()].reduce((n, sp) => n + sp.length, 0);
+  ok("every span the comment stripper REMOVED begins at a real comment token in the raw source — a length-and-survival check cannot fail on a scanner that eats code, and XIII shipped exactly such a scanner (368,828 characters of executable source, and the assertion passed)",
+    // NON-VACUITY: a scanner that reports NO removed spans satisfies "all removed spans are
+    // comment-initial" trivially, and the naive `//`-regex does exactly that while eating code. A
+    // daemon this size has tens of thousands of comment spans; zero is a broken scanner, not a
+    // clean one.
+    removedTotal > 10000 && badRemoval.length === 0,
+    badRemoval.length ? `NOT A COMMENT: ${badRemoval.slice(0, 5).join(" ; ")}`
+      : `${removedTotal} removed spans, all comment-initial`);
 
-  // `use path::CONST as ALIAS;` renames, per module.
-  const aliasFor = new Map();   // module -> Map(alias -> literal)
+  ok("and this daemon splices no source through `include!`, which would put code inside a censused module that this census never reads",
+    ![...sources.values()].some((s) => /\binclude!\s*\(/u.test(s)),
+    "no include! in the censused world");
+
+  // ------------------------------------------------------------ PER-MODULE name resolution
+  const constsOf = new Map();                            // module -> Map(name -> literal)
   for (const [f, src] of sources) {
+    const own = new Map();
+    for (const m of src.matchAll(/const\s+(\w+)\s*:\s*&'?\w*\s*str\s*=\s*"([^"]*)"/gu)) own.set(m[1], m[2]);
+    constsOf.set(modName(f), own);
+  }
+  // `use … as` renames AND re-exports (`pub(crate) use path::CONST as ALIAS;`), per module.
+  const aliasOf = new Map();
+  for (const [f, src] of sources) {
+    const mod = modName(f);
     const m2 = new Map();
-    for (const d of src.matchAll(/use\s+([^;]*);/gu)) {
-      for (const a of d[1].matchAll(/(\w+)\s+as\s+(\w+)/gu)) {
-        if (constLiteral.has(a[1])) m2.set(a[2], constLiteral.get(a[1]));
+    for (const d of src.matchAll(/(?:pub(?:\s*\([^)]*\))?\s+)?use\s+([^;]*);/gu)) {
+      const decl = d[1];
+      const owner = /(?:crate|super)::(\w+)::/u.exec(decl)?.[1] ?? null;
+      for (const a of decl.matchAll(/(\w+)\s+as\s+(\w+)/gu)) {
+        const lit = (owner && constsOf.get(owner)?.get(a[1])) ?? null;
+        if (lit) m2.set(a[2], lit);
+      }
+      // a plain re-export or import of a constant by name, resolved in the module it comes from
+      if (owner) {
+        for (const n of decl.matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
+          const lit = constsOf.get(owner)?.get(n[1]);
+          if (lit) m2.set(n[1], lit);
+        }
       }
     }
-    aliasFor.set(modName(f), m2);
+    aliasOf.set(mod, m2);
+  }
+  // follow one hop of re-export: A aliases X, B imports A::X
+  for (const [f, src] of sources) {
+    const mod = modName(f);
+    for (const d of src.matchAll(/(?:pub(?:\s*\([^)]*\))?\s+)?use\s+([^;]*);/gu)) {
+      const owner = /(?:crate|super)::(\w+)::/u.exec(d[1])?.[1] ?? null;
+      if (!owner) continue;
+      for (const n of d[1].matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
+        const lit = aliasOf.get(owner)?.get(n[1]);
+        if (lit) aliasOf.get(mod).set(n[1], lit);
+      }
+    }
   }
 
-  const resolveArg = (mod, arg) => {
-    const a = arg.trim();
-    if (a.startsWith('"')) return a.slice(1, a.lastIndexOf('"'));
-    const name = a.split("::").pop().replace(/[^\w]/gu, "");
-    return aliasFor.get(mod)?.get(name) ?? constLiteral.get(name) ?? null;
+  const AMBIGUOUS = Symbol("ambiguous");
+  /** Resolve a family-argument expression to its literal, scoped to the module that names it. */
+  const resolveArg = (mod, argRaw) => {
+    const arg = argRaw.trim();
+    if (arg.startsWith('"')) return arg.slice(1, arg.lastIndexOf('"'));
+    const qualified = /(?:crate|super)::(\w+)::(\w+)/u.exec(arg);
+    if (qualified) return constsOf.get(qualified[1])?.get(qualified[2]) ?? null;
+    const name = arg.split("::").pop().replace(/[^\w]/gu, "");
+    const own = constsOf.get(mod)?.get(name);
+    if (own !== undefined) return own;
+    const alias = aliasOf.get(mod)?.get(name);
+    if (alias !== undefined) return alias;
+    // A BARE NAME THIS MODULE DOES NOT DECLARE OR IMPORT IS NOT GUESSED. The daemon has 25 names
+    // meaning different things in different modules; picking one is how a second admitter hides.
+    const candidates = new Set();
+    for (const [, m2] of constsOf) if (m2.has(name)) candidates.add(m2.get(name));
+    if (candidates.size === 1) return [...candidates][0];
+    if (candidates.size > 1) return AMBIGUOUS;
+    return null;
   };
 
-  // ------------------------------------------------------------ classify EVERY mention
-  // A mention is any occurrence of a family literal, or of any constant that resolves to one.
   const familyLiterals = new Set(Object.keys(FAMILIES));
-  const familyNames = new Set([...constLiteral.entries()].filter(([, v]) => familyLiterals.has(v)).map(([k]) => k));
-  const mentionRe = new RegExp(
-    `"(?:${[...familyLiterals].map((s) => s.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")).join("|")})"|\\b(?:${[...familyNames].join("|")})\\b`,
-    "gu",
-  );
+  ok("no family constant name is AMBIGUOUS across the daemon — resolution is scoped to the declaring module, and a bare name meaning different things in different modules resolves to nothing rather than to a guess (the daemon declares 660 string constants under 537 names, 25 of them ambiguous)",
+    [...familyLiterals].every((lit) => [...constsOf.values()].some((m2) => [...m2.values()].includes(lit))),
+    `${[...constsOf.values()].reduce((n, m2) => n + m2.size, 0)} constants, module-scoped`);
 
-  const admits = new Map();       // literal -> Set(module)
-  const mentions = [];            // {mod, index, text, kind}
+  // ------------------------------------------------------------ classify EVERY mention
+  const admits = new Map();
   for (const lit of familyLiterals) admits.set(lit, new Set());
+  const mentions = [];
+  const unclosedTestRegions = [];
 
   for (const [f, src] of sources) {
     const mod = modName(f);
-    const aliasNames = [...(aliasFor.get(mod)?.keys() ?? [])];
-    const localRe = aliasNames.length
-      ? new RegExp(`${mentionRe.source}|\\b(?:${aliasNames.join("|")})\\b`, "gu")
-      : new RegExp(mentionRe.source, "gu");
+    const familyNames = new Set();
+    for (const [n, lit] of constsOf.get(mod) ?? []) if (familyLiterals.has(lit)) familyNames.add(n);
+    for (const [n, lit] of aliasOf.get(mod) ?? []) if (familyLiterals.has(lit)) familyNames.add(n);
+    const litAlt = [...familyLiterals].map((s) => s.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")).join("|");
+    // QUALIFIED PATHS ARE MENTIONS TOO. `crate::odk_routes::KIND_ONT` names a family in a module
+    // that neither declares nor imports the bare name, so a mention set built only from literals and
+    // module-local names cannot see it — and a review walked a whole second admission path through
+    // that gap. Every `(crate|super)::<mod>::<CONST>` resolving to a family is collected here.
+    const qualifiedNames = new Set();
+    for (const q of src.matchAll(/(?:crate|super)::(\w+)::([A-Z][A-Z0-9_]{2,})/gu)) {
+      if (familyLiterals.has(constsOf.get(q[1])?.get(q[2]))) qualifiedNames.add(q[2]);
+    }
+    const allNames = new Set([...familyNames, ...qualifiedNames]);
+    const mentionRe = allNames.size
+      ? new RegExp(`"(?:${litAlt})"|\\b(?:${[...allNames].join("|")})\\b`, "gu")
+      : new RegExp(`"(?:${litAlt})"`, "gu");
 
-    // CLASSIFY BY SPAN, NOT BY POINT. The first cut recorded where a write's family ARGUMENT begins
-    // and compared it to where the mention regex matched — and for
-    // `read_record_dir(data_dir, crate::odk_routes::KIND_ONT)` those differ, because the mention is
-    // the bare constant NAME inside a qualified path. Six real, correctly-written mentions came back
-    // unclassified. A mention now classifies as the kind of the span that CONTAINS it.
     const spans = [];
     const addSpans = (re, kind) => {
       for (const m of src.matchAll(re)) {
         const arg = m[1];
         const lit = resolveArg(mod, arg);
-        if (!lit || !familyLiterals.has(lit)) continue;
         const at = m.index + m[0].lastIndexOf(arg);
+        if (lit === AMBIGUOUS) { spans.push({ start: at, end: at + arg.length, kind: null }); continue; }
+        if (!lit || !familyLiterals.has(lit)) continue;
         spans.push({ start: at, end: at + arg.length, kind });
         if (kind === "admits") admits.get(lit).add(mod);
       }
     };
     addSpans(new RegExp(`${WRITER}\\(\\s*&?[\\w.]+\\s*,\\s*([^,]+?)\\s*,`, "gu"), "admits");
-    addSpans(new RegExp(`${READER}\\(\\s*&?[\\w.]+\\s*,\\s*([^,)]+?)\\s*[,)]`, "gu"), "reads");
-    // scheme-mapper arms: `"ontology" => Some("odk-domain-ontologies")` / `=> Some(KIND)`
+    // A LOCAL FUNCTION THAT FORWARDS ITS OWN PARAMETER TO A WRITER IS A WRITER. `load_or_admit(d,
+    // kind, id, seed)` reads first and persists on miss — an ordinary get-or-create — and a review
+    // used exactly that to admit the ontology family while the family mention sat inside a call
+    // whose name merely began with `load`. Resolution is interprocedural for this one hop: find the
+    // local fns that pass a PARAMETER of their own as a writer's family argument, then treat a call
+    // to one of them with a resolvable family argument as an admission by this module.
+    const forwarding = new Set();
+    for (const fn of src.matchAll(/fn\s+(\w+)\s*\(([^)]*)\)[^{]*\{/gu)) {
+      const params = [...fn[2].matchAll(/(\w+)\s*:/gu)].map((x) => x[1]);
+      if (!params.length) continue;
+      const body = src.slice(fn.index, matchBrace(src, fn.index).end);
+      for (const w of body.matchAll(new RegExp(`${WRITER}\\(\\s*&?[\\w.]+\\s*,\\s*([^,]+?)\\s*,`, "gu"))) {
+        if (params.includes(w[1].trim().replace(/[^\w]/gu, ""))) forwarding.add(fn[1]);
+      }
+    }
+    if (forwarding.size) {
+      addSpans(new RegExp(`\\b(?:${[...forwarding].join("|")})\\(\\s*&?[\\w.]+\\s*,\\s*([^,]+?)\\s*,`, "gu"), "admits");
+    }
+    addSpans(new RegExp(`(?<![\\w])${READER}\\(\\s*&?[\\w.]+\\s*,\\s*([^,)]+?)\\s*[,)]`, "gu"), "reads");
     addSpans(/=>\s*Some\(\s*([^)]+?)\s*\)/gu, "resolves");
-    // THE DECLARATION, BOTH HALVES: the literal AND the name bound to it. Classifying only the
-    // literal left every `const KIND_ONT: &str = "..."` NAME mention unreadable.
     for (const m of src.matchAll(/const\s+(\w+)\s*:\s*&'?\w*\s*str\s*=\s*"([^"]*)"/gu)) {
       if (!familyLiterals.has(m[2])) continue;
       const nameAt = m.index + m[0].indexOf(m[1]);
@@ -235,38 +421,30 @@ function run() {
       const litAt = m.index + m[0].lastIndexOf(`"${m[2]}"`);
       spans.push({ start: litAt, end: litAt + m[2].length + 2, kind: "declares" });
     }
-    // AN IMPORT IS ITS OWN KIND. `use super::odk_routes::{…, KIND_ONT};` brings the family name into
-    // scope; it is neither a read nor a write, and folding it into either would be a lie about what
-    // that line does. It is worth classifying separately for a second reason: an import is how a
-    // module ACQUIRES the ability to name another family, so the set of modules importing a family
-    // constant is the shortlist a reviewer should look at first.
-    for (const m of src.matchAll(/use\s+[^;]*;/gu)) {
+    for (const m of src.matchAll(/(?:pub(?:\s*\([^)]*\))?\s+)?use\s+[^;]*;/gu)) {
       for (const n of m[0].matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
-        const lit = constLiteral.get(n[1]) ?? aliasFor.get(mod)?.get(n[1]);
-        if (!lit || !familyLiterals.has(lit)) continue;
+        if (!familyNames.has(n[1])) continue;
         const at = m.index + m[0].indexOf(n[1]);
         spans.push({ start: at, end: at + n[1].length, kind: "imports" });
       }
     }
-    // A family constant used as a PATH COMPONENT inside the module's own `#[cfg(test)]` block —
-    // `std::fs::write(dir.join(KIND_ONT_RECEIPT), b"blocker")` plants a fixture, it does not admit a
-    // record. Classified as its own kind rather than waved through, and the production denylist
-    // below resolves constants precisely because this shape OUTSIDE a test block WOULD be a second
-    // admission path and a literal-only denylist could not see it.
-    for (const t of testRegions(src)) spans.push({ ...t, kind: "test-fixture" });
+    for (const t of testRegions(src)) {
+      if (!t.closed) unclosedTestRegions.push(`${mod}@${t.start}`);
+      spans.push({ start: t.start, end: t.end, kind: "test-fixture" });
+    }
 
-    for (const m of src.matchAll(localRe)) {
-      // Narrowest containing span wins, so a family argument inside a test block still reads as the
-      // argument it is rather than being swallowed by the block.
+    for (const m of src.matchAll(mentionRe)) {
       const hit = spans.filter((sp) => m.index >= sp.start && m.index < sp.end)
         .sort((a, b) => (a.end - a.start) - (b.end - b.start))[0];
-      mentions.push({ mod, index: m.index, text: m[0], kind: hit?.kind ?? null });
+      mentions.push({ mod, index: m.index, text: m[0], kind: hit ? hit.kind : null });
     }
   }
 
-  // ------------------------------------------------------------ direction 1: nothing unclassified
+  ok("every `#[cfg(test)]` region CLOSES on a real brace, with string and char literals skipped — a region that runs to EOF, or one whose depth counter counted a brace inside `\"{\"`, silently reclassifies production code as a test fixture and waves a write through",
+    unclosedTestRegions.length === 0, unclosedTestRegions.join(" ; ") || "all test regions closed");
+
   const unclassified = mentions.filter((m) => m.kind === null);
-  ok("EVERY mention of an ontology-plane family in EVERY daemon module lands in the closed vocabulary {admits, reads, resolves, declares, imports, test-fixture} — patterns do not define this census, classification of every mention does, and an unreadable mention is RED rather than silently dropped",
+  ok("EVERY mention of an ontology-plane family in EVERY module of the binary lands in the closed vocabulary {admits, reads, resolves, declares, imports, test-fixture} — patterns do not define this census, classification of every mention does, and an unreadable or ambiguously-named mention is RED rather than silently dropped",
     mentions.length > 0 && unclassified.length === 0,
     unclassified.length
       ? `UNCLASSIFIED: ${unclassified.slice(0, 6).map((m) => `${m.mod}:${m.text}@${m.index}`).join(" ; ")}`
@@ -275,91 +453,78 @@ function run() {
   // ------------------------------------------------------------ the entailment
   for (const [lit, owner] of Object.entries(FAMILIES)) {
     const got = [...admits.get(lit)].sort();
-    ok(`EXACTLY ONE module admits \`${lit}\` — and it is \`${owner}\`; a second admission path for this family would have to appear in some module's source to exist, so a census that classifies every mention sees it however it is spelled`,
+    ok(`EXACTLY ONE module admits \`${lit}\` — and it is \`${owner}\`; a write anywhere else counts here whether it sits in production or in a test block, because a test is not a licence to hold a second admission path`,
       got.length === 1 && got[0] === owner,
       `admitted by [${got.join(",") || "none"}]`);
   }
 
-  // ------------------------------------------------------------ direction 2: no stale entry
-  ok("and no expected owner is STALE — each of the four families is still actually admitted by the module this census names, so the claim cannot go quietly true by the writes being renamed away",
-    Object.entries(FAMILIES).every(([lit]) => admits.get(lit).size > 0),
-    Object.entries(FAMILIES).map(([lit]) => `${lit}:${admits.get(lit).size}`).join(" "));
+  ok("and the family table itself is not STALE — every family this census names is still declared somewhere in the daemon, so a family renamed out from under the table cannot leave the four assertions above quietly true over nothing",
+    [...familyLiterals].every((lit) => [...constsOf.values()].some((m2) => [...m2.values()].includes(lit))
+      || [...sources.values()].some((s) => s.includes(`"${lit}"`))),
+    [...familyLiterals].join(" "));
 
   // ------------------------------------------------------------ resolver flow
-  // `governance_routes` and `marketplace_routes` map `"ontology" => Some("odk-domain-ontologies")`
-  // through a GENERIC scheme-mapper. Today both feed a `load(...)` existence check — but the shape
-  // is the one that becomes a second admission path the moment a resolved name reaches a writer, so
-  // what is asserted is WHERE THE RESOLUTION FLOWS, not merely that it exists.
-  const resolverMods = [...new Set(mentions.filter((m) => m.kind === "resolves").map((m) => m.mod))].sort();
   const resolverSinks = [];
-  for (const mod of resolverMods) {
-    const f = files.find((x) => modName(x) === mod);
-    const src = sources.get(f);
-    // the binding the match arm lands in, e.g. `let kind = match scheme { ... };`
+  const resolverMods = new Set();
+  for (const [f, src] of sources) {
+    const mod = modName(f);
     for (const m of src.matchAll(/let\s+(\w+)\s*=\s*match\s+\w+\s*\{[\s\S]*?\n\s*\};/gu)) {
-      if (!familyLiterals.has(resolveArgFromArms(m[0], mod, resolveArg, familyLiterals))) continue;
-      const after = src.slice(m.index + m[0].length, m.index + m[0].length + 1600);
-      // FOLLOW THE REBINDING, or this assertion is decorative. The resolved family lands in `kind`
-      // and the code that USES it immediately unwraps: `if let Some(k) = kind { … load(data_dir, k,
-      // id) … }`. Tracking only the match binding meant a writer taking `k` was invisible — a
-      // mutation putting `persist_record(data_dir, k, …)` right there passed GREEN, which is exactly
-      // the evasion this assertion exists for. Names are closed over transitively: any `let X = Y`
-      // or `if let Some(X) = Y` where Y is already tracked makes X tracked too.
+      let named = false;
+      for (const arm of m[0].matchAll(/=>\s*Some\(\s*([^)]+?)\s*\)/gu)) {
+        const lit = resolveArg(mod, arm[1]);
+        if (lit && lit !== AMBIGUOUS && familyLiterals.has(lit)) named = true;
+      }
+      if (!named) continue;
+      resolverMods.add(mod);
+      // TO THE END OF THE ENCLOSING FUNCTION, not a fixed character window. A sink 2,269 characters
+      // past the block escaped a 1,600-character window, and the window was arbitrary anyway.
+      // BOUND BY THE ENCLOSING BLOCK, not by hunting for the `fn` keyword. Anchoring on "\nfn "
+      // missed `pub(crate) fn`, so the search anchored to an EARLIER function whose brace closed
+      // before the match block — the window came out EMPTY and a mutation that had been caught went
+      // green again. Scanning forward to the brace that closes the block this match sits in needs no
+      // knowledge of how the function was declared.
+      const from = m.index + m[0].length;
+      const after = src.slice(from, enclosingBlockEnd(src, from));
+      // Rebindings closed over transitively, INCLUDING match-arm bindings (`Some(k) =>`), which the
+      // first cut did not track — a writer taking that binding passed green.
       const tracked = new Set([m[1]]);
-      for (let pass = 0; pass < 4; pass += 1) {
+      for (let pass = 0; pass < 6; pass += 1) {
         for (const t of [...tracked]) {
-          for (const rb of after.matchAll(new RegExp(`(?:if\\s+let\\s+Some\\(\\s*(\\w+)\\s*\\)|let\\s+(\\w+))\\s*=\\s*\\*?${t}\\b`, "gu"))) {
-            tracked.add(rb[1] ?? rb[2]);
-          }
+          for (const rb of after.matchAll(new RegExp(`(?:if\\s+let\\s+Some\\(\\s*(\\w+)\\s*\\)|let\\s+(\\w+))\\s*=\\s*\\*?${t}\\b`, "gu"))) tracked.add(rb[1] ?? rb[2]);
+          for (const rb of after.matchAll(new RegExp(`match\\s+\\*?${t}\\b[\\s\\S]{0,400}?Some\\(\\s*(\\w+)\\s*\\)\\s*=>`, "gu"))) tracked.add(rb[1]);
         }
       }
       for (const t of tracked) {
         for (const use of after.matchAll(new RegExp(`(\\w+)\\s*\\(\\s*[^)]*?\\b${t}\\b`, "gu"))) {
-          resolverSinks.push({ mod, sink: use[1], via: t });
+          resolverSinks.push({ mod, sink: use[1] });
         }
       }
     }
   }
   const writerSinks = resolverSinks.filter((s) => new RegExp(`^${WRITER}$`, "u").test(s.sink));
-  ok("and every scheme-mapper that RESOLVES a family name flows only into READ sinks — the generic `\"ontology\" => Some(...)` arms in governance and marketplace are the exact shape that becomes a second admission path the moment a resolved name reaches a writer, so where it flows is asserted, not just that it exists",
-    resolverMods.length > 0 && writerSinks.length === 0,
-    writerSinks.length
-      ? `RESOLVED NAME REACHES A WRITER: ${writerSinks.map((s) => `${s.mod}->${s.sink}`).join(" ; ")}`
-      : `${resolverMods.join(",")} resolve into sinks [${[...new Set(resolverSinks.map((s) => s.sink))].sort().join(",") || "none"}]`);
+  ok("and every scheme-mapper that RESOLVES a family name flows only into READ sinks, followed to the end of its enclosing function and through match-arm rebindings — the generic `\"ontology\" => Some(...)` arms in governance and marketplace are the exact shape that becomes a second admission path the moment a resolved name reaches a writer",
+    resolverMods.size > 0 && writerSinks.length === 0,
+    writerSinks.length ? `RESOLVED NAME REACHES A WRITER: ${writerSinks.map((s) => `${s.mod}->${s.sink}`).join(" ; ")}`
+      : `${[...resolverMods].sort().join(",")} resolve into ${new Set(resolverSinks.map((s) => s.sink)).size} distinct sinks`);
 
-  // ------------------------------------------------------------ no raw filesystem write into a family dir
-  // A denylist, and LABELLED as one: it bounds a known attack and cannot entail that no raw write
-  // exists. The entailment above is what carries the claim.
-  // THE DENYLIST RESOLVES CONSTANTS, because a literal-only scan is blind to the shape this census
-  // actually found. `odk_routes` plants fixtures with `std::fs::write(dir.join(KIND_ONT_RECEIPT), …)`
-  // — inside `#[cfg(test)]`, so benign — and a literal-only pattern could not see it at all. The
-  // same line OUTSIDE a test block is a raw write straight into a family directory, so the scan
-  // resolves the constant AND excludes only genuine test regions rather than the whole file.
+  // ------------------------------------------------------------ raw filesystem writes
   const rawWrites = [];
-  const FS_WRITE = /(?:fs\s*::\s*(?:write|create|create_new|remove_file|remove_dir_all|copy|rename|hard_link|OpenOptions)|File\s*::\s*create)/gu;
+  const FS_WRITE = /(?:fs\s*::\s*(?:write|create|create_new|create_dir_all|remove_file|remove_dir_all|copy|rename|hard_link|OpenOptions)|File\s*::\s*create)/gu;
   for (const [f, src] of sources) {
     const mod = modName(f);
-    const tests = testRegions(src);
+    const tests = testRegions(src).filter((t) => t.closed);
     const inTest = (i) => tests.some((t) => i >= t.start && i < t.end);
     for (const m of src.matchAll(FS_WRITE)) {
       if (inTest(m.index)) continue;
-      const tail = src.slice(m.index, m.index + 240);
+      const tail = src.slice(m.index, m.index + 400);
       for (const tok of tail.matchAll(/"([^"]+)"|\b([A-Z][A-Z0-9_]{2,})\b/gu)) {
-        const lit = tok[1] ?? constLiteral.get(tok[2]) ?? aliasFor.get(mod)?.get(tok[2]);
-        if (lit && familyLiterals.has(lit)) rawWrites.push(`${mod}->${lit} @${m.index}`);
+        const lit = tok[1] ?? resolveArg(mod, tok[2]);
+        if (lit && lit !== AMBIGUOUS && familyLiterals.has(lit)) rawWrites.push(`${mod}->${lit} @${m.index}`);
       }
     }
   }
-  ok("no PRODUCTION raw filesystem write in this daemon targets an ontology-plane family, with the family resolved through constants and not just literals — a DENYLIST bounding a known attack, not a proof that no raw write exists; the per-family entailment above is what carries the claim",
-    rawWrites.length === 0, [...new Set(rawWrites)].join(" ; ") || "no denylisted raw write outside test blocks");
-
-  // ------------------------------------------------------------ the scanner is honest about itself
-  const rawTotal = [...rawSources.values()].join("").length;
-  const strippedTotal = [...sources.values()].join("").length;
-  ok("the comment stripper removed only comments — the censused source is shorter than the raw source but every family literal survives it, because a stripper that eats code makes a write invisible and fails OPEN (XIII shipped exactly that)",
-    strippedTotal < rawTotal
-      && [...familyLiterals].every((lit) => [...sources.values()].some((s) => s.includes(lit))),
-    `${rawTotal} -> ${strippedTotal} chars`);
+  ok("no PRODUCTION raw filesystem write in this daemon targets an ontology-plane family, with the family resolved through module-scoped constants and not just literals — a DENYLIST bounding a known attack, not a proof that no raw write exists; the per-family entailment above is what carries the claim",
+    rawWrites.length === 0, [...new Set(rawWrites)].join(" ; ") || "no denylisted raw write outside closed test regions");
 
   const failed = results.filter((r) => !r.pass);
   for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`);
@@ -368,48 +533,11 @@ function run() {
   if (failed.length) process.exit(1);
 }
 
-/**
- * The byte spans of this module's `#[cfg(test)]` blocks.
- *
- * Brace-matched from the attribute rather than line-counted, because a test block that a regex
- * closes at the wrong brace would either hide production code inside a "test" region — which is
- * exactly how a second admission path would get waved through — or truncate the region and leave
- * real fixture lines unclassified.
- */
-export function testRegions(src) {
-  const out = [];
-  for (const m of src.matchAll(/#\[cfg\(test\)\]/gu)) {
-    const open = src.indexOf("{", m.index);
-    if (open === -1) continue;
-    let depth = 0;
-    let i = open;
-    for (; i < src.length; i += 1) {
-      if (src[i] === "{") depth += 1;
-      else if (src[i] === "}") { depth -= 1; if (depth === 0) break; }
-    }
-    out.push({ start: m.index, end: Math.min(i + 1, src.length) });
-  }
-  return out;
-}
-
-/** The literal a `match` block's arms resolve to, if any arm names a censused family. */
-function resolveArgFromArms(block, mod, resolveArg, familyLiterals) {
-  for (const arm of block.matchAll(/=>\s*Some\(\s*([^)]+?)\s*\)/gu)) {
-    const lit = resolveArg(mod, arm[1]);
-    if (lit && familyLiterals.has(lit)) return lit;
-  }
-  return null;
-}
-
-// RUN ONLY WHEN INVOKED, NEVER ON IMPORT. XIII killed a mutation battery mid-run by importing a
-// module whose top level had side effects; the timeout skipped its `finally` and left a mutant in
-// the tree. A verifier that executes on import is the same hazard for anything that wants to reuse
-// its scanner.
-const INVOKED_DIRECTLY = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
-if (INVOKED_DIRECTLY) {
-  try {
-    run();
-  } catch (error) {
+// Run only when invoked, never on import: a module with top-level side effects is the hazard that
+// left a mutant in the tree when XIII imported one from a `node -e` one-liner.
+const INVOKED = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (INVOKED) {
+  try { run(); } catch (error) {
     console.error(`FAIL ontology-admission-census — ${error?.stack || error}`);
     process.exit(1);
   }

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -37,8 +37,8 @@
       "id": "ontology-admission-census",
       "npm_script": "check:ontology-admission-census",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs",
-      "runtime_assertions": 14,
-      "assertion_names_sha256": "145e21f5270f2ceca4ec213575438134b0147bfcf0f07aa57e30a52c904da4a1"
+      "runtime_assertions": 17,
+      "assertion_names_sha256": "5d84d6d5251c3725f56676e1aa05038c60dc1329546189d7e21686db79633965"
     },
     {
       "id": "governance-journey",

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -38,7 +38,7 @@
       "npm_script": "check:ontology-admission-census",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs",
       "runtime_assertions": 13,
-      "assertion_names_sha256": "0f282670556256718514edb027636e35db264d0fc5821de12db03990201c860c"
+      "assertion_names_sha256": "f01711a9b61edac84a391114ca05889b6161797abe45074cca18fb9817e54d94"
     },
     {
       "id": "governance-journey",

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -37,8 +37,8 @@
       "id": "ontology-admission-census",
       "npm_script": "check:ontology-admission-census",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs",
-      "runtime_assertions": 24,
-      "assertion_names_sha256": "b00344f001689c38b506a4c05adff7d6d42bfce673ecf66bd63696c25e2063ae"
+      "runtime_assertions": 25,
+      "assertion_names_sha256": "6aa8b726f40305b6646380a5c07f082cf93fbcbc6965e8e54e0e24356244b185"
     },
     {
       "id": "governance-journey",

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -37,8 +37,8 @@
       "id": "ontology-admission-census",
       "npm_script": "check:ontology-admission-census",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs",
-      "runtime_assertions": 11,
-      "assertion_names_sha256": "d752ff0d6c58d5e85942ec4a4bae46e14aeac54586ce94483dce061a5c9b0f17"
+      "runtime_assertions": 13,
+      "assertion_names_sha256": "0f282670556256718514edb027636e35db264d0fc5821de12db03990201c860c"
     },
     {
       "id": "governance-journey",

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -34,6 +34,13 @@
       "assertion_names_sha256": "a6295d669c82fb4c79b1d02d2516cdbde4705f922cf3577c01a4b43498392bc7"
     },
     {
+      "id": "ontology-admission-census",
+      "npm_script": "check:ontology-admission-census",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs",
+      "runtime_assertions": 11,
+      "assertion_names_sha256": "d752ff0d6c58d5e85942ec4a4bae46e14aeac54586ce94483dce061a5c9b0f17"
+    },
+    {
       "id": "governance-journey",
       "npm_script": "check:governance-journey",
       "source": "apps/hypervisor/scripts/verify-hypervisor-governance-journey.mjs",

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -38,7 +38,7 @@
       "npm_script": "check:ontology-admission-census",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs",
       "runtime_assertions": 25,
-      "assertion_names_sha256": "6aa8b726f40305b6646380a5c07f082cf93fbcbc6965e8e54e0e24356244b185"
+      "assertion_names_sha256": "e997ce110b97489ce17d1776658ea99ac71987322cfa442dae4ccdcbd88a1eeb"
     },
     {
       "id": "governance-journey",

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -37,8 +37,8 @@
       "id": "ontology-admission-census",
       "npm_script": "check:ontology-admission-census",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs",
-      "runtime_assertions": 13,
-      "assertion_names_sha256": "f01711a9b61edac84a391114ca05889b6161797abe45074cca18fb9817e54d94"
+      "runtime_assertions": 14,
+      "assertion_names_sha256": "145e21f5270f2ceca4ec213575438134b0147bfcf0f07aa57e30a52c904da4a1"
     },
     {
       "id": "governance-journey",

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -37,8 +37,8 @@
       "id": "ontology-admission-census",
       "npm_script": "check:ontology-admission-census",
       "source": "apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs",
-      "runtime_assertions": 17,
-      "assertion_names_sha256": "5d84d6d5251c3725f56676e1aa05038c60dc1329546189d7e21686db79633965"
+      "runtime_assertions": 24,
+      "assertion_names_sha256": "b00344f001689c38b506a4c05adff7d6d42bfce673ecf66bd63696c25e2063ae"
     },
     {
       "id": "governance-journey",

--- a/crates/ontology-census/Cargo.toml
+++ b/crates/ontology-census/Cargo.toml
@@ -1,0 +1,20 @@
+# The ontology admission census EXTRACTOR.
+#
+# Its own crate, deliberately. It needs `syn` to read Rust, and `ioi-types` — where this first
+# lived — carries a standing note that it keeps minimal dependencies to remain stable; a parser does
+# not belong in a core type crate's graph. It was briefly an `examples/` target for that reason, but
+# `.gitignore` excludes `examples/` wholesale to keep vendored third-party trees out of the repo, so
+# a load-bearing tool living there would never have reached CI at all.
+[package]
+name = "ioi-ontology-census"
+version = "0.1.0"
+edition = "2021"
+description = "Parses the hypervisor daemon's module graph with syn and emits its record-admission facts as JSON"
+license.workspace = true
+repository = "https://github.com/ioi-foundation/ioi"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+proc-macro2 = "1"
+syn = { version = "2.0.116", features = ["full", "visit"] }

--- a/crates/ontology-census/Cargo.toml
+++ b/crates/ontology-census/Cargo.toml
@@ -16,5 +16,5 @@ repository = "https://github.com/ioi-foundation/ioi"
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-proc-macro2 = "1"
+proc-macro2 = { version = "1", features = ["span-locations"] }
 syn = { version = "2.0.116", features = ["full", "visit"] }

--- a/crates/ontology-census/src/main.rs
+++ b/crates/ontology-census/src/main.rs
@@ -1,206 +1,259 @@
 //! Ontology admission census EXTRACTOR — a real Rust parser, emitting the facts as JSON.
 //!
-//! An EXAMPLE target, deliberately. `syn` is a dev-dependency of this crate and the crate's own note
-//! says it keeps minimal dependencies to remain stable; an example may use dev-dependencies without
-//! putting a parser into a core type crate's runtime graph, and it builds only when asked for.
-//! Run: `cargo run --locked -p ioi-types --example ontology-admission-extract -- <daemon-main.rs>`.
+//! Its own crate, deliberately. `syn` is a dev-dependency of `ioi-types`, whose note says it keeps
+//! minimal dependencies to remain stable, and `.gitignore` excludes `examples/` wholesale, so an
+//! example target would never reach CI. A small crate of its own puts the parser nowhere near a core
+//! type crate's runtime graph and still ships.
 //!
-//! WHY THIS EXISTS, and why it replaced a hand-rolled reader. Next-legs XIV Leg 3a built the
+//! WHY THIS EXISTS, and why hand-rolling was abandoned TWICE. Next-legs XIV Leg 3a first built the
 //! no-second-spine entailment by scanning the daemon's source with regexes. Three merge-blocking
-//! review rounds each defeated it, and the defeats sorted into two buckets: CENSUS LOGIC (a rule
-//! that was wrong or decorative) and LANGUAGE READING (a Rust construct the scanner mis-modelled).
-//! Round two produced six language-reading defeats; round three produced five more — module-scope
-//! path visibility (`use super::odk_routes;` then `odk_routes::KIND_ONT`), raw strings desyncing a
-//! brace walk, `async fn` and other declaration forms an enclosing-function heuristic could not
-//! find, and module-file resolution order shadowing a nested module with a flat sibling.
+//! review rounds each defeated it, and the defeats sorted into two buckets: CENSUS LOGIC (a rule that
+//! was wrong or decorative) and LANGUAGE READING (a Rust construct the scanner mis-modelled). The
+//! owner pre-committed the decision before round three ran: modelling the next construct retires an
+//! INSTANCE, a real parser retires the CLASS.
 //!
-//! The owner pre-committed the decision before that round ran: modelling the next construct retires
-//! an INSTANCE, a real parser retires the CLASS. Every construct above is free here, because `syn`
-//! already knows Rust — items, paths, use-trees, attributes, string and raw-string literals, and
-//! declaration forms are all just AST.
+//! The first attempt at that ruling was executed IN NAME ONLY. `syn` was added to the dependency
+//! graph, the files were parsed into an AST — and the traversal on top stayed hand-rolled, a private
+//! `expr_children` covering roughly fifteen of syn's forty-odd `Expr` variants. A `Visit` impl with
+//! ZERO overrides was instantiated and driven across every expression, so the code READ as though a
+//! complete visitor were running while it did nothing at all. A fourth review demonstrated twelve of
+//! fourteen ordinary second-admitter constructs passing green: `.await` (775 of them in this daemon),
+//! `tokio::spawn` (34), impl methods (81 impl blocks), match-arm guards, struct literals, nested
+//! items, `let … else`, `unsafe` blocks, macro arguments, method-call writers. The scar the owner
+//! bound from it: A PRE-COMMITTED BOUNDARY IS EXECUTED BY ITS MECHANISM, NOT BY ITS DEPENDENCY.
 //!
-//! WHAT IT EMITS, and nothing more. This tool decides no policy. It reports what the source SAYS —
-//! which modules exist, what each names, where each family literal is written and read — and the
+//! So the traversal here IS `syn::visit::Visit`, with overrides only where a fact must be recorded.
+//! Every expression position, every `Stmt::Item`, every `ImplItem` and `TraitItem`, every arm guard
+//! and `let … else` block is reached by syn's own default recursion. The one thing syn does not walk
+//! is a macro's token stream, so that is scanned explicitly rather than left as a hole.
+//!
+//! POSITIVE CLASSIFICATION, NEVER ABSENCE. The same review found the deeper defect: a construct the
+//! walk missed produced no entry, and every judgement downstream was derived from the entries — so a
+//! COVERAGE GAP was indistinguishable from SAFETY. This tool therefore reports every mention of a
+//! name of interest together with the SYNTACTIC ROLE it appears in, and the gate holds a closed set
+//! of roles it can classify. A mention in a role the gate does not know is RED. A gap in coverage now
+//! reads as a finding, which is the only direction that can be trusted.
+//!
+//! WHAT IT EMITS, and nothing more. This tool decides no policy — it does not know what an ontology
+//! family is; the caller passes the prefixes it cares about. It reports what the source SAYS, and the
 //! JavaScript gate decides what that means. Keeping extraction and judgement apart is what lets the
 //! judgement keep its mutation anchors while the substrate underneath changes.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use proc_macro2::TokenTree;
 use serde::Serialize;
-use syn::{Expr, ExprCall, ExprPath, File, Item, ItemConst, Lit, UseTree};
+use syn::visit::{self, Visit};
+use syn::{Expr, File, Lit, UseTree};
 
-/// One record-writing or record-reading call site, with the family argument RESOLVED.
-#[derive(Serialize, Default)]
-struct CallSite {
-    callee: String,
-    /// The family literal this call names, once constants and aliases are resolved. `None` means
-    /// the census could not tie the argument to a literal — which the gate treats as RED, never as
-    /// "not a family".
-    family: Option<String>,
-    /// The argument as written, for the diagnostic.
-    written: String,
+/// This file's own bytes, baked in at COMPILE time. A binary built from different source reports a
+/// different digest than the source on disk hashes to, which is how the gate refuses a stale
+/// extractor without trusting a timestamp — cargo treats a source whose mtime moved backwards as
+/// up-to-date, and an mtime comparison then passes on exactly the hazard it claims to catch.
+const SELF_SOURCE: &str = include_str!("main.rs");
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100_0000_01b3);
+    }
+    h
+}
+
+/// A name of interest, recorded WITH the syntactic role it appears in. The role is the gate's whole
+/// defence against a coverage gap reading as safety: the gate classifies every role or goes RED.
+#[derive(Serialize)]
+struct Mention {
+    name: String,
+    role: String,
+    in_fn: String,
     in_test: bool,
 }
 
-#[derive(Serialize, Default)]
-struct ModuleFacts {
-    name: String,
-    path: String,
-    /// `const NAME: &str = "literal"` declared in THIS module. Per-module, because the daemon
-    /// declares 660 constants under 537 names and 25 of those names mean different things in
-    /// different modules.
-    consts: BTreeMap<String, String>,
-    /// Every name this module brings into scope, mapped to the module it came from and the item.
-    /// Covers `use m::C`, `use m::C as A`, `use m::{a, b::C}`, `use m::*`, and `use m;` — the last
-    /// being the module-as-path-prefix form that defeated the hand-rolled reader.
-    imports: Vec<Import>,
-    /// Modules declared by this file. A `#[path]` target is carried after a unit separator so the
-    /// walker can resolve it without a second parse; the gate reads only the name before it.
-    child_mods: Vec<ChildMod>,
-    calls: Vec<CallSite>,
-    /// Raw filesystem calls, with every argument as written. The record-writer census cannot see a
-    /// lane that bypasses the writers entirely and puts bytes in a family directory itself, and the
-    /// regression floor this substrate inherited includes exactly that mutation.
-    fs_calls: Vec<FsCall>,
-    /// Every path expression whose final segment is a name this module could resolve to a family,
-    /// with the syntactic role it appears in. A name used in a role the gate does not know about is
-    /// a mention the census cannot read — which must be RED, never silently dropped.
-    family_mentions: Vec<Mention>,
-    /// Functions that both RESOLVE a family name and WRITE a record. The gate refuses these; the
-    /// extractor only reports which functions do both, using real item boundaries rather than a
-    /// backwards search for the `fn` keyword.
-    resolve_and_write_fns: Vec<String>,
-    /// Per function, every path leaf and string literal it names. The gate resolves these to decide
-    /// whether a function that makes a raw filesystem call also names a family — dataflow-free and
-    /// fail-closed, the same shape as the resolve-and-write rule.
-    fn_leaves: BTreeMap<String, Vec<String>>,
-    /// Per function, the `=> Some(X)` arm values as WRITTEN. The extractor does not decide whether
-    /// any of them names a family — that is the gate's job, and reporting a bare boolean instead
-    /// made every `Ok(id) => Some(id.principal_ref)` look like a family resolver.
-    resolver_arms: BTreeMap<String, Vec<String>>,
-}
-
+/// A call to a record writer or reader, with every leaf in its argument subtree.
 #[derive(Serialize)]
-struct FsCall {
+struct CallSite {
     callee: String,
-    args: Vec<String>,
-    /// The function this call sits in. A family usually reaches a raw write through a local — `let p
-    /// = dir.join(KIND_ONT); fs::write(p.join(id), …)` — so the family is nowhere in the call's own
-    /// arguments, and the gate needs the enclosing function to see them together.
+    kind: &'static str,
+    /// Every string literal and constant-shaped path leaf anywhere under this call's arguments. The
+    /// family usually sits inside a chain — `dir.join(KIND_ONT).join(id)` — so quoting the top-level
+    /// argument flattens away the one token that matters.
+    leaves: Vec<String>,
     in_fn: String,
     in_test: bool,
 }
 
 #[derive(Serialize)]
-struct Mention {
-    name: String,
-    role: String,
+struct FsCall {
+    callee: String,
+    leaves: Vec<String>,
+    in_fn: String,
     in_test: bool,
 }
 
 #[derive(Serialize, Clone)]
 struct ChildMod {
     name: String,
-    /// The `#[path = "…"]` target, when the declaration carries one. This daemon declares every
-    /// route module that way so cargo's autobin does not treat each file as its own binary target,
-    /// so a walker that only knows rustc's default resolution finds none of them.
+    /// The `#[path = "…"]` target, when the declaration carries one. This daemon declares every route
+    /// module that way so cargo's autobin does not treat each file as its own binary target, so a
+    /// walker that only knows rustc's default resolution finds none of them.
     explicit_path: Option<String>,
+    in_test: bool,
 }
 
 #[derive(Serialize)]
 struct Import {
     /// The module the item comes from, e.g. `odk_routes`. `None` for a bare `use some_module;`.
     from: Option<String>,
-    /// The item name as declared at the source.
     item: String,
-    /// The name this module refers to it by.
     local: String,
-    /// True for `use path::*` — a glob brings in names this file never spells.
     glob: bool,
-    /// True for `use some_module;` — the module itself, used later as a path prefix.
+    /// True for `use super::odk_routes;` and `use super::odk_routes as ont;` — the MODULE itself,
+    /// used later as a path prefix. Both forms are in this daemon today, and a resolver that only
+    /// matches item names treats every `ont::KIND_ONT` after one as an unresolvable runtime value.
     module_only: bool,
 }
 
-fn lit_str(expr: &Expr) -> Option<String> {
-    if let Expr::Lit(l) = expr {
-        if let Lit::Str(s) = &l.lit {
-            return Some(s.value());
-        }
-    }
-    None
+#[derive(Serialize, Default)]
+struct ModuleFacts {
+    /// THE IDENTITY: the module's path from the repo root. Keying by file stem collapses two files
+    /// that share a basename into one module, which MERGES their admitters — precisely the hole this
+    /// census exists to see. `hypervisor_daemon_routes/shadow/odk_routes.rs` reported as `odk_routes`
+    /// once made a second admitter read as the recorded one.
+    key: String,
+    /// The file stem, for diagnostics and for resolving `mod::CONST` paths. Never an identity.
+    stem: String,
+    /// `const NAME: &str = "literal"` and `static NAME: &str = "literal"` declared in THIS module.
+    /// Per-module, because the daemon declares 660 constants under 537 names and 25 of those names
+    /// mean different things in different modules.
+    consts: BTreeMap<String, String>,
+    /// `const NAME: &str = other::PLACE;` — a constant defined as another constant. Three of these
+    /// exist in this daemon and the previous resolver could follow none of them.
+    const_refs: BTreeMap<String, String>,
+    /// A constant whose initialiser this extractor cannot read to a literal — `concat!(…)`, a call, a
+    /// cast. Reported, never dropped: the gate decides, and an unreadable initialiser whose tokens
+    /// mention a name of interest is a finding, not an absence.
+    const_opaque: Vec<String>,
+    imports: Vec<Import>,
+    child_mods: Vec<ChildMod>,
+    calls: Vec<CallSite>,
+    fs_calls: Vec<FsCall>,
+    mentions: Vec<Mention>,
+    /// Every function this module declares — free, impl method, or trait default — mapped to the
+    /// leaves in its body. Declared for EVERY function, so a lookup miss is a real absence rather
+    /// than the silent empty list an impl method used to produce for a third of this daemon.
+    fn_leaves: BTreeMap<String, Vec<String>>,
+    /// Per function, the leaves of every `=> Some(X)` match-arm value.
+    resolver_arms: BTreeMap<String, Vec<String>>,
+    /// Functions that both RESOLVE a family name and WRITE a record.
+    resolve_and_write_fns: Vec<String>,
 }
 
-fn path_of(expr: &Expr) -> Option<Vec<String>> {
-    if let Expr::Path(ExprPath { path, .. }) = expr {
-        return Some(path.segments.iter().map(|s| s.ident.to_string()).collect());
-    }
-    if let Expr::Reference(r) = expr {
-        return path_of(&r.expr);
-    }
-    None
+/// A constant-shaped identifier: the only shape a family name reaches a call site under, other than
+/// a string literal, given Rust's naming lint.
+fn is_const_ident(s: &str) -> bool {
+    s.len() > 1
+        && s.chars().any(|c| c.is_ascii_uppercase())
+        && s.chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
 }
 
-fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
+/// TEST CLASSIFICATION FAILS TOWARD PRODUCTION. Only a bare `#[cfg(test)]` marks a subtree as test.
+/// Anything that could compile into a production build — `cfg(any(test, …))`, `cfg(all(test, …))`,
+/// `cfg_attr`, a feature gate — classifies as PRODUCTION. The direction matters: the recorded
+/// admission map is built from production writes, and a test write mistaken for production only ever
+/// widens what must be justified, while a production write mistaken for a test write silently
+/// pre-authorises a second spine. That mistake was live: three families were recorded as
+/// multi-admitter on the strength of fixtures, which authorised the fixture's module to write them
+/// for real.
+fn is_bare_cfg_test(attrs: &[syn::Attribute]) -> bool {
     attrs.iter().any(|a| {
-        let mut found = false;
-        if a.path().is_ident("cfg") {
-            let _ = a.parse_nested_meta(|meta| {
-                if meta.path.is_ident("test") {
-                    found = true;
-                }
-                Ok(())
-            });
-        }
-        found
+        a.path().is_ident("cfg")
+            && matches!(&a.meta, syn::Meta::List(l) if l.tokens.to_string().trim() == "test")
     })
 }
 
-fn flatten_use(tree: &UseTree, prefix: &mut Vec<String>, out: &mut Vec<Import>) {
-    match tree {
-        UseTree::Path(p) => {
-            prefix.push(p.ident.to_string());
-            flatten_use(&p.tree, prefix, out);
-            prefix.pop();
+fn path_segments(p: &syn::Path) -> Vec<String> {
+    p.segments.iter().map(|s| s.ident.to_string()).collect()
+}
+
+/// Every string literal and constant-shaped path leaf under an expression, found by syn's own
+/// recursion rather than a hand-rolled child list.
+#[derive(Default)]
+struct LeafGrab {
+    out: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for LeafGrab {
+    fn visit_expr(&mut self, e: &'ast Expr) {
+        match e {
+            Expr::Lit(l) => {
+                if let Lit::Str(s) = &l.lit {
+                    self.out.push(s.value());
+                }
+            }
+            Expr::Path(p) => {
+                let segs = path_segments(&p.path);
+                if segs.last().is_some_and(|s| is_const_ident(s)) {
+                    self.out.push(segs.join("::"));
+                }
+            }
+            _ => {}
         }
-        UseTree::Name(n) => {
-            let item = n.ident.to_string();
-            // `use super::odk_routes;` — the MODULE itself. The hand-rolled reader had no notion of
-            // this and every `odk_routes::KIND_ONT` after it was invisible; the daemon already
-            // writes this style in `event_stream_routes.rs` and `work_result_routes.rs`.
-            let module_only = prefix.last().is_some_and(|p| p == "super" || p == "crate");
-            out.push(Import {
-                from: if module_only {
-                    None
-                } else {
-                    prefix.last().cloned()
-                },
-                item: item.clone(),
-                local: item.clone(),
-                glob: false,
-                module_only,
-            });
+        visit::visit_expr(self, e);
+    }
+
+    fn visit_macro(&mut self, m: &'ast syn::Macro) {
+        grab_tokens(m.tokens.clone(), &mut self.out);
+        visit::visit_macro(self, m);
+    }
+}
+
+fn grab_tokens(ts: proc_macro2::TokenStream, out: &mut Vec<String>) {
+    for t in ts {
+        match t {
+            TokenTree::Literal(l) => {
+                let raw = l.to_string();
+                if raw.starts_with('"') || raw.starts_with('r') {
+                    if let Ok(s) = syn::parse_str::<syn::LitStr>(&raw) {
+                        out.push(s.value());
+                    }
+                }
+            }
+            TokenTree::Ident(i) => {
+                let n = i.to_string();
+                if is_const_ident(&n) {
+                    out.push(n);
+                }
+            }
+            TokenTree::Group(g) => grab_tokens(g.stream(), out),
+            TokenTree::Punct(_) => {}
         }
-        UseTree::Rename(r) => out.push(Import {
-            from: prefix.last().cloned(),
-            item: r.ident.to_string(),
-            local: r.rename.to_string(),
-            glob: false,
-            module_only: prefix.last().is_some_and(|p| p == "super" || p == "crate"),
-        }),
-        UseTree::Glob(_) => out.push(Import {
-            from: prefix.last().cloned(),
-            item: "*".into(),
-            local: "*".into(),
-            glob: true,
-            module_only: false,
-        }),
-        UseTree::Group(g) => {
-            for t in &g.items {
-                flatten_use(t, prefix, out);
+    }
+}
+
+/// Every identifier in a token stream, however deeply grouped.
+fn macro_token_idents(ts: proc_macro2::TokenStream) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut stack = vec![ts];
+    while let Some(s) = stack.pop() {
+        for t in s {
+            match t {
+                TokenTree::Ident(i) => out.push(i.to_string()),
+                TokenTree::Group(g) => stack.push(g.stream()),
+                _ => {}
             }
         }
     }
+    out
+}
+
+fn expr_leaves(e: &Expr) -> Vec<String> {
+    let mut g = LeafGrab::default();
+    g.visit_expr(e);
+    g.out
 }
 
 const WRITERS: &[&str] = &[
@@ -224,340 +277,482 @@ const FS_CALLS: &[&str] = &[
     "hard_link",
 ];
 
-struct Collector<'a> {
-    facts: &'a mut ModuleFacts,
-    in_test: bool,
+/// THE CENSUS COLLECTOR — a real `syn::visit::Visit`. Every override records a fact and then hands
+/// control back to syn's default recursion, so no construct is reachable only because this file
+/// happens to name it.
+struct Collector {
+    facts: ModuleFacts,
+    test_depth: usize,
     fn_stack: Vec<String>,
+    /// The syntactic role a mention found right now sits in. Pushed by the constructs that give a
+    /// name its meaning — a writer's arguments, a reader's, a raw filesystem call's, a constant's
+    /// initialiser — and inherited by everything beneath.
+    roles: Vec<String>,
+    /// Indices into `facts.calls` / `facts.fs_calls` for the calls currently open, so every leaf
+    /// found beneath one is attributed to it however deeply it nests.
+    open_calls: Vec<usize>,
+    open_fs: Vec<usize>,
+    interests: Vec<String>,
+    wrote_in_fn: Vec<bool>,
 }
 
-impl Collector<'_> {
-    fn visit_expr(&mut self, e: &Expr) {
-        if let Expr::Call(ExprCall { func, args, .. }) = e {
-            if let Some(segs) = path_of(func) {
-                let callee = segs.last().cloned().unwrap_or_default();
-                let is_w = WRITERS.contains(&callee.as_str());
-                let is_r = READERS.contains(&callee.as_str());
-                // A RAW FILESYSTEM CALL, recorded with every argument as written. `syn` gives the
-                // full path, so `std::fs::write` and a `use std::fs as sysfs` alias are the same
-                // node — the alias games that defeated a text scan do not arise.
-                if FS_CALLS.contains(&callee.as_str())
-                    && segs
-                        .iter()
-                        .any(|s| s == "fs" || s == "File" || s.ends_with("fs"))
-                {
-                    self.facts.fs_calls.push(FsCall {
-                        callee: segs.join("::"),
-                        // EVERY LEAF, not the top-level shape. The family usually sits inside a
-                        // method chain — `dir.join(KIND_ONT).join(id)` — and quoting only the outer
-                        // expression flattens it to `<expr>`, losing the one token that matters.
-                        args: args.iter().flat_map(leaves).collect(),
-                        in_fn: self.fn_stack.last().cloned().unwrap_or_default(),
-                        in_test: self.in_test,
-                    });
+impl Collector {
+    fn in_test(&self) -> bool {
+        self.test_depth > 0
+    }
+
+    fn role(&self) -> String {
+        self.roles
+            .last()
+            .cloned()
+            .unwrap_or_else(|| "module".into())
+    }
+
+    fn cur_fn(&self) -> String {
+        self.fn_stack.last().cloned().unwrap_or_default()
+    }
+
+    fn interesting(&self, s: &str) -> bool {
+        self.interests.iter().any(|p| s.starts_with(p.as_str()))
+    }
+
+    /// Record one leaf: attribute it to every open call, to the enclosing function, and — when it is
+    /// a name of interest — to the mention log with its role.
+    fn leaf(&mut self, text: String) {
+        for i in self.open_calls.clone() {
+            self.facts.calls[i].leaves.push(text.clone());
+        }
+        for i in self.open_fs.clone() {
+            self.facts.fs_calls[i].leaves.push(text.clone());
+        }
+        let f = self.cur_fn();
+        if !f.is_empty() {
+            self.facts
+                .fn_leaves
+                .entry(f.clone())
+                .or_default()
+                .push(text.clone());
+        }
+        // The interest test reads the LAST SEGMENT, not the whole path. Judging
+        // `crate::ontology_projection_routes::RECORD_DIR` by the joined string finds a lowercase
+        // character and discards it — which is exactly how a module that writes another module's
+        // family under a fully-qualified path disappeared from the admitter map.
+        let tail = text.rsplit("::").next().unwrap_or(&text).to_string();
+        if self.interesting(&text) || is_const_ident(&tail) {
+            let role = self.role();
+            self.facts.mentions.push(Mention {
+                name: text,
+                role,
+                in_fn: f,
+                in_test: self.in_test(),
+            });
+        }
+    }
+
+    fn enter_fn(&mut self, name: String, attrs: &[syn::Attribute]) -> bool {
+        let test = is_bare_cfg_test(attrs);
+        if test {
+            self.test_depth += 1;
+        }
+        self.facts.fn_leaves.entry(name.clone()).or_default();
+        self.fn_stack.push(name);
+        self.wrote_in_fn.push(false);
+        self.roles.push("fn-body".into());
+        test
+    }
+
+    fn exit_fn(&mut self, test: bool) {
+        self.roles.pop();
+        let wrote = self.wrote_in_fn.pop().unwrap_or(false);
+        if let Some(name) = self.fn_stack.pop() {
+            // RULE 7, structurally: a function that RESOLVES a family name may not also WRITE a
+            // record. Conservative, dataflow-free, fail-closed — widening it later is a governed act.
+            if wrote
+                && self.facts.resolver_arms.contains_key(&name)
+                && !self.facts.resolve_and_write_fns.contains(&name)
+            {
+                self.facts.resolve_and_write_fns.push(name);
+            }
+        }
+        if test {
+            self.test_depth -= 1;
+        }
+    }
+
+    /// Classify a call, open it, and name the role its whole argument subtree inherits.
+    fn open_call(&mut self, callee_segs: &[String], is_method: bool) -> (bool, bool, bool) {
+        let Some(name) = callee_segs.last() else {
+            return (false, false, false);
+        };
+        let is_w = WRITERS.contains(&name.as_str());
+        let is_r = READERS.contains(&name.as_str());
+        // A raw filesystem entry point, recognised on the FULL path syn gives, so `std::fs::write`
+        // and a `use std::fs as sysfs` alias are the same node.
+        let is_fs = FS_CALLS.contains(&name.as_str())
+            && (is_method
+                || callee_segs
+                    .iter()
+                    .any(|s| s == "fs" || s == "File" || s.ends_with("fs")));
+        if is_w || is_r {
+            self.facts.calls.push(CallSite {
+                callee: callee_segs.join("::"),
+                kind: if is_w { "write" } else { "read" },
+                leaves: Vec::new(),
+                in_fn: self.cur_fn(),
+                in_test: self.in_test(),
+            });
+            let idx = self.facts.calls.len() - 1;
+            self.open_calls.push(idx);
+            self.roles
+                .push(if is_w { "write-arg" } else { "read-arg" }.into());
+            if is_w {
+                if let Some(last) = self.wrote_in_fn.last_mut() {
+                    *last = true;
                 }
-                if (is_w || is_r) && args.len() >= 2 {
-                    let arg = &args[1];
-                    let written = quote_expr(arg);
-                    let family = lit_str(arg).or_else(|| path_of(arg).map(|p| p.join("::")));
-                    self.facts.calls.push(CallSite {
-                        callee: callee.clone(),
-                        family,
-                        written,
-                        in_test: self.in_test,
-                    });
-                    if is_w {
-                        if let Some(f) = self.fn_stack.last() {
-                            if self.facts.resolver_arms.contains_key(f)
-                                && !self.facts.resolve_and_write_fns.contains(f)
-                            {
-                                self.facts.resolve_and_write_fns.push(f.clone());
+            }
+            return (true, true, false);
+        }
+        if is_fs {
+            self.facts.fs_calls.push(FsCall {
+                callee: callee_segs.join("::"),
+                leaves: Vec::new(),
+                in_fn: self.cur_fn(),
+                in_test: self.in_test(),
+            });
+            let idx = self.facts.fs_calls.len() - 1;
+            self.open_fs.push(idx);
+            self.roles.push("fs-arg".into());
+            return (true, false, true);
+        }
+        (false, false, false)
+    }
+
+    fn close_call(&mut self, opened: (bool, bool, bool)) {
+        let (opened_any, was_record, was_fs) = opened;
+        if !opened_any {
+            return;
+        }
+        self.roles.pop();
+        if was_record {
+            self.open_calls.pop();
+        }
+        if was_fs {
+            self.open_fs.pop();
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for Collector {
+    fn visit_expr(&mut self, e: &'ast Expr) {
+        match e {
+            Expr::Lit(l) => {
+                if let Lit::Str(s) = &l.lit {
+                    self.leaf(s.value());
+                }
+            }
+            Expr::Path(p) => {
+                let segs = path_segments(&p.path);
+                if segs.last().is_some_and(|s| is_const_ident(s)) {
+                    self.leaf(segs.join("::"));
+                }
+            }
+            _ => {}
+        }
+        let opened = match e {
+            Expr::Call(c) => match &*c.func {
+                Expr::Path(p) => self.open_call(&path_segments(&p.path), false),
+                _ => (false, false, false),
+            },
+            Expr::MethodCall(m) => self.open_call(&[m.method.to_string()], true),
+            _ => (false, false, false),
+        };
+        visit::visit_expr(self, e);
+        self.close_call(opened);
+    }
+
+    /// syn does not walk a macro's tokens — they are not parsed as expressions. Left alone this is a
+    /// hole exactly the size of `json!`, `format!` and `write!`, so the tokens are scanned here.
+    fn visit_macro(&mut self, m: &'ast syn::Macro) {
+        let mac = path_segments(&m.path).last().cloned().unwrap_or_default();
+        let mut found = Vec::new();
+        grab_tokens(m.tokens.clone(), &mut found);
+        // A WRITER CALL INSIDE MACRO TOKENS IS STILL A WRITER CALL. syn hands over the token stream
+        // unparsed, so `json!({ "w": persist_record(d, KIND, id, r) })` reaches `visit_expr` as
+        // nothing at all. Naming a writer anywhere in the tokens re-attributes every family leaf in
+        // them to the writing role — over-attribution, deliberately, because the alternative is a
+        // write the census reports as a mere mention.
+        let names_writer = macro_token_idents(m.tokens.clone())
+            .iter()
+            .any(|i| WRITERS.contains(&i.as_str()));
+        self.roles.push(if names_writer {
+            "write-arg".to_string()
+        } else {
+            format!("macro:{mac}")
+        });
+        for t in found {
+            self.leaf(t);
+        }
+        self.roles.pop();
+        visit::visit_macro(self, m);
+    }
+
+    fn visit_item_const(&mut self, i: &'ast syn::ItemConst) {
+        let test = is_bare_cfg_test(&i.attrs);
+        if test {
+            self.test_depth += 1;
+        }
+        self.record_const(&i.ident.to_string(), &i.expr);
+        self.roles.push("const-init".into());
+        visit::visit_item_const(self, i);
+        self.roles.pop();
+        if test {
+            self.test_depth -= 1;
+        }
+    }
+
+    /// `static` was invisible to the previous extractor entirely, so the rule forbidding a foreign
+    /// module from DECLARING a family name was defeated by changing one keyword.
+    fn visit_item_static(&mut self, i: &'ast syn::ItemStatic) {
+        let test = is_bare_cfg_test(&i.attrs);
+        if test {
+            self.test_depth += 1;
+        }
+        self.record_const(&i.ident.to_string(), &i.expr);
+        self.roles.push("static-init".into());
+        visit::visit_item_static(self, i);
+        self.roles.pop();
+        if test {
+            self.test_depth -= 1;
+        }
+    }
+
+    fn visit_item_use(&mut self, i: &'ast syn::ItemUse) {
+        let mut prefix = Vec::new();
+        flatten_use(&i.tree, &mut prefix, &mut self.facts.imports);
+        visit::visit_item_use(self, i);
+    }
+
+    fn visit_item_mod(&mut self, i: &'ast syn::ItemMod) {
+        let test = is_bare_cfg_test(&i.attrs);
+        if test {
+            self.test_depth += 1;
+        }
+        if i.content.is_none() {
+            let explicit = i.attrs.iter().find_map(|a| {
+                if !a.path().is_ident("path") {
+                    return None;
+                }
+                match &a.meta {
+                    syn::Meta::NameValue(nv) => match &nv.value {
+                        Expr::Lit(l) => match &l.lit {
+                            Lit::Str(sl) => Some(sl.value()),
+                            _ => None,
+                        },
+                        _ => None,
+                    },
+                    _ => None,
+                }
+            });
+            self.facts.child_mods.push(ChildMod {
+                name: i.ident.to_string(),
+                explicit_path: explicit,
+                in_test: self.in_test(),
+            });
+        }
+        visit::visit_item_mod(self, i);
+        if test {
+            self.test_depth -= 1;
+        }
+    }
+
+    fn visit_item_fn(&mut self, i: &'ast syn::ItemFn) {
+        let t = self.enter_fn(i.sig.ident.to_string(), &i.attrs);
+        visit::visit_item_fn(self, i);
+        self.exit_fn(t);
+    }
+
+    /// Impl methods are 81 blocks of this daemon's house style. The previous extractor ran a
+    /// collector over them but never created their `fn_leaves` entry, so the raw-filesystem rule's
+    /// "and the function around it names a family" half looked up an empty list for 32% of the
+    /// production filesystem calls in the tree — dead for every one of them.
+    fn visit_impl_item_fn(&mut self, i: &'ast syn::ImplItemFn) {
+        let t = self.enter_fn(i.sig.ident.to_string(), &i.attrs);
+        visit::visit_impl_item_fn(self, i);
+        self.exit_fn(t);
+    }
+
+    fn visit_trait_item_fn(&mut self, i: &'ast syn::TraitItemFn) {
+        let t = self.enter_fn(i.sig.ident.to_string(), &i.attrs);
+        visit::visit_trait_item_fn(self, i);
+        self.exit_fn(t);
+    }
+
+    fn visit_item_impl(&mut self, i: &'ast syn::ItemImpl) {
+        let test = is_bare_cfg_test(&i.attrs);
+        if test {
+            self.test_depth += 1;
+        }
+        visit::visit_item_impl(self, i);
+        if test {
+            self.test_depth -= 1;
+        }
+    }
+
+    fn visit_expr_match(&mut self, m: &'ast syn::ExprMatch) {
+        for arm in &m.arms {
+            if let Expr::Call(c) = &*arm.body {
+                if let Expr::Path(p) = &*c.func {
+                    if path_segments(&p.path).last().is_some_and(|s| s == "Some") {
+                        if let Some(inner) = c.args.first() {
+                            let leaves = expr_leaves(inner);
+                            if !leaves.is_empty() {
+                                self.facts
+                                    .resolver_arms
+                                    .entry(self.cur_fn())
+                                    .or_default()
+                                    .extend(leaves);
                             }
                         }
                     }
                 }
             }
         }
-        syn::visit::visit_expr(&mut Noop, e);
-        for child in expr_children(e) {
-            self.visit_expr(&child);
-        }
+        visit::visit_expr_match(self, m);
     }
 }
 
-struct Noop;
-impl<'ast> syn::visit::Visit<'ast> for Noop {}
-
-fn quote_expr(e: &Expr) -> String {
-    match e {
-        Expr::Lit(_) => lit_str(e).map(|s| format!("{s:?}")).unwrap_or_default(),
-        _ => path_of(e)
-            .map(|p| p.join("::"))
-            .unwrap_or_else(|| "<expr>".into()),
-    }
-}
-
-/// Every path segment and string literal inside an expression, however deeply nested.
-fn leaves(e: &Expr) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut stack = vec![e.clone()];
-    while let Some(cur) = stack.pop() {
-        if let Some(s) = lit_str(&cur) {
-            out.push(format!("{s:?}"));
-        }
-        if let Some(p) = path_of(&cur) {
-            out.push(p.join("::"));
-        }
-        // ONE SOURCE OF CHILDREN. `expr_children` already yields a method call's receiver and
-        // arguments; pushing them again here doubled every node per level and turned this walk
-        // exponential — the gate hung rather than failing, which is the worse direction.
-        for c in expr_children(&cur) {
-            stack.push(c);
-        }
-    }
-    out
-}
-
-/// Child expressions worth walking. Deliberately broad and shallow rather than a full visitor: the
-/// gate only needs call sites, and a missed child is a missed CALL, which shows up as a family the
-/// census cannot see — the gate's RED path — rather than as a silent pass.
-fn expr_children(e: &Expr) -> Vec<Expr> {
-    let mut out = Vec::new();
-    match e {
-        Expr::Block(b) => collect_block(&b.block, &mut out),
-        Expr::If(i) => {
-            out.push((*i.cond).clone());
-            collect_block(&i.then_branch, &mut out);
-            if let Some((_, els)) = &i.else_branch {
-                out.push((**els).clone());
-            }
-        }
-        Expr::Match(m) => {
-            out.push((*m.expr).clone());
-            for arm in &m.arms {
-                out.push((*arm.body).clone());
-            }
-        }
-        Expr::Call(c) => {
-            for a in &c.args {
-                out.push(a.clone());
-            }
-        }
-        Expr::MethodCall(c) => {
-            out.push((*c.receiver).clone());
-            for a in &c.args {
-                out.push(a.clone());
-            }
-        }
-        Expr::Let(l) => out.push((*l.expr).clone()),
-        Expr::Assign(a) => out.push((*a.right).clone()),
-        Expr::Return(r) => {
-            if let Some(v) = &r.expr {
-                out.push((**v).clone());
-            }
-        }
-        Expr::Reference(r) => out.push((*r.expr).clone()),
-        Expr::Try(t) => out.push((*t.expr).clone()),
-        Expr::Unary(u) => out.push((*u.expr).clone()),
-        Expr::Binary(b) => {
-            out.push((*b.left).clone());
-            out.push((*b.right).clone());
-        }
-        Expr::ForLoop(f) => {
-            out.push((*f.expr).clone());
-            collect_block(&f.body, &mut out);
-        }
-        Expr::While(w) => {
-            out.push((*w.cond).clone());
-            collect_block(&w.body, &mut out);
-        }
-        Expr::Loop(l) => collect_block(&l.body, &mut out),
-        Expr::Closure(c) => out.push((*c.body).clone()),
-        Expr::Group(g) => out.push((*g.expr).clone()),
-        Expr::Paren(p) => out.push((*p.expr).clone()),
-        _ => {}
-    }
-    out
-}
-
-fn collect_block(b: &syn::Block, out: &mut Vec<Expr>) {
-    for st in &b.stmts {
-        match st {
-            syn::Stmt::Expr(e, _) => out.push(e.clone()),
-            syn::Stmt::Local(l) => {
-                if let Some(init) = &l.init {
-                    out.push((*init.expr).clone());
+impl Collector {
+    fn record_const(&mut self, name: &str, expr: &Expr) {
+        match expr {
+            Expr::Lit(l) => match &l.lit {
+                Lit::Str(s) => {
+                    self.facts.consts.insert(name.to_string(), s.value());
                 }
+                _ => self.facts.const_opaque.push(name.to_string()),
+            },
+            Expr::Path(p) => {
+                self.facts
+                    .const_refs
+                    .insert(name.to_string(), path_segments(&p.path).join("::"));
             }
-            _ => {}
+            Expr::Reference(r) => self.record_const(name, &r.expr),
+            _ => self.facts.const_opaque.push(name.to_string()),
         }
     }
 }
 
-/// The `=> Some(X)` arm values in this function body, as written. The gate resolves them.
-fn resolver_arms(block: &syn::Block) -> Vec<String> {
-    let mut found = Vec::new();
-    let mut stack: Vec<Expr> = Vec::new();
-    collect_block(block, &mut stack);
-    while let Some(e) = stack.pop() {
-        if let Expr::Match(m) = &e {
-            for arm in &m.arms {
-                if let Expr::Call(c) = &*arm.body {
-                    if path_of(&c.func).is_some_and(|p| p.last().is_some_and(|s| s == "Some")) {
-                        if let Some(inner) = c.args.first() {
-                            found.push(quote_expr(inner));
-                        }
-                    }
-                }
-            }
+fn flatten_use(tree: &UseTree, prefix: &mut Vec<String>, out: &mut Vec<Import>) {
+    match tree {
+        UseTree::Path(p) => {
+            prefix.push(p.ident.to_string());
+            flatten_use(&p.tree, prefix, out);
+            prefix.pop();
         }
-        for c in expr_children(&e) {
-            stack.push(c);
-        }
-    }
-    found
-}
-
-fn walk_items(items: &[Item], in_test: bool, facts: &mut ModuleFacts) {
-    for item in items {
-        match item {
-            Item::Const(ItemConst { ident, expr, .. }) => {
-                if let Some(v) = lit_str(expr) {
-                    facts.family_mentions.push(Mention {
-                        name: ident.to_string(),
-                        role: "declares".into(),
-                        in_test,
-                    });
-                    facts.consts.insert(ident.to_string(), v);
-                }
-            }
-            Item::Use(u) => {
-                let mut prefix = Vec::new();
-                flatten_use(&u.tree, &mut prefix, &mut facts.imports);
-            }
-            Item::Mod(m) => {
-                let test_here = in_test || has_cfg_test(&m.attrs);
-                if let Some((_, inner)) = &m.content {
-                    walk_items(inner, test_here, facts);
+        UseTree::Name(n) => {
+            let item = n.ident.to_string();
+            let module_only = prefix.last().is_some_and(|p| p == "super" || p == "crate");
+            out.push(Import {
+                from: if module_only {
+                    None
                 } else {
-                    // `#[path = "…"]` is how this daemon declares every route module — the files
-                    // live in a subdirectory so cargo's autobin does not treat each as its own
-                    // binary target. A walker that only knows rustc's default resolution finds none
-                    // of them.
-                    let explicit = m.attrs.iter().find_map(|a| {
-                        if !a.path().is_ident("path") {
-                            return None;
-                        }
-                        match &a.meta {
-                            syn::Meta::NameValue(nv) => match &nv.value {
-                                syn::Expr::Lit(l) => match &l.lit {
-                                    syn::Lit::Str(sl) => Some(sl.value()),
-                                    _ => None,
-                                },
-                                _ => None,
-                            },
-                            _ => None,
-                        }
-                    });
-                    facts.child_mods.push(ChildMod {
-                        name: m.ident.to_string(),
-                        explicit_path: explicit,
-                    });
-                }
+                    prefix.last().cloned()
+                },
+                item: item.clone(),
+                local: item.clone(),
+                glob: false,
+                module_only,
+            });
+        }
+        UseTree::Rename(r) => {
+            let module_only = prefix.last().is_some_and(|p| p == "super" || p == "crate");
+            out.push(Import {
+                from: if module_only {
+                    None
+                } else {
+                    prefix.last().cloned()
+                },
+                item: r.ident.to_string(),
+                local: r.rename.to_string(),
+                glob: false,
+                module_only,
+            });
+        }
+        UseTree::Glob(_) => out.push(Import {
+            from: prefix.last().cloned(),
+            item: "*".into(),
+            local: "*".into(),
+            glob: true,
+            module_only: false,
+        }),
+        UseTree::Group(g) => {
+            for t in &g.items {
+                flatten_use(t, prefix, out);
             }
-            Item::Fn(f) => {
-                let test_here = in_test || has_cfg_test(&f.attrs);
-                let name = f.sig.ident.to_string();
-                let arms = resolver_arms(&f.block);
-                if !arms.is_empty() {
-                    facts.resolver_arms.insert(name.clone(), arms);
-                }
-                let mut body_exprs = Vec::new();
-                collect_block(&f.block, &mut body_exprs);
-                let mut all_leaves = Vec::new();
-                for e in &body_exprs {
-                    all_leaves.extend(leaves(e));
-                }
-                facts.fn_leaves.insert(name.clone(), all_leaves);
-                let mut c = Collector {
-                    facts,
-                    in_test: test_here,
-                    fn_stack: vec![name],
-                };
-                for e in body_exprs {
-                    c.visit_expr(&e);
-                }
-            }
-            Item::Impl(i) => {
-                let test_here = in_test || has_cfg_test(&i.attrs);
-                for it in &i.items {
-                    if let syn::ImplItem::Fn(f) = it {
-                        let name = f.sig.ident.to_string();
-                        let arms = resolver_arms(&f.block);
-                        if !arms.is_empty() {
-                            facts.resolver_arms.insert(name.clone(), arms);
-                        }
-                        let mut c = Collector {
-                            facts,
-                            in_test: test_here,
-                            fn_stack: vec![name],
-                        };
-                        let mut exprs = Vec::new();
-                        collect_block(&f.block, &mut exprs);
-                        for e in exprs {
-                            c.visit_expr(&e);
-                        }
-                    }
-                }
-            }
-            _ => {}
         }
     }
 }
 
-/// Resolve `mod name;` the way rustc does, from the DECLARING file's own position.
+/// Resolve `mod name;` the way rustc does, from the DECLARING file's own position. A file that is
+/// itself a module root resolves siblings; any other module resolves children under its own
+/// directory. Taking the sibling FIRST silently reads a flat namesake instead of the real nested file.
 fn child_path(decl_file: &Path, name: &str) -> Option<PathBuf> {
     let dir = decl_file.parent()?;
     let stem = decl_file.file_stem()?.to_string_lossy().to_string();
-    // A file that is itself a module root (`mod.rs`, or the crate root) resolves siblings; any other
-    // module resolves children under its own directory. Taking the sibling FIRST — as the hand-rolled
-    // reader did — silently reads a flat namesake instead of the real nested file.
-    let nested = dir.join(&stem).join(format!("{name}.rs"));
-    if nested.exists() {
-        return Some(nested);
-    }
-    let nested_mod = dir.join(&stem).join(name).join("mod.rs");
-    if nested_mod.exists() {
-        return Some(nested_mod);
-    }
-    let sibling = dir.join(format!("{name}.rs"));
-    if sibling.exists() {
-        return Some(sibling);
-    }
-    let sibling_mod = dir.join(name).join("mod.rs");
-    if sibling_mod.exists() {
-        return Some(sibling_mod);
+    for cand in [
+        dir.join(&stem).join(format!("{name}.rs")),
+        dir.join(&stem).join(name).join("mod.rs"),
+        dir.join(format!("{name}.rs")),
+        dir.join(name).join("mod.rs"),
+    ] {
+        if cand.exists() {
+            return Some(cand);
+        }
     }
     None
 }
 
+fn repo_key(p: &Path, root: &Path) -> String {
+    p.strip_prefix(root)
+        .unwrap_or(p)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
 fn main() {
-    let root = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| "crates/node/src/bin/hypervisor-daemon.rs".to_string());
-    let entry = PathBuf::from(&root);
-    let mut queue = vec![entry.clone()];
+    let mut args = std::env::args().skip(1);
+    let mut entry = String::new();
+    let mut interests: Vec<String> = Vec::new();
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--interest" => interests.push(args.next().unwrap_or_default()),
+            other => entry = other.to_string(),
+        }
+    }
+    if entry.is_empty() {
+        entry = "crates/node/src/bin/hypervisor-daemon.rs".to_string();
+    }
+    let entry_path = PathBuf::from(&entry);
+    let repo_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+    let mut queue = vec![entry_path.clone()];
     let mut seen: Vec<PathBuf> = Vec::new();
     let mut modules: Vec<ModuleFacts> = Vec::new();
 
     while let Some(file) = queue.pop() {
-        let canon = file.canonicalize().unwrap_or(file.clone());
+        let canon = file.canonicalize().unwrap_or_else(|_| file.clone());
         if seen.contains(&canon) {
             continue;
         }
         seen.push(canon.clone());
+        // A module the walker cannot READ is not a module it may skip: the census's closed world is
+        // exactly the set of files it opened, and a silent `continue` shrinks that world without
+        // shrinking the claim.
         let src = match std::fs::read_to_string(&file) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(e) => {
+                eprintln!("UNREADABLE MODULE {}: {e}", file.display());
+                std::process::exit(2);
+            }
         };
         let parsed: File = match syn::parse_file(&src) {
             Ok(p) => p,
@@ -566,31 +761,58 @@ fn main() {
                 std::process::exit(2);
             }
         };
-        let mut facts = ModuleFacts {
-            name: file
-                .file_stem()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string(),
-            path: file.to_string_lossy().to_string(),
-            ..Default::default()
+        let mut c = Collector {
+            facts: ModuleFacts {
+                key: repo_key(&canon, &repo_root),
+                stem: file
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string(),
+                ..Default::default()
+            },
+            test_depth: 0,
+            fn_stack: Vec::new(),
+            roles: Vec::new(),
+            open_calls: Vec::new(),
+            open_fs: Vec::new(),
+            interests: interests.clone(),
+            wrote_in_fn: Vec::new(),
         };
-        walk_items(&parsed.items, false, &mut facts);
-        for child in facts.child_mods.clone() {
+        for item in &parsed.items {
+            c.visit_item(item);
+        }
+        let facts = c.facts;
+        for child in &facts.child_mods {
             let resolved = match &child.explicit_path {
                 Some(rel) => file.parent().map(|d| d.join(rel)).filter(|p| p.exists()),
                 None => child_path(&file, &child.name),
             };
-            if let Some(p) = resolved {
-                queue.push(p);
+            match resolved {
+                Some(p) => queue.push(p),
+                None => {
+                    // An unresolvable `mod` is a module the census cannot see. Dropping it silently
+                    // is how a census loses eight modules and still reports a passing count.
+                    eprintln!(
+                        "UNRESOLVED MODULE `{}` declared in {}",
+                        child.name,
+                        file.display()
+                    );
+                    std::process::exit(2);
+                }
             }
         }
         modules.push(facts);
     }
 
     let out = serde_json::json!({
-        "schema": "ioi.ontology-admission-census.v1",
-        "entry": root,
+        "schema": "ioi.ontology-admission-census.v2",
+        "entry": entry,
+        "extractor_source_fnv1a64": format!("{:016x}", fnv1a64(SELF_SOURCE.as_bytes())),
+        "interests": interests,
+        "writers": WRITERS,
+        "readers": READERS,
+        "fs_calls": FS_CALLS,
         "modules": modules,
     });
     println!("{}", serde_json::to_string(&out).expect("serialise census"));

--- a/crates/ontology-census/src/main.rs
+++ b/crates/ontology-census/src/main.rs
@@ -16,23 +16,54 @@
 //! graph, the files were parsed into an AST — and the traversal on top stayed hand-rolled, a private
 //! `expr_children` covering roughly fifteen of syn's forty-odd `Expr` variants. A `Visit` impl with
 //! ZERO overrides was instantiated and driven across every expression, so the code READ as though a
-//! complete visitor were running while it did nothing at all. A fourth review demonstrated twelve of
-//! fourteen ordinary second-admitter constructs passing green: `.await` (775 of them in this daemon),
-//! `tokio::spawn` (34), impl methods (81 impl blocks), match-arm guards, struct literals, nested
-//! items, `let … else`, `unsafe` blocks, macro arguments, method-call writers. The scar the owner
-//! bound from it: A PRE-COMMITTED BOUNDARY IS EXECUTED BY ITS MECHANISM, NOT BY ITS DEPENDENCY.
+//! complete visitor were running while it did nothing at all. A fourth review demonstrated ordinary
+//! second-admitter constructs passing green against it — every one of them is now a committed anchor
+//! of class `construct` in `apps/hypervisor/ontology-admission-census.mutants.v1.json`, replayable
+//! rather than recounted. The scar the owner bound from it:
+//! A PRE-COMMITTED BOUNDARY IS EXECUTED BY ITS MECHANISM, NOT BY ITS DEPENDENCY. So the traversal
+//! here IS `syn::visit::Visit`, with overrides only where a fact must be recorded.
 //!
-//! So the traversal here IS `syn::visit::Visit`, with overrides only where a fact must be recorded.
-//! Every expression position, every `Stmt::Item`, every `ImplItem` and `TraitItem`, every arm guard
-//! and `let … else` block is reached by syn's own default recursion. The one thing syn does not walk
-//! is a macro's token stream, so that is scanned explicitly rather than left as a hole.
+//! AND WHY A CLOSED SET OF ROLES WAS STILL NOT ENOUGH. The fourth round's repair reported every
+//! mention WITH its syntactic role and let the gate hold a closed set of roles, so that a construct
+//! the walk stopped reading would surface as an UNKNOWN ROLE rather than as an absence. A fifth
+//! review defeated that too, and the diagnosis the owner bound as a scar is exact:
 //!
-//! POSITIVE CLASSIFICATION, NEVER ABSENCE. The same review found the deeper defect: a construct the
-//! walk missed produced no entry, and every judgement downstream was derived from the entries — so a
-//! COVERAGE GAP was indistinguishable from SAFETY. This tool therefore reports every mention of a
-//! name of interest together with the SYNTACTIC ROLE it appears in, and the gate holds a closed set
-//! of roles it can classify. A mention in a role the gate does not know is RED. A gap in coverage now
-//! reads as a finding, which is the only direction that can be trusted.
+//!     A CLOSED SET OF ROLES CLOSES NOTHING UNLESS THE SET OF THINGS THAT PRODUCE A ROLE IS ITSELF
+//!     ENTAILED.
+//!
+//! Roles were produced by AST positions this file happened to override. A family name in a position
+//! no override reached — a `match` arm PATTERN, an attribute's tokens, a byte string, a file pulled
+//! in by `include!`, a name assembled by `concat!` from pieces none of which is a family name —
+//! produced NO mention at all, so there was no role to be unknown about. Ten such mutants were
+//! planted; SEVEN of them passed the landing gate completely green once the mutant's own commit
+//! re-derived its population pins, which is what a landing commit does as a matter of routine. Only
+//! three were caught on a claim. Every one of the ten is a committed anchor in
+//! `apps/hypervisor/ontology-admission-census.mutants.v1.json`, so that count is replayable against
+//! the commit before this one rather than asserted here.
+//!
+//! SO MENTIONS ARE DERIVED FROM THE RAW TOKEN STREAM, AND THE AST ONLY ASSIGNS ROLES. Every file is
+//! parsed ONCE into a `proc_macro2::TokenStream`; that stream is walked exhaustively — every literal,
+//! every identifier, at every depth of every group — and it is the TOTAL population of mentions, by
+//! construction, because a name that is in the file is a token in the file. The same stream is then
+//! handed to `syn` and the visitor labels the positions it understands. The gate matches the two by
+//! SOURCE POSITION. A token the role-assigner never labelled is a SILENT MENTION and is RED. A
+//! coverage gap can no longer read as safety, because the thing being counted is no longer produced
+//! by the thing that might be incomplete.
+//!
+//! THREE TOTALITY EDGES, ALL FAIL-CLOSED, because "the tokens of the file" is only total if the set
+//! of files and the set of tokens are themselves total:
+//!   1. `include!` SPLICES another file's tokens into this one. A target this walk has not read is
+//!      RED-UNRESOLVED and aborts extraction — never absent. Resolved targets are spliced into the
+//!      INCLUDING module's facts, which is what `include!` means.
+//!   2. A CONSTRUCTED name never appears as a token. `concat!` and `stringify!` are FOLLOWED INTO
+//!      THEIR EXPANSION and the assembled value is emitted as a synthesised mention at the macro's
+//!      own position; an assembly with a piece this census cannot read is reported as unreadable and
+//!      the gate refuses it. Runtime assembly is reported wherever it sits inside a writer's or a
+//!      filesystem call's own arguments, so the gate can test its pieces against family-name
+//!      fragments.
+//!   3. Once this holds, A DEMONSTRATED SILENCE IS NOT A BUG TO PATCH — it is a falsification of the
+//!      design, and the owner's standing instruction is to stop and escalate rather than to model
+//!      one more construct.
 //!
 //! WHAT IT EMITS, and nothing more. This tool decides no policy — it does not know what an ontology
 //! family is; the caller passes the prefixes it cares about. It reports what the source SAYS, and the
@@ -42,15 +73,16 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use proc_macro2::TokenTree;
+use proc_macro2::{LineColumn, TokenStream, TokenTree};
 use serde::Serialize;
+use syn::spanned::Spanned;
 use syn::visit::{self, Visit};
-use syn::{Expr, File, Lit, UseTree};
+use syn::{Expr, File, Lit, Pat, UseTree};
 
-/// This file's own bytes, baked in at COMPILE time. A binary built from different source reports a
-/// different digest than the source on disk hashes to, which is how the gate refuses a stale
-/// extractor without trusting a timestamp — cargo treats a source whose mtime moved backwards as
-/// up-to-date, and an mtime comparison then passes on exactly the hazard it claims to catch.
+/// This file's own bytes, baked in at COMPILE time, so the binary can report which source it was
+/// built from. It is NOT compared against the source on disk — a digest the gate computes from the
+/// same source it then builds certifies nothing, because tampering moves both sides. The gate holds
+/// a COMMITTED PIN and compares both the binary's baked digest and the on-disk bytes against it.
 const SELF_SOURCE: &str = include_str!("main.rs");
 
 fn fnv1a64(bytes: &[u8]) -> u64 {
@@ -62,14 +94,37 @@ fn fnv1a64(bytes: &[u8]) -> u64 {
     h
 }
 
-/// A name of interest, recorded WITH the syntactic role it appears in. The role is the gate's whole
-/// defence against a coverage gap reading as safety: the gate classifies every role or goes RED.
+/// A name of interest, recorded WITH the syntactic role it appears in AND the source position the
+/// token walk will independently have found. The position is what makes the two populations
+/// comparable; the role is what the gate classifies.
 #[derive(Serialize)]
 struct Mention {
     name: String,
     role: String,
     in_fn: String,
     in_test: bool,
+    src: String,
+    line: usize,
+    col: usize,
+    /// True when this value was SYNTHESISED rather than read from a token — the expansion of a
+    /// compile-time `concat!`/`stringify!`. No single token carries the assembled text, so the
+    /// gate's reverse totality check exempts these and pins them separately.
+    synthesized: bool,
+}
+
+/// EVERY literal and constant-shaped identifier in the file's raw token stream. This is the census's
+/// total population: the AST assigns roles to positions in here, and a position it never assigns is
+/// the finding.
+#[derive(Serialize)]
+struct TokenMention {
+    text: String,
+    /// `str` for a string literal (raw forms included), `byte-str` for `b"…"`, `ident` for a
+    /// constant-shaped identifier. Byte strings are here because they were a live silence: a family
+    /// name spelled `b"odk-…"` reached a writer through `from_utf8` with no mention at all.
+    kind: &'static str,
+    src: String,
+    line: usize,
+    col: usize,
 }
 
 /// A call to a record writer or reader, with every leaf in its argument subtree.
@@ -91,6 +146,39 @@ struct FsCall {
     leaves: Vec<String>,
     in_fn: String,
     in_test: bool,
+}
+
+/// An `include!`/`include_str!`/`include_bytes!` site. `include!` SPLICES Rust source and is
+/// followed; the other two carry data and are recorded so the gate can pin the population.
+#[derive(Serialize)]
+struct IncludeSite {
+    mac: String,
+    arg: Option<String>,
+    resolved: Option<String>,
+    spliced: bool,
+    in_test: bool,
+    src: String,
+    line: usize,
+}
+
+/// A string ASSEMBLY. Compile-time assemblies (`concat!`, `stringify!`) are recorded wherever they
+/// appear and followed into their expansion when readable. Runtime assemblies are recorded only
+/// where they sit inside a writer's or filesystem call's own arguments — the population the gate
+/// judges — and the boundary is the open-call stack, not a name list.
+#[derive(Serialize)]
+struct Assembly {
+    kind: String,
+    compile_time: bool,
+    pieces: Vec<String>,
+    readable: bool,
+    assembled: Option<String>,
+    in_fn: String,
+    in_test: bool,
+    in_write_arg: bool,
+    in_fs_arg: bool,
+    src: String,
+    line: usize,
+    col: usize,
 }
 
 #[derive(Serialize, Clone)]
@@ -125,25 +213,33 @@ struct ModuleFacts {
     key: String,
     /// The file stem, for diagnostics and for resolving `mod::CONST` paths. Never an identity.
     stem: String,
+    /// Every file whose tokens are part of this module — the module's own file first, then anything
+    /// `include!` spliced into it.
+    sources: Vec<String>,
     /// `const NAME: &str = "literal"` and `static NAME: &str = "literal"` declared in THIS module.
-    /// Per-module, because the daemon declares 660 constants under 537 names and 25 of those names
-    /// mean different things in different modules.
+    /// Per-module, because the daemon declares hundreds of constants and some names mean different
+    /// things in different modules.
     consts: BTreeMap<String, String>,
-    /// `const NAME: &str = other::PLACE;` — a constant defined as another constant. Three of these
-    /// exist in this daemon and the previous resolver could follow none of them.
+    /// `Type::NAME` associated constants, keyed by their qualified spelling. Kept out of `consts`
+    /// because Rust namespaces them by type and flattening them into the module map would let one
+    /// impl's constant answer for a bare name it does not define.
+    assoc_consts: BTreeMap<String, String>,
+    /// `const NAME: &str = other::PLACE;` — a constant defined as another constant.
     const_refs: BTreeMap<String, String>,
-    /// A constant whose initialiser this extractor cannot read to a literal — `concat!(…)`, a call, a
-    /// cast. Reported, never dropped: the gate decides, and an unreadable initialiser whose tokens
-    /// mention a name of interest is a finding, not an absence.
+    /// A constant whose initialiser this extractor cannot read to a literal — `env!(…)`, a call, a
+    /// cast. Reported, never dropped: the gate decides, and an unreadable initialiser is a finding.
     const_opaque: Vec<String>,
     imports: Vec<Import>,
     child_mods: Vec<ChildMod>,
     calls: Vec<CallSite>,
     fs_calls: Vec<FsCall>,
     mentions: Vec<Mention>,
+    token_mentions: Vec<TokenMention>,
+    includes: Vec<IncludeSite>,
+    assemblies: Vec<Assembly>,
     /// Every function this module declares — free, impl method, or trait default — mapped to the
     /// leaves in its body. Declared for EVERY function, so a lookup miss is a real absence rather
-    /// than the silent empty list an impl method used to produce for a third of this daemon.
+    /// than the silent empty list an impl method used to produce.
     fn_leaves: BTreeMap<String, Vec<String>>,
     /// Per function, the leaves of every `=> Some(X)` match-arm value.
     resolver_arms: BTreeMap<String, Vec<String>>,
@@ -179,8 +275,78 @@ fn path_segments(p: &syn::Path) -> Vec<String> {
     p.segments.iter().map(|s| s.ident.to_string()).collect()
 }
 
+/// The position a path MENTION is anchored at: its LAST segment's identifier, which is the token the
+/// raw walk independently records. Anchoring at the whole path's span would not correspond to any
+/// single token and the two populations could never be matched.
+fn path_pos(p: &syn::Path) -> LineColumn {
+    p.segments
+        .last()
+        .map(|s| s.ident.span().start())
+        .unwrap_or(LineColumn { line: 0, column: 0 })
+}
+
+/// A string literal's value, whether it is written `"…"`, `r#"…"#` or `b"…"`. Byte strings were a
+/// live silence: `std::str::from_utf8(b"odk-…")` put a family name in a writer's arguments with no
+/// mention recorded anywhere.
+fn lit_text(l: &Lit) -> Option<String> {
+    match l {
+        Lit::Str(s) => Some(s.value()),
+        Lit::ByteStr(b) => String::from_utf8(b.value()).ok(),
+        _ => None,
+    }
+}
+
+fn token_lit_text(l: &proc_macro2::Literal) -> Option<(String, &'static str)> {
+    let raw = l.to_string();
+    if let Ok(s) = syn::parse_str::<syn::LitStr>(&raw) {
+        return Some((s.value(), "str"));
+    }
+    if let Ok(b) = syn::parse_str::<syn::LitByteStr>(&raw) {
+        return String::from_utf8(b.value()).ok().map(|v| (v, "byte-str"));
+    }
+    None
+}
+
+/// THE TOTAL POPULATION. Every literal and every constant-shaped identifier in a token stream, at
+/// every depth of every group, with the position of the token itself. Nothing here consults the AST,
+/// which is the point: a construct syn models badly, or a position this file forgot to override,
+/// cannot remove a token from a file.
+fn token_walk(ts: TokenStream, src: &str, out: &mut Vec<TokenMention>) {
+    for t in ts {
+        match t {
+            TokenTree::Literal(l) => {
+                if let Some((v, kind)) = token_lit_text(&l) {
+                    let p = l.span().start();
+                    out.push(TokenMention {
+                        text: v,
+                        kind,
+                        src: src.to_string(),
+                        line: p.line,
+                        col: p.column,
+                    });
+                }
+            }
+            TokenTree::Ident(i) => {
+                let n = i.to_string();
+                if is_const_ident(&n) {
+                    let p = i.span().start();
+                    out.push(TokenMention {
+                        text: n,
+                        kind: "ident",
+                        src: src.to_string(),
+                        line: p.line,
+                        col: p.column,
+                    });
+                }
+            }
+            TokenTree::Group(g) => token_walk(g.stream(), src, out),
+            TokenTree::Punct(_) => {}
+        }
+    }
+}
+
 /// Every string literal and constant-shaped path leaf under an expression, found by syn's own
-/// recursion rather than a hand-rolled child list.
+/// recursion rather than a hand-rolled child list. Used where only the VALUES matter.
 #[derive(Default)]
 struct LeafGrab {
     out: Vec<String>,
@@ -190,8 +356,8 @@ impl<'ast> Visit<'ast> for LeafGrab {
     fn visit_expr(&mut self, e: &'ast Expr) {
         match e {
             Expr::Lit(l) => {
-                if let Lit::Str(s) = &l.lit {
-                    self.out.push(s.value());
+                if let Some(v) = lit_text(&l.lit) {
+                    self.out.push(v);
                 }
             }
             Expr::Path(p) => {
@@ -206,47 +372,36 @@ impl<'ast> Visit<'ast> for LeafGrab {
     }
 
     fn visit_macro(&mut self, m: &'ast syn::Macro) {
-        grab_tokens(m.tokens.clone(), &mut self.out);
+        for (v, _) in token_values(m.tokens.clone()) {
+            self.out.push(v);
+        }
         visit::visit_macro(self, m);
     }
 }
 
-fn grab_tokens(ts: proc_macro2::TokenStream, out: &mut Vec<String>) {
-    for t in ts {
-        match t {
-            TokenTree::Literal(l) => {
-                let raw = l.to_string();
-                if raw.starts_with('"') || raw.starts_with('r') {
-                    if let Ok(s) = syn::parse_str::<syn::LitStr>(&raw) {
-                        out.push(s.value());
+/// Literal values and constant-shaped identifiers in a token stream, WITH their positions.
+fn token_values(ts: TokenStream) -> Vec<(String, LineColumn)> {
+    let mut out = Vec::new();
+    fn walk(ts: TokenStream, out: &mut Vec<(String, LineColumn)>) {
+        for t in ts {
+            match t {
+                TokenTree::Literal(l) => {
+                    if let Some((v, _)) = token_lit_text(&l) {
+                        out.push((v, l.span().start()));
                     }
                 }
-            }
-            TokenTree::Ident(i) => {
-                let n = i.to_string();
-                if is_const_ident(&n) {
-                    out.push(n);
+                TokenTree::Ident(i) => {
+                    let n = i.to_string();
+                    if is_const_ident(&n) {
+                        out.push((n, i.span().start()));
+                    }
                 }
-            }
-            TokenTree::Group(g) => grab_tokens(g.stream(), out),
-            TokenTree::Punct(_) => {}
-        }
-    }
-}
-
-/// Every identifier in a token stream, however deeply grouped.
-fn macro_token_idents(ts: proc_macro2::TokenStream) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut stack = vec![ts];
-    while let Some(s) = stack.pop() {
-        for t in s {
-            match t {
-                TokenTree::Ident(i) => out.push(i.to_string()),
-                TokenTree::Group(g) => stack.push(g.stream()),
-                _ => {}
+                TokenTree::Group(g) => walk(g.stream(), out),
+                TokenTree::Punct(_) => {}
             }
         }
     }
+    walk(ts, &mut out);
     out
 }
 
@@ -254,6 +409,24 @@ fn expr_leaves(e: &Expr) -> Vec<String> {
     let mut g = LeafGrab::default();
     g.visit_expr(e);
     g.out
+}
+
+/// Split a macro's tokens on top-level commas — `concat!`'s argument list.
+fn comma_pieces(ts: TokenStream) -> Vec<Vec<TokenTree>> {
+    let mut out: Vec<Vec<TokenTree>> = vec![Vec::new()];
+    for t in ts {
+        if let TokenTree::Punct(p) = &t {
+            if p.as_char() == ',' {
+                out.push(Vec::new());
+                continue;
+            }
+        }
+        out.last_mut().expect("non-empty").push(t);
+    }
+    if out.last().is_some_and(|v| v.is_empty()) {
+        out.pop();
+    }
+    out
 }
 
 const WRITERS: &[&str] = &[
@@ -276,17 +449,44 @@ const FS_CALLS: &[&str] = &[
     "rename",
     "hard_link",
 ];
+/// COMPILE-TIME name assembly: the two constructs that can produce a `&'static str` family name
+/// without the name ever existing as a token. Both are followed into their expansion.
+const COMPILE_ASSEMBLY: &[&str] = &["concat", "stringify"];
+/// RUNTIME assembly. Recorded only inside a writer's or filesystem call's own arguments.
+const ASSEMBLY_MACROS: &[&str] = &[
+    "format",
+    "format_args",
+    "write",
+    "writeln",
+    "print",
+    "println",
+    "eprint",
+    "eprintln",
+    "panic",
+];
+const ASSEMBLY_METHODS: &[&str] = &[
+    "push_str",
+    "join",
+    "concat",
+    "replace",
+    "replacen",
+    "insert_str",
+    "to_owned",
+    "to_string",
+];
+/// The file-splicing and file-reading macros. `include!` is followed; the data forms are pinned.
+const INCLUDE_MACROS: &[&str] = &["include", "include_str", "include_bytes"];
 
 /// THE CENSUS COLLECTOR — a real `syn::visit::Visit`. Every override records a fact and then hands
 /// control back to syn's default recursion, so no construct is reachable only because this file
-/// happens to name it.
+/// happens to name it. The visitor's job is to LABEL positions; the token walk owns the population.
 struct Collector {
     facts: ModuleFacts,
     test_depth: usize,
     fn_stack: Vec<String>,
     /// The syntactic role a mention found right now sits in. Pushed by the constructs that give a
     /// name its meaning — a writer's arguments, a reader's, a raw filesystem call's, a constant's
-    /// initialiser — and inherited by everything beneath.
+    /// initialiser, a pattern, an attribute — and inherited by everything beneath.
     roles: Vec<String>,
     /// Indices into `facts.calls` / `facts.fs_calls` for the calls currently open, so every leaf
     /// found beneath one is attributed to it however deeply it nests.
@@ -294,11 +494,20 @@ struct Collector {
     open_fs: Vec<usize>,
     interests: Vec<String>,
     wrote_in_fn: Vec<bool>,
+    /// The enclosing `impl`/`trait` type name, so an associated constant is recorded under the
+    /// qualified spelling that actually reaches it.
+    impl_ty: Vec<String>,
+    /// The file whose tokens are being labelled right now — the module's own, or a spliced include.
+    cur_src: String,
 }
 
 impl Collector {
     fn in_test(&self) -> bool {
         self.test_depth > 0
+    }
+
+    fn cur_impl_ty(&self) -> String {
+        self.impl_ty.last().cloned().unwrap_or_default()
     }
 
     fn role(&self) -> String {
@@ -317,8 +526,13 @@ impl Collector {
     }
 
     /// Record one leaf: attribute it to every open call, to the enclosing function, and — when it is
-    /// a name of interest — to the mention log with its role.
-    fn leaf(&mut self, text: String) {
+    /// a name of interest — to the mention log with its role and the position of the token it came
+    /// from. The position is what lets the gate match this population against the token walk's.
+    fn leaf(&mut self, text: String, pos: LineColumn) {
+        self.leaf_at(text, pos, None, false);
+    }
+
+    fn leaf_at(&mut self, text: String, pos: LineColumn, role: Option<&str>, synthesized: bool) {
         for i in self.open_calls.clone() {
             self.facts.calls[i].leaves.push(text.clone());
         }
@@ -339,14 +553,27 @@ impl Collector {
         // family under a fully-qualified path disappeared from the admitter map.
         let tail = text.rsplit("::").next().unwrap_or(&text).to_string();
         if self.interesting(&text) || is_const_ident(&tail) {
-            let role = self.role();
+            let role = role.map(|r| r.to_string()).unwrap_or_else(|| self.role());
             self.facts.mentions.push(Mention {
                 name: text,
                 role,
                 in_fn: f,
                 in_test: self.in_test(),
+                src: self.cur_src.clone(),
+                line: pos.line,
+                col: pos.column,
+                synthesized,
             });
         }
+    }
+
+    /// Label a whole token stream — a macro's arguments, an attribute's tokens — under one role.
+    fn token_leaves(&mut self, ts: TokenStream, role: &str) {
+        self.roles.push(role.to_string());
+        for (v, p) in token_values(ts) {
+            self.leaf(v, p);
+        }
+        self.roles.pop();
     }
 
     fn enter_fn(&mut self, name: String, attrs: &[syn::Attribute]) -> bool {
@@ -440,23 +667,198 @@ impl Collector {
             self.open_fs.pop();
         }
     }
+
+    fn record_assembly(
+        &mut self,
+        kind: String,
+        compile_time: bool,
+        pieces: Vec<String>,
+        readable: bool,
+        assembled: Option<String>,
+        pos: LineColumn,
+    ) {
+        self.facts.assemblies.push(Assembly {
+            kind,
+            compile_time,
+            pieces,
+            readable,
+            assembled,
+            in_fn: self.cur_fn(),
+            in_test: self.in_test(),
+            in_write_arg: !self.open_calls.is_empty(),
+            in_fs_arg: !self.open_fs.is_empty(),
+            src: self.cur_src.clone(),
+            line: pos.line,
+            col: pos.column,
+        });
+    }
+
+    /// FOLLOW A COMPILE-TIME ASSEMBLY INTO ITS EXPANSION. `concat!("od", "k-domain-ontologies")`
+    /// names a family that appears in no token; evaluating it here is what makes the token
+    /// population total for constructed names too. An assembly with a piece this census cannot read
+    /// — `env!`, a nested macro — is recorded UNREADABLE and the gate refuses it rather than
+    /// guessing at what it expands to.
+    fn follow_compile_assembly(&mut self, mac: &str, tokens: TokenStream, pos: LineColumn) {
+        if mac == "stringify" {
+            let text = tokens.to_string();
+            self.record_assembly(
+                "stringify".into(),
+                true,
+                vec![text.clone()],
+                true,
+                Some(text.clone()),
+                pos,
+            );
+            let role = self.role();
+            self.leaf_at(text, pos, Some(&role), true);
+            return;
+        }
+        let mut pieces = Vec::new();
+        let mut readable = true;
+        for piece in comma_pieces(tokens) {
+            match piece.as_slice() {
+                [TokenTree::Literal(l)] => match token_lit_text(l) {
+                    Some((v, _)) => pieces.push(v),
+                    None => readable = false,
+                },
+                _ => readable = false,
+            }
+        }
+        let assembled = if readable {
+            Some(pieces.concat())
+        } else {
+            None
+        };
+        self.record_assembly(
+            "concat".into(),
+            true,
+            pieces,
+            readable,
+            assembled.clone(),
+            pos,
+        );
+        if let Some(v) = assembled {
+            let role = self.role();
+            self.leaf_at(v, pos, Some(&role), true);
+        }
+    }
+
+    /// A COMPILE-TIME ASSEMBLY NESTED INSIDE ANOTHER MACRO'S TOKENS. syn hands a macro's tokens over
+    /// unparsed, so `json!({ "k": concat!("od", "k-…") })` never reaches `visit_macro` for the inner
+    /// `concat!` at all — the outer scan sees two innocent literals and the assembled name exists
+    /// nowhere. Most of this daemon's compile-time assemblies sit in exactly that position, under
+    /// `include_str!`: the expression walk alone found TWO, and the gate's pinned population — which
+    /// is where that number reproduces — is EIGHT. Leaving it to the expression walk would have
+    /// pinned two and called the population closed.
+    fn follow_nested_assembly(&mut self, ts: TokenStream) {
+        let items: Vec<TokenTree> = ts.into_iter().collect();
+        for (i, t) in items.iter().enumerate() {
+            if let TokenTree::Group(g) = t {
+                let is_assembly_args = i >= 2
+                    && matches!(&items[i - 1], TokenTree::Punct(p) if p.as_char() == '!')
+                    && matches!(&items[i - 2], TokenTree::Ident(id) if COMPILE_ASSEMBLY.contains(&id.to_string().as_str()));
+                if is_assembly_args {
+                    let TokenTree::Ident(id) = &items[i - 2] else {
+                        unreachable!("guarded by the match above")
+                    };
+                    self.follow_compile_assembly(&id.to_string(), g.stream(), id.span().start());
+                }
+                self.follow_nested_assembly(g.stream());
+            }
+        }
+    }
+
+    fn record_const(&mut self, name: &str, expr: &Expr) {
+        match expr {
+            Expr::Lit(l) => match lit_text(&l.lit) {
+                Some(v) => {
+                    self.facts.consts.insert(name.to_string(), v);
+                }
+                None => self.facts.const_opaque.push(name.to_string()),
+            },
+            Expr::Path(p) => {
+                self.facts
+                    .const_refs
+                    .insert(name.to_string(), path_segments(&p.path).join("::"));
+            }
+            Expr::Reference(r) => self.record_const(name, &r.expr),
+            _ => self.facts.const_opaque.push(name.to_string()),
+        }
+    }
+
+    /// An associated constant — `impl Shadow { const FAM: &str = "…"; }`. Kept under its QUALIFIED
+    /// spelling so it answers for `Shadow::FAM` and never for a bare `FAM` it does not define.
+    fn record_assoc_const(&mut self, ty: &str, name: &str, expr: &Expr) {
+        if let Expr::Lit(l) = expr {
+            if let Some(v) = lit_text(&l.lit) {
+                self.facts.assoc_consts.insert(format!("{ty}::{name}"), v);
+                return;
+            }
+        }
+        if let Expr::Reference(r) = expr {
+            return self.record_assoc_const(ty, name, &r.expr);
+        }
+        self.facts.const_opaque.push(format!("{ty}::{name}"));
+    }
+
+    /// The DECLARATION SITE of a constant is a token of the name too. Labelling it is not decoration:
+    /// the token walk finds `KIND_ONT` where it is declared, that identifier resolves to a family,
+    /// and an unlabelled position is by construction a silent mention.
+    fn decl_name(&mut self, ident: &syn::Ident) {
+        let n = ident.to_string();
+        if !is_const_ident(&n) {
+            return;
+        }
+        let pos = ident.span().start();
+        self.leaf_at(n, pos, Some("decl-name"), false);
+    }
 }
 
 impl<'ast> Visit<'ast> for Collector {
     fn visit_expr(&mut self, e: &'ast Expr) {
         match e {
             Expr::Lit(l) => {
-                if let Lit::Str(s) = &l.lit {
-                    self.leaf(s.value());
+                if let Some(v) = lit_text(&l.lit) {
+                    self.leaf(v, l.lit.span().start());
                 }
             }
             Expr::Path(p) => {
                 let segs = path_segments(&p.path);
                 if segs.last().is_some_and(|s| is_const_ident(s)) {
-                    self.leaf(segs.join("::"));
+                    self.leaf(segs.join("::"), path_pos(&p.path));
                 }
             }
             _ => {}
+        }
+        // RUNTIME ASSEMBLY inside a writer's or filesystem call's arguments. `+` on strings and the
+        // string-building methods are how a family name is composed from pieces that are each
+        // innocent; the gate tests the pieces against family-name fragments.
+        if !self.open_calls.is_empty() || !self.open_fs.is_empty() {
+            match e {
+                Expr::Binary(b) if matches!(b.op, syn::BinOp::Add(_)) => {
+                    let mut pieces = expr_leaves(&b.left);
+                    pieces.extend(expr_leaves(&b.right));
+                    let pos = b.op.span().start();
+                    self.record_assembly("binary-add".into(), false, pieces, false, None, pos);
+                }
+                Expr::MethodCall(mc)
+                    if ASSEMBLY_METHODS.contains(&mc.method.to_string().as_str()) =>
+                {
+                    let mut pieces = expr_leaves(&mc.receiver);
+                    for a in &mc.args {
+                        pieces.extend(expr_leaves(a));
+                    }
+                    self.record_assembly(
+                        format!("method:{}", mc.method),
+                        false,
+                        pieces,
+                        false,
+                        None,
+                        mc.method.span().start(),
+                    );
+                }
+                _ => {}
+            }
         }
         let opened = match e {
             Expr::Call(c) => match &*c.func {
@@ -471,29 +873,137 @@ impl<'ast> Visit<'ast> for Collector {
     }
 
     /// syn does not walk a macro's tokens — they are not parsed as expressions. Left alone this is a
-    /// hole exactly the size of `json!`, `format!` and `write!`, so the tokens are scanned here.
+    /// hole exactly the size of `json!`, `format!` and `write!`, so the tokens are scanned here, and
+    /// the file-splicing and name-assembling macros are followed rather than merely scanned.
     fn visit_macro(&mut self, m: &'ast syn::Macro) {
         let mac = path_segments(&m.path).last().cloned().unwrap_or_default();
-        let mut found = Vec::new();
-        grab_tokens(m.tokens.clone(), &mut found);
+
+        if INCLUDE_MACROS.contains(&mac.as_str()) {
+            let arg = match comma_pieces(m.tokens.clone()).first().map(|p| p.as_slice()) {
+                Some([TokenTree::Literal(l)]) => token_lit_text(l).map(|(v, _)| v),
+                _ => None,
+            };
+            let pos = m
+                .path
+                .segments
+                .last()
+                .map(|s| s.ident.span().start())
+                .unwrap_or(LineColumn { line: 0, column: 0 });
+            self.facts.includes.push(IncludeSite {
+                mac: mac.clone(),
+                arg,
+                resolved: None,
+                spliced: false,
+                in_test: self.in_test(),
+                src: self.cur_src.clone(),
+                line: pos.line,
+            });
+        }
+
+        let mac_pos = m
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.span().start())
+            .unwrap_or(LineColumn { line: 0, column: 0 });
+        if COMPILE_ASSEMBLY.contains(&mac.as_str()) {
+            self.follow_compile_assembly(&mac, m.tokens.clone(), mac_pos);
+        } else if ASSEMBLY_MACROS.contains(&mac.as_str())
+            && (!self.open_calls.is_empty() || !self.open_fs.is_empty())
+        {
+            let pieces = token_values(m.tokens.clone())
+                .into_iter()
+                .map(|(v, _)| v)
+                .collect();
+            self.record_assembly(format!("macro:{mac}"), false, pieces, false, None, mac_pos);
+        }
+        self.follow_nested_assembly(m.tokens.clone());
+
         // A WRITER CALL INSIDE MACRO TOKENS IS STILL A WRITER CALL. syn hands over the token stream
         // unparsed, so `json!({ "w": persist_record(d, KIND, id, r) })` reaches `visit_expr` as
         // nothing at all. Naming a writer anywhere in the tokens re-attributes every family leaf in
         // them to the writing role — over-attribution, deliberately, because the alternative is a
         // write the census reports as a mere mention.
-        let names_writer = macro_token_idents(m.tokens.clone())
+        let names_writer = token_idents(m.tokens.clone())
             .iter()
             .any(|i| WRITERS.contains(&i.as_str()));
-        self.roles.push(if names_writer {
+        let role = if names_writer {
             "write-arg".to_string()
         } else {
             format!("macro:{mac}")
-        });
-        for t in found {
-            self.leaf(t);
-        }
-        self.roles.pop();
+        };
+        self.token_leaves(m.tokens.clone(), &role);
         visit::visit_macro(self, m);
+    }
+
+    /// An ATTRIBUTE's tokens are tokens of the file. `#[serde(rename = "odk-…")]` mints a family
+    /// name in a position no expression visitor reaches, and it was a demonstrated silence.
+    fn visit_attribute(&mut self, a: &'ast syn::Attribute) {
+        let name = path_segments(a.path()).last().cloned().unwrap_or_default();
+        let role = format!("attr:{name}");
+        match &a.meta {
+            syn::Meta::List(l) => self.token_leaves(l.tokens.clone(), &role),
+            syn::Meta::NameValue(nv) => {
+                if let Expr::Lit(l) = &nv.value {
+                    if let Some(v) = lit_text(&l.lit) {
+                        let pos = l.lit.span().start();
+                        self.leaf_at(v, pos, Some(&role), false);
+                    }
+                }
+            }
+            syn::Meta::Path(_) => {}
+        }
+        // Deliberately NOT delegating to syn's default: it would re-walk `Meta::NameValue`'s
+        // expression through `visit_expr` and record the same position twice.
+    }
+
+    /// A PATTERN carries literals and constant paths. `match kind { k @ "odk-…" => write(k) }` was a
+    /// live, fully-green second admitter: the family name reached a writer and no expression
+    /// position ever held it.
+    fn visit_pat(&mut self, p: &'ast Pat) {
+        match p {
+            Pat::Lit(l) => {
+                if let Some(v) = lit_text(&l.lit) {
+                    let pos = l.lit.span().start();
+                    self.leaf_at(v, pos, Some("pattern-lit"), false);
+                }
+            }
+            Pat::Path(pp) => {
+                let segs = path_segments(&pp.path);
+                if segs.last().is_some_and(|s| is_const_ident(s)) {
+                    let pos = path_pos(&pp.path);
+                    self.leaf_at(segs.join("::"), pos, Some("pattern-path"), false);
+                }
+            }
+            Pat::TupleStruct(t) => {
+                let segs = path_segments(&t.path);
+                if segs.last().is_some_and(|s| is_const_ident(s)) {
+                    let pos = path_pos(&t.path);
+                    self.leaf_at(segs.join("::"), pos, Some("pattern-path"), false);
+                }
+            }
+            Pat::Struct(s) => {
+                let segs = path_segments(&s.path);
+                if segs.last().is_some_and(|s| is_const_ident(s)) {
+                    let pos = path_pos(&s.path);
+                    self.leaf_at(segs.join("::"), pos, Some("pattern-path"), false);
+                }
+            }
+            Pat::Ident(i) => self.decl_name(&i.ident),
+            _ => {}
+        }
+        visit::visit_pat(self, p);
+    }
+
+    /// Constant-shaped identifiers in TYPE position — a const generic argument, an associated type
+    /// path. Rare in this daemon and labelled anyway, because "rare" is not "entailed".
+    fn visit_type_path(&mut self, t: &'ast syn::TypePath) {
+        let segs = path_segments(&t.path);
+        if segs.last().is_some_and(|s| is_const_ident(s)) {
+            let pos = path_pos(&t.path);
+            self.leaf_at(segs.join("::"), pos, Some("type-path"), false);
+        }
+        visit::visit_type_path(self, t);
     }
 
     fn visit_item_const(&mut self, i: &'ast syn::ItemConst) {
@@ -502,6 +1012,7 @@ impl<'ast> Visit<'ast> for Collector {
             self.test_depth += 1;
         }
         self.record_const(&i.ident.to_string(), &i.expr);
+        self.decl_name(&i.ident);
         self.roles.push("const-init".into());
         visit::visit_item_const(self, i);
         self.roles.pop();
@@ -510,7 +1021,7 @@ impl<'ast> Visit<'ast> for Collector {
         }
     }
 
-    /// `static` was invisible to the previous extractor entirely, so the rule forbidding a foreign
+    /// `static` was invisible to an earlier extractor entirely, so the rule forbidding a foreign
     /// module from DECLARING a family name was defeated by changing one keyword.
     fn visit_item_static(&mut self, i: &'ast syn::ItemStatic) {
         let test = is_bare_cfg_test(&i.attrs);
@@ -518,6 +1029,7 @@ impl<'ast> Visit<'ast> for Collector {
             self.test_depth += 1;
         }
         self.record_const(&i.ident.to_string(), &i.expr);
+        self.decl_name(&i.ident);
         self.roles.push("static-init".into());
         visit::visit_item_static(self, i);
         self.roles.pop();
@@ -526,9 +1038,57 @@ impl<'ast> Visit<'ast> for Collector {
         }
     }
 
+    fn visit_impl_item_const(&mut self, i: &'ast syn::ImplItemConst) {
+        let test = is_bare_cfg_test(&i.attrs);
+        if test {
+            self.test_depth += 1;
+        }
+        self.record_assoc_const(&self.cur_impl_ty(), &i.ident.to_string(), &i.expr);
+        self.decl_name(&i.ident);
+        self.roles.push("const-init".into());
+        visit::visit_impl_item_const(self, i);
+        self.roles.pop();
+        if test {
+            self.test_depth -= 1;
+        }
+    }
+
+    fn visit_trait_item_const(&mut self, i: &'ast syn::TraitItemConst) {
+        let test = is_bare_cfg_test(&i.attrs);
+        if test {
+            self.test_depth += 1;
+        }
+        if let Some((_, e)) = &i.default {
+            self.record_assoc_const(&self.cur_impl_ty(), &i.ident.to_string(), e);
+        }
+        self.decl_name(&i.ident);
+        self.roles.push("const-init".into());
+        visit::visit_trait_item_const(self, i);
+        self.roles.pop();
+        if test {
+            self.test_depth -= 1;
+        }
+    }
+
+    fn visit_foreign_item_static(&mut self, i: &'ast syn::ForeignItemStatic) {
+        self.decl_name(&i.ident);
+        visit::visit_foreign_item_static(self, i);
+    }
+
+    /// A `use` tree's identifiers are tokens of the file, and one of them may be a constant this
+    /// census resolves to a family. `use super::odk_routes::KIND_ONT as ONT_DIR;` puts TWO such
+    /// tokens in the file and neither sits in any expression.
     fn visit_item_use(&mut self, i: &'ast syn::ItemUse) {
         let mut prefix = Vec::new();
         flatten_use(&i.tree, &mut prefix, &mut self.facts.imports);
+        let mut idents = Vec::new();
+        use_tree_idents(&i.tree, &mut idents);
+        for id in idents {
+            let n = id.to_string();
+            if is_const_ident(&n) {
+                self.leaf_at(n, id.span().start(), Some("use-path"), false);
+            }
+        }
         visit::visit_item_use(self, i);
     }
 
@@ -571,10 +1131,10 @@ impl<'ast> Visit<'ast> for Collector {
         self.exit_fn(t);
     }
 
-    /// Impl methods are 81 blocks of this daemon's house style. The previous extractor ran a
-    /// collector over them but never created their `fn_leaves` entry, so the raw-filesystem rule's
-    /// "and the function around it names a family" half looked up an empty list for 32% of the
-    /// production filesystem calls in the tree — dead for every one of them.
+    /// Impl methods are the daemon's house style. An earlier extractor ran a collector over them but
+    /// never created their `fn_leaves` entry, so the raw-filesystem rule's "and the function around
+    /// it names a family" half looked up an empty list for every production filesystem call that
+    /// sits in an impl method — dead for every one of them.
     fn visit_impl_item_fn(&mut self, i: &'ast syn::ImplItemFn) {
         let t = self.enter_fn(i.sig.ident.to_string(), &i.attrs);
         visit::visit_impl_item_fn(self, i);
@@ -592,7 +1152,22 @@ impl<'ast> Visit<'ast> for Collector {
         if test {
             self.test_depth += 1;
         }
+        self.impl_ty.push(type_name(&i.self_ty));
         visit::visit_item_impl(self, i);
+        self.impl_ty.pop();
+        if test {
+            self.test_depth -= 1;
+        }
+    }
+
+    fn visit_item_trait(&mut self, i: &'ast syn::ItemTrait) {
+        let test = is_bare_cfg_test(&i.attrs);
+        if test {
+            self.test_depth += 1;
+        }
+        self.impl_ty.push(i.ident.to_string());
+        visit::visit_item_trait(self, i);
+        self.impl_ty.pop();
         if test {
             self.test_depth -= 1;
         }
@@ -621,24 +1196,48 @@ impl<'ast> Visit<'ast> for Collector {
     }
 }
 
-impl Collector {
-    fn record_const(&mut self, name: &str, expr: &Expr) {
-        match expr {
-            Expr::Lit(l) => match &l.lit {
-                Lit::Str(s) => {
-                    self.facts.consts.insert(name.to_string(), s.value());
-                }
-                _ => self.facts.const_opaque.push(name.to_string()),
-            },
-            Expr::Path(p) => {
-                self.facts
-                    .const_refs
-                    .insert(name.to_string(), path_segments(&p.path).join("::"));
+fn type_name(t: &syn::Type) -> String {
+    match t {
+        syn::Type::Path(p) => path_segments(&p.path).join("::"),
+        syn::Type::Reference(r) => type_name(&r.elem),
+        _ => String::new(),
+    }
+}
+
+fn use_tree_idents<'a>(tree: &'a UseTree, out: &mut Vec<&'a syn::Ident>) {
+    match tree {
+        UseTree::Path(p) => {
+            out.push(&p.ident);
+            use_tree_idents(&p.tree, out);
+        }
+        UseTree::Name(n) => out.push(&n.ident),
+        UseTree::Rename(r) => {
+            out.push(&r.ident);
+            out.push(&r.rename);
+        }
+        UseTree::Glob(_) => {}
+        UseTree::Group(g) => {
+            for t in &g.items {
+                use_tree_idents(t, out);
             }
-            Expr::Reference(r) => self.record_const(name, &r.expr),
-            _ => self.facts.const_opaque.push(name.to_string()),
         }
     }
+}
+
+/// Every identifier in a token stream, however deeply grouped.
+fn token_idents(ts: TokenStream) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut stack = vec![ts];
+    while let Some(s) = stack.pop() {
+        for t in s {
+            match t {
+                TokenTree::Ident(i) => out.push(i.to_string()),
+                TokenTree::Group(g) => stack.push(g.stream()),
+                _ => {}
+            }
+        }
+    }
+    out
 }
 
 fn flatten_use(tree: &UseTree, prefix: &mut Vec<String>, out: &mut Vec<Import>) {
@@ -718,6 +1317,34 @@ fn repo_key(p: &Path, root: &Path) -> String {
         .replace('\\', "/")
 }
 
+fn die(msg: String) -> ! {
+    eprintln!("{msg}");
+    std::process::exit(2);
+}
+
+/// Read a file, tokenise it ONCE, and parse the AST FROM THE SAME TOKEN STREAM. Sharing the stream
+/// is not an optimisation — it is what makes the two populations comparable: every span the visitor
+/// reports is literally a span the token walk saw, so a position mismatch can only mean the visitor
+/// failed to label a token, never that two parses disagreed about where a token is.
+fn read_and_parse(file: &Path) -> (TokenStream, File) {
+    let src = match std::fs::read_to_string(file) {
+        Ok(s) => s,
+        // A module the walker cannot READ is not a module it may skip: the census's closed world is
+        // exactly the set of files it opened, and a silent `continue` shrinks that world without
+        // shrinking the claim.
+        Err(e) => die(format!("UNREADABLE MODULE {}: {e}", file.display())),
+    };
+    let ts: TokenStream = match src.parse() {
+        Ok(t) => t,
+        Err(e) => die(format!("TOKENISE FAILURE {}: {e}", file.display())),
+    };
+    let parsed: File = match syn::parse2(ts.clone()) {
+        Ok(p) => p,
+        Err(e) => die(format!("PARSE FAILURE {}: {e}", file.display())),
+    };
+    (ts, parsed)
+}
+
 fn main() {
     let mut args = std::env::args().skip(1);
     let mut entry = String::new();
@@ -744,31 +1371,18 @@ fn main() {
             continue;
         }
         seen.push(canon.clone());
-        // A module the walker cannot READ is not a module it may skip: the census's closed world is
-        // exactly the set of files it opened, and a silent `continue` shrinks that world without
-        // shrinking the claim.
-        let src = match std::fs::read_to_string(&file) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("UNREADABLE MODULE {}: {e}", file.display());
-                std::process::exit(2);
-            }
-        };
-        let parsed: File = match syn::parse_file(&src) {
-            Ok(p) => p,
-            Err(e) => {
-                eprintln!("PARSE FAILURE {}: {e}", file.display());
-                std::process::exit(2);
-            }
-        };
+        let key = repo_key(&canon, &repo_root);
+        let (ts, parsed) = read_and_parse(&file);
+
         let mut c = Collector {
             facts: ModuleFacts {
-                key: repo_key(&canon, &repo_root),
+                key: key.clone(),
                 stem: file
                     .file_stem()
                     .unwrap_or_default()
                     .to_string_lossy()
                     .to_string(),
+                sources: vec![key.clone()],
                 ..Default::default()
             },
             test_depth: 0,
@@ -778,10 +1392,57 @@ fn main() {
             open_fs: Vec::new(),
             interests: interests.clone(),
             wrote_in_fn: Vec::new(),
+            impl_ty: Vec::new(),
+            cur_src: key.clone(),
         };
+        token_walk(ts, &key, &mut c.facts.token_mentions);
         for item in &parsed.items {
             c.visit_item(item);
         }
+
+        // `include!` SPLICES another file's source into this one, so its tokens are this module's
+        // tokens and its writes are this module's writes. A target that cannot be resolved or read
+        // is RED-UNRESOLVED and aborts — an include the walk has not read is the one thing a total
+        // token population cannot survive.
+        let mut inc_i = 0;
+        while inc_i < c.facts.includes.len() {
+            let (mac, arg, from_src) = {
+                let s = &c.facts.includes[inc_i];
+                (s.mac.clone(), s.arg.clone(), s.src.clone())
+            };
+            inc_i += 1;
+            if mac != "include" {
+                continue;
+            }
+            let Some(rel) = arg else {
+                die(format!(
+                    "UNREADABLE include! ARGUMENT in {from_src} — a spliced file this census cannot name is a hole in its token population"
+                ));
+            };
+            let base = repo_root.join(&from_src);
+            let target = match base.parent().map(|d| d.join(&rel)) {
+                Some(p) if p.exists() => p,
+                _ => die(format!(
+                    "UNRESOLVED include!(\"{rel}\") in {from_src} — the spliced file is not on disk where the include names it"
+                )),
+            };
+            let tcanon = target.canonicalize().unwrap_or_else(|_| target.clone());
+            let tkey = repo_key(&tcanon, &repo_root);
+            if c.facts.sources.contains(&tkey) {
+                continue;
+            }
+            let (tts, tparsed) = read_and_parse(&target);
+            c.facts.sources.push(tkey.clone());
+            c.facts.includes[inc_i - 1].resolved = Some(tkey.clone());
+            c.facts.includes[inc_i - 1].spliced = true;
+            token_walk(tts, &tkey, &mut c.facts.token_mentions);
+            c.cur_src = tkey;
+            for item in &tparsed.items {
+                c.visit_item(item);
+            }
+            c.cur_src = key.clone();
+        }
+
         let facts = c.facts;
         for child in &facts.child_mods {
             let resolved = match &child.explicit_path {
@@ -790,29 +1451,30 @@ fn main() {
             };
             match resolved {
                 Some(p) => queue.push(p),
-                None => {
-                    // An unresolvable `mod` is a module the census cannot see. Dropping it silently
-                    // is how a census loses eight modules and still reports a passing count.
-                    eprintln!(
-                        "UNRESOLVED MODULE `{}` declared in {}",
-                        child.name,
-                        file.display()
-                    );
-                    std::process::exit(2);
-                }
+                // An unresolvable `mod` is a module the census cannot see. Dropping it silently
+                // is how a census loses eight modules and still reports a passing count.
+                None => die(format!(
+                    "UNRESOLVED MODULE `{}` declared in {}",
+                    child.name,
+                    file.display()
+                )),
             }
         }
         modules.push(facts);
     }
 
     let out = serde_json::json!({
-        "schema": "ioi.ontology-admission-census.v2",
+        "schema": "ioi.ontology-admission-census.v3",
         "entry": entry,
         "extractor_source_fnv1a64": format!("{:016x}", fnv1a64(SELF_SOURCE.as_bytes())),
         "interests": interests,
         "writers": WRITERS,
         "readers": READERS,
         "fs_calls": FS_CALLS,
+        "compile_assembly": COMPILE_ASSEMBLY,
+        "assembly_macros": ASSEMBLY_MACROS,
+        "assembly_methods": ASSEMBLY_METHODS,
+        "include_macros": INCLUDE_MACROS,
         "modules": modules,
     });
     println!("{}", serde_json::to_string(&out).expect("serialise census"));

--- a/crates/ontology-census/src/main.rs
+++ b/crates/ontology-census/src/main.rs
@@ -50,7 +50,7 @@
 //! coverage gap can no longer read as safety, because the thing being counted is no longer produced
 //! by the thing that might be incomplete.
 //!
-//! THREE TOTALITY EDGES, ALL FAIL-CLOSED, because "the tokens of the file" is only total if the set
+//! TWO TOTALITY EDGES, both fail-closed, because "the tokens of the file" is only total if the set
 //! of files and the set of tokens are themselves total:
 //!   1. `include!` SPLICES another file's tokens into this one. A target this walk has not read is
 //!      RED-UNRESOLVED and aborts extraction — never absent. Resolved targets are spliced into the
@@ -58,12 +58,24 @@
 //!   2. A CONSTRUCTED name never appears as a token. `concat!` and `stringify!` are FOLLOWED INTO
 //!      THEIR EXPANSION and the assembled value is emitted as a synthesised mention at the macro's
 //!      own position; an assembly with a piece this census cannot read is reported as unreadable and
-//!      the gate refuses it. Runtime assembly is reported wherever it sits inside a writer's or a
-//!      filesystem call's own arguments, so the gate can test its pieces against family-name
-//!      fragments.
-//!   3. Once this holds, A DEMONSTRATED SILENCE IS NOT A BUG TO PATCH — it is a falsification of the
-//!      design, and the owner's standing instruction is to stop and escalate rather than to model
-//!      one more construct.
+//!      the gate refuses it.
+//!
+//! AND TWO BOUNDARIES THAT ARE NAMED RATHER THAN CLOSED, because a design that has been falsified
+//! twice does not earn a third hardening edge — that is construct-modelling one layer up, and the
+//! owner ruled it out by name.
+//!
+//!   · THE FILE SET IS NOT RUSTC'S FILE SET. `mod` has no totality edge equivalent to `include!`'s
+//!     and is not getting one. A `#[cfg_attr(…, path = …)]` redirect is invisible here — this walk
+//!     reads only a bare `#[path]` — and a `mod` declared inside a `macro_rules!` body never reaches
+//!     `visit_item_mod` at all, because syn hands macro tokens over unparsed. In both cases rustc
+//!     compiles one file and this census reads another, or none. Demonstrated: a syntactically
+//!     invalid decoy makes the daemon build clean and this extractor exit non-zero. Neither
+//!     construct exists in the daemon today; entailing the file set belongs to the run that entails
+//!     the resolver.
+//!   · RESOLUTION IS NOT TOTAL, AND THAT IS THE REAL BOUND. See the gate's header: the token
+//!     population is total, but the population the gate JUDGES is `token ∩ resolves-to-a-family`,
+//!     and resolution is a partial function. Its failures are no longer silent — every one is
+//!     counted in a named, pinned bucket — but they are not adjudicated either.
 //!
 //! WHAT IT EMITS, and nothing more. This tool decides no policy — it does not know what an ontology
 //! family is; the caller passes the prefixes it cares about. It reports what the source SAYS, and the
@@ -292,6 +304,10 @@ fn lit_text(l: &Lit) -> Option<String> {
     match l {
         Lit::Str(s) => Some(s.value()),
         Lit::ByteStr(b) => String::from_utf8(b.value()).ok(),
+        // `c"odk-…"`. A review found this exact hole after byte strings were added for the same
+        // reason: the population claim is over EVERY literal form the language has, and enumerating
+        // two of three is the claim being false about the third.
+        Lit::CStr(c) => c.value().to_str().ok().map(str::to_owned),
         _ => None,
     }
 }
@@ -303,6 +319,9 @@ fn token_lit_text(l: &proc_macro2::Literal) -> Option<(String, &'static str)> {
     }
     if let Ok(b) = syn::parse_str::<syn::LitByteStr>(&raw) {
         return String::from_utf8(b.value()).ok().map(|v| (v, "byte-str"));
+    }
+    if let Ok(c) = syn::parse_str::<syn::LitCStr>(&raw) {
+        return c.value().to_str().ok().map(|v| (v.to_owned(), "c-str"));
     }
     None
 }

--- a/crates/ontology-census/src/main.rs
+++ b/crates/ontology-census/src/main.rs
@@ -1,0 +1,597 @@
+//! Ontology admission census EXTRACTOR — a real Rust parser, emitting the facts as JSON.
+//!
+//! An EXAMPLE target, deliberately. `syn` is a dev-dependency of this crate and the crate's own note
+//! says it keeps minimal dependencies to remain stable; an example may use dev-dependencies without
+//! putting a parser into a core type crate's runtime graph, and it builds only when asked for.
+//! Run: `cargo run --locked -p ioi-types --example ontology-admission-extract -- <daemon-main.rs>`.
+//!
+//! WHY THIS EXISTS, and why it replaced a hand-rolled reader. Next-legs XIV Leg 3a built the
+//! no-second-spine entailment by scanning the daemon's source with regexes. Three merge-blocking
+//! review rounds each defeated it, and the defeats sorted into two buckets: CENSUS LOGIC (a rule
+//! that was wrong or decorative) and LANGUAGE READING (a Rust construct the scanner mis-modelled).
+//! Round two produced six language-reading defeats; round three produced five more — module-scope
+//! path visibility (`use super::odk_routes;` then `odk_routes::KIND_ONT`), raw strings desyncing a
+//! brace walk, `async fn` and other declaration forms an enclosing-function heuristic could not
+//! find, and module-file resolution order shadowing a nested module with a flat sibling.
+//!
+//! The owner pre-committed the decision before that round ran: modelling the next construct retires
+//! an INSTANCE, a real parser retires the CLASS. Every construct above is free here, because `syn`
+//! already knows Rust — items, paths, use-trees, attributes, string and raw-string literals, and
+//! declaration forms are all just AST.
+//!
+//! WHAT IT EMITS, and nothing more. This tool decides no policy. It reports what the source SAYS —
+//! which modules exist, what each names, where each family literal is written and read — and the
+//! JavaScript gate decides what that means. Keeping extraction and judgement apart is what lets the
+//! judgement keep its mutation anchors while the substrate underneath changes.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use syn::{Expr, ExprCall, ExprPath, File, Item, ItemConst, Lit, UseTree};
+
+/// One record-writing or record-reading call site, with the family argument RESOLVED.
+#[derive(Serialize, Default)]
+struct CallSite {
+    callee: String,
+    /// The family literal this call names, once constants and aliases are resolved. `None` means
+    /// the census could not tie the argument to a literal — which the gate treats as RED, never as
+    /// "not a family".
+    family: Option<String>,
+    /// The argument as written, for the diagnostic.
+    written: String,
+    in_test: bool,
+}
+
+#[derive(Serialize, Default)]
+struct ModuleFacts {
+    name: String,
+    path: String,
+    /// `const NAME: &str = "literal"` declared in THIS module. Per-module, because the daemon
+    /// declares 660 constants under 537 names and 25 of those names mean different things in
+    /// different modules.
+    consts: BTreeMap<String, String>,
+    /// Every name this module brings into scope, mapped to the module it came from and the item.
+    /// Covers `use m::C`, `use m::C as A`, `use m::{a, b::C}`, `use m::*`, and `use m;` — the last
+    /// being the module-as-path-prefix form that defeated the hand-rolled reader.
+    imports: Vec<Import>,
+    /// Modules declared by this file. A `#[path]` target is carried after a unit separator so the
+    /// walker can resolve it without a second parse; the gate reads only the name before it.
+    child_mods: Vec<ChildMod>,
+    calls: Vec<CallSite>,
+    /// Raw filesystem calls, with every argument as written. The record-writer census cannot see a
+    /// lane that bypasses the writers entirely and puts bytes in a family directory itself, and the
+    /// regression floor this substrate inherited includes exactly that mutation.
+    fs_calls: Vec<FsCall>,
+    /// Every path expression whose final segment is a name this module could resolve to a family,
+    /// with the syntactic role it appears in. A name used in a role the gate does not know about is
+    /// a mention the census cannot read — which must be RED, never silently dropped.
+    family_mentions: Vec<Mention>,
+    /// Functions that both RESOLVE a family name and WRITE a record. The gate refuses these; the
+    /// extractor only reports which functions do both, using real item boundaries rather than a
+    /// backwards search for the `fn` keyword.
+    resolve_and_write_fns: Vec<String>,
+    /// Per function, every path leaf and string literal it names. The gate resolves these to decide
+    /// whether a function that makes a raw filesystem call also names a family — dataflow-free and
+    /// fail-closed, the same shape as the resolve-and-write rule.
+    fn_leaves: BTreeMap<String, Vec<String>>,
+    /// Per function, the `=> Some(X)` arm values as WRITTEN. The extractor does not decide whether
+    /// any of them names a family — that is the gate's job, and reporting a bare boolean instead
+    /// made every `Ok(id) => Some(id.principal_ref)` look like a family resolver.
+    resolver_arms: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Serialize)]
+struct FsCall {
+    callee: String,
+    args: Vec<String>,
+    /// The function this call sits in. A family usually reaches a raw write through a local — `let p
+    /// = dir.join(KIND_ONT); fs::write(p.join(id), …)` — so the family is nowhere in the call's own
+    /// arguments, and the gate needs the enclosing function to see them together.
+    in_fn: String,
+    in_test: bool,
+}
+
+#[derive(Serialize)]
+struct Mention {
+    name: String,
+    role: String,
+    in_test: bool,
+}
+
+#[derive(Serialize, Clone)]
+struct ChildMod {
+    name: String,
+    /// The `#[path = "…"]` target, when the declaration carries one. This daemon declares every
+    /// route module that way so cargo's autobin does not treat each file as its own binary target,
+    /// so a walker that only knows rustc's default resolution finds none of them.
+    explicit_path: Option<String>,
+}
+
+#[derive(Serialize)]
+struct Import {
+    /// The module the item comes from, e.g. `odk_routes`. `None` for a bare `use some_module;`.
+    from: Option<String>,
+    /// The item name as declared at the source.
+    item: String,
+    /// The name this module refers to it by.
+    local: String,
+    /// True for `use path::*` — a glob brings in names this file never spells.
+    glob: bool,
+    /// True for `use some_module;` — the module itself, used later as a path prefix.
+    module_only: bool,
+}
+
+fn lit_str(expr: &Expr) -> Option<String> {
+    if let Expr::Lit(l) = expr {
+        if let Lit::Str(s) = &l.lit {
+            return Some(s.value());
+        }
+    }
+    None
+}
+
+fn path_of(expr: &Expr) -> Option<Vec<String>> {
+    if let Expr::Path(ExprPath { path, .. }) = expr {
+        return Some(path.segments.iter().map(|s| s.ident.to_string()).collect());
+    }
+    if let Expr::Reference(r) = expr {
+        return path_of(&r.expr);
+    }
+    None
+}
+
+fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        let mut found = false;
+        if a.path().is_ident("cfg") {
+            let _ = a.parse_nested_meta(|meta| {
+                if meta.path.is_ident("test") {
+                    found = true;
+                }
+                Ok(())
+            });
+        }
+        found
+    })
+}
+
+fn flatten_use(tree: &UseTree, prefix: &mut Vec<String>, out: &mut Vec<Import>) {
+    match tree {
+        UseTree::Path(p) => {
+            prefix.push(p.ident.to_string());
+            flatten_use(&p.tree, prefix, out);
+            prefix.pop();
+        }
+        UseTree::Name(n) => {
+            let item = n.ident.to_string();
+            // `use super::odk_routes;` — the MODULE itself. The hand-rolled reader had no notion of
+            // this and every `odk_routes::KIND_ONT` after it was invisible; the daemon already
+            // writes this style in `event_stream_routes.rs` and `work_result_routes.rs`.
+            let module_only = prefix.last().is_some_and(|p| p == "super" || p == "crate");
+            out.push(Import {
+                from: if module_only {
+                    None
+                } else {
+                    prefix.last().cloned()
+                },
+                item: item.clone(),
+                local: item.clone(),
+                glob: false,
+                module_only,
+            });
+        }
+        UseTree::Rename(r) => out.push(Import {
+            from: prefix.last().cloned(),
+            item: r.ident.to_string(),
+            local: r.rename.to_string(),
+            glob: false,
+            module_only: prefix.last().is_some_and(|p| p == "super" || p == "crate"),
+        }),
+        UseTree::Glob(_) => out.push(Import {
+            from: prefix.last().cloned(),
+            item: "*".into(),
+            local: "*".into(),
+            glob: true,
+            module_only: false,
+        }),
+        UseTree::Group(g) => {
+            for t in &g.items {
+                flatten_use(t, prefix, out);
+            }
+        }
+    }
+}
+
+const WRITERS: &[&str] = &[
+    "persist_record",
+    "persist_record_durable",
+    "remove_record",
+    "persist_promoted",
+    "admit_required",
+];
+const READERS: &[&str] = &["load", "read_record_dir", "json_get", "load_record"];
+/// Filesystem entry points a lane could use to put bytes in a family directory without a writer.
+const FS_CALLS: &[&str] = &[
+    "write",
+    "create",
+    "create_new",
+    "create_dir_all",
+    "remove_file",
+    "remove_dir_all",
+    "copy",
+    "rename",
+    "hard_link",
+];
+
+struct Collector<'a> {
+    facts: &'a mut ModuleFacts,
+    in_test: bool,
+    fn_stack: Vec<String>,
+}
+
+impl Collector<'_> {
+    fn visit_expr(&mut self, e: &Expr) {
+        if let Expr::Call(ExprCall { func, args, .. }) = e {
+            if let Some(segs) = path_of(func) {
+                let callee = segs.last().cloned().unwrap_or_default();
+                let is_w = WRITERS.contains(&callee.as_str());
+                let is_r = READERS.contains(&callee.as_str());
+                // A RAW FILESYSTEM CALL, recorded with every argument as written. `syn` gives the
+                // full path, so `std::fs::write` and a `use std::fs as sysfs` alias are the same
+                // node — the alias games that defeated a text scan do not arise.
+                if FS_CALLS.contains(&callee.as_str())
+                    && segs
+                        .iter()
+                        .any(|s| s == "fs" || s == "File" || s.ends_with("fs"))
+                {
+                    self.facts.fs_calls.push(FsCall {
+                        callee: segs.join("::"),
+                        // EVERY LEAF, not the top-level shape. The family usually sits inside a
+                        // method chain — `dir.join(KIND_ONT).join(id)` — and quoting only the outer
+                        // expression flattens it to `<expr>`, losing the one token that matters.
+                        args: args.iter().flat_map(leaves).collect(),
+                        in_fn: self.fn_stack.last().cloned().unwrap_or_default(),
+                        in_test: self.in_test,
+                    });
+                }
+                if (is_w || is_r) && args.len() >= 2 {
+                    let arg = &args[1];
+                    let written = quote_expr(arg);
+                    let family = lit_str(arg).or_else(|| path_of(arg).map(|p| p.join("::")));
+                    self.facts.calls.push(CallSite {
+                        callee: callee.clone(),
+                        family,
+                        written,
+                        in_test: self.in_test,
+                    });
+                    if is_w {
+                        if let Some(f) = self.fn_stack.last() {
+                            if self.facts.resolver_arms.contains_key(f)
+                                && !self.facts.resolve_and_write_fns.contains(f)
+                            {
+                                self.facts.resolve_and_write_fns.push(f.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        syn::visit::visit_expr(&mut Noop, e);
+        for child in expr_children(e) {
+            self.visit_expr(&child);
+        }
+    }
+}
+
+struct Noop;
+impl<'ast> syn::visit::Visit<'ast> for Noop {}
+
+fn quote_expr(e: &Expr) -> String {
+    match e {
+        Expr::Lit(_) => lit_str(e).map(|s| format!("{s:?}")).unwrap_or_default(),
+        _ => path_of(e)
+            .map(|p| p.join("::"))
+            .unwrap_or_else(|| "<expr>".into()),
+    }
+}
+
+/// Every path segment and string literal inside an expression, however deeply nested.
+fn leaves(e: &Expr) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut stack = vec![e.clone()];
+    while let Some(cur) = stack.pop() {
+        if let Some(s) = lit_str(&cur) {
+            out.push(format!("{s:?}"));
+        }
+        if let Some(p) = path_of(&cur) {
+            out.push(p.join("::"));
+        }
+        // ONE SOURCE OF CHILDREN. `expr_children` already yields a method call's receiver and
+        // arguments; pushing them again here doubled every node per level and turned this walk
+        // exponential — the gate hung rather than failing, which is the worse direction.
+        for c in expr_children(&cur) {
+            stack.push(c);
+        }
+    }
+    out
+}
+
+/// Child expressions worth walking. Deliberately broad and shallow rather than a full visitor: the
+/// gate only needs call sites, and a missed child is a missed CALL, which shows up as a family the
+/// census cannot see — the gate's RED path — rather than as a silent pass.
+fn expr_children(e: &Expr) -> Vec<Expr> {
+    let mut out = Vec::new();
+    match e {
+        Expr::Block(b) => collect_block(&b.block, &mut out),
+        Expr::If(i) => {
+            out.push((*i.cond).clone());
+            collect_block(&i.then_branch, &mut out);
+            if let Some((_, els)) = &i.else_branch {
+                out.push((**els).clone());
+            }
+        }
+        Expr::Match(m) => {
+            out.push((*m.expr).clone());
+            for arm in &m.arms {
+                out.push((*arm.body).clone());
+            }
+        }
+        Expr::Call(c) => {
+            for a in &c.args {
+                out.push(a.clone());
+            }
+        }
+        Expr::MethodCall(c) => {
+            out.push((*c.receiver).clone());
+            for a in &c.args {
+                out.push(a.clone());
+            }
+        }
+        Expr::Let(l) => out.push((*l.expr).clone()),
+        Expr::Assign(a) => out.push((*a.right).clone()),
+        Expr::Return(r) => {
+            if let Some(v) = &r.expr {
+                out.push((**v).clone());
+            }
+        }
+        Expr::Reference(r) => out.push((*r.expr).clone()),
+        Expr::Try(t) => out.push((*t.expr).clone()),
+        Expr::Unary(u) => out.push((*u.expr).clone()),
+        Expr::Binary(b) => {
+            out.push((*b.left).clone());
+            out.push((*b.right).clone());
+        }
+        Expr::ForLoop(f) => {
+            out.push((*f.expr).clone());
+            collect_block(&f.body, &mut out);
+        }
+        Expr::While(w) => {
+            out.push((*w.cond).clone());
+            collect_block(&w.body, &mut out);
+        }
+        Expr::Loop(l) => collect_block(&l.body, &mut out),
+        Expr::Closure(c) => out.push((*c.body).clone()),
+        Expr::Group(g) => out.push((*g.expr).clone()),
+        Expr::Paren(p) => out.push((*p.expr).clone()),
+        _ => {}
+    }
+    out
+}
+
+fn collect_block(b: &syn::Block, out: &mut Vec<Expr>) {
+    for st in &b.stmts {
+        match st {
+            syn::Stmt::Expr(e, _) => out.push(e.clone()),
+            syn::Stmt::Local(l) => {
+                if let Some(init) = &l.init {
+                    out.push((*init.expr).clone());
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// The `=> Some(X)` arm values in this function body, as written. The gate resolves them.
+fn resolver_arms(block: &syn::Block) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut stack: Vec<Expr> = Vec::new();
+    collect_block(block, &mut stack);
+    while let Some(e) = stack.pop() {
+        if let Expr::Match(m) = &e {
+            for arm in &m.arms {
+                if let Expr::Call(c) = &*arm.body {
+                    if path_of(&c.func).is_some_and(|p| p.last().is_some_and(|s| s == "Some")) {
+                        if let Some(inner) = c.args.first() {
+                            found.push(quote_expr(inner));
+                        }
+                    }
+                }
+            }
+        }
+        for c in expr_children(&e) {
+            stack.push(c);
+        }
+    }
+    found
+}
+
+fn walk_items(items: &[Item], in_test: bool, facts: &mut ModuleFacts) {
+    for item in items {
+        match item {
+            Item::Const(ItemConst { ident, expr, .. }) => {
+                if let Some(v) = lit_str(expr) {
+                    facts.family_mentions.push(Mention {
+                        name: ident.to_string(),
+                        role: "declares".into(),
+                        in_test,
+                    });
+                    facts.consts.insert(ident.to_string(), v);
+                }
+            }
+            Item::Use(u) => {
+                let mut prefix = Vec::new();
+                flatten_use(&u.tree, &mut prefix, &mut facts.imports);
+            }
+            Item::Mod(m) => {
+                let test_here = in_test || has_cfg_test(&m.attrs);
+                if let Some((_, inner)) = &m.content {
+                    walk_items(inner, test_here, facts);
+                } else {
+                    // `#[path = "…"]` is how this daemon declares every route module — the files
+                    // live in a subdirectory so cargo's autobin does not treat each as its own
+                    // binary target. A walker that only knows rustc's default resolution finds none
+                    // of them.
+                    let explicit = m.attrs.iter().find_map(|a| {
+                        if !a.path().is_ident("path") {
+                            return None;
+                        }
+                        match &a.meta {
+                            syn::Meta::NameValue(nv) => match &nv.value {
+                                syn::Expr::Lit(l) => match &l.lit {
+                                    syn::Lit::Str(sl) => Some(sl.value()),
+                                    _ => None,
+                                },
+                                _ => None,
+                            },
+                            _ => None,
+                        }
+                    });
+                    facts.child_mods.push(ChildMod {
+                        name: m.ident.to_string(),
+                        explicit_path: explicit,
+                    });
+                }
+            }
+            Item::Fn(f) => {
+                let test_here = in_test || has_cfg_test(&f.attrs);
+                let name = f.sig.ident.to_string();
+                let arms = resolver_arms(&f.block);
+                if !arms.is_empty() {
+                    facts.resolver_arms.insert(name.clone(), arms);
+                }
+                let mut body_exprs = Vec::new();
+                collect_block(&f.block, &mut body_exprs);
+                let mut all_leaves = Vec::new();
+                for e in &body_exprs {
+                    all_leaves.extend(leaves(e));
+                }
+                facts.fn_leaves.insert(name.clone(), all_leaves);
+                let mut c = Collector {
+                    facts,
+                    in_test: test_here,
+                    fn_stack: vec![name],
+                };
+                for e in body_exprs {
+                    c.visit_expr(&e);
+                }
+            }
+            Item::Impl(i) => {
+                let test_here = in_test || has_cfg_test(&i.attrs);
+                for it in &i.items {
+                    if let syn::ImplItem::Fn(f) = it {
+                        let name = f.sig.ident.to_string();
+                        let arms = resolver_arms(&f.block);
+                        if !arms.is_empty() {
+                            facts.resolver_arms.insert(name.clone(), arms);
+                        }
+                        let mut c = Collector {
+                            facts,
+                            in_test: test_here,
+                            fn_stack: vec![name],
+                        };
+                        let mut exprs = Vec::new();
+                        collect_block(&f.block, &mut exprs);
+                        for e in exprs {
+                            c.visit_expr(&e);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Resolve `mod name;` the way rustc does, from the DECLARING file's own position.
+fn child_path(decl_file: &Path, name: &str) -> Option<PathBuf> {
+    let dir = decl_file.parent()?;
+    let stem = decl_file.file_stem()?.to_string_lossy().to_string();
+    // A file that is itself a module root (`mod.rs`, or the crate root) resolves siblings; any other
+    // module resolves children under its own directory. Taking the sibling FIRST — as the hand-rolled
+    // reader did — silently reads a flat namesake instead of the real nested file.
+    let nested = dir.join(&stem).join(format!("{name}.rs"));
+    if nested.exists() {
+        return Some(nested);
+    }
+    let nested_mod = dir.join(&stem).join(name).join("mod.rs");
+    if nested_mod.exists() {
+        return Some(nested_mod);
+    }
+    let sibling = dir.join(format!("{name}.rs"));
+    if sibling.exists() {
+        return Some(sibling);
+    }
+    let sibling_mod = dir.join(name).join("mod.rs");
+    if sibling_mod.exists() {
+        return Some(sibling_mod);
+    }
+    None
+}
+
+fn main() {
+    let root = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "crates/node/src/bin/hypervisor-daemon.rs".to_string());
+    let entry = PathBuf::from(&root);
+    let mut queue = vec![entry.clone()];
+    let mut seen: Vec<PathBuf> = Vec::new();
+    let mut modules: Vec<ModuleFacts> = Vec::new();
+
+    while let Some(file) = queue.pop() {
+        let canon = file.canonicalize().unwrap_or(file.clone());
+        if seen.contains(&canon) {
+            continue;
+        }
+        seen.push(canon.clone());
+        let src = match std::fs::read_to_string(&file) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let parsed: File = match syn::parse_file(&src) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("PARSE FAILURE {}: {e}", file.display());
+                std::process::exit(2);
+            }
+        };
+        let mut facts = ModuleFacts {
+            name: file
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string(),
+            path: file.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        walk_items(&parsed.items, false, &mut facts);
+        for child in facts.child_mods.clone() {
+            let resolved = match &child.explicit_path {
+                Some(rel) => file.parent().map(|d| d.join(rel)).filter(|p| p.exists()),
+                None => child_path(&file, &child.name),
+            };
+            if let Some(p) = resolved {
+                queue.push(p);
+            }
+        }
+        modules.push(facts);
+    }
+
+    let out = serde_json::json!({
+        "schema": "ioi.ontology-admission-census.v1",
+        "entry": root,
+        "modules": modules,
+    });
+    println!("{}", serde_json::to_string(&out).expect("serialise census"));
+}

--- a/crates/ontology-census/src/main.rs
+++ b/crates/ontology-census/src/main.rs
@@ -398,22 +398,52 @@ impl<'ast> Visit<'ast> for LeafGrab {
     }
 }
 
-/// Literal values and constant-shaped identifiers in a token stream, WITH their positions.
+/// Literal values and constant-shaped identifiers in a token stream, WITH their positions AND WITH
+/// THEIR PATH QUALIFIERS.
+///
+/// REBUILDING THE QUALIFIER IS NOT A NICETY — IT IS THE DIFFERENCE BETWEEN A RIGHT ANSWER AND A
+/// CONFIDENT WRONG ONE. An earlier version recorded `TokenTree::Ident` bare, so
+/// `json!({ "w": persist_record(d, super::odk_routes::KIND_ONT, i, r) })` produced the mention
+/// `KIND_ONT` with the qualifier thrown away. The gate then resolved that bare tail against the
+/// LOCAL module's constant table — and a module declaring its own `const KIND_ONT` made the census
+/// adjudicate another module's family constant as innocent, at zero delta to every pin. Twenty-three
+/// constant names in this daemon are declared in more than one module with different values, so the
+/// collision is ordinary rather than contrived.
+///
+/// The qualifier is IN THE TOKENS; only this function was discarding it. `::` arrives as two joint
+/// `Punct(':')`, so walking back over `Ident ':' ':'` reassembles the path rustc actually resolves,
+/// and the position stays the LAST segment's — the same anchor the raw token walk and the AST both
+/// record, so the three populations still match.
 fn token_values(ts: TokenStream) -> Vec<(String, LineColumn)> {
     let mut out = Vec::new();
     fn walk(ts: TokenStream, out: &mut Vec<(String, LineColumn)>) {
-        for t in ts {
+        let items: Vec<TokenTree> = ts.into_iter().collect();
+        for (i, t) in items.iter().enumerate() {
             match t {
                 TokenTree::Literal(l) => {
-                    if let Some((v, _)) = token_lit_text(&l) {
+                    if let Some((v, _)) = token_lit_text(l) {
                         out.push((v, l.span().start()));
                     }
                 }
-                TokenTree::Ident(i) => {
-                    let n = i.to_string();
-                    if is_const_ident(&n) {
-                        out.push((n, i.span().start()));
+                TokenTree::Ident(id) => {
+                    let n = id.to_string();
+                    if !is_const_ident(&n) {
+                        continue;
                     }
+                    let mut segs = vec![n];
+                    let mut j = i;
+                    while j >= 3
+                        && matches!(&items[j - 1], TokenTree::Punct(p) if p.as_char() == ':')
+                        && matches!(&items[j - 2], TokenTree::Punct(p) if p.as_char() == ':')
+                    {
+                        let TokenTree::Ident(prev) = &items[j - 3] else {
+                            break;
+                        };
+                        segs.push(prev.to_string());
+                        j -= 3;
+                    }
+                    segs.reverse();
+                    out.push((segs.join("::"), id.span().start()));
                 }
                 TokenTree::Group(g) => walk(g.stream(), out),
                 TokenTree::Punct(_) => {}


### PR DESCRIPTION
Next-legs XIV Leg 3a, round five.

The previous cut reported every mention of a family name **with its syntactic role** and held a closed set of roles in the gate, so a construct the walk stopped reading would surface as an UNKNOWN ROLE rather than as an absence. A merge-blocking review defeated it, and the diagnosis is bound as a scar:

> **A closed set of roles closes nothing unless the set of things that produce a role is itself entailed.**

Roles were produced by AST positions the extractor happened to override. A family name in a position no override reached produced **no mention at all** — and there is no role to be unknown about when there is no mention.

**Ten mutants of that class were planted and seven passed completely green** once the mutant's own commit re-derived its population pins, which is what a landing commit does as a matter of routine. A `match` arm pattern carrying the family to a writer, the same through `if let`, a raw filesystem write behind a pattern, `b"odk-…"` through `from_utf8`, `concat!("od", "k-domain-ontologies")`, `#[serde(rename)]` minting the name, and an `include!` of an unwalked file holding the entire second admitter.

## What lands

- **Mentions come from the raw token stream; the AST only assigns roles.** Each file is tokenised once and the *same* stream is handed to `syn`, so a token's span and a labelled mention's span are the same object. The gate matches the two by source position **in both directions**.
- **Three totality edges, fail-closed** — `include!` spliced into the including module (unresolvable target aborts extraction); `concat!`/`stringify!` followed into their expansion, including nested inside other macros' token streams; runtime assembly inside a writer's own arguments refused when a piece is a fragment of a family name.
- **The freshness digest becomes a committed pin.** The previous check compared the on-disk source against the binary's baked digest *after* running `cargo build` — it could never fail. Demonstrated: editing the extractor and rebuilding leaves both sides agreeing at the same new digest.
- **A committed, replayable mutation battery** (`ontology-admission-census.mutants.v1.json`, 26 anchors) that re-derives population pins before scoring, so a pin-only red counts as OFF-TARGET. Wired into CI after the floors gate.
- **Three of this tree's own counts corrected at source.** One was false; two reproduced nowhere.

## Evidence

`check:ontology-admission-census` **24/24** — 88 modules, 106,724 tokens walked, 282 family-resolving, every one labelled, zero silences, zero orphan labels.
Battery: **25 anchors RED-ON-TARGET, 1 named residual, 27/27 as recorded, tree restored.**
Floors pin re-derived in-commit (17 → 24); `check:verifier-floors` green against a freshly regenerated artifact set. The five bundled gates, typecheck, lint and `cargo fmt --check` all green.

## Named residual

A family name assembled at **runtime** from innocent pieces, bound to a local, passed to a writer. Closing it needs dataflow this census does not do — the conservative function-scope rule that would catch it fires on 198 of this daemon's production writer functions, which is a pinned exception list, not a gate. The call lands in the pinned runtime-parameter bucket, so it is **counted**: a named absence, not a silence. It is asserted in the battery in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)