### PR TITLE
ci(aft): claim-discipline + whitepaper checkers join the formal floor (AFT-CB P0.1 rider)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,16 @@ jobs:
       - name: Formal census (no silent orphan modules)
         run: bash .github/scripts/run_aft_formal_checks.sh --census-only
 
+      # Claim discipline is part of the same floor: no unconditional or
+      # rounded tolerance claim in the AFT corpus, and the whitepaper's
+      # A1–A9 assumption ledger + interim conditional claim stay intact.
+      # Both cheap; run on every build.
+      - name: AFT claim discipline (no unconditional / rounded tolerance claims)
+        run: bash .github/scripts/check_aft_claim_discipline.sh
+
+      - name: Whitepaper assumption ledger + interim claim intact
+        run: bash .github/scripts/check_aft_whitepaper_claims.sh
+
       - name: Determine whether formal sources changed
         id: formal_diff
         run: |


### PR DESCRIPTION
Closes the P0.1 residual: `check_aft_claim_discipline.sh` and
`check_aft_whitepaper_claims.sh` landed with #300/#299 but were wired into no
workflow. Both now run on every build as steps of the `aft_formal_floor` job.

Gate evidence (composed master `19068b3a0`):
- `check_aft_claim_discipline.sh` → PASS
- `check_aft_whitepaper_claims.sh` → claims OK (A1–A9 + interim claim, 11361 chars)
- Mutation drill: injected unconditional "99% Byzantine Tolerance" sentence → exit 1 naming the file; reverted → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)