### PR TITLE
feat(formal): BoundaryLiveness — seal cadence + two-tier separation at n≤4; premise-contract requalification (AFT-CB P2.2)

### DIFF
--- a/.github/scripts/run_aft_formal_checks.sh
+++ b/.github/scripts/run_aft_formal_checks.sh
@@ -32,6 +32,8 @@ MODELS=(
   "canonical_ordering/CanonicalCollapseRecursiveContinuity.cfg|canonical_ordering/CanonicalCollapseRecursiveContinuity.tla"
   "common_boundary/BoundaryRing.cfg|common_boundary/BoundaryRing.tla"
   "common_boundary/BoundaryRing4.cfg|common_boundary/BoundaryRing.tla"
+  "common_boundary/BoundaryLiveness.cfg|common_boundary/BoundaryLiveness.tla"
+  "common_boundary/BoundaryLivenessHandover.cfg|common_boundary/BoundaryLiveness.tla"
 )
 
 # Census: every .tla module under FORMAL_DIR (excluding symlinks and

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryLiveness.cfg
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryLiveness.cfg
@@ -1,0 +1,19 @@
+\* AFT-CB P2.2 — cadence at n = 4, all members responsive (T4b's positive
+\* case, model-checked at n<=4): seals reach the target and so does the
+\* live tier.
+SPECIFICATION LivenessSpec
+
+INVARIANTS
+  TypeInvariant
+
+PROPERTY
+  SealCadenceReached
+  LiveTierProgressReached
+
+CONSTANTS
+  Members = {m1, m2, m3, m4}
+  Standbys = {sb1}
+  Responsive = {m1, m2, m3, m4, sb1}
+  MaxSeals = 2
+  MaxBlocks = 3
+  HandoverEnabled = TRUE

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryLiveness.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryLiveness.tla
@@ -1,0 +1,157 @@
+---- MODULE BoundaryLiveness ----
+(***************************************************************************)
+(* AFT-CB P2.2 — SEAL CADENCE, not chain liveness (T4b), and the two-tier  *)
+(* separation property.                                                    *)
+(*                                                                         *)
+(* Claim scope (standing rule 2, stated exactly): the cadence and          *)
+(* separation results below are model-checked at n≤4 — never "proven".    *)
+(* Live-tier liveness (T4a) is the engine's own obligation, tracked at     *)
+(* R10 and deliberately NOT claimed here: LiveBlock below is a progress    *)
+(* ABSTRACTION that reads no ring variable, so the separation property is  *)
+(* visible by construction and checked by TLC.                             *)
+(*                                                                         *)
+(* A5 is modeled as FAIRNESS: weak fairness on responsive members' acks    *)
+(* and on seal assembly is exactly the post-GST eventual-delivery          *)
+(* abstraction (T4b's Assumes line carries A5; this module says where it   *)
+(* lives).  A2/A3's safety content is BoundaryRing's business (P2.1) —    *)
+(* this module checks progress, with honest-shaped members only.           *)
+(*                                                                         *)
+(* The action set includes the assurance-preserving handover (§9): an     *)
+(* unresponsive member can be replaced by a responsive standby when        *)
+(* HandoverEnabled — modeled as an available transition; its safety terms *)
+(* (old-ring unanimity + new-ring acceptance) are P2.3's obligation, not   *)
+(* re-proved here.  NO EJECTION ACTION EXISTS AT THIS LAYER: weighted      *)
+(* ejection is live-tier-only (spec §5), and the strong ring changes only  *)
+(* by handover here.                                                       *)
+(*                                                                         *)
+(* Mutation drill (leg-mandated): one member permanently silent with       *)
+(* handover disabled ⇒ SealCadenceReached goes RED while                   *)
+(* LiveTierProgressReached stays GREEN — both directions of the tier       *)
+(* split, demonstrated by the same counterexample run.                     *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+  Members,          \* the initial ring configuration
+  Standbys,         \* standby pool for handover (disjoint from Members)
+  Responsive,       \* the responsive subset of Members \cup Standbys
+  MaxSeals,         \* cadence target the property demands be reached
+  MaxBlocks,        \* live-tier progress target
+  HandoverEnabled   \* BOOLEAN: is the §9 handover transition available?
+
+ASSUME LivenessConstants ==
+  /\ Standbys \cap Members = {}
+  /\ Responsive \subseteq (Members \cup Standbys)
+  /\ MaxSeals \in Nat \ {0}
+  /\ MaxBlocks \in Nat \ {0}
+  /\ HandoverEnabled \in BOOLEAN
+
+VARIABLES
+  ring,        \* current configuration (changes only by handover)
+  acked,       \* members of ring that final-acked the CURRENT slot
+  sealCount,   \* seals closed so far (the cadence measure)
+  liveBlocks,  \* live-tier progress abstraction (reads no ring state)
+  version      \* configuration version (increments on handover)
+
+vars == <<ring, acked, sealCount, liveBlocks, version>>
+
+TypeInvariant ==
+  /\ ring \subseteq (Members \cup Standbys)
+  /\ acked \subseteq ring
+  /\ sealCount \in 0..MaxSeals
+  /\ liveBlocks \in 0..MaxBlocks
+  /\ version \in Nat
+
+Init ==
+  /\ ring = Members
+  /\ acked = {}
+  /\ sealCount = 0
+  /\ liveBlocks = 0
+  /\ version = 0
+
+(* A responsive ring member final-acks the current slot.  Unresponsive    *)
+(* members simply never take this action — silence is the absence of a    *)
+(* step, not a message (spec §10's discipline holds even in the liveness  *)
+(* model).                                                                 *)
+Ack(m) ==
+  /\ m \in ring
+  /\ m \in Responsive
+  /\ m \notin acked
+  /\ sealCount < MaxSeals
+  /\ acked' = acked \cup {m}
+  /\ UNCHANGED <<ring, sealCount, liveBlocks, version>>
+
+(* The n-of-n close: EVERY current ring member has acked.  Unanimity is    *)
+(* the whole point — one silent member freezes this action forever (L2's  *)
+(* forced trade, conceded by T4b).                                         *)
+SealClose ==
+  /\ acked = ring
+  /\ ring # {}
+  /\ sealCount < MaxSeals
+  /\ sealCount' = sealCount + 1
+  /\ acked' = {}
+  /\ UNCHANGED <<ring, liveBlocks, version>>
+
+(* The live tier produces blocks reading NO ring variable: the guard and   *)
+(* effect mention only liveBlocks.  A stalled ring cannot disable this     *)
+(* action — that is the separation property, structurally.                 *)
+LiveBlock ==
+  /\ liveBlocks < MaxBlocks
+  /\ liveBlocks' = liveBlocks + 1
+  /\ UNCHANGED <<ring, acked, sealCount, version>>
+
+(* Assurance-preserving handover (§9), abstracted to its liveness role:    *)
+(* an unresponsive member is replaced by a responsive standby and the      *)
+(* configuration version advances.  Enabled only when the deployment       *)
+(* provides the ceremony (HandoverEnabled) — the mutation drill disables   *)
+(* it to prove the cadence property fails for the right reason.            *)
+Handover(m, sb) ==
+  /\ HandoverEnabled
+  /\ m \in ring
+  /\ m \notin Responsive
+  /\ sb \in Standbys
+  /\ sb \in Responsive
+  /\ sb \notin ring
+  /\ ring' = (ring \ {m}) \cup {sb}
+  /\ acked' = acked \ {m}
+  /\ version' = version + 1
+  /\ UNCHANGED <<sealCount, liveBlocks>>
+
+(* Terminal self-loop so a finished run is quiescence, not deadlock.       *)
+Terminating ==
+  /\ sealCount = MaxSeals
+  /\ liveBlocks = MaxBlocks
+  /\ UNCHANGED vars
+
+SomeAck == \E m \in Members \cup Standbys : Ack(m)
+SomeHandover == \E m \in Members, sb \in Standbys : Handover(m, sb)
+
+Next ==
+  \/ SomeAck
+  \/ SealClose
+  \/ LiveBlock
+  \/ SomeHandover
+  \/ Terminating
+
+(* Fairness IS the A5 abstraction: post-GST, enabled progress steps        *)
+(* eventually happen.  Weak fairness per responsive participant's ack,     *)
+(* plus seal assembly, live production, and the handover ceremony when     *)
+(* available.                                                              *)
+LivenessSpec ==
+  /\ Init
+  /\ [][Next]_vars
+  /\ \A m \in Members \cup Standbys : WF_vars(Ack(m))
+  /\ WF_vars(SealClose)
+  /\ WF_vars(LiveBlock)
+  /\ WF_vars(SomeHandover)
+
+(* The cadence property (T4b shape): seals actually reach the target —    *)
+(* positive seals, not merely eventual aborts.                             *)
+SealCadenceReached == <>(sealCount = MaxSeals)
+
+(* The separation property: the live tier reaches its target regardless    *)
+(* of ring state — checked GREEN in every configuration including the      *)
+(* mutation drill where cadence is RED.                                    *)
+LiveTierProgressReached == <>(liveBlocks = MaxBlocks)
+
+====

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryLivenessHandover.cfg
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/BoundaryLivenessHandover.cfg
@@ -1,0 +1,20 @@
+\* AFT-CB P2.2 — the handover path exercised positively: m3 is permanently
+\* unresponsive, the ceremony is available, and cadence still reaches its
+\* target because the standby replaces the silent seat.  The live tier is
+\* untouched either way.
+SPECIFICATION LivenessSpec
+
+INVARIANTS
+  TypeInvariant
+
+PROPERTY
+  SealCadenceReached
+  LiveTierProgressReached
+
+CONSTANTS
+  Members = {m1, m2, m3}
+  Standbys = {sb1}
+  Responsive = {m1, m2, sb1}
+  MaxSeals = 2
+  MaxBlocks = 3
+  HandoverEnabled = TRUE

--- a/internal-docs/architecture/protocols/aft/formal/nested_guardian/NestedGuardianRecoveryRecurringInductionCore.tla
+++ b/internal-docs/architecture/protocols/aft/formal/nested_guardian/NestedGuardianRecoveryRecurringInductionCore.tla
@@ -1,4 +1,16 @@
 ---- MODULE NestedGuardianRecoveryRecurringInductionCore ----
+(***************************************************************************)
+(* PREMISE-CONTRACT KERNEL (requalified 2026-08-17, AFT-CB P2.2, standing  *)
+(* rule 2 — labels claim only what is checked).  `RecoveryInductionBase == *)
+(* <>RecoveryClosedPrefix(1)` and the step contracts below are PREMISES:   *)
+(* assumed contracts whose sufficiency to close the prefix is what this    *)
+(* module checks — the premises themselves are NOT derived here from a     *)
+(* Byzantine network plus a dishonest-weight bound (the Q3 finding).  The  *)
+(* boundary lane's successor does not inherit these premises: the          *)
+(* common-boundary cadence obligations are checked directly, under         *)
+(* explicit fairness, in common_boundary/BoundaryLiveness.tla              *)
+(* (model-checked at n≤4, stated as such — never "proven").               *)
+(***************************************************************************)
 EXTENDS Naturals, FiniteSets, TLC
 
 CONSTANT Validators, Witnesses, Blocks, Slots, Epochs, QuorumSize, MaxReassignmentDepth,

--- a/internal-docs/architecture/protocols/aft/formal/nested_guardian/README.md
+++ b/internal-docs/architecture/protocols/aft/formal/nested_guardian/README.md
@@ -47,11 +47,18 @@ As with `GuardianMajority`, the proof surface is split:
   with the recovery kernel and exports the recovery-transfer landing
   soundness condition plus an explicit recovery-recurring recurrence contract
   and bounded closed-prefix recurrence properties.
-- `NestedGuardianRecoveryRecurringInductionCore.tla` packages the first
-  induction-shaped layer over that recovery-inclusive recurring core: it
-  binds the base closed-prefix obligation together with the bounded step
-  obligations up to cycle `c` and checks that those premises suffice to close
-  the prefix at cycle `c`.
+- `NestedGuardianRecoveryRecurringInductionCore.tla` is a PREMISE-CONTRACT
+  KERNEL (requalified 2026-08-17, AFT-CB P2.2): it packages the first
+  induction-shaped layer over that recovery-inclusive recurring core,
+  binding the base closed-prefix obligation together with the bounded step
+  obligations up to cycle `c` and checking that those premises suffice to
+  close the prefix at cycle `c`. The premises themselves — including
+  `RecoveryInductionBase == <>RecoveryClosedPrefix(1)` — are ASSUMED
+  contracts, never derived here from a Byzantine network plus a
+  dishonest-weight bound; the boundary lane checks its own cadence
+  obligations directly under explicit fairness in
+  `../common_boundary/BoundaryLiveness.tla` (model-checked at n≤4, stated
+  as such) rather than inheriting these premises.
 - `NestedGuardianRecoveryRecurringProof.tla` packages the next proof-oriented
   layer: it lifts the bounded induction kernel into a parameterized
   recurrence theorem surface over arbitrary `TotalCycles`.


### PR DESCRIPTION
## AFT-CB leg P2.2 — liveness derived, premises retired

`formal/common_boundary/BoundaryLiveness.tla` + two registered configs.
**Seal cadence, not chain liveness** (T4b): the live-tier abstraction reads
no ring variable, so separation is structural and TLC-checked. A5 lives as
fairness; the assurance-preserving handover is in the action set; no
ejection action exists at this layer. Claim scope stated exactly:
**model-checked at n≤4**, never "proven".

## Gate evidence
- TLC `BoundaryLiveness.cfg` (n=4 responsive): `SealCadenceReached` + `LiveTierProgressReached` + `TypeInvariant` green, complete search.
- TLC `BoundaryLivenessHandover.cfg` (n=3, one silent, handover enabled): cadence recovers through the standby; green.
- Census 26 = 13 executed + 13 manual.
- Requalification greps: `premise-contract` label in the Core module header and README; `model-checked at n≤4` in the module.

## Mutation drill (leg-mandated, both directions on ONE mutation)
Silent member + `HandoverEnabled = FALSE`:
- `SealCadenceReached` → **"Error: Temporal properties were violated"** with the stalled-ring counterexample (acked frozen at the responsive pair, seals never advance);
- `LiveTierProgressReached` → **green on the identical run** (live tier reaches its target while the ring is frozen).

Both directions of the tier split, proven by the same mutation. (Drill note recorded: run drills with the harness's own `-deadlock` flag — without it TLC's deadlock check preempts liveness evaluation.)

## Q3 requalification
`NestedGuardianRecoveryRecurringInductionCore.tla` + the nested_guardian
README label the `RecoveryInductionBase`-style contracts as
**premise-contract kernels** — assumed, never derived from a Byzantine
network + weight bound — with the boundary lane checking its own cadence
directly under explicit fairness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)