### PR TITLE
docs(whitepaper): A10 joins the AFT assumption ledger — P1.3 round-1 reopen (AFT-CB P0.1)

### DIFF
--- a/.github/scripts/check_aft_whitepaper_claims.sh
+++ b/.github/scripts/check_aft_whitepaper_claims.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 # AFT-CB P0.1 gate: the whitepaper's AFT section (§5.3) must carry the
-# A1–A9 assumption ledger, the interim conditional claim, and no rounded
-# percentage tolerance claim. Fails the build otherwise.
+# A1–A10 assumption ledger (A10 added by the P1.3 round-1 reopen), the
+# interim conditional claim, and no rounded percentage tolerance claim.
+# Fails the build otherwise.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WHITEPAPER="${ROOT_DIR}/docs/architecture/whitepaper.tex"
@@ -26,7 +27,7 @@ section = tail[: next_sub.start() + 1] if next_sub else tail
 
 errors = []
 
-for i in range(1, 10):
+for i in range(1, 11):
     if not re.search(r"\\textbf\{A%d\}" % i, section):
         errors.append(f"assumption ledger row A{i} missing")
 
@@ -54,5 +55,5 @@ if errors:
         print(f"  - {err}", file=sys.stderr)
     sys.exit(1)
 
-print(f"claims OK: A1–A9 ledger + interim claim present; no rounded tolerance figures ({len(section)} chars scanned)")
+print(f"claims OK: A1–A10 ledger + interim claim present; no rounded tolerance figures ({len(section)} chars scanned)")
 PY

--- a/docs/architecture/whitepaper.tex
+++ b/docs/architecture/whitepaper.tex
@@ -7303,12 +7303,15 @@ registry. Nothing safety-critical cites A5.
   \textbf{A3} honest single-final-ack discipline over crash-consistent
   storage.
 \item
-  \textbf{A4} anti-eclipse: a submitter can reach at least one honest
-  signer (completeness only).
+  \textbf{A4} reachability to at least one honest signer: for submitters
+  (completeness) and for retrievers (availability's serving path) — the
+  second edge added by program review round 2, whose audit found the
+  availability theorem consuming it while this row disclaimed it.
 \item
-  \textbf{A5} post-GST synchrony and bounded dishonest bonded weight
-  (liveness and the live tier only; no strong-lineage safety claim cites
-  A5).
+  \textbf{A5} post-GST synchrony — pairwise delivery within the bound
+  between honest parties, i.e.\ a full honest mesh — and bounded
+  dishonest bonded weight (liveness, seal cadence, and the live tier
+  only; no strong-lineage safety claim cites A5).
 \item
   \textbf{A6} a historical-freshness anchor, exactly one deployed, each
   separately priced: a recent authenticated checkpoint; forward-secure or
@@ -7330,18 +7333,24 @@ registry. Nothing safety-critical cites A5.
   including full-media imaging).
 \item
   \textbf{A9} verifiable-delay-function sequentiality with a bounded,
-  published adversary hardware advantage (a physical assumption, used only
-  by succession timing and the elapsed-history hardening).
+  published adversary hardware advantage (a physical assumption). Its
+  true blast radius, stated per program review round 2: A9 is the
+  protocol's objective clock wherever ticks are read — cadence
+  references, evidence deadlines, tick stamps, re-genesis admissibility,
+  sortition — with safety-critical consumption confined to the
+  elapsed-history hardening and the design-open succession extension.
 \item
-  \textbf{A10} succession-medium observation: an object anchored in the
-  pre-named public succession medium by a given tick is observed by the
-  acting successor within a bounded further tick count. A scoped
-  availability assumption on one bulletin — not cross-partition delivery
-  — consumed by pre-consented succession alone; the uniqueness and
-  lineage ladder never cites it. Added by program review round 1, which
-  refuted the prior succession argument under pure asynchrony: succession
-  cannot distinguish a dead ring from a partitioned one without some such
-  bound, so the ledger prices it explicitly.
+  \textbf{A10} succession-path observation: a bound on the acting
+  successor's view of pre-consented-succession evidence. Added by
+  program review round 1, which refuted the prior succession argument
+  under pure asynchrony (succession cannot distinguish a dead ring from
+  a partitioned one without some such bound); review round 2 then
+  refuted the bulletin-based formulation this row first priced, so the
+  succession extension's claims are withdrawn to design-open and this
+  entry is PROVISIONAL: its final shape (currently commissioned as
+  observation of a standby-committed set, not a bulletin) lands with the
+  respecification and its own review. Consumed by the succession
+  extension alone; the uniqueness and lineage ladder never cites it.
 \end{itemize}
 
 Until the program's proof and validation gates pass, the only claim printed

--- a/docs/architecture/whitepaper.tex
+++ b/docs/architecture/whitepaper.tex
@@ -7310,20 +7310,38 @@ registry. Nothing safety-critical cites A5.
   (liveness and the live tier only; no strong-lineage safety claim cites
   A5).
 \item
-  \textbf{A6} a historical-freshness mechanism, exactly one of four, each
+  \textbf{A6} a historical-freshness anchor, exactly one deployed, each
   separately priced: a recent authenticated checkpoint; forward-secure or
-  puncturable signatures with secure key erasure; an external objective
-  checkpoint; or verifiable-delay elapsed-history (requires A9).
+  puncturable signatures with secure key erasure; or an external objective
+  checkpoint. Verifiable-delay elapsed-history is a hardening layer over
+  an anchor — it prices and delays long-range forgery (requires A9) and is
+  not a standalone anchor: a patient or hardware-advantaged forger can
+  accumulate an equal-or-longer delay chain, so chain length alone never
+  selects the live head (adversarial finding, program review round 1).
 \item
   \textbf{A7} proof-system soundness (succinct verification only;
   full-replay verification needs A1 alone).
 \item
-  \textbf{A8} per-seal key evolution with verified immediate erasure
-  (everlasting safety against later compromise of former members).
+  \textbf{A8} per-seal key evolution with verified immediate erasure:
+  no signing-capable material ever persists to a medium that outlives its
+  slot — durable state holds only the current forward-secure key state,
+  destructively updated, and the ack journal holds signature outputs only
+  (everlasting safety against later compromise of former members,
+  including full-media imaging).
 \item
   \textbf{A9} verifiable-delay-function sequentiality with a bounded,
   published adversary hardware advantage (a physical assumption, used only
-  by succession timing and freshness comparison).
+  by succession timing and the elapsed-history hardening).
+\item
+  \textbf{A10} succession-medium observation: an object anchored in the
+  pre-named public succession medium by a given tick is observed by the
+  acting successor within a bounded further tick count. A scoped
+  availability assumption on one bulletin — not cross-partition delivery
+  — consumed by pre-consented succession alone; the uniqueness and
+  lineage ladder never cites it. Added by program review round 1, which
+  refuted the prior succession argument under pure asynchrony: succession
+  cannot distinguish a dead ring from a partitioned one without some such
+  bound, so the ledger prices it explicitly.
 \end{itemize}
 
 Until the program's proof and validation gates pass, the only claim printed


### PR DESCRIPTION
The P1.3 fresh-context adversarial review (refutation stance; filed in the
program's ignored reviews registry) REFUTED the pre-consented succession
theorem under pure asynchrony and named the smuggled delivery assumption.
Per the program's assumption-creep rule, the ledger updates — the proof
does not soften.

- **A10 added**: succession-medium observation — an object anchored in the
  pre-named public succession medium by tick X is observed by the acting
  successor within a bounded further tick count. Scoped availability on one
  bulletin, not cross-partition delivery; consumed by T5d alone; the
  uniqueness/lineage ladder never cites it.
- **A6 requalified**: elapsed-history is a hardening layer, not a
  standalone freshness anchor (drill k refuted the standalone reading — a
  patient/σ-fast forger accumulates an equal-or-longer chain).
- **A8 strengthened**: no signing-capable material ever persists to a
  slot-outliving medium (closes the durable-journal key-window the review
  found between A3 and A8).

Gate: `check_aft_whitepaper_claims.sh` now requires A1–A10 → "claims OK:
A1–A10 ledger + interim claim present". Mutation: renamed the A10 row →
CLAIMS FAIL naming exactly it; restored → OK.

Companion repairs to the two P1 docs ride their own open PRs (#304, #305).

🤖 Generated with [Claude Code](https://claude.com/claude-code)