### PR TITLE
fix(ci): AFT formal floor — module census + first CI wiring of the formal harness (AFT-CB P0.5)

### DIFF
--- a/.github/scripts/run_aft_formal_checks.sh
+++ b/.github/scripts/run_aft_formal_checks.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FORMAL_DIR="internal-docs/architecture/protocols/aft/formal"
+MANIFEST_PATH="${ROOT_DIR}/${FORMAL_DIR}/manual-discharge.json"
 FORMAL_CACHE_DIR="${ROOT_DIR}/.internal/formal-cache"
 JAR_PATH="${FORMAL_CACHE_DIR}/tools/tla/tla2tools.jar"
 JAR_URL="https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar"
@@ -10,6 +12,113 @@ TLAPS_INSTALL_DIR="${TLAPS_DIR}/install"
 TLAPS_ARCHIVE="${TLAPS_DIR}/tlapm.tar.gz"
 TLAPM_BIN="${TLAPS_INSTALL_DIR}/bin/tlapm"
 TLAPS_STDLIB="${TLAPS_INSTALL_DIR}/lib/tlapm/stdlib/TLAPS.tla"
+
+# Every TLAPS proof the harness discharges, relative to FORMAL_DIR.
+PROOFS=(
+  "guardian_majority/GuardianMajorityProof.tla"
+  "nested_guardian/NestedGuardianProof.tla"
+  "AsymptoteProof.tla"
+  "canonical_ordering/CanonicalOrderingProof.tla"
+)
+
+# Every TLC model the harness checks, as "cfg|tla", relative to FORMAL_DIR.
+MODELS=(
+  "guardian_majority/GuardianMajority.cfg|guardian_majority/GuardianMajority.tla"
+  "nested_guardian/NestedGuardian.cfg|nested_guardian/NestedGuardian.tla"
+  "Asymptote.cfg|Asymptote.tla"
+  "canonical_ordering/CanonicalOrdering.cfg|canonical_ordering/CanonicalOrdering.tla"
+  "canonical_ordering/CanonicalOrderingRetrievability.cfg|canonical_ordering/CanonicalOrderingRetrievability.tla"
+  "canonical_ordering/CanonicalCollapseRecursiveContinuity.cfg|canonical_ordering/CanonicalCollapseRecursiveContinuity.tla"
+)
+
+# Census: every .tla module under FORMAL_DIR (excluding symlinks and
+# .tlacache) must be either executed by this harness or carried in
+# manual-discharge.json with a reason. An unlisted module fails the build:
+# the formal corpus admits no silent orphans.
+census() {
+  local executed=()
+  local p m
+  for p in "${PROOFS[@]}"; do executed+=("${p}"); done
+  for m in "${MODELS[@]}"; do executed+=("${m##*|}"); done
+
+  EXECUTED_MODULES="$(printf '%s\n' "${executed[@]}")" \
+  FORMAL_DIR_ABS="${ROOT_DIR}/${FORMAL_DIR}" \
+  MANIFEST_PATH="${MANIFEST_PATH}" \
+  python3 <<'PY'
+import json
+import os
+import sys
+
+formal = os.environ["FORMAL_DIR_ABS"]
+executed = set(filter(None, os.environ["EXECUTED_MODULES"].split("\n")))
+manifest_path = os.environ["MANIFEST_PATH"]
+
+discovered = set()
+for root, dirs, files in os.walk(formal):
+    dirs[:] = [d for d in dirs if d != ".tlacache"]
+    for name in files:
+        if not name.endswith(".tla"):
+            continue
+        full = os.path.join(root, name)
+        if os.path.islink(full):
+            continue
+        discovered.add(os.path.relpath(full, formal))
+
+errors = []
+
+for module in sorted(executed):
+    if module not in discovered:
+        errors.append(f"executed module missing on disk: {module}")
+
+try:
+    with open(manifest_path) as fh:
+        manifest = json.load(fh)
+except FileNotFoundError:
+    errors.append(f"manual-discharge manifest missing: {manifest_path}")
+    manifest = {"modules": []}
+except json.JSONDecodeError as exc:
+    print(f"CENSUS FAIL: manifest is not valid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+required_fields = ("module", "reason", "last_discharged", "discharged_by")
+manual = set()
+for entry in manifest.get("modules", []):
+    missing = [k for k in required_fields if not str(entry.get(k, "")).strip()]
+    if missing:
+        errors.append(
+            f"manifest entry {entry.get('module', '<unnamed>')} missing fields: {missing}"
+        )
+        continue
+    module = entry["module"]
+    if module in manual:
+        errors.append(f"manifest lists module twice: {module}")
+    manual.add(module)
+    if module not in discovered:
+        errors.append(f"manifest lists module not on disk: {module}")
+    if module in executed:
+        errors.append(f"manifest lists module the harness already executes: {module}")
+
+for module in sorted(discovered - executed - manual):
+    errors.append(f"module neither executed by the harness nor manifest-marked: {module}")
+
+if errors:
+    print("CENSUS FAIL:", file=sys.stderr)
+    for err in errors:
+        print(f"  - {err}", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    f"census OK: {len(discovered)} modules = "
+    f"{len(executed)} executed + {len(manual)} manifest-marked (manual)"
+)
+PY
+}
+
+census
+
+if [[ "${1:-}" == "--census-only" ]]; then
+  exit 0
+fi
 
 platform() {
   local os arch
@@ -71,13 +180,12 @@ run_model() {
   popd >/dev/null
 }
 
-run_proof "internal-docs/architecture/protocols/aft/formal/guardian_majority" "GuardianMajorityProof.tla"
-run_proof "internal-docs/architecture/protocols/aft/formal/nested_guardian" "NestedGuardianProof.tla"
-run_proof "internal-docs/architecture/protocols/aft/formal" "AsymptoteProof.tla"
-run_proof "internal-docs/architecture/protocols/aft/formal/canonical_ordering" "CanonicalOrderingProof.tla"
-run_model "internal-docs/architecture/protocols/aft/formal/guardian_majority" "GuardianMajority.cfg" "GuardianMajority.tla"
-run_model "internal-docs/architecture/protocols/aft/formal/nested_guardian" "NestedGuardian.cfg" "NestedGuardian.tla"
-run_model "internal-docs/architecture/protocols/aft/formal" "Asymptote.cfg" "Asymptote.tla"
-run_model "internal-docs/architecture/protocols/aft/formal/canonical_ordering" "CanonicalOrdering.cfg" "CanonicalOrdering.tla"
-run_model "internal-docs/architecture/protocols/aft/formal/canonical_ordering" "CanonicalOrderingRetrievability.cfg" "CanonicalOrderingRetrievability.tla"
-run_model "internal-docs/architecture/protocols/aft/formal/canonical_ordering" "CanonicalCollapseRecursiveContinuity.cfg" "CanonicalCollapseRecursiveContinuity.tla"
+for proof in "${PROOFS[@]}"; do
+  run_proof "${FORMAL_DIR}/$(dirname "${proof}")" "$(basename "${proof}")"
+done
+
+for model in "${MODELS[@]}"; do
+  cfg="${model%%|*}"
+  tla="${model##*|}"
+  run_model "${FORMAL_DIR}/$(dirname "${tla}")" "$(basename "${cfg}")" "$(basename "${tla}")"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,3 +300,57 @@ jobs:
       # deliberately rather than closed by guessing: `OQ-4` — whether the ioi.ai web UI ships, and
       # from which root — is an open question in the implementation guide, and inventing a
       # working-directory here would answer it by accident.
+
+  aft_formal_floor:
+    name: AFT Formal Floor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # The census is the floor: every .tla module under the AFT formal tree
+      # must be either executed by the harness or carried in
+      # manual-discharge.json with a reason. Cheap; runs on every build.
+      - name: Formal census (no silent orphan modules)
+        run: bash .github/scripts/run_aft_formal_checks.sh --census-only
+
+      - name: Determine whether formal sources changed
+        id: formal_diff
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            RANGE="origin/${{ github.base_ref }}...HEAD"
+          else
+            BEFORE="${{ github.event.before }}"
+            if [[ -z "$BEFORE" || "$BEFORE" =~ ^0+$ ]]; then
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            RANGE="$BEFORE..${{ github.sha }}"
+          fi
+          if git diff --name-only $RANGE -- \
+              internal-docs/architecture/protocols/aft/formal \
+              .github/scripts/run_aft_formal_checks.sh \
+              | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Java for TLC
+        if: steps.formal_diff.outputs.changed == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      # Full discharge (4 TLAPS proofs + 6 TLC models) runs when the formal
+      # tree or the harness changed; the census above runs unconditionally.
+      - name: Full formal discharge (proofs + models)
+        if: steps.formal_diff.outputs.changed == 'true'
+        run: bash .github/scripts/run_aft_formal_checks.sh

--- a/internal-docs/architecture/protocols/aft/formal/manual-discharge.json
+++ b/internal-docs/architecture/protocols/aft/formal/manual-discharge.json
@@ -1,0 +1,83 @@
+{
+  "policy": "Every .tla module under this directory (excluding symlinks and .tlacache) must be either executed by .github/scripts/run_aft_formal_checks.sh or carried here with a reason. The census in that script enforces this in CI; an unlisted module fails the build. Entries here are honest debt markers, not endorsements: promotion into the executed harness retires an entry.",
+  "modules": [
+    {
+      "module": "canonical_ordering/CanonicalOrderingOmissionTrace.tla",
+      "reason": "Bounded TLC witness trace reaching the concrete omission-dominance state; a witness artifact run on demand, not a standing invariant check.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual TLC run by the corpus authors; see canonical_ordering/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecovery.tla",
+      "reason": "Bounded TLC model of threshold recovery-or-missingness; not yet promoted into the standing harness lane.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual TLC run by the corpus authors; see nested_guardian/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianLiveness.tla",
+      "reason": "Bounded churn liveness harness (post-GST weak fairness); long TLC runtime; not yet promoted into the standing harness lane.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual TLC run by the corpus authors; see nested_guardian/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecurringLiveness.tla",
+      "reason": "Cycle-parameterized recurring churn/finalize/bootstrap liveness kernel; long TLC runtime; not yet promoted into the standing harness lane.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual TLC run by the corpus authors; see nested_guardian/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecurringLivenessCore.tla",
+      "reason": "Shared core module instantiated by the recurring liveness harnesses; discharged through its instantiating modules' manual runs.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual runs of the instantiating modules; see nested_guardian/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecurringLivenessFourCycle.tla",
+      "reason": "Four-cycle instantiation of the recurring liveness core (sharpens the bounded-reuse vs unbounded-recurrence gap); long TLC runtime; manual lane.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual TLC run by the corpus authors; see nested_guardian/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecoveryRecurringLiveness.tla",
+      "reason": "Recovery-gated recurring liveness harness; long TLC runtime; manual lane.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual TLC run by the corpus authors; see nested_guardian/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecoveryRecurringLivenessCore.tla",
+      "reason": "Shared core module for the recovery-gated recurring harnesses; discharged through its instantiating modules' manual runs.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual runs of the instantiating modules; see nested_guardian/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecoveryRecurringInductionCore.tla",
+      "reason": "Packages the base + bounded-step premise contracts for closed-prefix induction. NOTE: flagged Q3 by the AFT-CB program \u2014 its liveness base is an assumed premise contract; superseded-by-derivation is scheduled (P2.2).",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual tlapm --timing run recorded in formal/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecoveryRecurringProof.tla",
+      "reason": "Parameterized recurrence theorem over arbitrary TotalCycles; tlapm runtime too long for the standing PR lane.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual tlapm --timing run recorded in formal/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecoveryClassicalAgreementReduction.tla",
+      "reason": "Finite classical-agreement reduction; tlapm runtime too long for the standing PR lane.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual tlapm --timing run recorded in formal/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecoveryClassicalAgreementTotality.tla",
+      "reason": "Total classical-agreement history lift; tlapm runtime too long for the standing PR lane.",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual tlapm --timing run recorded in formal/README.md"
+    },
+    {
+      "module": "nested_guardian/NestedGuardianRecoveryClassicalAgreementCollapse.tla",
+      "reason": "Semantic-collapse wrapper carrying the corpus's final recurrence sentence; tlapm runtime too long for the standing PR lane. NOTE: its headline claim is requalified by the AFT-CB program (P0.2).",
+      "last_discharged": "pre-2026-08-16 (date not recorded in-repo)",
+      "discharged_by": "manual tlapm --timing run recorded in formal/README.md"
+    }
+  ]
+}


### PR DESCRIPTION
## AFT-CB program, leg P0.5 (kills Q9)

**Finding (worse than surveyed):** the formal corpus had **zero CI presence**. `run_aft_formal_checks.sh` existed but no workflow invoked it — the Convergent Formal Checks workflow it served was deleted, leaving only a stranded compatibility entrypoint — and 13 of 23 `.tla` modules were not in the harness under any lane.

**Change:**
- `run_aft_formal_checks.sh` gains a **census gate**: every `.tla` module under `formal/` (excluding symlinks and `.tlacache`) must be either executed by the harness or carried in `manual-discharge.json` with `reason` / `last_discharged` / `discharged_by`. Unlisted, double-listed, missing-on-disk, and executed-but-manifest-marked modules all fail. `--census-only` runs the cheap lane. Proof/model targets are refactored into arrays feeding both the census and the run loops, so the executed set cannot drift from the checked set.
- `manual-discharge.json`: 13 honest debt markers (the recurring/recovery/classical-agreement chain, both liveness harnesses, the omission witness trace). The Q3-flagged premise-contract kernel and the requalification-scheduled collapse wrapper are marked as such.
- `ci.yml`: new **AFT Formal Floor** job — census on every build; full TLAPS + TLC discharge when the formal tree or the harness changes (or on `workflow_dispatch`).

**Gate evidence (local):** `census OK: 23 modules = 10 executed + 13 manifest-marked (manual)`.

**Mutation drills (all RED, then reverted GREEN):**
1. `touch formal/Orphan.tla` → `CENSUS FAIL: module neither executed nor manifest-marked`
2. removed a manifest entry → RED on that module
3. manifest-listed an executed module (`Asymptote.tla`) → `CENSUS FAIL: manifest lists module the harness already executes`

**Scope note (labels claim only what's checked):** the full TLAPS/TLC discharge was not run locally (tool downloads + long proofs); this PR's own CI run exercises it via the path filter, since the formal tree changed. Promotion of the 13 manual modules into the executed lane is a named residual for later legs (P2.2 supersedes the Q3 kernel by derivation).

Ledger: `internal-docs/prompts/aft-cb-execution/LEDGER.md` (untracked registry by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)