### PR TITLE
fix(security): env-ops leases authorized on RESOURCES not ACTION — a proven-live privilege escalation, closed at the chokepoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,7 @@ jobs:
           npm run check:model-router-decisions --workspace=@ioi/hypervisor-app
           npm run check:backup-restore --workspace=@ioi/hypervisor-app
           npm run check:environment-custody --workspace=@ioi/hypervisor-app
+          npm run check:env-lease-authority --workspace=@ioi/hypervisor-app
           npm run check:operational-depth --workspace=@ioi/hypervisor-app
           npm run check:ontology-backend-families --workspace=@ioi/hypervisor-app
           npm run check:ontology-admission-census --workspace=@ioi/hypervisor-app

--- a/apps/hypervisor/package.json
+++ b/apps/hypervisor/package.json
@@ -29,6 +29,7 @@
     "check:model-router-decisions": "node scripts/verify-hypervisor-model-router-decisions.mjs",
     "check:backup-restore": "node scripts/verify-hypervisor-backup-restore.mjs",
     "check:environment-custody": "node scripts/verify-hypervisor-environment-custody.mjs",
+    "check:env-lease-authority": "node scripts/verify-hypervisor-env-lease-authority.mjs",
     "check:operational-depth": "node scripts/verify-hypervisor-operational-depth.mjs",
     "check:ontology-backend-families": "node scripts/verify-hypervisor-ontology-backend-families.mjs",
     "check:ontology-admission-census": "node scripts/verify-hypervisor-ontology-admission-census.mjs",

--- a/apps/hypervisor/scripts/verify-hypervisor-env-lease-authority.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-env-lease-authority.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// ENVIRONMENT-LEASE AUTHORITY — the env-ops seam authorizes on a lease's ACTION, not merely its
+// resources, and the lease minters resolve a caller instead of hardcoding the operator.
+//
+// WHAT THIS EXISTS TO CATCH, PROVEN LIVE BEFORE IT WAS FIXED. Next-legs XIV Leg 4 drove a real daemon
+// end to end and produced side effects — a file written, `bash -lc` executed — through a privilege
+// escalation that every green gate in the estate had missed and that canon actively asserted CLOSED:
+//
+//   · `POST /v1/hypervisor/environments/:id/ports/:port/expose` resolved no caller and minted an
+//     `environment.port` capability lease, returning it as `accessToken`.
+//   · `supervisor_routes::lease_binds_env` — the check the `/supervisor/` env-ops consumer runs —
+//     tested only that the grant's RESOURCES named the environment, NEVER its ACTION. So a
+//     port-forward lease, or an `environment.editor.open` lease, was a full ReadFile/WriteFile/Exec
+//     bearer over the workspace.
+//   · `/supervisor/:env/...EnvironmentOpsService/:method` is OUTSIDE `/v1/`, so `auth_gate` never
+//     sees it — the lease check is its only protection.
+//
+// THE FIX, AND WHAT THIS GATE ASSERTS AS ITS FINDING (the exploit, run as the test):
+//   1. THE CHOKEPOINT. A lease may drive env-ops iff its action is `environment.ops`. A port lease
+//      and an editor lease are minted, and each is PROVEN UNABLE to WriteFile or Exec — asserted by
+//      the ABSENCE OF THE SIDE EFFECT (no file on disk, no marker from a command), never by a status
+//      code alone. A response is the writer's own product; the file is the truth.
+//   2. THE POSITIVE CONTROL. A legitimate `environment.ops` lease CAN drive them — so assertion 1 is
+//      not merely "every request 401s".
+//   3. THE MINTERS RESOLVE A CALLER. In `exposed_untrusted` posture the ops-lease and port-expose
+//      minters REFUSE, where they used to mint an operator lease for anyone.
+//
+// WHAT IT DOES NOT CLOSE, NAMED SO IT CANNOT CHANGE UNNOTICED. OWNER-BINDING. The minters resolve WHO
+// the caller is, not whether that caller OWNS the environment — because an environment has no owner
+// pin (defect 1a / ADR 0035). So in `authenticated_managed` posture an authenticated NON-OWNER can
+// still mint an `environment.ops` lease for another principal's environment and drive env-ops. This
+// gate ASSERTS that residual in both directions: it is real today, and the day it closes this
+// assertion flips and must be updated in the commit that closes it. The fix is the same scope-pin
+// shape as 1a and the authority-grant XV item.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { startIsolatedPlane } from "./lib/isolated-daemon.mjs";
+import { emitVerifierCensus } from "./lib/verifier-census.mjs";
+
+const B64 = (s) => Buffer.from(s, "utf8").toString("base64");
+const results = [];
+const ok = (name, cond, detail) => results.push({ name, pass: !!cond, detail: detail || "" });
+
+async function jd(url, { method = "GET", headers = {}, body } = {}) {
+  const r = await fetch(url, { method, headers: { "content-type": "application/json", ...headers }, body });
+  const t = await r.text();
+  let j; try { j = JSON.parse(t); } catch { j = t; }
+  return { status: r.status, j };
+}
+
+const opsUrl = (D, env, m) => `${D}/supervisor/${env}/supervisor.v1.EnvironmentOpsService/${m}`;
+
+async function run() {
+  const plane = await startIsolatedPlane({ serve: false });
+  if (!plane) { console.error("BLOCKED — no daemon binary (exit 2)"); process.exit(2); }
+  const D = plane.daemonUrl;
+  const dataDir = plane.dataDir;
+  try {
+    const env = "auth-victim";
+    const safeId = env.replace(/[^A-Za-z0-9_-]/g, "_");
+    const ws = path.join(dataDir, "environments", safeId, "workspace");
+    await jd(`${D}/v1/hypervisor/environments`, { method: "POST", body: JSON.stringify({ environment_id: env }) });
+    await jd(`${D}/v1/hypervisor/environments/${env}/start`, { method: "POST", body: "{}" });
+    ok("the isolated daemon is in local_development posture and the victim workspace exists on disk — the precondition the whole exploit needs",
+      fs.existsSync(ws), `workspace=${ws} exists=${fs.existsSync(ws)}`);
+
+    // Authenticate a principal (the bootstrap operator) so the editor lease and the residual mint
+    // have a real session; it stands in for 'any authenticated principal' because no minter checks
+    // ownership and the environment has no owner to compare against.
+    const log = (() => { try { return fs.readFileSync(path.join(dataDir, "isolated-daemon.log"), "utf8"); } catch { return ""; } })();
+    const btok = (log.match(/(ioi_bootstrap_[0-9a-f]+)/) || [])[1];
+    let auth = {};
+    if (btok) {
+      const bs = await jd(`${D}/v1/hypervisor/auth/bootstrap`, { method: "POST", body: JSON.stringify({ token: btok, password: "verifier-pw-123" }) });
+      if (bs.j?.session_token) auth = { authorization: `Bearer ${bs.j.session_token}` };
+    }
+    ok("a principal session was acquired for the authenticated-path assertions", !!auth.authorization, auth.authorization ? "session acquired" : "NO session (bootstrap token not found)");
+
+    // ---------------------------------------------------------------- the port lease
+    const portMint = await jd(`${D}/v1/hypervisor/environments/${env}/ports/8080/expose`, { method: "POST", body: "{}" });
+    const portTok = portMint.j?.accessToken;
+    ok("a port-forward lease still mints (it has a legitimate purpose — this gate does not forbid the lease, it forbids the lease driving env-ops)",
+      portMint.status === 200 && !!portTok, `status=${portMint.status} token=${portTok ? portTok.slice(0, 16) + "…" : "NONE"}`);
+
+    const portMarker = `port-lease-write-${safeId}.txt`;
+    const wfPort = await jd(opsUrl(D, env, "WriteFile"), { method: "POST", headers: { authorization: `Bearer ${portTok}` }, body: JSON.stringify({ path: portMarker, content: B64("x") }) });
+    const portWroteFile = fs.existsSync(path.join(ws, portMarker));
+    ok("THE CHOKEPOINT — a port lease CANNOT WriteFile through the env-ops seam, PROVEN BY THE ABSENCE OF THE FILE, not by the status alone: its action is `environment.port`, and the seam requires `environment.ops`",
+      wfPort.status !== 200 && !portWroteFile, `status=${wfPort.status} file_on_disk=${portWroteFile}`);
+
+    const portExec = path.join(dataDir, `port-lease-exec-${safeId}`);
+    const exPort = await jd(opsUrl(D, env, "Exec"), { method: "POST", headers: { authorization: `Bearer ${portTok}` }, body: JSON.stringify({ command: `touch ${portExec}` }) });
+    ok("THE CHOKEPOINT — a port lease CANNOT Exec through the env-ops seam, PROVEN BY THE ABSENCE OF THE COMMAND'S SIDE EFFECT: no marker file was created",
+      exPort.status !== 200 && !fs.existsSync(portExec), `status=${exPort.status} side_effect=${fs.existsSync(portExec)}`);
+
+    // ---------------------------------------------------------------- the editor lease
+    let editorTok = null;
+    if (auth.authorization) {
+      const em = await jd(`${D}/v1/hypervisor/editor-access-leases`, { method: "POST", headers: auth, body: JSON.stringify({ environment_id: env, service_id: "eds_x" }) });
+      editorTok = em.j?.lease_id ?? em.j?.grant?.grant_id;
+    }
+    const editorMarker = `editor-lease-write-${safeId}.txt`;
+    const wfEditor = editorTok ? await jd(opsUrl(D, env, "WriteFile"), { method: "POST", headers: { authorization: `Bearer ${editorTok}` }, body: JSON.stringify({ path: editorMarker, content: B64("x") }) }) : { status: "no-lease" };
+    const editorWroteFile = fs.existsSync(path.join(ws, editorMarker));
+    ok("THE CHOKEPOINT — an `environment.editor.open` lease CANNOT WriteFile through the env-ops seam either, PROVEN BY THE ABSENCE OF THE FILE: the action check does not special-case one non-ops action, it requires the ops action",
+      !!editorTok && wfEditor.status !== 200 && !editorWroteFile, `editorTok=${!!editorTok} status=${wfEditor.status} file_on_disk=${editorWroteFile}`);
+
+    // ---------------------------------------------------------------- the positive control
+    const opsMint = await jd(`${D}/v1/hypervisor/environments/${env}/ops-lease`, { method: "POST", body: "{}" });
+    const opsTok = opsMint.j?.accessToken;
+    const opsMarker = `ops-lease-write-${safeId}.txt`;
+    const wfOps = opsTok ? await jd(opsUrl(D, env, "WriteFile"), { method: "POST", headers: { authorization: `Bearer ${opsTok}` }, body: JSON.stringify({ path: opsMarker, content: B64("legit") }) }) : { status: "no-lease" };
+    const opsWroteFile = fs.existsSync(path.join(ws, opsMarker));
+    ok("THE POSITIVE CONTROL — a legitimate `environment.ops` lease CAN WriteFile, so the chokepoint assertions above are refusing on the ACTION and not merely 401-ing every request",
+      wfOps.status === 200 && opsWroteFile, `status=${wfOps.status} file_on_disk=${opsWroteFile}`);
+
+    // ---------------------------------------------------------------- the minters resolve a caller
+    const EXPOSED = { "x-forwarded-for": "203.0.113.9" };
+    const opsExposed = await jd(`${D}/v1/hypervisor/environments/${env}/ops-lease`, { method: "POST", headers: EXPOSED, body: "{}" });
+    ok("the OPS-LEASE MINTER refuses an exposed-untrusted surface (it used to hardcode the operator subject and mint for anyone); the refusal is a 401/403, not a minted token",
+      opsExposed.status === 401 || opsExposed.status === 403, `status=${opsExposed.status} token=${opsExposed.j?.accessToken ?? "none"}`);
+    const portExposed = await jd(`${D}/v1/hypervisor/environments/${env}/ports/8080/expose`, { method: "POST", headers: EXPOSED, body: "{}" });
+    ok("the PORT-EXPOSE MINTER refuses an exposed-untrusted surface for the same reason",
+      portExposed.status === 401 || portExposed.status === 403, `status=${portExposed.status} token=${portExposed.j?.accessToken ?? "none"}`);
+
+    // ---------------------------------------------------------------- the EDITOR-EXPOSE seam, WIRED
+    // The chokepoint above closes the `/supervisor/` env-ops consumer. The editor proxy is a SECOND
+    // consumer of the workspace: `handle_editor_service_expose` used to gate only on a lease being
+    // ACTIVE — action-blind and resource-blind — so a port lease, an ops lease, or an editor lease
+    // for ANOTHER environment could bind a victim's IDE proxy. The pure predicate is unit-tested six
+    // ways in Rust; THIS asserts the HANDLER actually calls it, because a refactor that drops the
+    // call would leave those unit tests green while the hole reopens — the exact failure class this
+    // run exists to end.
+    //
+    // The fixture is the product record shape: the service is CREATED through its real route, then
+    // advanced to `ready` with an internal port — the one transition `editor_host` provisioning would
+    // make once openvscode is installed, which the sandbox cannot do. The auth gate reads the
+    // service's `environment_id` and the lease; it never consults the live runtime, so the auth
+    // decision is identical whether openvscode is real or the record is advanced here.
+    if (auth.authorization) {
+      const created = await jd(`${D}/v1/hypervisor/editor-services`, { method: "POST", headers: auth, body: JSON.stringify({ environment_id: env }) });
+      const svcId = created.j?.editorService?.service_id ?? created.j?.service?.service_id ?? created.j?.service_id;
+      const recPath = svcId ? path.join(dataDir, "editor-services", `${svcId}.json`) : null;
+      if (recPath && fs.existsSync(recPath)) {
+        const rec = JSON.parse(fs.readFileSync(recPath, "utf8"));
+        const productShape = rec.schema_version === "ioi.hypervisor.editor-access-service.v1" && rec.environment_id === env;
+        rec.phase = "ready";
+        rec.internal_port = 59999; // no live runtime behind it; the auth gate does not read it
+        fs.writeFileSync(recPath, JSON.stringify(rec));
+        ok("the editor-service fixture is the PRODUCT RECORD SHAPE — created through its own route and advanced to `ready`, the transition provisioning makes; only phase+port moved, so the auth gate sees exactly what it sees in production",
+          productShape, `schema=${rec.schema_version} env=${rec.environment_id}`);
+
+        const editEal = await jd(`${D}/v1/hypervisor/editor-access-leases`, { method: "POST", headers: auth, body: JSON.stringify({ environment_id: env, service_id: svcId }) });
+        const editTok = editEal.j?.lease_id ?? editEal.j?.grant?.grant_id;
+        const goodExpose = editTok ? await jd(`${D}/v1/hypervisor/editor-services/${svcId}/expose`, { method: "POST", body: JSON.stringify({ lease_id: editTok }) }) : { status: "no-lease", j: {} };
+        ok("THE POSITIVE CONTROL — a matching `environment.editor.open` lease naming this service DOES expose it, so the refusals below are on the action/resource and not a blanket denial",
+          goodExpose.j?.ok !== false && goodExpose.status !== 403, `status=${goodExpose.status} ok=${goodExpose.j?.ok}`);
+
+        const portMint2 = await jd(`${D}/v1/hypervisor/environments/${env}/ports/9090/expose`, { method: "POST", body: "{}" });
+        const portTok2 = portMint2.j?.accessToken;
+        const portExpose = portTok2 ? await jd(`${D}/v1/hypervisor/editor-services/${svcId}/expose`, { method: "POST", body: JSON.stringify({ lease_id: portTok2 }) }) : { status: "no-lease", j: {} };
+        ok("THE WIRING — the editor-expose handler REFUSES a port lease (action `environment.port`), proving it calls the action/resource predicate and does not merely check the lease is active; a 403, not a bound proxy",
+          portExpose.status === 403 && portExpose.j?.ok === false, `status=${portExpose.status} ok=${portExpose.j?.ok}`);
+
+        // an editor lease for a DIFFERENT environment must not expose THIS service
+        const otherEnv = "auth-other";
+        await jd(`${D}/v1/hypervisor/environments`, { method: "POST", body: JSON.stringify({ environment_id: otherEnv }) });
+        const otherEal = await jd(`${D}/v1/hypervisor/editor-access-leases`, { method: "POST", headers: auth, body: JSON.stringify({ environment_id: otherEnv, service_id: "eds_other" }) });
+        const otherTok = otherEal.j?.lease_id ?? otherEal.j?.grant?.grant_id;
+        const crossExpose = otherTok ? await jd(`${D}/v1/hypervisor/editor-services/${svcId}/expose`, { method: "POST", body: JSON.stringify({ lease_id: otherTok }) }) : { status: "no-lease", j: {} };
+        ok("THE WIRING, cross-environment — an `environment.editor.open` lease minted for a DIFFERENT environment cannot expose this service; the resource check is on THIS service's environment",
+          crossExpose.status === 403 && crossExpose.j?.ok === false, `status=${crossExpose.status} ok=${crossExpose.j?.ok}`);
+      } else {
+        ok("the editor-service fixture was created for the wiring assertions", false, `service_id=${svcId} recPath=${recPath}`);
+      }
+    }
+
+    // ---------------------------------------------------------------- the NAMED RESIDUAL (1a)
+    // An authenticated NON-OWNER minting an environment.ops lease for another principal's environment
+    // still succeeds, because no environment has an owner pin to check. This is asserted TRUE so that
+    // the day 1a closes it, this gate goes red and the residual is retired in that commit.
+    let residualOpen = false, residualDetail = "no session to test with";
+    if (auth.authorization) {
+      const crossMint = await jd(`${D}/v1/hypervisor/environments/${env}/ops-lease`, { method: "POST", headers: auth, body: "{}" });
+      const crossTok = crossMint.j?.accessToken;
+      const crossMarker = `residual-nonowner-${safeId}.txt`;
+      const wfCross = crossTok ? await jd(opsUrl(D, env, "WriteFile"), { method: "POST", headers: { authorization: `Bearer ${crossTok}` }, body: JSON.stringify({ path: crossMarker, content: B64("residual") }) }) : { status: "no-lease" };
+      residualOpen = wfCross.status === 200 && fs.existsSync(path.join(ws, crossMarker));
+      residualDetail = `authenticated non-owner mint status=${crossMint.status}, env-ops write status=${wfCross.status}, wrote=${fs.existsSync(path.join(ws, crossMarker))}`;
+    }
+    ok("NAMED RESIDUAL (defect 1a) — an authenticated NON-OWNER can STILL mint an `environment.ops` lease for another principal's environment and drive env-ops, because no environment has an owner pin; this assertion is TRUE by design and MUST flip in the commit that lands the environment owner model",
+      residualOpen, residualDetail);
+
+    const fails = results.filter((r) => !r.pass);
+    for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+    console.log(`\n${results.length - fails.length}/${results.length} passed`);
+    emitVerifierCensus({ verifierId: "env-lease-authority", sourceUrl: import.meta.url, results });
+    await plane.stop();
+    process.exit(fails.length ? 1 : 0);
+  } catch (error) {
+    for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? ` — ${r.detail}` : ""}`);
+    console.error(`FAIL env-lease-authority — ${error?.stack || error}`);
+    await plane.stop();
+    process.exit(1);
+  }
+}
+
+const INVOKED = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (INVOKED) run();

--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -230,7 +230,7 @@ const RECORDED_TEST_WRITES = {
 const PINNED = {
   modules: 88,
   familyMentions: 300,
-  tokenMentions: 106724,
+  tokenMentions: 106824,
   judgedTokenPositions: 282,
   productionWriterCalls: { family: 72, nonFamilyLiteral: 204, runtimeParameter: 290 },
   productionFsCalls: 228,
@@ -251,7 +251,7 @@ const PINNED = {
    * Burning these down, and entailing the resolver so they need not exist, is next-legs XV.
    */
   unadjudicable: {
-    "foreign-qualified": 3494,
+    "foreign-qualified": 3495,
     "opaque-initialiser": 1554,
     "bare-undeclared": 517,
     "ambiguous-module": 0,

--- a/apps/hypervisor/verifier-floors.v1.json
+++ b/apps/hypervisor/verifier-floors.v1.json
@@ -153,6 +153,14 @@
       "assertion_names_sha256": "d8f97b56224f06f837f6ba29d0a2104af58ccfe57cb1f8df5f8304955a9c1c3c"
     },
     {
+      "id": "env-lease-authority",
+      "npm_script": "check:env-lease-authority",
+      "source": "apps/hypervisor/scripts/verify-hypervisor-env-lease-authority.mjs",
+      "runtime_assertions": 14,
+      "assertion_names_sha256": "d5392e84c8669bc4928aae707234b43c413147b18e76937c1164bd822c619e25",
+      "note": "Exercises a PROVEN-LIVE privilege escalation as its finding: a port/editor capability lease driving env-ops WriteFile/Exec, asserted refused by the ABSENCE of the side effect. Includes a named residual (defect 1a) asserted TRUE that flips when the environment owner model lands."
+    },
+    {
       "id": "environment-custody",
       "npm_script": "check:environment-custody",
       "source": "apps/hypervisor/scripts/verify-hypervisor-environment-custody.mjs",

--- a/crates/node/src/bin/hypervisor_daemon_routes/authority_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/authority_routes.rs
@@ -26,10 +26,35 @@ use super::{iso_now, persist_record, read_record_dir, DaemonState};
 /// authority grant/revoke is NEVER caller-asserted. Without this the subject was copied from the
 /// body, so an unauthenticated caller could mint a grant with `resources:["environment:X"]` and any
 /// subject, which `supervisor_routes::lease_binds_env` then turns into a working env-ops WebSocket
-/// lease token (the measured escalation this fix closes). local_development ⇒ the server operator
-/// constant; authenticated_managed ⇒ the authenticated principal (`user://<principal_id>`) or a
-/// typed 401; exposed_untrusted ⇒ a typed 403.
-fn resolve_authority_subject(
+/// lease token. local_development ⇒ the server operator constant; authenticated_managed ⇒ the
+/// authenticated principal (`user://<principal_id>`) or a typed 401; exposed_untrusted ⇒ a typed 403.
+///
+/// THIS CLOSES THE CLASS FOR THE GENERIC GRANT ROUTE ONLY, AND THAT SCOPING WAS A FALSE "CLOSED".
+/// A previous version of this comment said "the measured escalation this fix closes" without
+/// qualification. Next-legs XIV Leg 4 PROVED LIVE that the same escalation is open through two OTHER
+/// minters this fix never touched:
+///   · `environment_routes::handle_env_port_expose` (`POST …/ports/:port/expose`) resolves no caller
+///     — it takes no `HeaderMap` — and mints `environment.port` for any env id, ANONYMOUSLY in the
+///     default posture. A file was written and `bash -lc` was executed through `/supervisor/` with
+///     the returned token.
+///   · `editor_routes::handle_editor_access_lease_create` resolves a principal but performs NO
+///     per-environment authorization on the body-supplied `environment_id`, so any authenticated
+///     NON-OWNER mints an ops bearer over another party's environment.
+/// AND THE ROOT IS `supervisor_routes::lease_binds_env`, WHICH CHECKS ONLY THE GRANT'S RESOURCES AND
+/// NEVER ITS ACTION — so an `environment.port` grant is a full `ReadFile`/`WriteFile`/`Exec` bearer.
+///
+/// WHAT LEG 4 CLOSES, STATED WITHOUT THE FALSE "CLOSED" THIS CORRECTION ITSELF FIRST CARRIED. The
+/// chokepoint: `supervisor_routes::authed` now calls a NEW sibling of `lease_binds_env`,
+/// `lease_authorizes_env_ops`, which requires the grant's ACTION to be `environment.ops` — so a
+/// port or editor lease can no longer drive env-ops. The MINTERS `handle_env_ops_lease` and
+/// `handle_env_port_expose` resolve their CALLER through this function and mint under the resolved
+/// subject, so an exposed/managed surface cannot forge either lease and each grant records who
+/// minted it. What Leg 4 does NOT close, and what the verifier `check:env-lease-authority` asserts
+/// TRUE as a residual: OWNER-BINDING. The minters resolve WHO the caller is, never whether that
+/// caller OWNS the environment — no environment has an owner pin (defect 1a / ADR 0035) — so an
+/// authenticated NON-OWNER can still mint `environment.ops` for another principal's environment in
+/// managed posture. That residual is 1a's shape, and it is open until the owner model lands.
+pub(crate) fn resolve_authority_subject(
     data_dir: &str,
     headers: &HeaderMap,
     code_auth_required: &str,

--- a/crates/node/src/bin/hypervisor_daemon_routes/editor_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/editor_routes.rs
@@ -487,10 +487,32 @@ pub(crate) async fn handle_editor_service_start(
     }
 }
 
+/// A grant may bind THIS editor service's proxy iff it carries the `environment.editor.open` action
+/// AND names this service (or its environment) in its resources. Pure so it is unit-tested without a
+/// live openvscode runtime, which the sandbox cannot install: "any active lease" — the check this
+/// replaced — let a port lease or an editor lease for a different environment bind a victim's IDE.
+fn grant_authorizes_editor_service(grant: &Value, service_id: &str, svc_env: &str) -> bool {
+    if grant.get("action").and_then(|v| v.as_str()) != Some("environment.editor.open") {
+        return false;
+    }
+    let want_service = format!("editor_service:{service_id}");
+    let want_env = format!("environment:{svc_env}");
+    grant
+        .get("resources")
+        .and_then(|r| r.as_array())
+        .map(|arr| {
+            arr.iter().any(|x| {
+                x.as_str() == Some(want_service.as_str())
+                    || (!svc_env.is_empty() && x.as_str() == Some(want_env.as_str()))
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// POST /v1/hypervisor/editor-services/:service_id/expose — bind a lease-authenticated WS proxy
 /// (WS-4) in front of the ready runtime's internal port. Body: `{ lease_id }`. The public URL is
 /// served by the proxy; the raw internal port is never exposed. Fail-closed: requires a ready
-/// service + an active capability lease.
+/// service + a lease that AUTHORIZES this service (`grant_authorizes_editor_service`).
 pub(crate) async fn handle_editor_service_expose(
     State(st): State<Arc<DaemonState>>,
     AxumPath(service_id): AxumPath<String>,
@@ -525,6 +547,29 @@ pub(crate) async fn handle_editor_service_expose(
             StatusCode::OK,
             Json(
                 json!({ "ok": false, "reason": format!("capability lease not active ({})", capability_lease_status(&st.data_dir, &lease_id)), "fail_closed": true }),
+            ),
+        );
+    }
+    // THE LEASE MUST BE FOR THIS EDITOR SERVICE, NOT MERELY ACTIVE. This gate used to check only that
+    // SOME lease was active, so any active lease in the estate — a port-forward lease, an ops lease,
+    // or an editor lease minted for a DIFFERENT environment — bound this service's proxy onto its
+    // workspace. That is the same action-blind/resource-blind hole Leg 4 closed at the `/supervisor/`
+    // env-ops seam, on the editor consumer. The lease must NAME this service (or its environment) in
+    // its resources AND carry the editor action, which is exactly what `handle_editor_access_lease_create`
+    // mints. Owner-binding — that the caller owns the environment — remains the 1a residual.
+    let svc_env = svc
+        .get("environment_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let editor_lease_ok = super::authority_routes::load_grant(&st.data_dir, &lease_id)
+        .map(|g| grant_authorizes_editor_service(&g, &service_id, &svc_env))
+        .unwrap_or(false);
+    if !editor_lease_ok {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                json!({ "ok": false, "reason": "the lease does not authorize this editor service — an active lease must carry the `environment.editor.open` action and name this service (or its environment) in its resources", "fail_closed": true }),
             ),
         );
     }
@@ -874,4 +919,56 @@ pub(crate) async fn handle_editor_access_lease_revoke(
             json!({ "ok": ok, "lease_id": lease_id, "revoke": rev_body, "status": if ok { "revoked" } else { "revoke_failed" } }),
         ),
     )
+}
+
+#[cfg(test)]
+mod editor_lease_tests {
+    use super::grant_authorizes_editor_service;
+    use serde_json::json;
+
+    #[test]
+    fn a_matching_editor_lease_authorizes_the_service() {
+        let g = json!({
+            "action": "environment.editor.open",
+            "resources": ["environment:e1", "editor_service:eds_1"],
+        });
+        assert!(grant_authorizes_editor_service(&g, "eds_1", "e1"));
+    }
+
+    #[test]
+    fn the_lease_environment_alone_authorizes_when_it_matches() {
+        let g = json!({ "action": "environment.editor.open", "resources": ["environment:e1"] });
+        assert!(grant_authorizes_editor_service(&g, "eds_1", "e1"));
+    }
+
+    #[test]
+    fn a_port_lease_does_not_authorize_the_editor_service_even_for_the_same_env() {
+        // The exact cross-consumer escalation: a port lease naming e1 must not bind e1's IDE proxy.
+        let g =
+            json!({ "action": "environment.port", "resources": ["environment:e1", "port:8080"] });
+        assert!(!grant_authorizes_editor_service(&g, "eds_1", "e1"));
+    }
+
+    #[test]
+    fn an_ops_lease_does_not_authorize_the_editor_service() {
+        let g = json!({ "action": "environment.ops", "resources": ["environment:e1"] });
+        assert!(!grant_authorizes_editor_service(&g, "eds_1", "e1"));
+    }
+
+    #[test]
+    fn an_editor_lease_for_a_different_environment_does_not_authorize_this_service() {
+        // Cross-principal: an editor lease minted for e2 must not bind e1's service.
+        let g = json!({
+            "action": "environment.editor.open",
+            "resources": ["environment:e2", "editor_service:eds_2"],
+        });
+        assert!(!grant_authorizes_editor_service(&g, "eds_1", "e1"));
+    }
+
+    #[test]
+    fn an_empty_environment_never_matches_by_environment() {
+        // A service with no environment_id must not be authorized by a bare `environment:` prefix.
+        let g = json!({ "action": "environment.editor.open", "resources": ["environment:"] });
+        assert!(!grant_authorizes_editor_service(&g, "eds_1", ""));
+    }
 }

--- a/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/environment_routes.rs
@@ -767,7 +767,34 @@ pub(crate) async fn handle_env_ports(
 pub(crate) async fn handle_env_port_expose(
     State(st): State<Arc<DaemonState>>,
     AxumPath((id, port)): AxumPath<(String, u64)>,
+    headers: HeaderMap,
 ) -> Result<Json<Value>, AppError> {
+    // POSTURE-RESOLVED CALLER, never the anonymous default, AND THE RESOLVED SUBJECT IS WHAT THE
+    // LEASE CARRIES. This route took no headers and minted an `environment.port` lease with the
+    // literal subject `"operator"` for anyone; Leg 4 proved that an anonymously-minted port lease
+    // drove WriteFile/Exec through `/supervisor/` (the env-ops seam now checks the lease ACTION,
+    // which stops a port lease reaching env-ops — but the mint itself must still resolve a caller so
+    // an exposed/managed surface cannot forge a port lease, and the grant must record WHO minted it
+    // so its own minter can revoke it). Exposed ⇒ 403, managed ⇒ real principal or 401, loopback ⇒
+    // operator. Owner-binding (does this caller own THIS environment) is the 1a residual — resolved
+    // here is the CALLER, not the owner.
+    let subject = match super::authority_routes::resolve_authority_subject(
+        &st.data_dir,
+        &headers,
+        "environment_port_expose_auth_required",
+        "environment_port_expose_exposed",
+    ) {
+        Ok(subject) => subject,
+        Err((code, body)) => {
+            let msg = body
+                .get("error")
+                .and_then(|e| e.get("message"))
+                .and_then(|m| m.as_str())
+                .unwrap_or("authority resolution refused")
+                .to_string();
+            return Err(AppError(code, msg));
+        }
+    };
     let Some(mut env) = load_env(&st.data_dir, &id) else {
         return Ok(Json(
             json!({ "ok": false, "reason": "environment not found" }),
@@ -791,7 +818,7 @@ pub(crate) async fn handle_env_port_expose(
     let listening = port_listening(port);
     let lease = super::authority_routes::issue_capability_lease(
         &st.data_dir,
-        "operator",
+        &subject,
         "environment.port",
         json!([format!("environment:{id}"), format!("port:{port}")]),
         3600,

--- a/crates/node/src/bin/hypervisor_daemon_routes/supervisor_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/supervisor_routes.rs
@@ -31,10 +31,28 @@ use super::DaemonState;
 pub(crate) async fn handle_env_ops_lease(
     State(st): State<Arc<DaemonState>>,
     AxumPath(env_id): AxumPath<String>,
-) -> Json<Value> {
+    headers: HeaderMap,
+) -> Response {
+    // THE SUBJECT IS RESOLVED FROM THE REQUEST POSTURE, NEVER THE LITERAL "operator". This route
+    // used to take no headers and hardcode the operator, so in `exposed_untrusted` and
+    // `authenticated_managed` it minted an env-ops lease that grants ReadFile/WriteFile/Exec for ANY
+    // principal — Next-legs XIV Leg 4 drove that live. The posture resolver refuses an exposed
+    // surface (403) and requires a real principal under managed auth (401); loopback local dev still
+    // resolves to the operator, which is the local trust model. OWNER-BINDING (this principal owns
+    // THIS environment) is the named residual: it requires the environment scope pin that defect 1a
+    // / ADR 0035 introduces, so an authenticated NON-OWNER can still mint here until that lands.
+    let subject = match super::authority_routes::resolve_authority_subject(
+        &st.data_dir,
+        &headers,
+        "environment_ops_lease_auth_required",
+        "environment_ops_lease_exposed",
+    ) {
+        Ok(s) => s,
+        Err((code, body)) => return (code, body).into_response(),
+    };
     let lease = issue_capability_lease(
         &st.data_dir,
-        "operator",
+        &subject,
         "environment.ops",
         json!([format!("environment:{env_id}")]),
         3600,
@@ -44,7 +62,7 @@ pub(crate) async fn handle_env_ops_lease(
         .and_then(|v| v.as_str())
         .unwrap_or_default()
         .to_string();
-    Json(json!({
+    ok_json(json!({
         "accessToken": id,
         "lease_id": id,
         "lease_ref": lease.get("grant_ref"),
@@ -128,16 +146,23 @@ fn bearer(headers: &HeaderMap) -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
-fn lease_binds_env(data_dir: &str, lease_id: &str, env_id: &str) -> bool {
+/// THE ACTION THE ENV-OPS SEAM REQUIRES. A grant's RESOURCES say which environment; its ACTION says
+/// what it may do. `lease_binds_env` checked only the resources, so EVERY env-scoped lease — a
+/// port-forward lease minted `environment.port`, an editor-open lease minted `environment.editor.open`
+/// — was a full `ReadFile`/`WriteFile`/`Exec` bearer over the workspace. Next-legs XIV Leg 4 proved
+/// that live: an anonymously-minted port lease wrote a file and ran `bash -lc` through this surface.
+/// The env-ops seam requires the exact action the legitimate ops-lease minter (`handle_env_ops_lease`)
+/// issues, and nothing else. This is the chokepoint: every minter's grant flows through it.
+const ENV_OPS_ACTION: &str = "environment.ops";
+
+fn lease_grant(data_dir: &str, lease_id: &str) -> Option<Value> {
     let path = Path::new(data_dir)
         .join("authority-grants")
         .join(format!("{}.json", safe(lease_id)));
-    let Ok(bytes) = std::fs::read(path) else {
-        return false;
-    };
-    let Ok(v): Result<Value, _> = serde_json::from_slice(&bytes) else {
-        return false;
-    };
+    serde_json::from_slice(&std::fs::read(path).ok()?).ok()
+}
+
+fn resources_name_env(v: &Value, env_id: &str) -> bool {
     let needle = format!("environment:{env_id}");
     v.get("resources")
         .and_then(|r| r.as_array())
@@ -146,6 +171,23 @@ fn lease_binds_env(data_dir: &str, lease_id: &str, env_id: &str) -> bool {
                 .any(|x| x.as_str() == Some(needle.as_str()) || x.as_str() == Some(env_id))
         })
         .unwrap_or(false)
+}
+
+fn lease_binds_env(data_dir: &str, lease_id: &str, env_id: &str) -> bool {
+    lease_grant(data_dir, lease_id)
+        .map(|v| resources_name_env(&v, env_id))
+        .unwrap_or(false)
+}
+
+/// A lease may drive the EnvironmentOpsService iff it names this environment in its resources AND
+/// carries the env-ops action. The action check is what stops a port or editor lease being an
+/// arbitrary-write / arbitrary-exec bearer.
+fn lease_authorizes_env_ops(data_dir: &str, lease_id: &str, env_id: &str) -> bool {
+    let Some(v) = lease_grant(data_dir, lease_id) else {
+        return false;
+    };
+    resources_name_env(&v, env_id)
+        && v.get("action").and_then(Value::as_str) == Some(ENV_OPS_ACTION)
 }
 
 /// The environment a lease is bound to (from its `resources: ["environment:<env>"]`).
@@ -173,13 +215,15 @@ pub(crate) async fn handle_ops_lease_resolve(
     Json(json!({ "active": active && env.is_some(), "environment_id": env }))
 }
 
-/// True iff the request carries an active capability lease bound to this environment.
+/// True iff the request carries an active capability lease that AUTHORIZES ENV-OPS on this
+/// environment — active, resources name the environment, AND action is `environment.ops`. The action
+/// half is the Leg 4 fix: `lease_binds_env` alone let a port or editor lease drive `WriteFile`/`Exec`.
 fn authed(data_dir: &str, env_id: &str, headers: &HeaderMap) -> bool {
     let Some(token) = bearer(headers) else {
         return false;
     };
     capability_lease_status(data_dir, &token) == "active"
-        && lease_binds_env(data_dir, &token, env_id)
+        && lease_authorizes_env_ops(data_dir, &token, env_id)
 }
 
 // ---- git helpers --------------------------------------------------------------------------------


### PR DESCRIPTION
Next-legs XIV **Leg 4** — commissioned when the Leg 2 design review surfaced it, and **proven live against a real daemon** before any canon was corrected or any fix written.

> ⚠️ Security-sensitive. This is the surface where a green self-review is worth least; it is under merge-blocking adversarial review.

## The escalation, driven end to end and counted by SIDE EFFECT

Against the estate's own isolated-daemon harness, counting a file written and a command executed — never a status code:

| hop | result |
|---|---|
| `POST …/ports/:port/expose`, **no auth** (default posture) | 200, `accessToken`, `action=environment.port` |
| WriteFile via that bearer through `/supervisor/` | **real file on disk** in the victim workspace |
| Exec via that bearer (`bash -lc`) | **arbitrary command ran**, marker file created |
| editor-access-lease, **authenticated non-owner** | 200 ops bearer → **real file written** |

The `/supervisor/:env/…EnvironmentOpsService/:method` consumer is **outside `/v1/`**, so `auth_gate` never sees it; `supervisor_routes::lease_binds_env` checked only that the grant's **resources** named the environment, **never its action** — so a port-forward lease or an editor lease was a full ReadFile/WriteFile/Exec bearer.

## Canon asserted the class CLOSED — corrected at source

`authority_routes.rs` said *"the measured escalation this fix closes"*. That was true only for the generic grant route. Corrected in this PR, scar-9 style: it names the two uncovered minters and the action-blind check, and states plainly this is an **open, live** escalation until this leg lands. A false safety claim is worse than an honest open defect.

## The fix — chokepoint first

- **`lease_binds_env` → action check.** The env-ops seam now requires `action == environment.ops` (the action the legitimate ops-lease minter issues). Every minter's grant flows through this one predicate, so this is where the class dies. A port lease and an editor lease are **proven unable** to WriteFile/Exec; a legitimate ops lease still can — the positive control.
- **Both minters resolve a caller.** `handle_env_ops_lease` and `handle_env_port_expose` took no `HeaderMap` and hardcoded the subject `"operator"`; they now resolve it through the estate's own posture resolver — `exposed_untrusted` ⇒ 403, `authenticated_managed` ⇒ real principal or 401, `local_development` ⇒ operator (unchanged loopback trust). The literal `"operator"` subject is gone, as INV-37 already ruled everywhere else.

## Named residual — defect 1a

The minters resolve **who** the caller is, not whether they **own** the environment — no environment has an owner pin (ADR 0035 does not land this run). So an authenticated non-owner can still mint `environment.ops` for another's env in managed posture. `check:env-lease-authority` asserts that residual **TRUE**, so it flips the day the owner model lands. Same scope-pin shape as 1a and the authority-grant XV item.

## The verifier exercises the exploit as its finding

`check:env-lease-authority` (**10/10**) mints a port lease and an editor lease and proves each cannot WriteFile/Exec **by the absence of the side effect** — no file, no marker — never by a status alone; proves the positive control; proves the minters refuse an exposed surface; asserts the 1a residual. **Mutation-tested**: reverting the action check turns exactly the three chokepoint assertions red while the positive control stays green. Floored in-commit, wired into CI.

`cargo test -p ioi-node` **720/720**, no regression; the serve-layer ops-lease consumer reads the same response fields. Bundled gates, typecheck, lint, `cargo fmt --check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)