### PR TITLE
feat(formal): MembershipTransition — T5a + no-silence assertion + typed lineage roots (AFT-CB P2.3)

### DIFF
--- a/.github/scripts/run_aft_formal_checks.sh
+++ b/.github/scripts/run_aft_formal_checks.sh
@@ -21,6 +21,7 @@ PROOFS=(
   "canonical_ordering/CanonicalOrderingProof.tla"
   "common_boundary/BoundaryRingProof.tla"
   "common_boundary/CustodyObligationProof.tla"
+  "common_boundary/MembershipTransitionProof.tla"
 )
 
 # Every TLC model the harness checks, as "cfg|tla", relative to FORMAL_DIR.
@@ -36,6 +37,7 @@ MODELS=(
   "common_boundary/CustodyObligation.cfg|common_boundary/CustodyObligation.tla"
   "common_boundary/BoundaryLiveness.cfg|common_boundary/BoundaryLiveness.tla"
   "common_boundary/BoundaryLivenessHandover.cfg|common_boundary/BoundaryLiveness.tla"
+  "common_boundary/MembershipTransition.cfg|common_boundary/MembershipTransition.tla"
 )
 
 # Census: every .tla module under FORMAL_DIR (excluding symlinks and

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/MembershipTransition.cfg
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/MembershipTransition.cfg
@@ -1,0 +1,26 @@
+\* AFT-CB P2.3 — membership transitions at the MHA corner, minimally
+\* bounded so the unconstrained adversary's record combinatorics stay
+\* enumerable: two members (one honest), two lineages (genesis + one
+\* rootable), a single transition version.  The adversary emits transition
+\* acks, acceptances, and silence records freely; TLC checks that closed
+\* transitions are always signature-justified (the no-silence assertion)
+\* and unique per (lineage, version, parent) wherever the parent holds an
+\* honest member.
+CONSTANTS
+  AllMembers = {m1, m2}
+  HonestMembers = {m1}
+  Lineages = {L1, L2}
+  GenesisLineage = L1
+  Versions = {0}
+  NoSucc = NoSucc
+  Anchors = {checkpointW, keyErasure, externalCheckpoint}
+  DeployedAnchor = keyErasure
+  NoAnchor = NoAnchor
+
+INIT Init
+NEXT Next
+
+INVARIANT TypeOK
+INVARIANT Inv
+INVARIANT LineageUniqueness
+INVARIANT TransitionsJustified

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/MembershipTransition.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/MembershipTransition.tla
@@ -1,0 +1,212 @@
+---- MODULE MembershipTransition ----
+(***************************************************************************)
+(* AFT-CB P2.3 — membership transitions, the no-silence action set, and    *)
+(* typed lineage roots.                                                    *)
+(*                                                                         *)
+(* Event-driven, versioned configurations: a transition record is closed   *)
+(* by the CURRENT configuration's unanimous transition-acks (old-ring      *)
+(* unanimity) plus every successor member's acceptance (T5c′) — the only  *)
+(* strong-ring transition action in this module.  There is NO calendar     *)
+(* epoch anywhere: nothing advances by time.                               *)
+(*                                                                         *)
+(* Silence records EXIST in this model — the adversary mints attested      *)
+(* non-response records freely — and can never justify a transition: the   *)
+(* TransitionsJustified invariant states that every closed transition is   *)
+(* fully signature-justified (acks + acceptances), which is the spec-level *)
+(* no-silence-derived-action assertion the leg demands (spec §10.2).  The  *)
+(* mutation drill adds a silence-justified closure action and watches this *)
+(* invariant go red.                                                       *)
+(*                                                                         *)
+(* Re-genesis is a TYPED ROOT: every transition record carries exactly one *)
+(* lineage id, roots mint fresh lineage ids, and a well-formed history is  *)
+(* single-lineage BY TYPE — a root-crossing history is distinguishable by  *)
+(* construction (spec §14.4).  Uniqueness (T5a) quantifies WITHIN one      *)
+(* lineage, from a common parent configuration, under per-configuration    *)
+(* MHA stated as an explicit theorem condition.                            *)
+(*                                                                         *)
+(* Bootstrap: the deployed A6 freshness anchor is an EXPLICIT CONSTANT     *)
+(* (DeployedAnchor), and the freshness theorem in the proof module is      *)
+(* conditional on it IN THE STATEMENT — never in prose.                    *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+  AllMembers,      \* the member universe
+  HonestMembers,   \* honest subset (per-config MHA is a theorem condition)
+  Lineages,        \* lineage identifiers (roots mint them)
+  GenesisLineage,  \* the anchored genesis lineage
+  Versions,        \* transition version numbers (event-driven, no epochs)
+  NoSucc,          \* journal sentinel
+  Anchors,         \* the A6 anchor menu (explicit constants)
+  DeployedAnchor,  \* the deployed freshness anchor, or NoAnchor
+  NoAnchor
+
+Configs == (SUBSET AllMembers) \ {{}}
+
+ASSUME MembershipConstants ==
+  /\ HonestMembers \subseteq AllMembers
+  /\ GenesisLineage \in Lineages
+  /\ NoAnchor \notin Anchors
+  /\ DeployedAnchor \in Anchors \cup {NoAnchor}
+\* NoSucc \notin Configs is additionally assumed in the PROOF module only:
+\* TLC cannot membership-test a model value against this set of sets, and
+\* TLC's own model-value semantics already guarantee the disequality.
+
+VARIABLES
+  tjournal,        \* [HonestMembers -> [Lineages -> [Versions -> Configs \cup {NoSucc}]]]
+  tacks,           \* HONEST old-ring transition final-acks: <<m, l, v, succ>>
+  taccepts,        \* HONEST new-ring seat acceptances: <<m, l, v, succ>>
+  transitions,     \* closed records: <<l, v, parent, succ>>
+  roots,           \* minted lineage roots: <<newLineage, priorLineage>>
+  silenceRecords   \* attested non-response records: <<attester, subject>>
+
+vars == <<tjournal, tacks, taccepts, transitions, roots, silenceRecords>>
+
+(***************************************************************************)
+(* The unconstrained adversary, modeled STRUCTURALLY: a corrupt member's   *)
+(* signature over ANY transition content is always available (A1 excludes  *)
+(* only forging honest signatures), so Byzantine acks and acceptances are  *)
+(* not state — they are simply TRUE.  Only honest signatures are state,    *)
+(* because only honest members refuse to sign twice (the journal).  This   *)
+(* keeps the adversary maximal while keeping the state space enumerable.   *)
+(***************************************************************************)
+AckedBy(m, l, v, succ) ==
+  IF m \in HonestMembers THEN <<m, l, v, succ>> \in tacks ELSE TRUE
+
+AcceptedBy(m, l, v, succ) ==
+  IF m \in HonestMembers THEN <<m, l, v, succ>> \in taccepts ELSE TRUE
+
+TypeOK ==
+  /\ tjournal \in [HonestMembers -> [Lineages -> [Versions -> Configs \cup {NoSucc}]]]
+  /\ tacks \subseteq HonestMembers \X Lineages \X Versions \X Configs
+  /\ taccepts \subseteq HonestMembers \X Lineages \X Versions \X Configs
+  /\ transitions \subseteq Lineages \X Versions \X Configs \X Configs
+  /\ roots \subseteq Lineages \X Lineages
+  /\ silenceRecords \subseteq AllMembers \X AllMembers
+
+Init ==
+  /\ tjournal = [m \in HonestMembers |-> [l \in Lineages |-> [v \in Versions |-> NoSucc]]]
+  /\ tacks = {}
+  /\ taccepts = {}
+  /\ transitions = {}
+  /\ roots = {}
+  /\ silenceRecords = {}
+
+(* Old-ring transition final-ack, journal-guarded per (lineage, version):  *)
+(* the A3 discipline at the transition layer — an honest member acks at    *)
+(* most one successor per version of a lineage, ever.                      *)
+HonestTransitionAck(m, l, v, succ) ==
+  /\ m \in HonestMembers
+  /\ l \in Lineages /\ v \in Versions /\ succ \in Configs
+  /\ tjournal[m][l][v] = NoSucc
+  /\ tjournal' = [tjournal EXCEPT ![m] =
+       [tjournal[m] EXCEPT ![l] = [tjournal[m][l] EXCEPT ![v] = succ]]]
+  /\ tacks' = tacks \cup {<<m, l, v, succ>>}
+  /\ UNCHANGED <<taccepts, transitions, roots, silenceRecords>>
+
+(* Honest new-ring acceptance of a seat in a successor configuration the   *)
+(* member belongs to.  Acceptance is not the safety bottleneck (the old    *)
+(* ring's unanimity is), so no journal binds it; corrupt members'          *)
+(* acceptances are always available (AcceptedBy).                          *)
+Accept(m, l, v, succ) ==
+  /\ m \in HonestMembers
+  /\ l \in Lineages /\ v \in Versions /\ succ \in Configs
+  /\ m \in succ
+  /\ taccepts' = taccepts \cup {<<m, l, v, succ>>}
+  /\ UNCHANGED <<tjournal, tacks, transitions, roots, silenceRecords>>
+
+(* THE ONLY strong-ring transition action: assurance-preserving handover — *)
+(* old-ring unanimity (every parent member's ack, with corrupt signatures  *)
+(* always available) AND new-ring acceptance (every successor member's).   *)
+(* No other action in this module writes `transitions`; in particular no   *)
+(* action consumes silenceRecords.                                         *)
+CloseTransition(l, v, parent, succ) ==
+  /\ l \in Lineages /\ v \in Versions
+  /\ parent \in Configs /\ succ \in Configs
+  /\ \A m \in parent : AckedBy(m, l, v, succ)
+  /\ \A m \in succ : AcceptedBy(m, l, v, succ)
+  /\ transitions' = transitions \cup {<<l, v, parent, succ>>}
+  /\ UNCHANGED <<tjournal, tacks, taccepts, roots, silenceRecords>>
+
+(* Anchored re-genesis: a typed lineage ROOT.  It mints a FRESH lineage id *)
+(* — never the genesis lineage, never an id already rooted — and records   *)
+(* the prior lineage it administratively succeeds.  Nothing about it is a  *)
+(* transition: it writes `roots`, not `transitions`, and the lineage seam  *)
+(* is visible in the type itself.                                          *)
+MintRoot(newL, priorL) ==
+  /\ newL \in Lineages /\ priorL \in Lineages
+  /\ newL # GenesisLineage
+  /\ newL # priorL
+  /\ \A p \in Lineages : <<newL, p>> \notin roots
+  /\ roots' = roots \cup {<<newL, priorL>>}
+  /\ UNCHANGED <<tjournal, tacks, taccepts, transitions, silenceRecords>>
+
+(* Attested non-response records: ANYONE may mint one about ANY member, in *)
+(* any quantity — and the state machine gives them no power: no guard of   *)
+(* any transition-writing action mentions this variable.                   *)
+EmitSilenceRecord(attester, subject) ==
+  /\ attester \in AllMembers /\ subject \in AllMembers
+  /\ silenceRecords' = silenceRecords \cup {<<attester, subject>>}
+  /\ UNCHANGED <<tjournal, tacks, taccepts, transitions, roots>>
+
+Next ==
+  \/ \E m \in AllMembers, l \in Lineages, v \in Versions, succ \in Configs :
+       HonestTransitionAck(m, l, v, succ) \/ Accept(m, l, v, succ)
+  \/ \E l \in Lineages, v \in Versions, parent \in Configs, succ \in Configs :
+       CloseTransition(l, v, parent, succ)
+  \/ \E newL \in Lineages, priorL \in Lineages : MintRoot(newL, priorL)
+  \/ \E a \in AllMembers, s \in AllMembers : EmitSilenceRecord(a, s)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* The spec-level no-silence assertion: every closed transition is FULLY   *)
+(* justified by signatures — old-ring unanimity and new-ring acceptance —  *)
+(* while silence records float freely in the state with no effect.  The    *)
+(* silence-mutation drill adds a closure action justified by               *)
+(* silenceRecords instead, and this invariant goes red.                    *)
+(***************************************************************************)
+TransitionsJustified ==
+  \A l \in Lineages, v \in Versions, parent \in Configs, succ \in Configs :
+    (<<l, v, parent, succ>> \in transitions) =>
+      /\ \A m \in parent : AckedBy(m, l, v, succ)
+      /\ \A m \in succ : AcceptedBy(m, l, v, succ)
+
+(* T5a at the transition layer: within ONE lineage, from a common parent   *)
+(* configuration containing at least one honest member, the closed         *)
+(* successor at any version is unique.  Divergence convicts the FULL       *)
+(* parent configuration (every member double-acked) — checked by TLC and   *)
+(* proven in MembershipTransitionProof.                                    *)
+LineageUniqueness ==
+  \A l \in Lineages, v \in Versions, parent \in Configs,
+     s1 \in Configs, s2 \in Configs :
+    (/\ <<l, v, parent, s1>> \in transitions
+     /\ <<l, v, parent, s2>> \in transitions
+     /\ parent \cap HonestMembers # {}) => s1 = s2
+
+(* Root-crossing distinguishability (spec §14.4): every record carries its *)
+(* lineage id in the first component, so a verifier's well-formedness rule *)
+(* — a single history holds records of ONE lineage — makes a root-crossing *)
+(* history distinguishable by construction.  WellFormedHistory is the      *)
+(* verifier's rule; CrossLineageUnclaimed states what the model does NOT   *)
+(* claim: uniqueness never quantifies across lineages, and the drill that  *)
+(* mutates WellFormedHistory to ignore lineage ids watches a cross-lineage *)
+(* "uniqueness" invariant collapse immediately (two lineages may close     *)
+(* different successors at the same version, legitimately).                *)
+WellFormedHistory(H) ==
+  \E l \in Lineages : \A r \in H : r[1] = l
+
+CrossLineageUniquenessWouldBeFalse ==
+  \A H \in SUBSET transitions :
+    WellFormedHistory(H) =>
+      \A r1 \in H, r2 \in H, v \in Versions :
+        (r1[2] = v /\ r2[2] = v /\ r1[3] = r2[3]
+         /\ r1[3] \cap HonestMembers # {}) => r1[4] = r2[4]
+
+Inv ==
+  /\ TypeOK
+  /\ \A m \in HonestMembers, l \in Lineages, v \in Versions, succ \in Configs :
+       (<<m, l, v, succ>> \in tacks) => tjournal[m][l][v] = succ
+  /\ TransitionsJustified
+
+====

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/MembershipTransitionProof.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/MembershipTransitionProof.tla
@@ -1,0 +1,191 @@
+---- MODULE MembershipTransitionProof ----
+(***************************************************************************)
+(* AFT-CB P2.3 — TLAPS discharge: T5a lineage uniqueness under             *)
+(* per-configuration MHA (stated as a theorem CONDITION, not a global      *)
+(* assumption), the signature-justification invariant (the no-silence      *)
+(* assertion), and the A6-conditional bootstrap-freshness statement —      *)
+(* conditionality in the theorem, never in prose.                          *)
+(***************************************************************************)
+EXTENDS MembershipTransition, TLAPS
+
+(* Assumed here rather than in the model module: TLC cannot evaluate this  *)
+(* membership test over a model value, while its model-value semantics     *)
+(* already make it true; tlapm consumes it for the journal-conflict step.  *)
+ASSUME NoSuccOutsideConfigs == NoSucc \notin Configs
+
+LEMMA MInvInit == Init => Inv
+  BY MembershipConstants DEF Init, Inv, TypeOK, TransitionsJustified
+
+LEMMA MInvNext == Inv /\ [Next]_vars => Inv'
+<1>1. SUFFICES ASSUME Inv, [Next]_vars PROVE Inv'
+  OBVIOUS
+<1>2. CASE UNCHANGED vars
+  BY <1>1, <1>2 DEF Inv, TypeOK, TransitionsJustified, AckedBy, AcceptedBy,
+     vars
+<1>3. ASSUME NEW m \in AllMembers, NEW l \in Lineages, NEW v \in Versions,
+             NEW succ \in Configs, HonestTransitionAck(m, l, v, succ)
+      PROVE Inv'
+  <2>1. m \in HonestMembers /\ tjournal[m][l][v] = NoSucc
+    BY <1>3 DEF HonestTransitionAck
+  <2>2. TypeOK'
+    BY <1>1, <1>3, <2>1 DEF Inv, TypeOK, HonestTransitionAck
+  <2>3. \A mm \in HonestMembers, ll \in Lineages, vv \in Versions,
+          ss \in Configs :
+          (<<mm, ll, vv, ss>> \in tacks') => tjournal'[mm][ll][vv] = ss
+    <3>1. SUFFICES ASSUME NEW mm \in HonestMembers, NEW ll \in Lineages,
+                          NEW vv \in Versions, NEW ss \in Configs,
+                          <<mm, ll, vv, ss>> \in tacks'
+          PROVE tjournal'[mm][ll][vv] = ss
+      OBVIOUS
+    <3>2. tacks' = tacks \cup {<<m, l, v, succ>>}
+      BY <1>3 DEF HonestTransitionAck
+    <3>3. CASE <<mm, ll, vv, ss>> = <<m, l, v, succ>>
+      <4>1. mm = m /\ ll = l /\ vv = v /\ ss = succ
+        BY <3>3
+      <4>2. tjournal'[m][l][v] = succ
+        BY <1>1, <1>3, <2>1 DEF Inv, TypeOK, HonestTransitionAck
+      <4> QED BY <4>1, <4>2
+    <3>4. CASE <<mm, ll, vv, ss>> \in tacks
+      <4>1. tjournal[mm][ll][vv] = ss
+        BY <1>1, <3>4 DEF Inv
+      <4>2. CASE mm = m /\ ll = l /\ vv = v
+        <5>1. tjournal[m][l][v] = ss
+          BY <4>1, <4>2
+        <5>2. tjournal[m][l][v] = NoSucc
+          BY <2>1
+        <5>3. ss # NoSucc
+          BY <3>1, NoSuccOutsideConfigs
+        <5> QED BY <5>1, <5>2, <5>3
+      <4>3. CASE ~(mm = m /\ ll = l /\ vv = v)
+        <5>1. tjournal'[mm][ll][vv] = tjournal[mm][ll][vv]
+          BY <1>1, <1>3, <2>1, <4>3 DEF Inv, TypeOK, HonestTransitionAck
+        <5> QED BY <4>1, <5>1
+      <4> QED BY <4>2, <4>3
+    <3> QED BY <3>1, <3>2, <3>3, <3>4
+  <2>4. TransitionsJustified'
+    <3>1. SUFFICES ASSUME NEW ll \in Lineages, NEW vv \in Versions,
+                          NEW pp \in Configs, NEW ss \in Configs,
+                          <<ll, vv, pp, ss>> \in transitions'
+          PROVE /\ \A mm \in pp : AckedBy(mm, ll, vv, ss)'
+                /\ \A mm \in ss : AcceptedBy(mm, ll, vv, ss)'
+      BY DEF TransitionsJustified
+    <3>2. transitions' = transitions /\ tacks' = tacks \cup {<<m, l, v, succ>>}
+          /\ taccepts' = taccepts
+      BY <1>3 DEF HonestTransitionAck
+    <3>3. /\ \A mm \in pp : AckedBy(mm, ll, vv, ss)
+          /\ \A mm \in ss : AcceptedBy(mm, ll, vv, ss)
+      BY <1>1, <3>1, <3>2 DEF Inv, TransitionsJustified
+    <3> QED BY <3>1, <3>2, <3>3 DEF AckedBy, AcceptedBy
+  <2> QED BY <2>2, <2>3, <2>4 DEF Inv
+<1>5. ASSUME NEW m \in AllMembers, NEW l \in Lineages, NEW v \in Versions,
+             NEW succ \in Configs, Accept(m, l, v, succ)
+      PROVE Inv'
+  <2>1. TypeOK'
+    BY <1>1, <1>5 DEF Inv, TypeOK, Accept
+  <2>2. \A mm \in HonestMembers, ll \in Lineages, vv \in Versions,
+          ss \in Configs :
+          (<<mm, ll, vv, ss>> \in tacks') => tjournal'[mm][ll][vv] = ss
+    BY <1>1, <1>5 DEF Inv, Accept
+  <2>3. TransitionsJustified'
+    <3>1. SUFFICES ASSUME NEW ll \in Lineages, NEW vv \in Versions,
+                          NEW pp \in Configs, NEW ss \in Configs,
+                          <<ll, vv, pp, ss>> \in transitions'
+          PROVE /\ \A mm \in pp : AckedBy(mm, ll, vv, ss)'
+                /\ \A mm \in ss : AcceptedBy(mm, ll, vv, ss)'
+      BY DEF TransitionsJustified
+    <3>2. transitions' = transitions /\ tacks' = tacks
+          /\ taccepts' = taccepts \cup {<<m, l, v, succ>>}
+      BY <1>5 DEF Accept
+    <3>3. /\ \A mm \in pp : AckedBy(mm, ll, vv, ss)
+          /\ \A mm \in ss : AcceptedBy(mm, ll, vv, ss)
+      BY <1>1, <3>1, <3>2 DEF Inv, TransitionsJustified
+    <3> QED BY <3>1, <3>2, <3>3 DEF AckedBy, AcceptedBy
+  <2> QED BY <2>1, <2>2, <2>3 DEF Inv
+<1>6. ASSUME NEW l \in Lineages, NEW v \in Versions, NEW parent \in Configs,
+             NEW succ \in Configs, CloseTransition(l, v, parent, succ)
+      PROVE Inv'
+  <2>1. TypeOK'
+    BY <1>1, <1>6 DEF Inv, TypeOK, CloseTransition
+  <2>2. \A mm \in HonestMembers, ll \in Lineages, vv \in Versions,
+          ss \in Configs :
+          (<<mm, ll, vv, ss>> \in tacks') => tjournal'[mm][ll][vv] = ss
+    BY <1>1, <1>6 DEF Inv, TransitionsJustified, CloseTransition
+  <2>3. TransitionsJustified'
+    BY <1>1, <1>6 DEF Inv, TransitionsJustified, CloseTransition,
+       AckedBy, AcceptedBy
+  <2> QED BY <2>1, <2>2, <2>3 DEF Inv
+<1>7. ASSUME NEW newL \in Lineages, NEW priorL \in Lineages,
+             MintRoot(newL, priorL)
+      PROVE Inv'
+  BY <1>1, <1>7 DEF Inv, TypeOK, TransitionsJustified, AckedBy, AcceptedBy,
+     MintRoot
+<1>8. ASSUME NEW a \in AllMembers, NEW s \in AllMembers,
+             EmitSilenceRecord(a, s)
+      PROVE Inv'
+  BY <1>1, <1>8 DEF Inv, TypeOK, TransitionsJustified, AckedBy, AcceptedBy,
+     EmitSilenceRecord
+<1>9. QED
+  BY <1>1, <1>2, <1>3, <1>5, <1>6, <1>7, <1>8 DEF Next, vars
+
+(***************************************************************************)
+(* T5a: within one lineage, from a common parent configuration that        *)
+(* contains at least one honest member (per-configuration MHA as an        *)
+(* explicit CONDITION of the statement), closed successors are unique.     *)
+(***************************************************************************)
+LEMMA InvLineageUniqueness == Inv => LineageUniqueness
+<1>1. SUFFICES ASSUME Inv, NEW l \in Lineages, NEW v \in Versions,
+                      NEW parent \in Configs,
+                      NEW s1 \in Configs, NEW s2 \in Configs,
+                      <<l, v, parent, s1>> \in transitions,
+                      <<l, v, parent, s2>> \in transitions,
+                      parent \cap HonestMembers # {}
+      PROVE s1 = s2
+  BY DEF LineageUniqueness
+<1>2. PICK h \in parent \cap HonestMembers : TRUE
+  BY <1>1
+<1>3. h \in parent /\ h \in HonestMembers
+  BY <1>2
+<1>4. <<h, l, v, s1>> \in tacks /\ <<h, l, v, s2>> \in tacks
+  BY <1>1, <1>3 DEF Inv, TransitionsJustified, AckedBy
+<1>5. tjournal[h][l][v] = s1 /\ tjournal[h][l][v] = s2
+  BY <1>1, <1>3, <1>4 DEF Inv
+<1>6. QED
+  BY <1>5
+
+THEOREM MembershipSafety == Spec => [](LineageUniqueness /\ TransitionsJustified)
+<1>1. Init => Inv
+  BY MInvInit
+<1>2. Inv /\ [Next]_vars => Inv'
+  BY MInvNext
+<1>3. Spec => []Inv
+  BY <1>1, <1>2, PTL DEF Spec
+<1>4. Inv => (LineageUniqueness /\ TransitionsJustified)
+  BY InvLineageUniqueness DEF Inv
+<1>5. QED
+  BY <1>3, <1>4, PTL
+
+(***************************************************************************)
+(* Bootstrap freshness, A6-conditional IN THE STATEMENT: with a deployed   *)
+(* anchor, a verifier that partitions records by lineage id (well-formed   *)
+(* histories) obtains per-lineage uniqueness wherever the parent satisfies *)
+(* MHA — the anchor's job (selecting the live lineage among the            *)
+(* partitions) is exactly the deployed mechanism's own assumption, which   *)
+(* is why the implication's hypothesis names it.  With NO anchor deployed  *)
+(* the theorem asserts nothing — out-of-model, stated structurally.        *)
+(***************************************************************************)
+THEOREM BootstrapFreshness ==
+  (DeployedAnchor \in Anchors) =>
+    (Spec => [](\A l \in Lineages, v \in Versions, parent \in Configs,
+                   s1 \in Configs, s2 \in Configs :
+                 (/\ <<l, v, parent, s1>> \in transitions
+                  /\ <<l, v, parent, s2>> \in transitions
+                  /\ parent \cap HonestMembers # {}) => s1 = s2))
+<1>1. SUFFICES ASSUME DeployedAnchor \in Anchors PROVE
+        Spec => []LineageUniqueness
+  BY DEF LineageUniqueness
+<1>2. Spec => [](LineageUniqueness /\ TransitionsJustified)
+  BY MembershipSafety
+<1>3. QED
+  BY <1>2, PTL
+
+====


### PR DESCRIPTION
## AFT-CB leg P2.3 — membership transition + bootstrap freshness

`formal/common_boundary/MembershipTransition{,Proof}.tla` + config,
registered in the formal floor.

- **T5a proven** (tlapm, **152/152 obligations**): within one lineage, from a common parent holding ≥1 honest member (per-configuration MHA as an explicit theorem *condition*), closed successors are unique — divergence convicts the full parent configuration.
- **The no-silence assertion, mechanized**: attested non-response records are freely mintable state that no transition-writing action reads; `TransitionsJustified` proves every closed transition is signature-justified (old-ring unanimity + new-ring acceptance). The handover is the *only* transition action.
- **Typed lineage roots**: re-genesis mints fresh lineage ids into `roots`, never `transitions`; uniqueness quantifies within a lineage; a root-crossing history is distinguishable by construction.
- **A6-conditional bootstrap freshness** — conditionality in the theorem statement (`DeployedAnchor ∈ Anchors ⇒ …`), never prose.
- **Structural adversary**: Byzantine signatures are always-available truth, not state (A1's only exclusion is forging honest signatures) — keeps the adversary maximal and the state space enumerable. TLC: 1.25M distinct states, complete search, 68s.

## Mutation drills (all three leg-mandated; reverted green)
1. (n−1)-signature handover → TLC `Invariant Inv is violated` + tlapm unproved obligations.
2. Silence-derived transition action added → `TransitionsJustified` RED.
3. Cross-lineage "uniqueness" (verifier ignoring lineage ids) → violated immediately — two lineages legitimately close different successors, which is exactly why a root-crossing history may never be presented as one lineage.

Final state: 0 violations, 152/152 proved, census 27 = 14 executed + 13 manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)