### PR TITLE
feat(formal): ForensicAccountability — T7 against the wire format; all-Byzantine double-seal extraction (AFT-CB P2.6)

### DIFF
--- a/.github/scripts/run_aft_formal_checks.sh
+++ b/.github/scripts/run_aft_formal_checks.sh
@@ -22,6 +22,7 @@ PROOFS=(
   "common_boundary/BoundaryRingProof.tla"
   "common_boundary/CustodyObligationProof.tla"
   "common_boundary/MembershipTransitionProof.tla"
+  "common_boundary/ForensicAccountabilityProof.tla"
 )
 
 # Every TLC model the harness checks, as "cfg|tla", relative to FORMAL_DIR.
@@ -38,6 +39,8 @@ MODELS=(
   "common_boundary/BoundaryLiveness.cfg|common_boundary/BoundaryLiveness.tla"
   "common_boundary/BoundaryLivenessHandover.cfg|common_boundary/BoundaryLiveness.tla"
   "common_boundary/MembershipTransition.cfg|common_boundary/MembershipTransition.tla"
+  "common_boundary/ForensicAccountability.cfg|common_boundary/ForensicAccountability.tla"
+  "common_boundary/ForensicAccountabilityAllByz.cfg|common_boundary/ForensicAccountability.tla"
 )
 
 # Census: every .tla module under FORMAL_DIR (excluding symlinks and

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/ForensicAccountability.cfg
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/ForensicAccountability.cfg
@@ -1,0 +1,20 @@
+\* AFT-CB P2.6 — the wire-format kernel at the MHA corner: one honest
+\* member, two Byzantine, one slot, two roots.  Under MHA no conflicting
+\* pair assembles (CertUniqueness's contrapositive keeps DoubleSealReached
+\* trivially true here); attribution completeness is checked over every
+\* assembled pair.  The all-Byzantine staged double-seal runs in
+\* ForensicAccountabilityAllByz.cfg.
+CONSTANTS
+  Ring = {m1, m2, m3}
+  HonestMembers = {m1}
+  Slots = {s1}
+  Roots = {rX, rY}
+  NoRoot = NoRoot
+
+INIT Init
+NEXT Next
+
+INVARIANT TypeOK
+INVARIANT Inv
+INVARIANT AttributionComplete
+INVARIANT CertUniqueness

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/ForensicAccountability.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/ForensicAccountability.tla
@@ -1,0 +1,141 @@
+---- MODULE ForensicAccountability ----
+(***************************************************************************)
+(* AFT-CB P2.6 — forensic accountability (T7), proven against the          *)
+(* WIRE-LEVEL certificate format.                                          *)
+(*                                                                         *)
+(* The wire format is part of the theorem (spec §12): a seal certificate   *)
+(* is a bitmap multisig — a record carrying, for EVERY ring member, that   *)
+(* member's individually verifiable signature share over the exact         *)
+(* domain-separated tuple.  Assembly is impossible without all n shares,   *)
+(* and decomposition back into per-member shares is total: any holder of   *)
+(* two conflicting certificates extracts, for every member, a pair of      *)
+(* conflicting shares — a self-contained conviction (T7), covering every   *)
+(* participant necessary for the violation (all n; the L9 maximum).        *)
+(*                                                                         *)
+(* The mutation drill swaps the encoding for an attribution-destroying     *)
+(* OPAQUE AGGREGATE — a certificate that proves "the ring signed" while    *)
+(* decomposing into nobody — and the attributability invariant goes red:   *)
+(* exactly the trade the spec's §12.4 forbids on any seal path.            *)
+(*                                                                         *)
+(* The staged double-seal gate runs at the ALL-BYZANTINE configuration     *)
+(* (HonestMembers = {}): both conflicting certificates assemble (nothing   *)
+(* stops an all-corrupt ring from double-sealing — that is above the       *)
+(* fault threshold), and TLC's DoubleSealReached violation trace IS the    *)
+(* extraction witness: the full necessary-participant set, recorded in     *)
+(* the leg ledger.                                                         *)
+(*                                                                         *)
+(* Adversary: structural (P2.3's pattern).  Corrupt members' shares over   *)
+(* any tuple are always available; honest shares exist only via the        *)
+(* journal-guarded honest ack (A3), which is why conflicting certificates  *)
+(* under MHA are impossible (P2.1's theorem, restated here over the wire   *)
+(* structure as CertUniqueness).                                           *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+  Ring,
+  HonestMembers,
+  Slots,
+  Roots,
+  NoRoot
+
+ASSUME ForensicConstants ==
+  /\ HonestMembers \subseteq Ring
+
+(* A wire-level share: member m's signature over the domain-separated      *)
+(* tuple (slot, root).  A certificate is bitmap-complete: it embeds the    *)
+(* share of EVERY member over ITS OWN (slot, root) — the record structure  *)
+(* IS the format; there is nothing else on the wire.                       *)
+Share(m, s, r) == <<m, s, r>>
+
+Cert(s, r) == [slot |-> s, root |-> r,
+               shares |-> {Share(m, s, r) : m \in Ring}]
+
+VARIABLES
+  journal,   \* [HonestMembers -> [Slots -> Roots \cup {NoRoot}]] (A3)
+  hshares,   \* honest shares in existence
+  certs      \* assembled certificates (wire records)
+
+vars == <<journal, hshares, certs>>
+
+ShareAvailable(m, s, r) ==
+  IF m \in HonestMembers THEN Share(m, s, r) \in hshares ELSE TRUE
+
+TypeOK ==
+  /\ journal \in [HonestMembers -> [Slots -> Roots \cup {NoRoot}]]
+  /\ hshares \subseteq HonestMembers \X Slots \X Roots
+  /\ certs \subseteq [slot : Slots, root : Roots,
+                      shares : SUBSET (Ring \X Slots \X Roots)]
+
+Init ==
+  /\ journal = [m \in HonestMembers |-> [s \in Slots |-> NoRoot]]
+  /\ hshares = {}
+  /\ certs = {}
+
+HonestSign(m, s, r) ==
+  /\ m \in HonestMembers
+  /\ s \in Slots /\ r \in Roots
+  /\ journal[m][s] = NoRoot
+  /\ journal' = [journal EXCEPT ![m] = [journal[m] EXCEPT ![s] = r]]
+  /\ hshares' = hshares \cup {Share(m, s, r)}
+  /\ UNCHANGED certs
+
+(* Assembly: anyone may assemble the bitmap-complete certificate once      *)
+(* every member's share over the exact tuple is available (corrupt         *)
+(* members' shares always are — A1 excludes only forging honest ones).     *)
+Assemble(s, r) ==
+  /\ s \in Slots /\ r \in Roots
+  /\ \A m \in Ring : ShareAvailable(m, s, r)
+  /\ certs' = certs \cup {Cert(s, r)}
+  /\ UNCHANGED <<journal, hshares>>
+
+Next ==
+  \/ \E m \in Ring, s \in Slots, r \in Roots : HonestSign(m, s, r)
+  \/ \E s \in Slots, r \in Roots : Assemble(s, r)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* THE EXTRACTION PROCEDURE (spec §12.5), specified over the wire records: *)
+(* given two certificates for one slot with different roots, the           *)
+(* extracted set is every member exhibiting a share in BOTH — a pair of    *)
+(* signatures by one key over conflicting tuples, each pair a              *)
+(* self-contained conviction.                                              *)
+(***************************************************************************)
+ExtractedSet(c1, c2) ==
+  {m \in Ring : /\ Share(m, c1.slot, c1.root) \in c1.shares
+                /\ Share(m, c2.slot, c2.root) \in c2.shares}
+
+Conflicting(c1, c2) ==
+  /\ c1.slot = c2.slot
+  /\ c1.root # c2.root
+
+(* T7 at the wire level: ANY two conflicting certificates decompose into   *)
+(* conflicting share pairs for EVERY ring member — the full necessary-     *)
+(* participant set (n-of-n makes each member necessary; L9 makes all-n     *)
+(* the maximum any protocol can attribute).                                *)
+AttributionComplete ==
+  \A c1 \in certs, c2 \in certs :
+    Conflicting(c1, c2) => ExtractedSet(c1, c2) = Ring
+
+(* P2.1's uniqueness, restated over the wire structure: under MHA (as a    *)
+(* condition), conflicting certificates cannot both assemble.              *)
+CertUniqueness ==
+  \A c1 \in certs, c2 \in certs :
+    (Conflicting(c1, c2)) => HonestMembers = {}
+
+(* Reachability witness target for the all-Byzantine staged double-seal:   *)
+(* TLC violating this invariant produces the trace in which both           *)
+(* conflicting certificates assemble and the extraction yields all n.      *)
+DoubleSealReached ==
+  ~\E c1 \in certs, c2 \in certs : Conflicting(c1, c2)
+
+Inv ==
+  /\ TypeOK
+  /\ \A m \in HonestMembers, s \in Slots, r \in Roots :
+       (Share(m, s, r) \in hshares) => journal[m][s] = r
+  /\ \A c \in certs :
+       /\ c.shares = {Share(m, c.slot, c.root) : m \in Ring}
+       /\ \A m \in HonestMembers : Share(m, c.slot, c.root) \in hshares
+
+====

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/ForensicAccountabilityAllByz.cfg
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/ForensicAccountabilityAllByz.cfg
@@ -1,0 +1,21 @@
+\* AFT-CB P2.6 — the staged double-seal at the ALL-BYZANTINE configuration
+\* (HonestMembers = {}): above the fault threshold both conflicting
+\* certificates assemble, and AttributionComplete still holds — the wire
+\* format convicts every participant.  The extraction-witness TRACE (both
+\* certs assembled, extraction = all of Ring) is produced by the
+\* DoubleSealReached violation run recorded in the leg ledger; this
+\* registered run checks that attribution survives even where uniqueness
+\* cannot.
+CONSTANTS
+  Ring = {m1, m2, m3}
+  HonestMembers = {}
+  Slots = {s1}
+  Roots = {rX, rY}
+  NoRoot = NoRoot
+
+INIT Init
+NEXT Next
+
+INVARIANT TypeOK
+INVARIANT Inv
+INVARIANT AttributionComplete

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/ForensicAccountabilityProof.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/ForensicAccountabilityProof.tla
@@ -1,0 +1,161 @@
+---- MODULE ForensicAccountabilityProof ----
+(***************************************************************************)
+(* AFT-CB P2.6 — TLAPS discharge of T7 over the wire format: attribution   *)
+(* completeness is a consequence of the bitmap-complete record structure,  *)
+(* and certificate uniqueness under MHA restates P2.1's theorem over the   *)
+(* wire.  The extraction procedure is ExtractedSet, and the theorem says   *)
+(* it returns ALL of Ring on any conflicting pair.                         *)
+(***************************************************************************)
+EXTENDS ForensicAccountability, TLAPS
+
+ASSUME NoRootOutsideRootsF == NoRoot \notin Roots
+
+LEMMA FInvInit == Init => Inv
+  BY ForensicConstants DEF Init, Inv, TypeOK
+
+LEMMA FInvNext == Inv /\ [Next]_vars => Inv'
+<1>1. SUFFICES ASSUME Inv, [Next]_vars PROVE Inv'
+  OBVIOUS
+<1>2. CASE UNCHANGED vars
+  BY <1>1, <1>2 DEF Inv, TypeOK, vars
+<1>3. ASSUME NEW m \in Ring, NEW s \in Slots, NEW r \in Roots,
+             HonestSign(m, s, r)
+      PROVE Inv'
+  <2>1. m \in HonestMembers /\ journal[m][s] = NoRoot
+    BY <1>3 DEF HonestSign
+  <2>2. TypeOK'
+    BY <1>1, <1>3, <2>1, ForensicConstants DEF Inv, TypeOK, HonestSign, Share
+  <2>3. \A mm \in HonestMembers, ss \in Slots, rr \in Roots :
+          (Share(mm, ss, rr) \in hshares') => journal'[mm][ss] = rr
+    <3>1. SUFFICES ASSUME NEW mm \in HonestMembers, NEW ss \in Slots,
+                          NEW rr \in Roots, Share(mm, ss, rr) \in hshares'
+          PROVE journal'[mm][ss] = rr
+      OBVIOUS
+    <3>2. hshares' = hshares \cup {Share(m, s, r)}
+      BY <1>3 DEF HonestSign
+    <3>3. CASE Share(mm, ss, rr) = Share(m, s, r)
+      <4>1. mm = m /\ ss = s /\ rr = r
+        BY <3>3 DEF Share
+      <4>2. journal'[m][s] = r
+        BY <1>1, <1>3, <2>1 DEF Inv, TypeOK, HonestSign
+      <4> QED BY <4>1, <4>2
+    <3>4. CASE Share(mm, ss, rr) \in hshares
+      <4>1. journal[mm][ss] = rr
+        BY <1>1, <3>4 DEF Inv
+      <4>2. CASE mm = m /\ ss = s
+        <5>1. journal[m][s] = rr
+          BY <4>1, <4>2
+        <5>2. rr # NoRoot
+          BY <3>1, NoRootOutsideRootsF
+        <5> QED BY <2>1, <5>1, <5>2
+      <4>3. CASE ~(mm = m /\ ss = s)
+        <5>1. journal'[mm][ss] = journal[mm][ss]
+          BY <1>1, <1>3, <2>1, <4>3 DEF Inv, TypeOK, HonestSign
+        <5> QED BY <4>1, <5>1
+      <4> QED BY <4>2, <4>3
+    <3> QED BY <3>1, <3>2, <3>3, <3>4
+  <2>4. \A c \in certs' :
+          /\ c.shares = {Share(mm, c.slot, c.root) : mm \in Ring}
+          /\ \A mm \in HonestMembers : Share(mm, c.slot, c.root) \in hshares'
+    <3>1. certs' = certs
+      BY <1>3 DEF HonestSign
+    <3>2. hshares \subseteq hshares'
+      BY <1>3 DEF HonestSign
+    <3> QED BY <1>1, <3>1, <3>2 DEF Inv
+  <2> QED BY <2>2, <2>3, <2>4 DEF Inv
+<1>4. ASSUME NEW s \in Slots, NEW r \in Roots, Assemble(s, r)
+      PROVE Inv'
+  <2>1. TypeOK'
+    <3>1. Cert(s, r) \in [slot : Slots, root : Roots,
+                          shares : SUBSET (Ring \X Slots \X Roots)]
+      BY <1>4 DEF Cert, Share
+    <3> QED BY <1>1, <1>4, <3>1 DEF Inv, TypeOK, Assemble
+  <2>2. \A mm \in HonestMembers, ss \in Slots, rr \in Roots :
+          (Share(mm, ss, rr) \in hshares') => journal'[mm][ss] = rr
+    BY <1>1, <1>4 DEF Inv, Assemble
+  <2>3. \A c \in certs' :
+          /\ c.shares = {Share(mm, c.slot, c.root) : mm \in Ring}
+          /\ \A mm \in HonestMembers : Share(mm, c.slot, c.root) \in hshares'
+    <3>1. SUFFICES ASSUME NEW c \in certs'
+          PROVE /\ c.shares = {Share(mm, c.slot, c.root) : mm \in Ring}
+                /\ \A mm \in HonestMembers :
+                     Share(mm, c.slot, c.root) \in hshares'
+      OBVIOUS
+    <3>2. certs' = certs \cup {Cert(s, r)} /\ hshares' = hshares
+      BY <1>4 DEF Assemble
+    <3>3. CASE c \in certs
+      BY <1>1, <3>2, <3>3 DEF Inv
+    <3>4. CASE c = Cert(s, r)
+      <4>1. c.shares = {Share(mm, s, r) : mm \in Ring}
+            /\ c.slot = s /\ c.root = r
+        BY <3>4 DEF Cert
+      <4>2. \A mm \in HonestMembers : Share(mm, s, r) \in hshares
+        <5>1. \A mm \in Ring : ShareAvailable(mm, s, r)
+          BY <1>4 DEF Assemble
+        <5> QED BY <5>1, ForensicConstants DEF ShareAvailable
+      <4> QED BY <3>2, <4>1, <4>2
+    <3> QED BY <3>1, <3>2, <3>3, <3>4
+  <2> QED BY <2>1, <2>2, <2>3 DEF Inv
+<1>5. QED
+  BY <1>1, <1>2, <1>3, <1>4 DEF Next, vars
+
+(***************************************************************************)
+(* T7: any two conflicting wire certificates decompose into conflicting    *)
+(* share pairs for EVERY ring member — the extraction procedure returns    *)
+(* the full necessary-participant set.  Purely structural: the record      *)
+(* format guarantees it, which is exactly why the format is part of the    *)
+(* theorem and an opaque aggregate destroys it (the mutation drill).       *)
+(***************************************************************************)
+LEMMA InvAttribution == Inv => AttributionComplete
+<1>1. SUFFICES ASSUME Inv, NEW c1 \in certs, NEW c2 \in certs,
+                      Conflicting(c1, c2)
+      PROVE ExtractedSet(c1, c2) = Ring
+  BY DEF AttributionComplete
+<1>2. c1.shares = {Share(mm, c1.slot, c1.root) : mm \in Ring}
+      /\ c2.shares = {Share(mm, c2.slot, c2.root) : mm \in Ring}
+  BY <1>1 DEF Inv
+<1>3. \A m \in Ring : /\ Share(m, c1.slot, c1.root) \in c1.shares
+                      /\ Share(m, c2.slot, c2.root) \in c2.shares
+  BY <1>2
+<1>4. QED
+  BY <1>3 DEF ExtractedSet
+
+(***************************************************************************)
+(* Certificate uniqueness under MHA, restated over the wire: a conflicting *)
+(* pair requires an honest member's shares over two roots at one slot,     *)
+(* which the journal forbids — so conflict implies zero honest members.    *)
+(***************************************************************************)
+LEMMA InvCertUniqueness == Inv => CertUniqueness
+<1>1. SUFFICES ASSUME Inv, NEW c1 \in certs, NEW c2 \in certs,
+                      Conflicting(c1, c2)
+      PROVE HonestMembers = {}
+  BY DEF CertUniqueness
+<1>2. SUFFICES ASSUME NEW h \in HonestMembers PROVE FALSE
+  OBVIOUS
+<1>3. Share(h, c1.slot, c1.root) \in hshares
+      /\ Share(h, c2.slot, c2.root) \in hshares
+  BY <1>1, <1>2 DEF Inv
+<1>4. journal[h][c1.slot] = c1.root /\ journal[h][c2.slot] = c2.root
+  <2>1. c1.slot \in Slots /\ c1.root \in Roots
+        /\ c2.slot \in Slots /\ c2.root \in Roots
+    BY <1>1 DEF Inv, TypeOK
+  <2> QED BY <1>1, <1>2, <1>3, <2>1 DEF Inv
+<1>5. c1.slot = c2.slot /\ c1.root # c2.root
+  BY <1>1 DEF Conflicting
+<1>6. QED
+  BY <1>4, <1>5
+
+THEOREM ForensicSafety ==
+  Spec => [](AttributionComplete /\ CertUniqueness)
+<1>1. Init => Inv
+  BY FInvInit
+<1>2. Inv /\ [Next]_vars => Inv'
+  BY FInvNext
+<1>3. Spec => []Inv
+  BY <1>1, <1>2, PTL DEF Spec
+<1>4. Inv => (AttributionComplete /\ CertUniqueness)
+  BY InvAttribution, InvCertUniqueness
+<1>5. QED
+  BY <1>3, <1>4, PTL
+
+====


### PR DESCRIPTION
## AFT-CB leg P2.6 — forensic accountability spec (T7)

`formal/common_boundary/ForensicAccountability{,Proof}.tla` + two configs,
registered in the formal floor.

- **The wire format is part of the theorem**: certificates are bitmap-complete records embedding every member's individually verifiable share over the exact tuple; `ExtractedSet` — the specified extraction procedure — runs on the records alone.
- **tlapm: all 146 obligations proved** — `AttributionComplete` (conflicting certificates decompose into conflicting share pairs for *every* member: the full necessary-participant set, the L9 maximum) and `CertUniqueness` (conflict ⇒ zero honest members).
- **The staged all-Byzantine double-seal** (leg gate): with `HonestMembers = {}` both conflicting certificates assemble, `AttributionComplete` still holds in the registered config, and the `DoubleSealReached` violation trace exhibits both wire records with all three members' shares visible — the extraction witness, readable off the trace.

## Mutation drill
Encoding swapped to an attribution-destroying opaque aggregate (`shares = {}`) → **`Invariant AttributionComplete is violated`** on-target at the all-Byzantine config + tlapm unproved. Reverted → 0 violations, 146/146.

Also recorded: the P2.5 feasibility probe (no sandbox blocker; no owner escalation needed for the SP1 toolchain; CPU proving viable — P2.5 proceeds as its own dedicated leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)