### PR TITLE
ci(aft): theorem-discipline checker into the formal floor + theorems index bullet (AFT-CB P1 rider)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,12 @@ jobs:
       - name: Whitepaper assumption ledger + interim claim intact
         run: bash .github/scripts/check_aft_whitepaper_claims.sh
 
+      # P1.2's machine convention: Assumes-line discipline over the
+      # common-boundary theorem corpus (A5/A9/A10 scoping, T8 quarantine,
+      # T1 timing denylist, pairing-table completeness).
+      - name: Theorem Assumes discipline (common boundary)
+        run: bash .github/scripts/check_aft_theorem_assumes.sh
+
       - name: Determine whether formal sources changed
         id: formal_diff
         run: |

--- a/internal-docs/architecture/protocols/aft/specs/README.md
+++ b/internal-docs/architecture/protocols/aft/specs/README.md
@@ -9,6 +9,7 @@ accepted ADRs remain canonical.
 Current theorem/protocol reference:
 
 - [`yellow_paper.tex`](./yellow_paper.tex): standalone LaTeX yellow paper for Asymptote Fault Tolerance (AFT), including the final theorem surface, self-contained protocol coverage, embedded formal-artifact context, and implementation correspondence
+- [`common_boundary_theorems.md`](./common_boundary_theorems.md): AFT-CB P1.2 paper theorems — T1–T9 with lower bounds L1/L2/L9 + L-E/L-H/L-LR/L-M, machine-checked `Assumes:` discipline (A5→T4a/T4b only, A9→T5b/T5d only, A10→T5d only; T8 probabilistic and quarantined), and the lower-bound pairing table (three named L-OPEN rows; T5d's claim withdrawn to design-open after four adversarial review rounds); conditional on the AFT model delta
 - [`common_boundary.md`](./common_boundary.md): AFT-CB P1.1 protocol specification — Boundary Ring + Unanimous Boundary Close: the nineteen-section normative spec (ack state machine, ack journal, oracle-free cutoffs, validate-and-hold, live-tier-only ejection, custody succession, bootstrap, receipt-or-silence, handover ceremony, proof-of-silence prohibition, batch-seal cadence, attribution-preserving encoding, per-seal key evolution, anchored re-genesis, VDF chain, pre-consented succession, sortition + watchtowers, the `pq` bit, the finality menu), every rule citing the A1–A9 ledger entries it consumes; conditional on the AFT model delta
 
 Current follow-on design program:


### PR DESCRIPTION
Closes the two P1 deferrals (recorded in the program ledger): the P1.2
Assumes-discipline checker now runs on every build in `aft_formal_floor`
(it had no CI presence since #305 merged), and the specs README indexes
`common_boundary_theorems.md`.

Gate evidence: `check_aft_theorem_assumes.sh` on merged master → "theorem
convention OK: 20 blocks". Its four mutation drills were recorded at #305;
the checker's CI wiring is the same command CI now runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)