### PR TITLE
feat(formal): BoundaryRing uniqueness kernel — TLAPS-discharged, TLC-explored at the MHA corner (AFT-CB P2.1)

### DIFF
--- a/.github/scripts/run_aft_formal_checks.sh
+++ b/.github/scripts/run_aft_formal_checks.sh
@@ -19,6 +19,7 @@ PROOFS=(
   "nested_guardian/NestedGuardianProof.tla"
   "AsymptoteProof.tla"
   "canonical_ordering/CanonicalOrderingProof.tla"
+  "common_boundary/BoundaryRingProof.tla"
 )
 
 # Every TLC model the harness checks, as "cfg|tla", relative to FORMAL_DIR.
@@ -29,6 +30,8 @@ MODELS=(
   "canonical_ordering/CanonicalOrdering.cfg|canonical_ordering/CanonicalOrdering.tla"
   "canonical_ordering/CanonicalOrderingRetrievability.cfg|canonical_ordering/CanonicalOrderingRetrievability.tla"
   "canonical_ordering/CanonicalCollapseRecursiveContinuity.cfg|canonical_ordering/CanonicalCollapseRecursiveContinuity.tla"
+  "common_boundary/BoundaryRing.cfg|common_boundary/BoundaryRing.tla"
+  "common_boundary/BoundaryRing4.cfg|common_boundary/BoundaryRing.tla"
 )
 
 # Census: every .tla module under FORMAL_DIR (excluding symlinks and

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryRing.cfg
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryRing.cfg
@@ -1,0 +1,18 @@
+\* AFT-CB P2.1 — TLC exploration of the Boundary Ring uniqueness kernel at
+\* the MHA corner: n = 3 with exactly ONE honest member (two unconstrained
+\* Byzantine emitters), two slots, two candidate roots, one artifact.
+\* The adversary schedules all delivery; TLC explores every interleaving.
+CONSTANTS
+  Ring = {m1, m2, m3}
+  HonestMembers = {m1}
+  Slots = {s1, s2}
+  Roots = {rX, rY}
+  Artifacts = {a1}
+  NoRoot = NoRoot
+
+INIT Init
+NEXT Next
+
+INVARIANT TypeOK
+INVARIANT Inv
+INVARIANT Uniqueness

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryRing.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryRing.tla
@@ -1,0 +1,161 @@
+---- MODULE BoundaryRing ----
+(***************************************************************************)
+(* AFT-CB P2.1 — the Boundary Ring action-level uniqueness kernel.         *)
+(*                                                                         *)
+(* Models one signer configuration (Ring) forming Unanimous Boundary      *)
+(* Closes per slot.  The adversary schedules all delivery (no synchrony    *)
+(* appears anywhere) and emits arbitrary well-signed messages for corrupt  *)
+(* members — the ONLY exclusion is forging an honest member's signature   *)
+(* (A1), modeled by HonestFinalAck being the sole producer of honest ack   *)
+(* records.  Honest final-acks are guarded by a durable single-entry       *)
+(* journal (A3).  Uniqueness is DERIVED from the inductive invariant under *)
+(* the Minimal Honesty Axiom (A2) — no admitted-equals-canonical           *)
+(* definition exists in this module (the Q2 defect class this kernel       *)
+(* exists to kill).                                                        *)
+(*                                                                         *)
+(* Spec source: specs/common_boundary.md §§0–2, §11–§12; theorem T1 in    *)
+(* specs/common_boundary_theorems.md.  The TLAPS discharge lives in        *)
+(* BoundaryRingProof.tla; the TLC configuration explores n = 3 with        *)
+(* exactly one honest member (the MHA corner).                             *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+  Ring,           \* the signer configuration C_v
+  HonestMembers,  \* the honest subset (MHA: nonempty — assumed in the proof)
+  Slots,          \* seal slots s
+  Roots,          \* candidate boundary roots
+  Artifacts,      \* submittable artifacts (COLLECT/RECONCILE structure)
+  NoRoot          \* journal sentinel: "no final-ack recorded for this slot"
+
+ASSUME ConstantAssumptions ==
+  /\ HonestMembers \subseteq Ring
+  /\ NoRoot \notin Roots
+
+VARIABLES
+  delivered,  \* subset of Artifacts \X Ring: what the adversary delivered where
+  declared,   \* [Ring -> [Slots -> SUBSET Artifacts]]: declared sets
+  journal,    \* [HonestMembers -> [Slots -> Roots \cup {NoRoot}]]: A3 journal
+  acks,       \* subset of Ring \X Slots \X Roots: final-ack shares in existence
+  closes      \* subset of Slots \X Roots: assembled UBCs
+
+vars == <<delivered, declared, journal, acks, closes>>
+
+TypeOK ==
+  /\ delivered \subseteq Artifacts \X Ring
+  /\ declared \in [Ring -> [Slots -> SUBSET Artifacts]]
+  /\ journal \in [HonestMembers -> [Slots -> Roots \cup {NoRoot}]]
+  /\ acks \subseteq Ring \X Slots \X Roots
+  /\ closes \subseteq Slots \X Roots
+
+Init ==
+  /\ delivered = {}
+  /\ declared = [m \in Ring |-> [s \in Slots |-> {}]]
+  /\ journal = [m \in HonestMembers |-> [s \in Slots |-> NoRoot]]
+  /\ acks = {}
+  /\ closes = {}
+
+(***************************************************************************)
+(* COLLECT: the adversary schedules delivery of any artifact to any        *)
+(* member, in any order, at any time.  No fairness, no bound — this is    *)
+(* where asynchrony lives.                                                 *)
+(***************************************************************************)
+Deliver(a, m) ==
+  /\ delivered' = delivered \cup {<<a, m>>}
+  /\ UNCHANGED <<declared, journal, acks, closes>>
+
+(***************************************************************************)
+(* RECONCILE/DECLARE: an honest member's declared set for a slot is drawn  *)
+(* from what it actually received (spec §3.1: cutoff is local — the       *)
+(* declared set is whatever was delivered when the member declares).       *)
+(* Corrupt members' declared sets are set arbitrarily by the adversary.    *)
+(***************************************************************************)
+HonestDeclare(m, s, A) ==
+  /\ m \in HonestMembers
+  /\ A \subseteq {a \in Artifacts : <<a, m>> \in delivered}
+  /\ declared' = [declared EXCEPT ![m] = [declared[m] EXCEPT ![s] = A]]
+  /\ UNCHANGED <<delivered, journal, acks, closes>>
+
+ByzantineDeclare(m, s, A) ==
+  /\ m \in Ring \ HonestMembers
+  /\ A \subseteq Artifacts
+  /\ declared' = [declared EXCEPT ![m] = [declared[m] EXCEPT ![s] = A]]
+  /\ UNCHANGED <<delivered, journal, acks, closes>>
+
+(***************************************************************************)
+(* FINAL-ACK, honest: journal-guarded (A3).  The journal entry is written  *)
+(* in the same atomic step that lets the share exist — spec §2.1's        *)
+(* "journal before the share leaves the process".  The guard              *)
+(* journal[m][s] = NoRoot is the single-final-ack discipline: once a root  *)
+(* is journaled for (m, s), no second honest share for that slot can ever  *)
+(* be produced (recovery replays bytes; it never re-decides — §2.2).      *)
+(***************************************************************************)
+HonestFinalAck(m, s, r) ==
+  /\ m \in HonestMembers
+  /\ r \in Roots
+  /\ s \in Slots
+  /\ journal[m][s] = NoRoot
+  /\ journal' = [journal EXCEPT ![m] = [journal[m] EXCEPT ![s] = r]]
+  /\ acks' = acks \cup {<<m, s, r>>}
+  /\ UNCHANGED <<delivered, declared, closes>>
+
+(***************************************************************************)
+(* The unconstrained Byzantine action: a corrupt member emits ANY          *)
+(* well-formed signed message, for any slot, any root, any number of       *)
+(* times, on any schedule.  Forging an honest signature is the only        *)
+(* exclusion (A1): m ranges over corrupt members only.  No journal binds   *)
+(* corrupt members.                                                        *)
+(***************************************************************************)
+ByzantineEmit(m, s, r) ==
+  /\ m \in Ring \ HonestMembers
+  /\ s \in Slots
+  /\ r \in Roots
+  /\ acks' = acks \cup {<<m, s, r>>}
+  /\ UNCHANGED <<delivered, declared, journal, closes>>
+
+(***************************************************************************)
+(* CLOSE: anyone (the adversary included) may assemble a UBC from shares   *)
+(* that exist — n-of-n: EVERY ring member's share over this exact          *)
+(* (slot, root).  There is no smaller quorum anywhere in this module (the  *)
+(* (n-1)-close mutation drill targets exactly this conjunct).              *)
+(***************************************************************************)
+CloseAct(s, r) ==
+  /\ s \in Slots
+  /\ r \in Roots
+  /\ \A m \in Ring : <<m, s, r>> \in acks
+  /\ closes' = closes \cup {<<s, r>>}
+  /\ UNCHANGED <<delivered, declared, journal, acks>>
+
+Next ==
+  \/ \E a \in Artifacts, m \in Ring : Deliver(a, m)
+  \/ \E m \in Ring, s \in Slots, A \in SUBSET Artifacts :
+       HonestDeclare(m, s, A) \/ ByzantineDeclare(m, s, A)
+  \/ \E m \in Ring, s \in Slots, r \in Roots :
+       HonestFinalAck(m, s, r) \/ ByzantineEmit(m, s, r)
+  \/ \E s \in Slots, r \in Roots : CloseAct(s, r)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* The derived property.  Uniqueness is NOT assumed anywhere above: no     *)
+(* definition equates "admitted" with "canonical"; closes is an ordinary   *)
+(* set any adversary schedule can try to populate twice.                   *)
+(***************************************************************************)
+Uniqueness ==
+  \A s \in Slots, r1 \in Roots, r2 \in Roots :
+    (<<s, r1>> \in closes /\ <<s, r2>> \in closes) => r1 = r2
+
+(***************************************************************************)
+(* The inductive invariant (discharged in BoundaryRingProof.tla):          *)
+(* an honest share always matches the journal entry (so an honest member   *)
+(* has at most one share per slot), and every close carries every          *)
+(* member's share.  Uniqueness follows under MHA.                          *)
+(***************************************************************************)
+Inv ==
+  /\ TypeOK
+  /\ \A m \in HonestMembers, s \in Slots, r \in Roots :
+       (<<m, s, r>> \in acks) => journal[m][s] = r
+  /\ \A s \in Slots, r \in Roots :
+       (<<s, r>> \in closes) => \A m \in Ring : <<m, s, r>> \in acks
+
+====

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryRing4.cfg
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryRing4.cfg
@@ -1,0 +1,17 @@
+\* AFT-CB P2.1 — the n = 4 exploration (one honest, three Byzantine), one
+\* slot and two roots to keep the interleaving space bounded while the
+\* Byzantine majority tries both roots freely.
+CONSTANTS
+  Ring = {m1, m2, m3, m4}
+  HonestMembers = {m1}
+  Slots = {s1}
+  Roots = {rX, rY}
+  Artifacts = {a1}
+  NoRoot = NoRoot
+
+INIT Init
+NEXT Next
+
+INVARIANT TypeOK
+INVARIANT Inv
+INVARIANT Uniqueness

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryRingProof.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryRingProof.tla
@@ -1,0 +1,141 @@
+---- MODULE BoundaryRingProof ----
+(***************************************************************************)
+(* AFT-CB P2.1 — TLAPS discharge of Boundary Ring uniqueness (T1).         *)
+(*                                                                         *)
+(* Structure: Init => Inv; Inv /\ [Next]_vars => Inv'; Inv /\ MHA =>       *)
+(* Uniqueness; composed to THEOREM Spec => []Uniqueness under the MHA      *)
+(* constant assumption.  Uniqueness is derived, never defined into         *)
+(* existence.                                                              *)
+(***************************************************************************)
+EXTENDS BoundaryRing, TLAPS
+
+ASSUME MHA == HonestMembers # {}
+
+LEMMA InvInit == Init => Inv
+  BY ConstantAssumptions DEF Init, Inv, TypeOK
+
+LEMMA InvNext == Inv /\ [Next]_vars => Inv'
+<1>1. SUFFICES ASSUME Inv, [Next]_vars PROVE Inv'
+  OBVIOUS
+<1>2. CASE UNCHANGED vars
+  BY <1>1, <1>2 DEF Inv, TypeOK, vars
+<1>3. ASSUME NEW a \in Artifacts, NEW m \in Ring, Deliver(a, m)
+      PROVE Inv'
+  BY <1>1, <1>3 DEF Inv, TypeOK, Deliver
+<1>4. ASSUME NEW m \in Ring, NEW s \in Slots, NEW A \in SUBSET Artifacts,
+             HonestDeclare(m, s, A)
+      PROVE Inv'
+  BY <1>1, <1>4 DEF Inv, TypeOK, HonestDeclare
+<1>5. ASSUME NEW m \in Ring, NEW s \in Slots, NEW A \in SUBSET Artifacts,
+             ByzantineDeclare(m, s, A)
+      PROVE Inv'
+  BY <1>1, <1>5 DEF Inv, TypeOK, ByzantineDeclare
+<1>6. ASSUME NEW m \in Ring, NEW s \in Slots, NEW r \in Roots,
+             HonestFinalAck(m, s, r)
+      PROVE Inv'
+  <2>1. m \in HonestMembers /\ journal[m][s] = NoRoot
+    BY <1>6 DEF HonestFinalAck
+  <2>2. TypeOK'
+    BY <1>1, <1>6, <2>1 DEF Inv, TypeOK, HonestFinalAck
+  <2>3. \A mm \in HonestMembers, ss \in Slots, rr \in Roots :
+          (<<mm, ss, rr>> \in acks') => journal'[mm][ss] = rr
+    <3>1. SUFFICES ASSUME NEW mm \in HonestMembers, NEW ss \in Slots,
+                          NEW rr \in Roots, <<mm, ss, rr>> \in acks'
+          PROVE journal'[mm][ss] = rr
+      OBVIOUS
+    <3>2. acks' = acks \cup {<<m, s, r>>}
+      BY <1>6 DEF HonestFinalAck
+    <3>3. CASE <<mm, ss, rr>> = <<m, s, r>>
+      <4>1. mm = m /\ ss = s /\ rr = r
+        BY <3>3
+      <4>2. journal'[m][s] = r
+        BY <1>1, <1>6, <2>1 DEF Inv, TypeOK, HonestFinalAck
+      <4> QED BY <4>1, <4>2
+    <3>4. CASE <<mm, ss, rr>> \in acks
+      <4>1. journal[mm][ss] = rr
+        BY <1>1, <3>4 DEF Inv
+      <4>2. CASE mm = m /\ ss = s
+        <5>1. journal[m][s] = rr
+          BY <4>1, <4>2
+        <5>2. rr \in Roots /\ NoRoot \notin Roots
+          BY <3>1, ConstantAssumptions
+        <5>3. FALSE
+          BY <2>1, <5>1, <5>2
+        <5> QED BY <5>3
+      <4>3. CASE ~(mm = m /\ ss = s)
+        <5>1. journal'[mm][ss] = journal[mm][ss]
+          BY <1>1, <1>6, <2>1, <4>3 DEF Inv, TypeOK, HonestFinalAck
+        <5> QED BY <4>1, <5>1
+      <4> QED BY <4>2, <4>3
+    <3> QED BY <3>1, <3>2, <3>3, <3>4
+  <2>4. \A ss \in Slots, rr \in Roots :
+          (<<ss, rr>> \in closes') => \A mm \in Ring : <<mm, ss, rr>> \in acks'
+    BY <1>1, <1>6 DEF Inv, HonestFinalAck
+  <2> QED BY <2>2, <2>3, <2>4 DEF Inv
+<1>7. ASSUME NEW m \in Ring, NEW s \in Slots, NEW r \in Roots,
+             ByzantineEmit(m, s, r)
+      PROVE Inv'
+  <2>1. m \notin HonestMembers
+    BY <1>7 DEF ByzantineEmit
+  <2>2. TypeOK'
+    BY <1>1, <1>7 DEF Inv, TypeOK, ByzantineEmit
+  <2>3. \A mm \in HonestMembers, ss \in Slots, rr \in Roots :
+          (<<mm, ss, rr>> \in acks') => journal'[mm][ss] = rr
+    BY <1>1, <1>7, <2>1 DEF Inv, ByzantineEmit
+  <2>4. \A ss \in Slots, rr \in Roots :
+          (<<ss, rr>> \in closes') => \A mm \in Ring : <<mm, ss, rr>> \in acks'
+    BY <1>1, <1>7 DEF Inv, ByzantineEmit
+  <2> QED BY <2>2, <2>3, <2>4 DEF Inv
+<1>8. ASSUME NEW s \in Slots, NEW r \in Roots, CloseAct(s, r)
+      PROVE Inv'
+  <2>1. TypeOK'
+    BY <1>1, <1>8 DEF Inv, TypeOK, CloseAct
+  <2>2. \A mm \in HonestMembers, ss \in Slots, rr \in Roots :
+          (<<mm, ss, rr>> \in acks') => journal'[mm][ss] = rr
+    BY <1>1, <1>8 DEF Inv, CloseAct
+  <2>3. \A ss \in Slots, rr \in Roots :
+          (<<ss, rr>> \in closes') => \A mm \in Ring : <<mm, ss, rr>> \in acks'
+    <3>1. SUFFICES ASSUME NEW ss \in Slots, NEW rr \in Roots,
+                          <<ss, rr>> \in closes'
+          PROVE \A mm \in Ring : <<mm, ss, rr>> \in acks'
+      OBVIOUS
+    <3>2. closes' = closes \cup {<<s, r>>} /\ acks' = acks
+      BY <1>8 DEF CloseAct
+    <3>3. CASE <<ss, rr>> \in closes
+      BY <1>1, <3>2, <3>3 DEF Inv
+    <3>4. CASE <<ss, rr>> = <<s, r>>
+      BY <1>8, <3>2, <3>4 DEF CloseAct
+    <3> QED BY <3>1, <3>2, <3>3, <3>4
+  <2> QED BY <2>1, <2>2, <2>3 DEF Inv
+<1>9. QED
+  BY <1>1, <1>2, <1>3, <1>4, <1>5, <1>6, <1>7, <1>8 DEF Next, vars
+
+LEMMA InvUniqueness == Inv => Uniqueness
+<1>1. SUFFICES ASSUME Inv, NEW s \in Slots, NEW r1 \in Roots, NEW r2 \in Roots,
+                      <<s, r1>> \in closes, <<s, r2>> \in closes
+      PROVE r1 = r2
+  BY DEF Uniqueness
+<1>2. PICK h \in HonestMembers : TRUE
+  BY MHA
+<1>3. h \in Ring
+  BY ConstantAssumptions
+<1>4. <<h, s, r1>> \in acks /\ <<h, s, r2>> \in acks
+  BY <1>1, <1>3 DEF Inv
+<1>5. journal[h][s] = r1 /\ journal[h][s] = r2
+  BY <1>1, <1>2, <1>4 DEF Inv
+<1>6. QED
+  BY <1>5
+
+THEOREM BoundaryUniqueness == Spec => []Uniqueness
+<1>1. Init => Inv
+  BY InvInit
+<1>2. Inv /\ [Next]_vars => Inv'
+  BY InvNext
+<1>3. Spec => []Inv
+  BY <1>1, <1>2, PTL DEF Spec
+<1>4. Inv => Uniqueness
+  BY InvUniqueness
+<1>5. QED
+  BY <1>3, <1>4, PTL
+
+====

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/TLAPS.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/TLAPS.tla
@@ -1,0 +1,1 @@
+../TLAPS.tla


### PR DESCRIPTION
## AFT-CB leg P2.1 — action-level uniqueness kernel (kills Q2)

New `formal/common_boundary/`: `BoundaryRing.tla` (model) +
`BoundaryRingProof.tla` (TLAPS) + two TLC configs, registered in the
formal-floor harness.

Uniqueness is **derived** from an inductive invariant — no
admitted-equals-canonical definition exists anywhere in the module (the Q2
defect class this kernel exists to kill). The adversary schedules ALL
delivery (no synchrony appears) and emits arbitrary well-signed messages
for corrupt members; forging honest signatures is the only exclusion (A1).
Honest final-acks are journal-guarded (A3). Close is n-of-n with no
smaller quorum anywhere.

## Gate evidence (all run locally with the repo's own toolchain)

- **tlapm: all 150 obligations proved** (`Init ⇒ Inv`, `Inv ∧ [Next]_vars ⇒ Inv′`, `Inv ⇒ Uniqueness` under MHA, composed to `THEOREM Spec ⇒ □Uniqueness`).
- **TLC n=3** (1 honest, 2 Byzantine, 2 slots, 2 roots): 1,003,520 distinct states, complete search, `TypeOK`/`Inv`/`Uniqueness` all hold, 29s.
- **TLC n=4** (1 honest, 3 Byzantine): 39,936 distinct states, green.
- Census: 25 modules = 12 executed + 13 manifest-marked.

## Mutation drills (leg-mandated, both lanes each, reverted green)

1. Journal guard dropped from `HonestFinalAck` → TLC `Invariant Inv is violated` + tlapm **1/150 obligations failed**.
2. (n−1)-signature `CloseAct` → TLC violation + tlapm unproved obligations.

Final state re-verified after reverts: 0 violations, 150/150 proved.
(Process note: the first drill's revert initially no-op'd via `git checkout`
on the then-untracked file and was caught by the immediately-following
green-verification run — the P0.1 revert-surgically scar, re-learned and
recorded in the ledger.)

Labels claim what was checked: the theorem is machine-discharged; TLC
bounds are model-checked at n≤4 and stated as such.

Part of AFT-CB (P1 wave review-complete; #304/#305/#306 in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)