### PR TITLE
fix(consensus): proof system is protocol truth, not process env — env selector and kernel mock succinct bytes deleted (AFT-CB P0.3)

### DIFF
--- a/crates/consensus/src/aft/guardian_majority/tests_parts/async_pipeline.rs
+++ b/crates/consensus/src/aft/guardian_majority/tests_parts/async_pipeline.rs
@@ -250,14 +250,19 @@ async fn asymptote_handle_quorum_certificate_advances_with_recursive_proof_backe
 }
 
 #[tokio::test]
-async fn asymptote_handle_quorum_certificate_advances_with_valid_succinct_predecessor_proof() {
+async fn asymptote_handle_quorum_certificate_rejects_succinct_labeled_predecessor_proof() {
+    // AFT-CB R4c: SuccinctSp1V1 is reserved for a real succinct backend.
+    // Even a predecessor whose bytes satisfy the zk plugin's simulated
+    // recipe must not let the pipeline advance. The header links are built
+    // manually because the extension-certificate builder itself refuses
+    // succinct-labeled predecessors.
     let mut engine = GuardianMajorityEngine::new(AftSafetyMode::Asymptote);
     engine.remember_validator_count(3, 3);
 
     let grandparent_collapse = test_canonical_collapse_object(1, None, [80u8; 32], [81u8; 32]);
     let mut previous_collapse =
         test_canonical_collapse_object(2, Some(&grandparent_collapse), [82u8; 32], [83u8; 32]);
-    bind_succinct_mock_continuity(&mut previous_collapse);
+    bind_simulated_succinct_continuity(&mut previous_collapse);
     engine
         .committed_collapses
         .insert(grandparent_collapse.height, grandparent_collapse.clone());
@@ -266,7 +271,16 @@ async fn asymptote_handle_quorum_certificate_advances_with_valid_succinct_predec
         .insert(previous_collapse.height, previous_collapse.clone());
 
     let mut header = build_progress_parent_header(3, 0);
-    link_header_to_previous_collapse(&mut header, &previous_collapse);
+    header.previous_canonical_collapse_commitment_hash =
+        canonical_collapse_commitment_hash_from_object(&previous_collapse).unwrap();
+    header.canonical_collapse_extension_certificate = Some(CanonicalCollapseExtensionCertificate {
+        predecessor_commitment: canonical_collapse_commitment(&previous_collapse),
+        predecessor_recursive_proof_hash: canonical_collapse_recursive_proof_hash(
+            &previous_collapse.continuity_recursive_proof,
+        )
+        .unwrap(),
+    });
+    header.parent_state_root = StateRoot(previous_collapse.resulting_state_root_hash.to_vec());
     let block_hash = to_root_hash(&header.hash().unwrap()).unwrap();
     engine
         .seen_headers
@@ -288,13 +302,12 @@ async fn asymptote_handle_quorum_certificate_advances_with_valid_succinct_predec
 
     <GuardianMajorityEngine as ConsensusEngine<ChainTransaction>>::handle_quorum_certificate(
         &mut engine,
-        qc.clone(),
+        qc,
     )
     .await
     .unwrap();
 
-    assert_eq!(engine.highest_qc.height, qc.height);
-    assert_eq!(engine.highest_qc.block_hash, qc.block_hash);
+    assert!(engine.highest_qc.height < 3);
 }
 
 #[tokio::test]
@@ -305,7 +318,7 @@ async fn asymptote_handle_quorum_certificate_rejects_invalid_succinct_predecesso
     let grandparent_collapse = test_canonical_collapse_object(1, None, [84u8; 32], [85u8; 32]);
     let mut previous_collapse =
         test_canonical_collapse_object(2, Some(&grandparent_collapse), [86u8; 32], [87u8; 32]);
-    bind_succinct_mock_continuity(&mut previous_collapse);
+    bind_simulated_succinct_continuity(&mut previous_collapse);
     previous_collapse
         .continuity_recursive_proof
         .proof_bytes

--- a/crates/consensus/src/aft/guardian_majority/tests_parts/base_asymptote.rs
+++ b/crates/consensus/src/aft/guardian_majority/tests_parts/base_asymptote.rs
@@ -1,21 +1,16 @@
 #[test]
-fn verify_canonical_collapse_backend_accepts_and_rejects_succinct_mock_proofs() {
+fn verify_canonical_collapse_backend_accepts_and_rejects_simulated_succinct_proofs() {
+    // Backend ROUTING only: the engine routes SuccinctSp1V1 to the zk
+    // driver, whose simulated lane accepts its own private recipe bytes and
+    // rejects mutations. The combined runtime path still rejects every
+    // succinct-labeled object at the types layer (AFT-CB R4c).
     let engine = GuardianMajorityEngine::new(AftSafetyMode::Asymptote);
     let mut collapse = test_canonical_collapse_object(1, None, [0x21u8; 32], [0x22u8; 32]);
-    let proof = &mut collapse.continuity_recursive_proof;
-    let public_inputs = canonical_collapse_continuity_public_inputs(
-        &proof.commitment,
-        proof.previous_canonical_collapse_commitment_hash,
-        proof.payload_hash,
-        proof.previous_recursive_proof_hash,
-    );
-    proof.proof_system = CanonicalCollapseContinuityProofSystem::SuccinctSp1V1;
-    proof.proof_bytes = canonical_collapse_succinct_mock_proof_bytes(&public_inputs)
-        .expect("succinct mock proof bytes");
+    bind_simulated_succinct_continuity(&mut collapse);
 
     engine
         .verify_canonical_collapse_backend(&collapse)
-        .expect("succinct backend proof should verify");
+        .expect("simulated succinct backend proof should verify");
 
     let mut mutated = collapse.clone();
     mutated.continuity_recursive_proof.proof_bytes[0] ^= 0xFF;

--- a/crates/consensus/src/aft/guardian_majority/tests_parts/canonical_surfaces.rs
+++ b/crates/consensus/src/aft/guardian_majority/tests_parts/canonical_surfaces.rs
@@ -1263,24 +1263,24 @@ fn asymptote_observe_committed_block_accepts_header_compatible_materialized_coll
 }
 
 #[test]
-fn asymptote_observe_committed_block_with_matching_succinct_collapse_enables_reset_promotion() {
-    let _guard = continuity_env_lock().lock().expect("continuity env lock");
-    let previous_env = std::env::var("IOI_AFT_CONTINUITY_PROOF_SYSTEM").ok();
-    std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", "succinct-sp1-v1");
-
+fn asymptote_observe_committed_block_rejects_succinct_labeled_collapse_until_real_backend() {
+    // AFT-CB R4c: SuccinctSp1V1 is a reserved wire variant. Until a real
+    // succinct backend lands, the reference runtime rejects any
+    // succinct-labeled collapse object outright — even one whose bytes
+    // satisfy the zk plugin's simulated recipe.
     let mut engine = GuardianMajorityEngine::new(AftSafetyMode::Asymptote);
     let collapse_chain = test_canonical_collapse_chain_ending(4, [0x31u8; 32], [0x32u8; 32]);
     seed_committed_collapse_chain(&mut engine, &collapse_chain);
     let previous_collapse = collapse_chain.last().unwrap().clone();
     let mut committed_header = build_progress_parent_header(5, 0);
     link_header_to_previous_collapse(&mut committed_header, &previous_collapse);
-    let committed_hash = to_root_hash(&committed_header.hash().unwrap()).unwrap();
-    let committed_collapse = derive_canonical_collapse_object_with_previous(
+    let mut committed_collapse = derive_canonical_collapse_object_with_previous(
         &committed_header,
         &[],
         Some(&previous_collapse),
     )
     .unwrap();
+    bind_simulated_succinct_continuity(&mut committed_collapse);
 
     let accepted =
         <GuardianMajorityEngine as ConsensusEngine<ChainTransaction>>::observe_committed_block(
@@ -1289,27 +1289,17 @@ fn asymptote_observe_committed_block_with_matching_succinct_collapse_enables_res
             Some(&committed_collapse),
         );
 
-    assert!(accepted);
-    <GuardianMajorityEngine as ConsensusEngine<ChainTransaction>>::reset(&mut engine, 5);
-
-    assert_eq!(engine.highest_qc.height, 5);
-    assert_eq!(engine.highest_qc.block_hash, committed_hash);
-
-    if let Some(value) = previous_env {
-        std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", value);
-    } else {
-        std::env::remove_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM");
-    }
+    assert!(!accepted);
 }
 
 #[test]
-fn asymptote_observe_committed_block_rejects_corrupted_local_succinct_predecessor_chain() {
-    let _guard = continuity_env_lock().lock().expect("continuity env lock");
-    let previous_env = std::env::var("IOI_AFT_CONTINUITY_PROOF_SYSTEM").ok();
-    std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", "succinct-sp1-v1");
-
+fn asymptote_observe_committed_block_rejects_corrupted_local_predecessor_chain() {
+    // The locally stored predecessor chain is HashPcdV1; corrupting the
+    // stored predecessor's proof bytes must reject the committed-block hint.
     let mut engine = GuardianMajorityEngine::new(AftSafetyMode::Asymptote);
-    let previous_collapse = test_canonical_collapse_object(4, None, [0x41u8; 32], [0x42u8; 32]);
+    let collapse_chain = test_canonical_collapse_chain_ending(4, [0x41u8; 32], [0x42u8; 32]);
+    seed_committed_collapse_chain(&mut engine, &collapse_chain);
+    let previous_collapse = collapse_chain.last().unwrap().clone();
     let mut stored_previous = previous_collapse.clone();
     stored_previous.continuity_recursive_proof.proof_bytes[0] ^= 0xFF;
     engine
@@ -1332,10 +1322,4 @@ fn asymptote_observe_committed_block_rejects_corrupted_local_succinct_predecesso
         );
 
     assert!(!accepted);
-
-    if let Some(value) = previous_env {
-        std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", value);
-    } else {
-        std::env::remove_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM");
-    }
 }

--- a/crates/consensus/src/aft/guardian_majority/tests_parts/support.rs
+++ b/crates/consensus/src/aft/guardian_majority/tests_parts/support.rs
@@ -21,7 +21,7 @@ use ioi_types::app::{
     canonical_asymptote_observer_challenges_hash, canonical_asymptote_observer_transcripts_hash,
     canonical_collapse_commitment, canonical_collapse_commitment_hash_from_object,
     canonical_collapse_continuity_public_inputs, canonical_collapse_recursive_proof_hash,
-    canonical_collapse_succinct_mock_proof_bytes, canonical_order_public_inputs,
+    canonical_order_public_inputs,
     canonical_order_public_inputs_hash, canonical_sealed_finality_proof_signing_bytes,
     derive_asymptote_observer_assignments, derive_canonical_collapse_object,
     derive_canonical_collapse_object_with_previous, derive_guardian_witness_assignments,
@@ -50,7 +50,6 @@ use ioi_types::codec;
 use ioi_types::error::ChainError;
 use libp2p::identity::Keypair;
 use std::collections::HashMap;
-use std::sync::{Mutex as StdMutex, OnceLock};
 
 fn sample_recovered_restart_entry(
     parent_header: &RecoveredCanonicalHeaderEntry,
@@ -825,11 +824,6 @@ fn extension_certificate_from_predecessor(
         .expect("extension certificate")
 }
 
-fn continuity_env_lock() -> &'static StdMutex<()> {
-    static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| StdMutex::new(()))
-}
-
 fn test_canonical_collapse_object(
     height: u64,
     previous: Option<&CanonicalCollapseObject>,
@@ -906,7 +900,13 @@ fn insert_published_collapse_chain(
     }
 }
 
-fn bind_succinct_mock_continuity(collapse: &mut CanonicalCollapseObject) {
+/// Relabels a collapse object's continuity proof as `SuccinctSp1V1`, carrying
+/// the zk plugin's own simulated recipe bytes. The kernel no longer defines
+/// any mock succinct bytes (AFT-CB P0.3): the types-level verifier rejects
+/// every succinct-labeled proof until a real backend lands (R4c), so this
+/// helper is only useful to (a) exercise the backend ROUTING directly and
+/// (b) prove the reservation rejection on combined paths.
+fn bind_simulated_succinct_continuity(collapse: &mut CanonicalCollapseObject) {
     let proof = &mut collapse.continuity_recursive_proof;
     let public_inputs = canonical_collapse_continuity_public_inputs(
         &proof.commitment,
@@ -915,8 +915,8 @@ fn bind_succinct_mock_continuity(collapse: &mut CanonicalCollapseObject) {
         proof.previous_recursive_proof_hash,
     );
     proof.proof_system = CanonicalCollapseContinuityProofSystem::SuccinctSp1V1;
-    proof.proof_bytes = canonical_collapse_succinct_mock_proof_bytes(&public_inputs)
-        .expect("succinct mock proof bytes");
+    proof.proof_bytes = zk_driver_succinct::simulated_continuity_proof_bytes(&public_inputs)
+        .expect("simulated succinct proof bytes");
 }
 
 fn link_header_to_previous_collapse(header: &mut BlockHeader, previous: &CanonicalCollapseObject) {

--- a/crates/plugins/zk-driver-succinct/src/lib.rs
+++ b/crates/plugins/zk-driver-succinct/src/lib.rs
@@ -15,10 +15,7 @@ use ioi_api::{
     zk::ZkProofSystem,
 };
 use ioi_types::{
-    app::{
-        CanonicalCollapseContinuityProofSystem,
-        CanonicalCollapseContinuityPublicInputs,
-    },
+    app::{CanonicalCollapseContinuityProofSystem, CanonicalCollapseContinuityPublicInputs},
     ibc::StateProofScheme,
 };
 use std::sync::Arc; // [FIX] Added async_trait import

--- a/crates/plugins/zk-driver-succinct/src/lib.rs
+++ b/crates/plugins/zk-driver-succinct/src/lib.rs
@@ -16,7 +16,7 @@ use ioi_api::{
 };
 use ioi_types::{
     app::{
-        canonical_collapse_succinct_mock_proof_bytes, CanonicalCollapseContinuityProofSystem,
+        CanonicalCollapseContinuityProofSystem,
         CanonicalCollapseContinuityPublicInputs,
     },
     ibc::StateProofScheme,
@@ -25,6 +25,28 @@ use std::sync::Arc; // [FIX] Added async_trait import
 
 // Re-export canonical types from the shared crate
 pub use zk_types::{BeaconPublicInputs, StateInclusionPublicInputs};
+
+/// Deterministic proof bytes for the SIMULATED (non-native) continuity lane.
+///
+/// This is the plugin's own simulation rule, private to the simulated driver:
+/// the kernel reference runtime no longer defines or accepts any mock
+/// succinct bytes (AFT-CB P0.3). Real `SuccinctSp1V1` bytes come only from
+/// the SP1 backend behind the `native` feature.
+pub fn simulated_continuity_proof_bytes(
+    public_inputs: &CanonicalCollapseContinuityPublicInputs,
+) -> Result<Vec<u8>, ioi_api::error::CryptoError> {
+    let inputs = bincode::serialize(public_inputs).map_err(|e| {
+        ioi_api::error::CryptoError::InvalidInput(format!(
+            "canonical collapse continuity public inputs invalid: {}",
+            e
+        ))
+    })?;
+    let mut preimage = b"zk-driver-succinct::simulated-continuity::v1".to_vec();
+    preimage.extend_from_slice(&inputs);
+    let digest = Sha256::digest(&preimage)
+        .map_err(|e| ioi_api::error::CryptoError::OperationFailed(e.to_string()))?;
+    Ok(digest.as_ref().to_vec())
+}
 
 /// A dummy ZK backend for simulation, fulfilling the ZkProofSystem trait.
 #[derive(Debug, Clone, Default)]
@@ -46,13 +68,7 @@ impl ZkProofSystem for SimulatedGroth16 {
         let target_root: [u8; 32] = if let Ok(inputs) =
             bincode::deserialize::<CanonicalCollapseContinuityPublicInputs>(public_inputs)
         {
-            let expected_proof =
-                canonical_collapse_succinct_mock_proof_bytes(&inputs).map_err(|e| {
-                    ioi_api::error::CryptoError::InvalidInput(format!(
-                        "canonical collapse continuity public inputs invalid: {}",
-                        e
-                    ))
-                })?;
+            let expected_proof = simulated_continuity_proof_bytes(&inputs)?;
             return Ok(proof == expected_proof.as_slice());
         } else if let Ok(inputs) = bincode::deserialize::<BeaconPublicInputs>(public_inputs) {
             inputs.new_state_root

--- a/crates/plugins/zk-driver-succinct/src/tests/continuity.rs
+++ b/crates/plugins/zk-driver-succinct/src/tests/continuity.rs
@@ -1,8 +1,8 @@
-use crate::SuccinctDriver;
+use crate::{simulated_continuity_proof_bytes, SuccinctDriver};
 use ioi_api::consensus::CanonicalCollapseContinuityVerifier;
 use ioi_types::app::{
-    canonical_collapse_succinct_mock_proof_bytes, CanonicalCollapseCommitment,
-    CanonicalCollapseContinuityProofSystem, CanonicalCollapseContinuityPublicInputs,
+    CanonicalCollapseCommitment, CanonicalCollapseContinuityProofSystem,
+    CanonicalCollapseContinuityPublicInputs,
 };
 
 fn sample_public_inputs() -> CanonicalCollapseContinuityPublicInputs {
@@ -19,10 +19,10 @@ fn sample_public_inputs() -> CanonicalCollapseContinuityPublicInputs {
 }
 
 #[test]
-fn mock_continuity_verifier_accepts_valid_succinct_proof() {
+fn simulated_continuity_verifier_accepts_valid_succinct_proof() {
     let driver = SuccinctDriver::new_mock();
     let inputs = sample_public_inputs();
-    let proof = canonical_collapse_succinct_mock_proof_bytes(&inputs).expect("mock proof");
+    let proof = simulated_continuity_proof_bytes(&inputs).expect("simulated proof");
 
     driver
         .verify_canonical_collapse_continuity(
@@ -30,14 +30,14 @@ fn mock_continuity_verifier_accepts_valid_succinct_proof() {
             &proof,
             &inputs,
         )
-        .expect("succinct continuity proof should verify");
+        .expect("simulated succinct continuity proof should verify");
 }
 
 #[test]
-fn mock_continuity_verifier_rejects_mutated_succinct_proof() {
+fn simulated_continuity_verifier_rejects_mutated_succinct_proof() {
     let driver = SuccinctDriver::new_mock();
     let inputs = sample_public_inputs();
-    let mut proof = canonical_collapse_succinct_mock_proof_bytes(&inputs).expect("mock proof");
+    let mut proof = simulated_continuity_proof_bytes(&inputs).expect("simulated proof");
     proof[0] ^= 0xFF;
 
     let result = driver.verify_canonical_collapse_continuity(
@@ -52,7 +52,7 @@ fn mock_continuity_verifier_rejects_mutated_succinct_proof() {
 }
 
 #[test]
-fn mock_continuity_verifier_rejects_reference_hash_proof_system() {
+fn simulated_continuity_verifier_rejects_reference_hash_proof_system() {
     let driver = SuccinctDriver::new_mock();
     let inputs = sample_public_inputs();
 

--- a/crates/types/src/app/consensus/collapse/proofs/continuity.rs
+++ b/crates/types/src/app/consensus/collapse/proofs/continuity.rs
@@ -27,32 +27,18 @@ pub fn canonical_collapse_continuity_public_inputs(
     }
 }
 
-/// Returns the mock proof bytes for the succinct recursive continuity backend.
-pub fn canonical_collapse_succinct_mock_proof_bytes(
-    public_inputs: &CanonicalCollapseContinuityPublicInputs,
-) -> Result<Vec<u8>, String> {
-    Ok(hash_consensus_bytes(&(
-        b"aft::canonical-collapse::succinct-mock-proof::v1",
-        public_inputs,
-    ))?
-    .to_vec())
-}
-
-fn canonical_collapse_continuity_proof_system_from_env() -> CanonicalCollapseContinuityProofSystem {
-    match std::env::var("IOI_AFT_CONTINUITY_PROOF_SYSTEM") {
-        Ok(value) if value.eq_ignore_ascii_case("succinct-sp1-v1") => {
-            CanonicalCollapseContinuityProofSystem::SuccinctSp1V1
-        }
-        _ => CanonicalCollapseContinuityProofSystem::HashPcdV1,
-    }
-}
-
 /// Returns the reference proof bytes for a recursive canonical-collapse proof step.
+///
+/// The reference runtime owns exactly one proof system: the `HashPcdV1` hash
+/// binding. `SuccinctSp1V1` is a reserved wire variant whose bytes can only be
+/// produced and verified by a real succinct backend (AFT-CB leg R4c); until
+/// that backend lands, this function refuses it in both the build and verify
+/// directions, so mock succinct bytes are unconstructable and unverifiable.
 pub fn canonical_collapse_recursive_proof_bytes(
     proof_system: CanonicalCollapseContinuityProofSystem,
     statement_hash: [u8; 32],
     previous_recursive_proof_hash: [u8; 32],
-    public_inputs: &CanonicalCollapseContinuityPublicInputs,
+    _public_inputs: &CanonicalCollapseContinuityPublicInputs,
 ) -> Result<Vec<u8>, String> {
     match proof_system {
         CanonicalCollapseContinuityProofSystem::HashPcdV1 => Ok(hash_consensus_bytes(&(
@@ -62,9 +48,11 @@ pub fn canonical_collapse_recursive_proof_bytes(
             previous_recursive_proof_hash,
         ))?
         .to_vec()),
-        CanonicalCollapseContinuityProofSystem::SuccinctSp1V1 => {
-            canonical_collapse_succinct_mock_proof_bytes(public_inputs)
-        }
+        CanonicalCollapseContinuityProofSystem::SuccinctSp1V1 => Err(
+            "SuccinctSp1V1 continuity proofs are reserved for a real succinct backend; \
+             the reference runtime can neither build nor verify them (AFT-CB R4c)"
+                .into(),
+        ),
     }
 }
 
@@ -80,7 +68,10 @@ pub fn canonical_collapse_recursive_proof(
     collapse: &CanonicalCollapseObject,
     previous: Option<&CanonicalCollapseRecursiveProof>,
 ) -> Result<CanonicalCollapseRecursiveProof, String> {
-    let proof_system = canonical_collapse_continuity_proof_system_from_env();
+    // The reference builder emits only the reference hash binding. Succinct
+    // proofs come only from a real succinct prover (AFT-CB R4c); consensus
+    // behavior never varies by process environment (Q6).
+    let proof_system = CanonicalCollapseContinuityProofSystem::HashPcdV1;
     let previous_recursive_proof_hash = if collapse.height <= 1 {
         if previous.is_some() {
             return Err(format!(

--- a/crates/types/src/app/consensus/tests_parts/collapse_continuity.rs
+++ b/crates/types/src/app/consensus/tests_parts/collapse_continuity.rs
@@ -583,26 +583,55 @@ fn canonical_collapse_recursive_proof_hash_changes_when_previous_step_changes() 
 }
 
 #[test]
-fn bind_canonical_collapse_continuity_can_emit_succinct_sp1_reference_proof() {
-    let _guard = continuity_env_lock().lock().expect("continuity env lock");
-    let previous_env = std::env::var("IOI_AFT_CONTINUITY_PROOF_SYSTEM").ok();
-    std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", "succinct-sp1-v1");
-
+fn succinct_sp1_labeled_proofs_are_rejected_until_a_real_backend_lands() {
     let previous = sample_canonical_collapse_object(1, None, 0xC1);
     let current = sample_canonical_collapse_object(2, Some(&previous), 0xC2);
+    let mut proof = current.continuity_recursive_proof.clone();
+    proof.proof_system = CanonicalCollapseContinuityProofSystem::SuccinctSp1V1;
 
-    assert_eq!(
-        current.continuity_recursive_proof.proof_system,
-        CanonicalCollapseContinuityProofSystem::SuccinctSp1V1
+    let err = verify_canonical_collapse_recursive_proof(&proof)
+        .expect_err("SuccinctSp1V1 proofs must be rejected by the reference verifier");
+    assert!(
+        err.contains("reserved for a real succinct backend"),
+        "expected the typed reservation error, got: {err}"
     );
-    verify_canonical_collapse_continuity(&current, Some(&previous))
-        .expect("succinct continuity proof should verify");
 
-    if let Some(value) = previous_env {
-        std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", value);
-    } else {
-        std::env::remove_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM");
+    let mut collapse = current.clone();
+    collapse.continuity_recursive_proof = proof;
+    assert!(
+        verify_canonical_collapse_continuity(&collapse, Some(&previous)).is_err(),
+        "continuity verification must reject SuccinctSp1V1-labeled proofs"
+    );
+}
+
+#[test]
+fn no_process_env_reads_in_consensus_collapse_sources() {
+    // Q6 gate: consensus-critical behavior must never vary by process
+    // environment. This scans the consensus sources so a reintroduced
+    // process-environment read fails the test, not a review. The needle
+    // is assembled at runtime so this gate's own source does not trip
+    // the scan.
+    let needle = ["std", "env"].join("::");
+    fn walk(dir: &std::path::Path, needle: &str, offenders: &mut Vec<String>) {
+        for entry in std::fs::read_dir(dir).expect("read consensus source dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, needle, offenders);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                let source = std::fs::read_to_string(&path).expect("read source file");
+                if source.contains(needle) {
+                    offenders.push(path.display().to_string());
+                }
+            }
+        }
     }
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/app/consensus");
+    let mut offenders = Vec::new();
+    walk(&root, &needle, &mut offenders);
+    assert!(
+        offenders.is_empty(),
+        "{needle} must not appear in consensus sources: {offenders:?}"
+    );
 }
 
 #[test]

--- a/crates/types/src/app/consensus/tests_parts/support.rs
+++ b/crates/types/src/app/consensus/tests_parts/support.rs
@@ -75,7 +75,6 @@ use crate::app::{
     SystemTransaction, ValidatorSetV1, ValidatorSetsV1, ValidatorV1,
 };
 use crate::codec;
-use std::sync::{Mutex, OnceLock};
 
 fn sample_archived_recovered_history_profile_for_tests(
 ) -> crate::app::ArchivedRecoveredHistoryProfile {
@@ -477,11 +476,6 @@ fn gf256_recovery_coding(share_count: u16, recovery_threshold: u16) -> RecoveryC
         share_count,
         recovery_threshold,
     }
-}
-
-fn continuity_env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 fn collect_index_combinations(total: usize, choose: usize) -> Vec<Vec<usize>> {

--- a/crates/validator/src/standard/orchestration/aft_collapse/tests.rs
+++ b/crates/validator/src/standard/orchestration/aft_collapse/tests.rs
@@ -5,7 +5,7 @@ use ioi_api::chain::QueryStateResponse;
 use ioi_types::app::{
     canonical_collapse_commitment, canonical_collapse_commitment_hash_from_object,
     canonical_collapse_continuity_public_inputs, canonical_collapse_extension_certificate,
-    canonical_collapse_recursive_proof_hash, canonical_collapse_succinct_mock_proof_bytes,
+    canonical_collapse_recursive_proof_hash,
     set_canonical_collapse_archived_recovered_history_anchor, AccountId,
     CanonicalCollapseContinuityProofSystem, CanonicalCollapseExtensionCertificate,
     QuorumCertificate, SignatureSuite, StateAnchor, StateRoot,
@@ -13,8 +13,8 @@ use ioi_types::app::{
 use ioi_types::error::ChainError;
 use std::any::Any;
 use std::collections::BTreeMap;
-use std::sync::{Mutex as StdMutex, OnceLock};
 use tokio::sync::Mutex;
+use zk_driver_succinct::simulated_continuity_proof_bytes;
 
 #[derive(Debug, Default)]
 struct TestWorkloadClient {
@@ -146,7 +146,13 @@ fn sample_block() -> Block<ChainTransaction> {
     }
 }
 
-fn bind_succinct_mock_continuity(collapse: &mut CanonicalCollapseObject) {
+/// Relabels a collapse object's continuity proof as `SuccinctSp1V1`, carrying
+/// the zk plugin's own simulated recipe bytes. The kernel no longer defines
+/// any mock succinct bytes (AFT-CB P0.3): the types-level verifier rejects
+/// every succinct-labeled proof until a real backend lands (R4c), so this
+/// helper is only useful to (a) exercise the backend ROUTING directly and
+/// (b) prove the reservation rejection on persisted paths.
+fn bind_simulated_succinct_continuity(collapse: &mut CanonicalCollapseObject) {
     let proof = &mut collapse.continuity_recursive_proof;
     let public_inputs = canonical_collapse_continuity_public_inputs(
         &proof.commitment,
@@ -155,8 +161,8 @@ fn bind_succinct_mock_continuity(collapse: &mut CanonicalCollapseObject) {
         proof.previous_recursive_proof_hash,
     );
     proof.proof_system = CanonicalCollapseContinuityProofSystem::SuccinctSp1V1;
-    proof.proof_bytes = canonical_collapse_succinct_mock_proof_bytes(&public_inputs)
-        .expect("succinct mock proof bytes");
+    proof.proof_bytes =
+        simulated_continuity_proof_bytes(&public_inputs).expect("simulated succinct proof bytes");
 }
 
 fn align_block_parent_to_previous_result(
@@ -166,13 +172,12 @@ fn align_block_parent_to_previous_result(
     block.header.parent_state_root = StateRoot(previous.resulting_state_root_hash.to_vec());
 }
 
-fn continuity_env_lock() -> &'static StdMutex<()> {
-    static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| StdMutex::new(()))
-}
-
 #[test]
-fn verify_canonical_collapse_backend_accepts_and_rejects_succinct_mock_proofs() {
+fn verify_canonical_collapse_backend_accepts_and_rejects_simulated_succinct_proofs() {
+    // Backend ROUTING only: the validator routes SuccinctSp1V1 to the zk
+    // driver, whose simulated lane accepts its own private recipe bytes and
+    // rejects mutations. The combined persisted path still rejects every
+    // succinct-labeled object at the types layer (AFT-CB R4c).
     let mut collapse = CanonicalCollapseObject {
         height: 1,
         previous_canonical_collapse_commitment_hash: [0u8; 32],
@@ -188,9 +193,10 @@ fn verify_canonical_collapse_backend_accepts_and_rejects_succinct_mock_proofs() 
     };
     ioi_types::app::bind_canonical_collapse_continuity(&mut collapse, None)
         .expect("bind continuity");
-    bind_succinct_mock_continuity(&mut collapse);
+    bind_simulated_succinct_continuity(&mut collapse);
 
-    verify_canonical_collapse_backend(&collapse).expect("succinct backend proof should verify");
+    verify_canonical_collapse_backend(&collapse)
+        .expect("simulated succinct backend proof should verify");
 
     let mut mutated = collapse.clone();
     mutated.continuity_recursive_proof.proof_bytes[0] ^= 0xFF;
@@ -245,66 +251,6 @@ async fn require_persisted_aft_canonical_collapse_accepts_matching_state() {
         .await
         .expect("persisted collapse");
     assert_eq!(loaded, collapse);
-}
-
-#[tokio::test]
-async fn require_persisted_aft_canonical_collapse_accepts_matching_succinct_state() {
-    let _guard = continuity_env_lock().lock().expect("continuity env lock");
-    let previous_env = std::env::var("IOI_AFT_CONTINUITY_PROOF_SYSTEM").ok();
-    std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", "succinct-sp1-v1");
-
-    let mut block = sample_block();
-    let previous = CanonicalCollapseObject {
-        height: block.header.height - 1,
-        previous_canonical_collapse_commitment_hash: [0u8; 32],
-        continuity_accumulator_hash: [0u8; 32],
-        continuity_recursive_proof: Default::default(),
-        archived_recovered_history_checkpoint_hash: [0u8; 32],
-        archived_recovered_history_profile_activation_hash: [0u8; 32],
-        archived_recovered_history_retention_receipt_hash: [0u8; 32],
-        ordering: Default::default(),
-        sealing: None,
-        transactions_root_hash: [3u8; 32],
-        resulting_state_root_hash: [4u8; 32],
-    };
-    let mut previous = previous;
-    ioi_types::app::bind_canonical_collapse_continuity(&mut previous, None)
-        .expect("bind previous continuity");
-    align_block_parent_to_previous_result(&mut block, &previous);
-    block.header.previous_canonical_collapse_commitment_hash =
-        canonical_collapse_commitment_hash_from_object(&previous).expect("previous hash");
-    block.header.canonical_collapse_extension_certificate = Some(
-        canonical_collapse_extension_certificate(block.header.height, &previous)
-            .expect("extension certificate"),
-    );
-    let collapse = derive_canonical_collapse_object_with_previous(
-        &block.header,
-        &block.transactions,
-        Some(&previous),
-    )
-    .expect("collapse");
-    let previous_key = aft_canonical_collapse_object_key(previous.height);
-    let key = aft_canonical_collapse_object_key(block.header.height);
-    let client = TestWorkloadClient::default();
-    client.raw_state.lock().await.insert(
-        previous_key,
-        codec::to_bytes_canonical(&previous).expect("encode previous"),
-    );
-    client.raw_state.lock().await.insert(
-        key,
-        codec::to_bytes_canonical(&collapse).expect("encode collapse"),
-    );
-
-    let loaded = require_persisted_aft_canonical_collapse_for_block(&client, &block)
-        .await
-        .expect("persisted succinct collapse");
-    assert_eq!(loaded, collapse);
-
-    if let Some(value) = previous_env {
-        std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", value);
-    } else {
-        std::env::remove_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM");
-    }
 }
 
 #[tokio::test]
@@ -366,11 +312,9 @@ async fn require_persisted_aft_canonical_collapse_accepts_archived_anchor_upgrad
 }
 
 #[tokio::test]
-async fn require_persisted_aft_canonical_collapse_rejects_corrupted_succinct_previous_chain() {
-    let _guard = continuity_env_lock().lock().expect("continuity env lock");
-    let previous_env = std::env::var("IOI_AFT_CONTINUITY_PROOF_SYSTEM").ok();
-    std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", "succinct-sp1-v1");
-
+async fn require_persisted_aft_canonical_collapse_rejects_corrupted_previous_chain() {
+    // The persisted predecessor chain is HashPcdV1; corrupting the persisted
+    // predecessor's proof bytes must fail durable-state advancement.
     let mut block = sample_block();
     let previous = CanonicalCollapseObject {
         height: block.header.height - 1,
@@ -418,20 +362,13 @@ async fn require_persisted_aft_canonical_collapse_rejects_corrupted_succinct_pre
 
     let error = require_persisted_aft_canonical_collapse_for_block(&client, &block)
         .await
-        .expect_err("corrupted succinct predecessor chain should fail");
+        .expect_err("corrupted predecessor chain should fail");
     assert!(
         error
             .to_string()
-            .contains("persisted canonical collapse object does not match")
-            || error.to_string().contains("continuity verification failed"),
+            .contains("canonical collapse proof bytes mismatch"),
         "unexpected error: {error}"
     );
-
-    if let Some(value) = previous_env {
-        std::env::set_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM", value);
-    } else {
-        std::env::remove_var("IOI_AFT_CONTINUITY_PROOF_SYSTEM");
-    }
 }
 
 #[tokio::test]
@@ -588,7 +525,15 @@ async fn resolve_live_aft_canonical_collapse_accepts_archived_anchor_upgrade() {
 }
 
 #[tokio::test]
-async fn require_persisted_aft_canonical_collapse_accepts_matching_succinct_backend_state() {
+async fn require_persisted_aft_canonical_collapse_rejects_succinct_labeled_previous_until_real_backend(
+) {
+    // AFT-CB R4c: SuccinctSp1V1 is a reserved wire variant. Even a persisted
+    // predecessor whose bytes satisfy the zk plugin's simulated recipe (so
+    // the backend ROUTING would accept it) must fail durable-state
+    // advancement, because the types-level verifier refuses every
+    // succinct-labeled proof until a real backend lands. The header links
+    // are built manually because the extension-certificate builder itself
+    // refuses succinct-labeled predecessors.
     let mut block = sample_block();
     let previous = CanonicalCollapseObject {
         height: block.header.height - 1,
@@ -606,40 +551,41 @@ async fn require_persisted_aft_canonical_collapse_accepts_matching_succinct_back
     let mut previous = previous;
     ioi_types::app::bind_canonical_collapse_continuity(&mut previous, None)
         .expect("bind previous continuity");
-    bind_succinct_mock_continuity(&mut previous);
+    bind_simulated_succinct_continuity(&mut previous);
     block.header.parent_state_root = StateRoot(previous.resulting_state_root_hash.to_vec());
     block.header.previous_canonical_collapse_commitment_hash =
         canonical_collapse_commitment_hash_from_object(&previous).expect("previous hash");
-    block.header.canonical_collapse_extension_certificate = Some(
-        canonical_collapse_extension_certificate(block.header.height, &previous)
-            .expect("extension certificate"),
-    );
-    let collapse = derive_canonical_collapse_object_with_previous(
-        &block.header,
-        &block.transactions,
-        Some(&previous),
-    )
-    .expect("collapse");
+    block.header.canonical_collapse_extension_certificate =
+        Some(CanonicalCollapseExtensionCertificate {
+            predecessor_commitment: canonical_collapse_commitment(&previous),
+            predecessor_recursive_proof_hash: canonical_collapse_recursive_proof_hash(
+                &previous.continuity_recursive_proof,
+            )
+            .expect("predecessor proof hash"),
+        });
     let previous_key = aft_canonical_collapse_object_key(previous.height);
-    let key = aft_canonical_collapse_object_key(block.header.height);
     let client = TestWorkloadClient::default();
     client.raw_state.lock().await.insert(
         previous_key,
         codec::to_bytes_canonical(&previous).expect("encode previous"),
     );
-    client.raw_state.lock().await.insert(
-        key,
-        codec::to_bytes_canonical(&collapse).expect("encode collapse"),
-    );
 
-    let loaded = require_persisted_aft_canonical_collapse_for_block(&client, &block)
+    let error = require_persisted_aft_canonical_collapse_for_block(&client, &block)
         .await
-        .expect("persisted succinct collapse");
-    assert_eq!(loaded, collapse);
+        .expect_err("succinct-labeled predecessor should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("reserved for a real succinct backend"),
+        "unexpected error: {error}"
+    );
 }
 
 #[tokio::test]
-async fn require_persisted_aft_canonical_collapse_rejects_invalid_succinct_backend_proof() {
+async fn require_persisted_aft_canonical_collapse_rejects_corrupted_persisted_proof_bytes() {
+    // The persisted CURRENT collapse carries corrupted HashPcdV1 proof
+    // bytes; the persisted-chain walk must reject it even though the
+    // derived expectation itself is valid.
     let mut block = sample_block();
     let previous = CanonicalCollapseObject {
         height: block.header.height - 1,
@@ -657,18 +603,13 @@ async fn require_persisted_aft_canonical_collapse_rejects_invalid_succinct_backe
     let mut previous = previous;
     ioi_types::app::bind_canonical_collapse_continuity(&mut previous, None)
         .expect("bind previous continuity");
-    bind_succinct_mock_continuity(&mut previous);
     block.header.parent_state_root = StateRoot(previous.resulting_state_root_hash.to_vec());
     block.header.previous_canonical_collapse_commitment_hash =
         canonical_collapse_commitment_hash_from_object(&previous).expect("previous hash");
-    block.header.canonical_collapse_extension_certificate =
-        Some(CanonicalCollapseExtensionCertificate {
-            predecessor_commitment: canonical_collapse_commitment(&previous),
-            predecessor_recursive_proof_hash: canonical_collapse_recursive_proof_hash(
-                &previous.continuity_recursive_proof,
-            )
-            .expect("predecessor proof hash"),
-        });
+    block.header.canonical_collapse_extension_certificate = Some(
+        canonical_collapse_extension_certificate(block.header.height, &previous)
+            .expect("extension certificate"),
+    );
     let collapse = derive_canonical_collapse_object_with_previous(
         &block.header,
         &block.transactions,
@@ -691,14 +632,11 @@ async fn require_persisted_aft_canonical_collapse_rejects_invalid_succinct_backe
 
     let error = require_persisted_aft_canonical_collapse_for_block(&client, &block)
         .await
-        .expect_err("invalid succinct proof should fail");
+        .expect_err("corrupted persisted proof bytes should fail");
     assert!(
         error
             .to_string()
-            .contains("persisted canonical collapse continuity verification failed")
-            || error
-                .to_string()
-                .contains("canonical collapse continuity backend verification failed"),
+            .contains("persisted canonical collapse continuity verification failed"),
         "unexpected error: {error}"
     );
 }


### PR DESCRIPTION
AFT-CB program, leg P0.3 (kills Q6, fences Q4). Ledger: internal-docs/prompts/aft-cb-execution/LEDGER.md (untracked registry by design).

## What changed

1. **Env selector deleted (Q6).** `canonical_collapse_continuity_proof_system_from_env` and the `IOI_AFT_CONTINUITY_PROOF_SYSTEM` env var are gone: consensus behavior never varies by process environment. The reference builder hardcodes `HashPcdV1`. A new source-scan gate, ioi-types test `no_process_env_reads_in_consensus_collapse_sources`, fails the suite if any process-env read reappears under `src/app/consensus` (the needle is assembled at runtime so the gate's own source does not trip the scan).

2. **Kernel mock succinct bytes deleted (R4c; closes the reachable half of Q4).** `canonical_collapse_succinct_mock_proof_bytes` no longer exists. `canonical_collapse_recursive_proof_bytes` returns `Err` for `SuccinctSp1V1` ("reserved for a real succinct backend"), so the reserved wire variant is rejected in BOTH directions — unconstructable by the builder and unverifiable by `verify_canonical_collapse_recursive_proof` and everything above it (continuity verification, extension certificates, observe/QC/persisted paths). Previously, state materialization accepted hash-mock "succinct" proofs because the verifier recomputed the same mock bytes.

3. **The zk plugin's simulated lane now carries its own private recipe.** `zk_driver_succinct::simulated_continuity_proof_bytes` (Sha256 over a plugin-owned domain tag + bincode public inputs) backs `SimulatedGroth16`; the kernel import is gone. Backend-ROUTING tests keep their accept/reject semantics against that recipe.

## Test surgery

**Deleted as subsumed:**
- ioi-validator `require_persisted_aft_canonical_collapse_accepts_matching_succinct_state` — env twin of `require_persisted_aft_canonical_collapse_accepts_matching_state` directly above it; identical body once the env selector is gone.

**Flipped to rejection** (positive succinct acceptance is impossible under R4c):
- consensus `asymptote_observe_committed_block_with_matching_succinct_collapse_enables_reset_promotion` → `..._rejects_succinct_labeled_collapse_until_real_backend`
- consensus `asymptote_handle_quorum_certificate_advances_with_valid_succinct_predecessor_proof` → `..._rejects_succinct_labeled_predecessor_proof`
- ioi-validator `require_persisted_aft_canonical_collapse_accepts_matching_succinct_backend_state` → `..._rejects_succinct_labeled_previous_until_real_backend` (asserts the R4c reservation message)

**Re-aimed at HashPcdV1** so the corruption lanes stay covered for the right reason (a succinct label is now rejected before any corruption is examined):
- consensus `asymptote_observe_committed_block_rejects_corrupted_local_succinct_predecessor_chain` → `..._rejects_corrupted_local_predecessor_chain`, now seeding a full height-1..4 chain so the rejection is attributable to the corrupted predecessor proof, not to a missing ancestor (the old height-4-without-ancestors setup rejected for the wrong reason)
- ioi-validator `require_persisted_aft_canonical_collapse_rejects_corrupted_succinct_previous_chain` → `..._rejects_corrupted_previous_chain` (pins "canonical collapse proof bytes mismatch")
- ioi-validator `require_persisted_aft_canonical_collapse_rejects_invalid_succinct_backend_proof` → `..._rejects_corrupted_persisted_proof_bytes` (the corrupted CURRENT persisted proof is now the actual subject)

**Renamed/kept** (backend ROUTING, semantics unchanged, plugin recipe bytes): `verify_canonical_collapse_backend_accepts_and_rejects_succinct_mock_proofs` → `..._simulated_succinct_proofs` in both consensus and validator; helper `bind_succinct_mock_continuity` → `bind_simulated_succinct_continuity`; consensus `asymptote_handle_quorum_certificate_rejects_invalid_succinct_predecessor_proof` keeps rejecting. Now-unused `continuity_env_lock` helpers and `Mutex`/`OnceLock` imports deleted in all three crates' test files.

## Gate evidence

| Command | Result |
| --- | --- |
| `cargo test --locked -p ioi-types` | 380 + 1 + 5 passed; 0 failed |
| `cargo test --locked -p zk-driver-succinct` | 3 passed; 0 failed |
| `cargo test --locked -p ioi-consensus --features aft` | 95 passed; 0 failed |
| `cargo test --locked -p ioi-validator` | 159 passed; 0 failed |

**Mutation drill:** reintroducing `let _ = std::env::var("IOI_AFT_CONTINUITY_PROOF_SYSTEM");` in `crates/types/src/app/consensus/collapse/proofs/continuity.rs` makes `no_process_env_reads_in_consensus_collapse_sources` FAIL, naming the offender file; after revert it PASSES (1 passed; 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
