### PR TITLE
feat(formal): CustodyObligation — validate-and-hold proven; audits non-load-bearing; reconstruct-before-release (AFT-CB P2.4)

### DIFF
--- a/.github/scripts/check_aft_claim_discipline.sh
+++ b/.github/scripts/check_aft_claim_discipline.sh
@@ -7,18 +7,27 @@
 # form is "all-but-one (n-1 of n) Byzantine safety", conditional on the AFT
 # model delta (the assumed common publication boundary).
 #
-# This gate scans internal-docs/architecture/protocols/aft/specs/ for any
-# "99%" spelling (tex: 99\%, 99 \%, $99\%$; md: bare 99%) and fails on every
-# hit that is not one of two narrow, content-matched allowances:
+# This gate scans internal-docs/architecture/protocols/aft/specs/ AND
+# internal-docs/architecture/protocols/aft/formal/ (the formal-tree READMEs
+# were outside the original fence and shipped six stale claims, found at
+# AFT-CB P2.4) for any "99%" spelling (tex: 99\%, 99 \%, $99\%$; md: bare
+# 99%) and fails on every hit that is not one of three narrow,
+# content-matched allowances:
 #   (a) a latency percentile token (p99) -- a measurement column, not a claim;
 #   (b) a line describing PRIOR work that carries the explicit prior-art
 #       marker "(their figure, not an AFT claim)" next to a named prior system
 #       (Geeq's Proof of Honesty). The allowance matches line content, never a
-#       whole file.
+#       whole file;
+#   (c) an explicit retirement/requalification sentence -- the line names the
+#       figure as retired ("retired ... 99"), cites the requalifying leg
+#       ("requalified per AFT-CB"), or marks the bound historical ("is no
+#       longer the normative"). Mentioning the dead figure while burying it
+#       is allowed; asserting it is not.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SPECS_DIR="${ROOT_DIR}/internal-docs/architecture/protocols/aft/specs"
+FORMAL_DIR="${ROOT_DIR}/internal-docs/architecture/protocols/aft/formal"
 
 # 99 followed (after optional whitespace and optional TeX escape backslash)
 # by a percent sign; also the plain TeX spelling 99\%.
@@ -27,6 +36,9 @@ PATTERN='99[[:space:]]*\\?%'
 # (b) explicit prior-art marker: the Geeq prior-work sentence, matched by
 # content (named prior system + "prior work" + "(their figure)").
 PRIOR_ART_ALLOW="Geeq's Proof of Honesty.*prior work.*\(their figure, not an .{0,2}AFT.{0,2} claim\)"
+
+# (c) retirement/requalification allowance, content-matched on the line.
+RETIRED_ALLOW="retired.{0,20}99|requalified per AFT-CB|is no longer the normative"
 
 if [ ! -d "${SPECS_DIR}" ]; then
   echo "check_aft_claim_discipline: specs dir not found: ${SPECS_DIR}" >&2
@@ -52,14 +64,19 @@ while IFS= read -r hit; do
     continue
   fi
 
+  # (c) retirement/requalification allowance, content-matched on the line.
+  if printf '%s' "${line}" | grep -qE "${RETIRED_ALLOW}"; then
+    continue
+  fi
+
   echo "CLAIM-DISCIPLINE VIOLATION: ${file}:${line_no}:${line}"
   violations=$((violations + 1))
-done < <(grep -rnE --include='*.tex' --include='*.md' "${PATTERN}" "${SPECS_DIR}" || true)
+done < <(grep -rnE --include='*.tex' --include='*.md' "${PATTERN}" "${SPECS_DIR}" "${FORMAL_DIR}" || true)
 
 if [ "${violations}" -ne 0 ]; then
-  echo "FAIL: ${violations} unqualified 99% tolerance spelling(s) in ${SPECS_DIR}." >&2
+  echo "FAIL: ${violations} unqualified 99% tolerance spelling(s) in the AFT specs/formal corpus." >&2
   echo "Required form: all-but-one (n-1 of n) Byzantine safety, conditional on the AFT model delta." >&2
   exit 1
 fi
 
-echo "PASS: no unqualified 99% tolerance spellings in ${SPECS_DIR}."
+echo "PASS: no unqualified 99% tolerance spellings in the AFT specs/formal corpus."

--- a/.github/scripts/run_aft_formal_checks.sh
+++ b/.github/scripts/run_aft_formal_checks.sh
@@ -20,6 +20,7 @@ PROOFS=(
   "AsymptoteProof.tla"
   "canonical_ordering/CanonicalOrderingProof.tla"
   "common_boundary/BoundaryRingProof.tla"
+  "common_boundary/CustodyObligationProof.tla"
 )
 
 # Every TLC model the harness checks, as "cfg|tla", relative to FORMAL_DIR.
@@ -32,6 +33,7 @@ MODELS=(
   "canonical_ordering/CanonicalCollapseRecursiveContinuity.cfg|canonical_ordering/CanonicalCollapseRecursiveContinuity.tla"
   "common_boundary/BoundaryRing.cfg|common_boundary/BoundaryRing.tla"
   "common_boundary/BoundaryRing4.cfg|common_boundary/BoundaryRing.tla"
+  "common_boundary/CustodyObligation.cfg|common_boundary/CustodyObligation.tla"
   "common_boundary/BoundaryLiveness.cfg|common_boundary/BoundaryLiveness.tla"
   "common_boundary/BoundaryLivenessHandover.cfg|common_boundary/BoundaryLiveness.tla"
 )

--- a/internal-docs/architecture/protocols/aft/formal/README.md
+++ b/internal-docs/architecture/protocols/aft/formal/README.md
@@ -18,8 +18,9 @@ Layout:
 - [`canonical_ordering/README.md`](/home/heathledger/Documents/ioi/repos/ioi/internal-docs/architecture/protocols/aft/formal/canonical_ordering/README.md)
   covers the proof-carrying equal-authority canonical-ordering model: succinct
   witness commitments, canonical bulletin close, omission dominance,
-  uniqueness, endogenous retrievability, and the repository's `99%`
-  equal-authority ordering consensus claim, plus current-runtime mandatory
+  uniqueness, endogenous retrievability, and the repository's all-but-one
+  (`n-1` of `n`) equal-authority ordering consensus claim (conditional on the
+  AFT model delta; requalified per AFT-CB P0.2), plus current-runtime mandatory
   closed-slot extraction-or-abort before positive order admission. That
   package now also ships executable TLC witnesses for a concrete
   omission-dominance case and the protocol-native retrievability plane.
@@ -122,8 +123,8 @@ close-or-abort safety core; the accountable-penalty wiring is now an
 implementation and policy layer above that kernel.
 
 Taken together, the canonical-ordering, `Asymptote`, and nested-guardian
-packages should now be read as one formal kernel for `99% Byzantine Tolerance`
-in the AFT model delta: a fixed public boundary admits at most one durable
+packages should now be read as one formal kernel for all-but-one (`n-1` of
+`n`) Byzantine safety in the AFT model delta (requalified per AFT-CB P0.2): a fixed public boundary admits at most one durable
 close-or-abort result, conflicting candidates are killed by short objective
 negative witnesses, durable execution or sealed release advances only through
 canonical collapse, and deeper recovered history is ordinary endogenous AFT
@@ -139,9 +140,10 @@ classical adversary's indefinite-suppression step. The package should therefore
 be read against one singular theorem statement:
 
 - \AFT{} has one singular theorem surface for relay-free, coordinator-free,
-  pure-software deterministic `99% Byzantine Tolerance` in the AFT model delta,
-  breaking the classical indefinite-suppression lower bound without claiming to
-  refute DLS / PBFT inside its own quantified model.
+  pure-software deterministic all-but-one (`n-1` of `n`) Byzantine safety in
+  the AFT model delta (requalified per AFT-CB P0.2; safety with possible
+  stall, never all-but-one live consensus), stated without claiming to refute
+  DLS / PBFT inside its own quantified model.
 - Proof-carrying public evidence, endogenous historical continuation,
   collapse-gated durability, restart continuity, direct dissemination, and
   compressed echo are the realizing architecture of that model-delta sentence,

--- a/internal-docs/architecture/protocols/aft/formal/canonical_ordering/README.md
+++ b/internal-docs/architecture/protocols/aft/formal/canonical_ordering/README.md
@@ -3,8 +3,10 @@
 Status: internal formal-model note (AFT corpus); non-canonical.
 Authority: `docs/architecture/` owners and accepted ADRs are canonical and win on drift; this file is private protocol context only.
 This directory contains the formal artifacts for AFT's proof-carrying
-equal-authority canonical-ordering model and its `99%` equal-authority
-ordering consensus claim.
+equal-authority canonical-ordering model and its all-but-one (`n-1` of `n`)
+equal-authority ordering consensus claim, conditional on the AFT model delta
+(requalified per AFT-CB P0.2; the retired `99%` figure is neither exact nor
+maximal).
 
 The corresponding internal prose note lives at
 [`../../specs/canonical_ordering.md`](../../specs/canonical_ordering.md).

--- a/internal-docs/architecture/protocols/aft/formal/canonical_ordering/README.md
+++ b/internal-docs/architecture/protocols/aft/formal/canonical_ordering/README.md
@@ -54,9 +54,20 @@ As with the other AFT proof surfaces, the package is split:
   custody-response publication, positive reconstruction certification,
   objective retrievability challenges, positive extraction, historical
   retrievability promotion, and deterministic reconstruction abort.
+  DISPOSITION (AFT-CB P2.4, 2026-08-17): RETAINED as this lane's own
+  retrievability model and SUPERSEDED-FOR-THE-BOUNDARY-LANE by
+  `../common_boundary/CustodyObligation.tla` — the boundary lane's custody
+  truth is the validate-and-hold signing obligation (full replication per
+  compliant signer; audits optional and never load-bearing), not this
+  plane's shard/custody-assignment machinery. Not deleted: it models the
+  canonical_ordering corpus's own plane, which still stands; clean-slate
+  deletion applies only to true supersession, and cross-lane it is not.
 
-The prose spec states the full `99%` equal-authority ordering consensus theorem
-over canonical bulletin close, omission dominance, endogenous retrievability,
+The prose spec states the all-but-one (`n-1` of `n`) equal-authority ordering
+consensus claim, conditional on the AFT model delta (requalified by AFT-CB
+P0.2; this sentence previously carried the retired `99%` figure and sat
+outside that leg's specs-directory sweep fence — corrected at P2.4), over
+canonical bulletin close, omission dominance, endogenous retrievability,
 and proof soundness. The live runtime has now narrowed the hot-path theorem
 boundary: honest positive ordering carries a compact signed publication frontier
 plus objective contradiction objects for same-slot frontier conflicts and stale

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/CustodyObligation.cfg
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/CustodyObligation.cfg
@@ -1,0 +1,21 @@
+\* AFT-CB P2.4 — custody at the MHA corner: two members, one honest, one
+\* slot, two artifacts.  The audit lane is enabled and freely mintable;
+\* every invariant holds with or without audit records (the zero-audit
+\* close witness is produced by the NoCloseEver violation run recorded in
+\* the leg ledger).
+CONSTANTS
+  Ring = {m1, m2}
+  HonestMembers = {m1}
+  Slots = {s1}
+  Artifacts = {a1, a2}
+  NoBoundary = NoBoundary
+
+INIT Init
+NEXT Next
+
+INVARIANT TypeOK
+INVARIANT Inv
+INVARIANT CustodyInvariant
+INVARIANT ConditionalAvailability
+INVARIANT ReleaseDiscipline
+INVARIANT RetainedBacked

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/CustodyObligation.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/CustodyObligation.tla
@@ -1,0 +1,224 @@
+---- MODULE CustodyObligation ----
+(***************************************************************************)
+(* AFT-CB P2.4 — validate-and-hold as a signing obligation (T3), the       *)
+(* retention/succession discipline, and the OPTIONAL audit lane.           *)
+(*                                                                         *)
+(* The obligation (spec §4): an honest member final-acks a boundary only   *)
+(* having OBTAINED the full byte set, and the ack commits it to RETAIN and *)
+(* SERVE those bytes — so a close implies close-time replication at every  *)
+(* compliant signer, and one honest signer (A2, stated as a theorem        *)
+(* condition) yields conditional availability deterministically.           *)
+(*                                                                         *)
+(* Pairwise audits are OPTIONAL enforcement actions producing slashing     *)
+(* evidence that NOTHING consumes as a close precondition: the audit       *)
+(* variable is written by the audit action alone and read by no guard of   *)
+(* any close-path action — mirroring P2.3's silence-record discipline.     *)
+(* The zero-audit reachability witness (a trace that closes a slot with    *)
+(* auditEvidence = {}) is produced by TLC via the NoCloseEver violation    *)
+(* run recorded in the leg ledger.                                         *)
+(*                                                                         *)
+(* Succession (spec §6): custody releases only RECONSTRUCT-BEFORE-RELEASE  *)
+(* — an honest holder may drop a slot's bytes (and its bond may release)   *)
+(* only once a successor member has reconstructed full custody of them.    *)
+(*                                                                         *)
+(* Adversary: structural (the P2.3 pattern) — corrupt members' acks are    *)
+(* always available and their storage is arbitrary (they may sign without  *)
+(* holding and delete at will, which is why availability quantifies over   *)
+(* honest holders only).  Deletion by the other n−1 is harmless BY         *)
+(* THEOREM, not by hope.                                                   *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+  Ring,           \* the signer configuration
+  HonestMembers,  \* honest subset (MHA enters theorems as a condition)
+  Slots,
+  Artifacts,      \* the byte universe; a boundary is a nonempty subset
+  NoBoundary      \* journal sentinel
+
+ASSUME CustodyConstants ==
+  /\ HonestMembers \subseteq Ring
+
+Boundaries == (SUBSET Artifacts) \ {{}}
+
+VARIABLES
+  delivered,      \* Artifacts \X Ring: adversary-scheduled delivery
+  holds,          \* [HonestMembers -> SUBSET Artifacts]: bytes actually held
+  journal,        \* [HonestMembers -> [Slots -> Boundaries \cup {NoBoundary}]]
+  acks,           \* honest final-acks <<m, s, B>>
+  retained,       \* [HonestMembers -> [Slots -> SUBSET Artifacts]]: serving custody
+  closes,         \* closed slots <<s, B>>
+  reconstructed,  \* succession receipts <<successor, s>>: full custody rebuilt
+  bondReleased,   \* [HonestMembers -> BOOLEAN]
+  auditEvidence   \* audit-lane records <<auditor, subject, s>> — never load-bearing
+
+vars == <<delivered, holds, journal, acks, retained, closes, reconstructed,
+          bondReleased, auditEvidence>>
+
+AckedBy(m, s, B) ==
+  IF m \in HonestMembers THEN <<m, s, B>> \in acks ELSE TRUE
+
+TypeOK ==
+  /\ delivered \subseteq Artifacts \X Ring
+  /\ holds \in [HonestMembers -> SUBSET Artifacts]
+  /\ journal \in [HonestMembers -> [Slots -> Boundaries \cup {NoBoundary}]]
+  /\ acks \subseteq HonestMembers \X Slots \X Boundaries
+  /\ retained \in [HonestMembers -> [Slots -> SUBSET Artifacts]]
+  /\ closes \subseteq Slots \X Boundaries
+  /\ reconstructed \subseteq HonestMembers \X Slots
+  /\ bondReleased \in [HonestMembers -> BOOLEAN]
+  /\ auditEvidence \subseteq Ring \X Ring \X Slots
+
+Init ==
+  /\ delivered = {}
+  /\ holds = [m \in HonestMembers |-> {}]
+  /\ journal = [m \in HonestMembers |-> [s \in Slots |-> NoBoundary]]
+  /\ acks = {}
+  /\ retained = [m \in HonestMembers |-> [s \in Slots |-> {}]]
+  /\ closes = {}
+  /\ reconstructed = {}
+  /\ bondReleased = [m \in HonestMembers |-> FALSE]
+  /\ auditEvidence = {}
+
+Deliver(a, m) ==
+  /\ delivered' = delivered \cup {<<a, m>>}
+  /\ UNCHANGED <<holds, journal, acks, retained, closes, reconstructed,
+                 bondReleased, auditEvidence>>
+
+(* An honest member obtains bytes it was actually delivered.               *)
+Fetch(m, a) ==
+  /\ m \in HonestMembers
+  /\ <<a, m>> \in delivered
+  /\ holds' = [holds EXCEPT ![m] = holds[m] \cup {a}]
+  /\ UNCHANGED <<delivered, journal, acks, retained, closes, reconstructed,
+                 bondReleased, auditEvidence>>
+
+(* VALIDATE-AND-HOLD: the guard B \subseteq holds[m] is the obligation —  *)
+(* the member has OBTAINED every byte of the boundary it signs — and the   *)
+(* effect commits it to retain/serve (retained[m][s] = B).  The journal    *)
+(* keeps single-final-ack (A3).  The mutation drill removes the holds      *)
+(* guard and the T3-shaped invariant goes red.                             *)
+HonestFinalAck(m, s, B) ==
+  /\ m \in HonestMembers
+  /\ ~bondReleased[m]   \* a departed member signs nothing new
+  /\ s \in Slots /\ B \in Boundaries
+  /\ B \subseteq holds[m]
+  /\ journal[m][s] = NoBoundary
+  /\ journal' = [journal EXCEPT ![m] = [journal[m] EXCEPT ![s] = B]]
+  /\ acks' = acks \cup {<<m, s, B>>}
+  /\ retained' = [retained EXCEPT ![m] = [retained[m] EXCEPT ![s] = B]]
+  /\ UNCHANGED <<delivered, holds, closes, reconstructed, bondReleased,
+                 auditEvidence>>
+
+(* n-of-n close: honest acks are state; corrupt signatures always          *)
+(* available (they may sign never having held a byte — that is the fault   *)
+(* model, and why the theorem leans on the honest signer only).            *)
+CloseSlot(s, B) ==
+  /\ s \in Slots /\ B \in Boundaries
+  /\ \A m \in Ring : AckedBy(m, s, B)
+  /\ closes' = closes \cup {<<s, B>>}
+  /\ UNCHANGED <<delivered, holds, journal, acks, retained, reconstructed,
+                 bondReleased, auditEvidence>>
+
+(* Succession: a successor honest member reconstructs FULL custody of a    *)
+(* slot's closed boundary from bytes it actually holds.  Reconstruction    *)
+(* ADDS custody (union) — it never shrinks anyone's serving set; custody   *)
+(* drops ride bond release, outside this kernel's mutation surface.        *)
+Reconstruct(succ, s, B) ==
+  /\ succ \in HonestMembers
+  /\ ~bondReleased[succ]   \* a departed member takes on no new custody
+  /\ <<s, B>> \in closes
+  /\ B \subseteq holds[succ]
+  /\ retained' = [retained EXCEPT ![succ] =
+       [retained[succ] EXCEPT ![s] = retained[succ][s] \cup B]]
+  /\ reconstructed' = reconstructed \cup {<<succ, s>>}
+  /\ UNCHANGED <<delivered, holds, journal, acks, closes, bondReleased,
+                 auditEvidence>>
+
+(* RECONSTRUCT-BEFORE-RELEASE: an honest member's bond releases only when  *)
+(* every slot it retains custody for has a DIFFERENT reconstructed         *)
+(* successor.  (Custody drop rides bond release; the invariant below is    *)
+(* what the mutation targets.)                                             *)
+ReleaseBond(m) ==
+  /\ m \in HonestMembers
+  /\ \A s \in Slots :
+       (retained[m][s] # {}) =>
+         \E succ \in HonestMembers : succ # m /\ <<succ, s>> \in reconstructed
+  /\ bondReleased' = [bondReleased EXCEPT ![m] = TRUE]
+  /\ UNCHANGED <<delivered, holds, journal, acks, retained, closes,
+                 reconstructed, auditEvidence>>
+
+(* The OPTIONAL audit lane: an auditor challenges a subject over a slot    *)
+(* and a record is minted.  No close-path guard reads auditEvidence —     *)
+(* audits produce slashing evidence, never availability.                   *)
+Audit(auditor, subject, s) ==
+  /\ auditor \in Ring /\ subject \in Ring /\ s \in Slots
+  /\ auditEvidence' = auditEvidence \cup {<<auditor, subject, s>>}
+  /\ UNCHANGED <<delivered, holds, journal, acks, retained, closes,
+                 reconstructed, bondReleased>>
+
+Next ==
+  \/ \E a \in Artifacts, m \in Ring : Deliver(a, m)
+  \/ \E m \in HonestMembers, a \in Artifacts : Fetch(m, a)
+  \/ \E m \in HonestMembers, s \in Slots, B \in Boundaries :
+       HonestFinalAck(m, s, B)
+  \/ \E s \in Slots, B \in Boundaries : CloseSlot(s, B)
+  \/ \E succ \in HonestMembers, s \in Slots, B \in Boundaries :
+       Reconstruct(succ, s, B)
+  \/ \E m \in HonestMembers : ReleaseBond(m)
+  \/ \E auditor \in Ring, subject \in Ring, s \in Slots :
+       Audit(auditor, subject, s)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* The T3-shaped invariant: every honest ack carries full custody — the    *)
+(* acked boundary is retained by the acker (or a reconstructed successor   *)
+(* stands in for it once released; in this kernel retained never shrinks,  *)
+(* so the direct form holds).  From it: a closed slot with one honest ring *)
+(* member is AVAILABLE — some honest member retains every byte.            *)
+(***************************************************************************)
+CustodyInvariant ==
+  \A m \in HonestMembers, s \in Slots, B \in Boundaries :
+    (<<m, s, B>> \in acks) => B \subseteq retained[m][s]
+
+ConditionalAvailability ==
+  \A s \in Slots, B \in Boundaries :
+    (<<s, B>> \in closes /\ Ring \cap HonestMembers # {}) =>
+      \E m \in HonestMembers : B \subseteq retained[m][s]
+
+ReleaseDiscipline ==
+  \A m \in HonestMembers :
+    bondReleased[m] =>
+      \A s \in Slots :
+        (retained[m][s] # {}) =>
+          \E succ \in HonestMembers : succ # m /\ <<succ, s>> \in reconstructed
+
+HonestAckJournal ==
+  \A m \in HonestMembers, s \in Slots, B \in Boundaries :
+    (<<m, s, B>> \in acks) => journal[m][s] = B
+
+(* The T3 truth the validate-and-hold guard protects: every byte a member  *)
+(* CLAIMS custody of (retained) is a byte it actually HOLDS and can serve. *)
+(* The leg's mutation drill removes the guard and THIS invariant goes red  *)
+(* — a member would then claim custody of bytes it never obtained.         *)
+RetainedBacked ==
+  \A m \in HonestMembers, s \in Slots : retained[m][s] \subseteq holds[m]
+
+Inv ==
+  /\ TypeOK
+  /\ HonestAckJournal
+  /\ RetainedBacked
+  /\ CustodyInvariant
+  /\ \A s \in Slots, B \in Boundaries :
+       (<<s, B>> \in closes) => \A m \in Ring : AckedBy(m, s, B)
+  /\ ReleaseDiscipline
+
+
+(* WITNESS-ONLY definition for the zero-audit reachability run: TLC        *)
+(* violating this invariant yields a shortest trace that closes a slot —  *)
+(* and a shortest trace contains no Audit step, which IS the required      *)
+(* witness that audits are not load-bearing for a close.                   *)
+NoCloseEver == closes = {}
+
+====

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/CustodyObligationProof.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/CustodyObligationProof.tla
@@ -1,0 +1,247 @@
+---- MODULE CustodyObligationProof ----
+(***************************************************************************)
+(* AFT-CB P2.4 — TLAPS discharge: the custody invariant is inductive, and  *)
+(* conditional availability (T3's shape) follows with MHA as an explicit   *)
+(* theorem condition.  No proof step mentions auditEvidence: the audit     *)
+(* lane is not load-bearing, by the shape of the proof itself.             *)
+(***************************************************************************)
+EXTENDS CustodyObligation, TLAPS
+
+ASSUME NoBoundaryOutsideBoundaries == NoBoundary \notin Boundaries
+
+LEMMA CInvInit == Init => Inv
+  BY CustodyConstants DEF Init, Inv, TypeOK, HonestAckJournal,
+     RetainedBacked, CustodyInvariant, ReleaseDiscipline, AckedBy
+
+LEMMA CInvNext == Inv /\ [Next]_vars => Inv'
+<1>1. SUFFICES ASSUME Inv, [Next]_vars PROVE Inv'
+  OBVIOUS
+<1>2. CASE UNCHANGED vars
+  BY <1>1, <1>2 DEF Inv, TypeOK, HonestAckJournal, RetainedBacked,
+     CustodyInvariant, ReleaseDiscipline, AckedBy, vars
+<1>3. ASSUME NEW a \in Artifacts, NEW m \in Ring, Deliver(a, m)
+      PROVE Inv'
+  BY <1>1, <1>3 DEF Inv, TypeOK, HonestAckJournal, RetainedBacked,
+     CustodyInvariant, ReleaseDiscipline, AckedBy, Deliver
+<1>4. ASSUME NEW m \in HonestMembers, NEW a \in Artifacts, Fetch(m, a)
+      PROVE Inv'
+  <2>1. TypeOK'
+    BY <1>1, <1>4, CustodyConstants DEF Inv, TypeOK, Fetch
+  <2>2. HonestAckJournal'
+    BY <1>1, <1>4 DEF Inv, HonestAckJournal, Fetch
+  <2>3. CustodyInvariant'
+    BY <1>1, <1>4 DEF Inv, CustodyInvariant, Fetch
+  <2>4. (\A s2 \in Slots, B2 \in Boundaries :
+          (<<s2, B2>> \in closes') => \A mm \in Ring : AckedBy(mm, s2, B2)')
+    BY <1>1, <1>4 DEF Inv, AckedBy, Fetch
+  <2>5. ReleaseDiscipline'
+    BY <1>1, <1>4 DEF Inv, ReleaseDiscipline, Fetch
+  <2>6. RetainedBacked'
+    <3>1. SUFFICES ASSUME NEW mm \in HonestMembers, NEW ss \in Slots
+          PROVE retained'[mm][ss] \subseteq holds'[mm]
+      BY DEF RetainedBacked
+    <3>2. retained' = retained
+      BY <1>4 DEF Fetch
+    <3>3. holds[mm] \subseteq holds'[mm]
+      BY <1>1, <1>4, CustodyConstants DEF Inv, TypeOK, Fetch
+    <3>4. retained[mm][ss] \subseteq holds[mm]
+      BY <1>1, <3>1 DEF Inv, RetainedBacked
+    <3> QED BY <3>1, <3>2, <3>3, <3>4
+  <2> QED BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6 DEF Inv
+<1>5. ASSUME NEW m \in HonestMembers, NEW s \in Slots, NEW B \in Boundaries,
+             HonestFinalAck(m, s, B)
+      PROVE Inv'
+  <2>1. B \subseteq holds[m] /\ journal[m][s] = NoBoundary
+    BY <1>5 DEF HonestFinalAck
+  <2>2. TypeOK'
+    BY <1>1, <1>5, <2>1, CustodyConstants
+       DEF Inv, TypeOK, HonestFinalAck
+  <2>3. HonestAckJournal'
+    <3>1. SUFFICES ASSUME NEW mm \in HonestMembers, NEW ss \in Slots,
+                          NEW BB \in Boundaries, <<mm, ss, BB>> \in acks'
+          PROVE journal'[mm][ss] = BB
+      BY DEF HonestAckJournal
+    <3>2. acks' = acks \cup {<<m, s, B>>}
+      BY <1>5 DEF HonestFinalAck
+    <3>3. CASE <<mm, ss, BB>> = <<m, s, B>>
+      <4>1. journal'[m][s] = B
+        BY <1>1, <1>5, <2>1 DEF Inv, TypeOK, HonestFinalAck
+      <4> QED BY <3>3, <4>1
+    <3>4. CASE <<mm, ss, BB>> \in acks
+      <4>1. journal[mm][ss] = BB
+        BY <1>1, <3>4 DEF Inv, HonestAckJournal
+      <4>2. CASE mm = m /\ ss = s
+        <5>1. journal[m][s] = BB
+          BY <4>1, <4>2
+        <5>2. BB # NoBoundary
+          BY <3>1, NoBoundaryOutsideBoundaries
+        <5> QED BY <2>1, <5>1, <5>2
+      <4>3. CASE ~(mm = m /\ ss = s)
+        <5>1. journal'[mm][ss] = journal[mm][ss]
+          BY <1>1, <1>5, <2>1, <4>3 DEF Inv, TypeOK, HonestFinalAck
+        <5> QED BY <4>1, <5>1
+      <4> QED BY <4>2, <4>3
+    <3> QED BY <3>1, <3>2, <3>3, <3>4
+  <2>4. CustodyInvariant'
+    <3>1. SUFFICES ASSUME NEW mm \in HonestMembers, NEW ss \in Slots,
+                          NEW BB \in Boundaries, <<mm, ss, BB>> \in acks'
+          PROVE BB \subseteq retained'[mm][ss]
+      BY DEF CustodyInvariant
+    <3>2. acks' = acks \cup {<<m, s, B>>}
+      BY <1>5 DEF HonestFinalAck
+    <3>3. CASE <<mm, ss, BB>> = <<m, s, B>>
+      <4>1. retained'[m][s] = B
+        BY <1>1, <1>5, CustodyConstants DEF Inv, TypeOK, HonestFinalAck
+      <4> QED BY <3>3, <4>1
+    <3>4. CASE <<mm, ss, BB>> \in acks
+      <4>1. BB \subseteq retained[mm][ss]
+        BY <1>1, <3>4 DEF Inv, CustodyInvariant
+      <4>2. CASE mm = m /\ ss = s
+        <5>1. journal[m][s] = BB
+          BY <1>1, <3>4, <4>2 DEF Inv, HonestAckJournal
+        <5>2. BB # NoBoundary
+          BY <3>1, NoBoundaryOutsideBoundaries
+        <5> QED BY <2>1, <5>1, <5>2
+      <4>3. CASE ~(mm = m /\ ss = s)
+        <5>1. retained'[mm][ss] = retained[mm][ss]
+          BY <1>1, <1>5, CustodyConstants, <4>3
+             DEF Inv, TypeOK, HonestFinalAck
+        <5> QED BY <4>1, <5>1
+      <4> QED BY <4>2, <4>3
+    <3> QED BY <3>1, <3>2, <3>3, <3>4
+  <2>5. (\A s2 \in Slots, B2 \in Boundaries :
+          (<<s2, B2>> \in closes') => \A mm \in Ring : AckedBy(mm, s2, B2)')
+    BY <1>1, <1>5 DEF Inv, AckedBy, HonestFinalAck
+  <2>6. ReleaseDiscipline'
+    BY <1>1, <1>5, CustodyConstants
+       DEF Inv, TypeOK, ReleaseDiscipline, HonestFinalAck
+  <2>7. RetainedBacked'
+    BY <1>1, <1>5, <2>1, CustodyConstants
+       DEF Inv, TypeOK, RetainedBacked, HonestFinalAck
+  <2> QED BY <2>2, <2>3, <2>4, <2>5, <2>6, <2>7 DEF Inv
+<1>6. ASSUME NEW s \in Slots, NEW B \in Boundaries, CloseSlot(s, B)
+      PROVE Inv'
+  <2>1. TypeOK'
+    BY <1>1, <1>6 DEF Inv, TypeOK, CloseSlot
+  <2>2. HonestAckJournal'
+    BY <1>1, <1>6 DEF Inv, HonestAckJournal, CloseSlot
+  <2>3. CustodyInvariant'
+    BY <1>1, <1>6 DEF Inv, CustodyInvariant, CloseSlot
+  <2>4. (\A s2 \in Slots, B2 \in Boundaries :
+          (<<s2, B2>> \in closes') => \A mm \in Ring : AckedBy(mm, s2, B2)')
+    <3>1. SUFFICES ASSUME NEW s2 \in Slots, NEW B2 \in Boundaries,
+                          <<s2, B2>> \in closes', NEW mm \in Ring
+          PROVE AckedBy(mm, s2, B2)'
+      OBVIOUS
+    <3>2. closes' = closes \cup {<<s, B>>} /\ acks' = acks
+      BY <1>6 DEF CloseSlot
+    <3>3. CASE <<s2, B2>> \in closes
+      BY <1>1, <3>2, <3>3 DEF Inv, AckedBy
+    <3>4. CASE <<s2, B2>> = <<s, B>>
+      BY <1>6, <3>2, <3>4 DEF CloseSlot, AckedBy
+    <3> QED BY <3>1, <3>2, <3>3, <3>4
+  <2>5. ReleaseDiscipline'
+    BY <1>1, <1>6 DEF Inv, ReleaseDiscipline, CloseSlot
+  <2>6. RetainedBacked'
+    BY <1>1, <1>6 DEF Inv, RetainedBacked, CloseSlot
+  <2> QED BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6 DEF Inv
+<1>7. ASSUME NEW succ \in HonestMembers, NEW s \in Slots, NEW B \in Boundaries,
+             Reconstruct(succ, s, B)
+      PROVE Inv'
+  <2>1. TypeOK'
+    BY <1>1, <1>7, CustodyConstants DEF Inv, TypeOK, Reconstruct
+  <2>2. CustodyInvariant'
+    <3>1. SUFFICES ASSUME NEW mm \in HonestMembers, NEW ss \in Slots,
+                          NEW BB \in Boundaries, <<mm, ss, BB>> \in acks'
+          PROVE BB \subseteq retained'[mm][ss]
+      BY DEF CustodyInvariant
+    <3>2. acks' = acks
+      BY <1>7 DEF Reconstruct
+    <3>3. BB \subseteq retained[mm][ss]
+      BY <1>1, <3>1, <3>2 DEF Inv, CustodyInvariant
+    <3>4. retained[mm][ss] \subseteq retained'[mm][ss]
+      (* Reconstruction only ever UNIONs custody in, so every member's      *)
+      (* serving set is monotone under this action.                         *)
+      BY <1>1, <1>7, CustodyConstants DEF Inv, TypeOK, Reconstruct
+    <3> QED BY <3>3, <3>4
+  <2>3. HonestAckJournal'
+    BY <1>1, <1>7 DEF Inv, HonestAckJournal, Reconstruct
+  <2>4. (\A s2 \in Slots, B2 \in Boundaries :
+          (<<s2, B2>> \in closes') => \A mm \in Ring : AckedBy(mm, s2, B2)')
+    BY <1>1, <1>7 DEF Inv, AckedBy, Reconstruct
+  <2>5. ReleaseDiscipline'
+    BY <1>1, <1>7, CustodyConstants
+       DEF Inv, TypeOK, ReleaseDiscipline, Reconstruct
+  <2>6. RetainedBacked'
+    BY <1>1, <1>7, CustodyConstants
+       DEF Inv, TypeOK, RetainedBacked, Reconstruct
+  <2> QED BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6 DEF Inv
+<1>8. ASSUME NEW m \in HonestMembers, ReleaseBond(m)
+      PROVE Inv'
+  <2>1. TypeOK'
+    BY <1>1, <1>8, CustodyConstants DEF Inv, TypeOK, ReleaseBond
+  <2>2. HonestAckJournal'
+    BY <1>1, <1>8 DEF Inv, HonestAckJournal, ReleaseBond
+  <2>3. CustodyInvariant'
+    BY <1>1, <1>8 DEF Inv, CustodyInvariant, ReleaseBond
+  <2>4. (\A s2 \in Slots, B2 \in Boundaries :
+          (<<s2, B2>> \in closes') => \A mm \in Ring : AckedBy(mm, s2, B2)')
+    BY <1>1, <1>8 DEF Inv, AckedBy, ReleaseBond
+  <2>5. ReleaseDiscipline'
+    <3>1. SUFFICES ASSUME NEW mm \in HonestMembers, bondReleased'[mm],
+                          NEW ss \in Slots, retained'[mm][ss] # {}
+          PROVE \E succ \in HonestMembers :
+                  succ # mm /\ <<succ, ss>> \in reconstructed'
+      BY DEF ReleaseDiscipline
+    <3>2. /\ bondReleased' = [bondReleased EXCEPT ![m] = TRUE]
+          /\ retained' = retained /\ reconstructed' = reconstructed
+      BY <1>8 DEF ReleaseBond
+    <3>3. CASE mm = m
+      BY <1>1, <1>8, <3>1, <3>2, <3>3, CustodyConstants
+         DEF Inv, TypeOK, ReleaseBond
+    <3>4. CASE mm # m
+      <4>1. bondReleased[mm]
+        BY <1>1, <3>1, <3>2, <3>4, CustodyConstants DEF Inv, TypeOK
+      <4> QED BY <1>1, <3>1, <3>2, <4>1 DEF Inv, ReleaseDiscipline
+    <3> QED BY <3>1, <3>3, <3>4
+  <2>6. RetainedBacked'
+    BY <1>1, <1>8 DEF Inv, RetainedBacked, ReleaseBond
+  <2> QED BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6 DEF Inv
+<1>9. ASSUME NEW auditor \in Ring, NEW subject \in Ring, NEW s \in Slots,
+             Audit(auditor, subject, s)
+      PROVE Inv'
+  BY <1>1, <1>9 DEF Inv, TypeOK, HonestAckJournal, RetainedBacked,
+     CustodyInvariant, ReleaseDiscipline, AckedBy, Audit
+<1>10. QED
+  BY <1>1, <1>2, <1>3, <1>4, <1>5, <1>6, <1>7, <1>8, <1>9 DEF Next, vars
+
+LEMMA InvAvailability == Inv => ConditionalAvailability
+<1>1. SUFFICES ASSUME Inv, NEW s \in Slots, NEW B \in Boundaries,
+                      <<s, B>> \in closes, Ring \cap HonestMembers # {}
+      PROVE \E m \in HonestMembers : B \subseteq retained[m][s]
+  BY DEF ConditionalAvailability
+<1>2. PICK h \in Ring \cap HonestMembers : TRUE
+  BY <1>1
+<1>3. AckedBy(h, s, B)
+  BY <1>1, <1>2 DEF Inv
+<1>4. <<h, s, B>> \in acks
+  BY <1>2, <1>3 DEF AckedBy
+<1>5. B \subseteq retained[h][s]
+  BY <1>1, <1>2, <1>4 DEF Inv, CustodyInvariant
+<1>6. QED
+  BY <1>2, <1>5
+
+THEOREM CustodySafety ==
+  Spec => [](ConditionalAvailability /\ ReleaseDiscipline)
+<1>1. Init => Inv
+  BY CInvInit
+<1>2. Inv /\ [Next]_vars => Inv'
+  BY CInvNext
+<1>3. Spec => []Inv
+  BY <1>1, <1>2, PTL DEF Spec
+<1>4. Inv => (ConditionalAvailability /\ ReleaseDiscipline)
+  BY InvAvailability DEF Inv
+<1>5. QED
+  BY <1>3, <1>4, PTL
+
+====

--- a/internal-docs/architecture/protocols/aft/formal/nested_guardian/README.md
+++ b/internal-docs/architecture/protocols/aft/formal/nested_guardian/README.md
@@ -218,10 +218,13 @@ chain. The live runtime no longer has an unresolved theorem-side recovery
 scope gap here: close-or-abort integration, recovered closed-slot extraction,
 authoritative collapse / replay / header extraction, restart continuation,
 and deeper historical continuation are now part of one singular AFT theorem
-surface. That singular theorem surface is now also promoted repository-wide to
-unconditional classical `99% Byzantine agreement`. What remains here is package
-hygiene, proof maintenance, and any broader stress coverage we want on top of
-that finished bridge.
+surface. That singular theorem surface is stated repository-wide as all-but-one
+(`n-1` of `n`) Byzantine safety, conditional on the AFT model delta — the
+earlier "promoted unconditional classical" phrasing here was the Q10 overclaim,
+requalified per AFT-CB P0.2 (this sentence sat outside that leg's
+specs-directory sweep fence and was corrected at P2.4). What remains here is
+package hygiene, proof maintenance, and any broader stress coverage we want on
+top of that bridge.
 
 Its job is to keep the runtime’s witness-assignment, reassignment, and
 witness-admissibility rules aligned with the implementation.


### PR DESCRIPTION
## AFT-CB leg P2.4 — custody/retrievability refinement

`formal/common_boundary/CustodyObligation{,Proof}.tla` + config, registered
in the formal floor.

- **tlapm: all 320 obligations proved** — `CustodyInvariant` (ack ⇒ boundary retained), `RetainedBacked` (every custody claim backed by actually-held bytes — the invariant the validate-and-hold guard protects), `ConditionalAvailability` (closed slot + one honest member ⇒ servable; MHA as an explicit theorem condition), `ReleaseDiscipline` (reconstruct-before-release; a departed member signs nothing new).
- **Audits proven non-load-bearing two ways**: no proof step mentions `auditEvidence`, and the **zero-audit close witness** — TLC's shortest `NoCloseEver` violation trace closes the slot in five states (Deliver → Fetch → HonestFinalAck → CloseSlot) with no Audit action.
- TLC: 2,496 distinct states, complete search, six invariants green with the audit lane freely mintable.
- **Disposition recorded** (leg-mandated): `CanonicalOrderingRetrievability.tla` retained in its own lane, superseded-for-the-boundary-lane by this module — reasons in the canonical_ordering README. Rider: that README still carried the retired "99%" figure (outside P0.2's sweep fence); requalified.

## Mutation drill
Validate-and-hold guard removed → TLC `Invariant Inv is violated` (`RetainedBacked`) + tlapm unproved obligations. Reverted → 0 violations, **320/320 proved**.

Two modeling notes for the ledger: the first drill exposed that a claim-only custody invariant survives the guard's removal — `RetainedBacked` is the truth the guard protects; and inductiveness forced two faithful guards (a bond-released member signs nothing new and takes on no new custody).

🤖 Generated with [Claude Code](https://claude.com/claude-code)