### PR TITLE
docs(whitepaper): AFT §5.3 assumption ledger A1–A9 + interim claim + frontier positioning (AFT-CB P0.1)

### DIFF
--- a/.github/scripts/check_aft_whitepaper_claims.sh
+++ b/.github/scripts/check_aft_whitepaper_claims.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# AFT-CB P0.1 gate: the whitepaper's AFT section (§5.3) must carry the
+# A1–A9 assumption ledger, the interim conditional claim, and no rounded
+# percentage tolerance claim. Fails the build otherwise.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WHITEPAPER="${ROOT_DIR}/docs/architecture/whitepaper.tex"
+
+python3 - "$WHITEPAPER" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+
+start = text.find("aft-challenge-dominant-settlement-finality")
+if start == -1:
+    print("CLAIMS FAIL: AFT section anchor not found", file=sys.stderr)
+    sys.exit(1)
+# Section runs to the next \subsection at the same level (5.4/6.x) or EOF.
+tail = text[start:]
+next_sub = re.search(r"\\subsection\{(?!5\.3)", tail[1:])
+section = tail[: next_sub.start() + 1] if next_sub else tail
+
+errors = []
+
+for i in range(1, 10):
+    if not re.search(r"\\textbf\{A%d\}" % i, section):
+        errors.append(f"assumption ledger row A{i} missing")
+
+interim = (
+    "Conditional weight-independent deterministic finality over a\n"
+    "common-publication substrate, with bounded-resource liveness and\n"
+    "genesis-relative succinct verification."
+)
+if interim not in section:
+    errors.append("interim conditional claim (verbatim) missing")
+
+for pattern, label in [
+    (r"9[0-9](?:\.[0-9]+)?\s*(?:\\%|percent)", "rounded percentage tolerance figure"),
+]:
+    match = re.search(pattern, section)
+    if match:
+        errors.append(f"{label} present: {match.group(0)!r}")
+
+if "Minimal Honesty Axiom" not in section:
+    errors.append("MHA definition missing")
+
+if errors:
+    print("CLAIMS FAIL:", file=sys.stderr)
+    for err in errors:
+        print(f"  - {err}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"claims OK: A1–A9 ledger + interim claim present; no rounded tolerance figures ({len(section)} chars scanned)")
+PY

--- a/docs/architecture/whitepaper.tex
+++ b/docs/architecture/whitepaper.tex
@@ -7285,6 +7285,71 @@ is missing or inconsistent, the slot aborts rather than settling unsafe
 state. No claim is made here that this design exceeds classical BFT bounds
 or is safe under a particular Byzantine threshold.
 
+\textbf{Assumption ledger and claim discipline (AFT-CB program).} Every
+claim this candidate makes cites only the following ledger entries; the
+program that owns this discipline is tracked in the internal research
+registry. Nothing safety-critical cites A5.
+
+\begin{itemize}
+\tightlist
+\item
+  \textbf{A1} signature unforgeability and hash collision resistance.
+\item
+  \textbf{A2} Minimal Honesty Axiom (MHA): at least one honest,
+  non-equivocating signer per publicly committed signer configuration.
+  Economically bought (bonds, diversity floors, activation queues), never
+  proven, and stated so.
+\item
+  \textbf{A3} honest single-final-ack discipline over crash-consistent
+  storage.
+\item
+  \textbf{A4} anti-eclipse: a submitter can reach at least one honest
+  signer (completeness only).
+\item
+  \textbf{A5} post-GST synchrony and bounded dishonest bonded weight
+  (liveness and the live tier only; no strong-lineage safety claim cites
+  A5).
+\item
+  \textbf{A6} a historical-freshness mechanism, exactly one of four, each
+  separately priced: a recent authenticated checkpoint; forward-secure or
+  puncturable signatures with secure key erasure; an external objective
+  checkpoint; or verifiable-delay elapsed-history (requires A9).
+\item
+  \textbf{A7} proof-system soundness (succinct verification only;
+  full-replay verification needs A1 alone).
+\item
+  \textbf{A8} per-seal key evolution with verified immediate erasure
+  (everlasting safety against later compromise of former members).
+\item
+  \textbf{A9} verifiable-delay-function sequentiality with a bounded,
+  published adversary hardware advantage (a physical assumption, used only
+  by succession timing and freshness comparison).
+\end{itemize}
+
+Until the program's proof and validation gates pass, the only claim printed
+for this candidate is the conditional form:
+
+\begin{quote}
+Conditional weight-independent deterministic finality over a
+common-publication substrate, with bounded-resource liveness and
+genesis-relative succinct verification.
+\end{quote}
+
+\textbf{Positioning on the impossibility frontier.} The candidate does not
+evade FLP, DLS, or the permissionless-consensus hierarchy: transferable
+finality certificates require a known bonded signer set per close, so the
+committed configuration is the admission price the theorems charge, not a
+removable weakness. Within one configuration, unanimity plus one honest,
+non-equivocating signer yields deterministic, asynchronous,
+weight-independent uniqueness and pre-cutoff inclusion; the quorum trade is
+exact (safety needs \(2q - n > f\), liveness needs \(q \leq n - f\), so at
+\(f = n-1\) only \(q = n\) is safe and one withholder can stall). This is
+all-but-one Byzantine safety with possible stall, never all-but-one live
+consensus; positive progress and reconfiguration carry separately stated
+synchrony and adversarial-weight bounds. Tolerance figures are stated in
+the exact all-but-one form; no rounded percentage tolerance figure is used
+anywhere in this candidate's claims.
+
 \textbf{Synchrony and challenge-epoch baseline.} The candidate assumes a
 weak-synchrony model: after Global Stabilization Time (GST), public messages are delivered
 within a bounded \(\Delta_{\mathrm{publish}}\), retrieval requests


### PR DESCRIPTION
## AFT-CB program, leg P0.1 (whitepaper half of Q10's claim-divergence kill)

Adds to §5.3 (research candidate section, framing unchanged and extended):
- **Assumption ledger A1–A9** — every candidate claim cites only these entries; nothing safety-critical cites A5 (synchrony/weight are liveness-only).
- **Interim conditional claim, verbatim** — the only claim printed until the program's proof/validation gates pass.
- **Frontier positioning** — FLP/DLS/permissionless-hierarchy admission price stated; exact q-of-n inequalities (2q−n>f safety, q≤n−f liveness, f=n−1 ⇒ q=n); all-but-one language with an explicit no-rounded-percentages rule.

**Gate:** `.github/scripts/check_aft_whitepaper_claims.sh` → `claims OK: A1–A9 ledger + interim claim present; no rounded tolerance figures`.
**Mutation drill:** deleting the A5 row → `CLAIMS FAIL: assumption ledger row A5 missing` (exit 1); restored → green.

**Residual:** the checker's CI wiring rides after #297 merges (one step added to the `aft_formal_floor` job) to avoid a ci.yml conflict between open leg PRs.

Ledger: `internal-docs/prompts/aft-cb-execution/LEDGER.md` (untracked registry by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)