### PR TITLE
feat(types): assumption lattice — every certificate profile labeled, composition reports the meet (AFT-CB R6)

### DIFF
--- a/crates/types/src/app/consensus/collapse.rs
+++ b/crates/types/src/app/consensus/collapse.rs
@@ -2,3 +2,4 @@ include!("collapse/foundation.rs");
 include!("collapse/recovery.rs");
 include!("collapse/headers.rs");
 include!("collapse/proofs.rs");
+include!("collapse/assumptions.rs");

--- a/crates/types/src/app/consensus/collapse/assumptions.rs
+++ b/crates/types/src/app/consensus/collapse/assumptions.rs
@@ -1,0 +1,344 @@
+// AFT-CB R6 — the assumption lattice (T6): every certificate profile
+// carries a machine-readable assumption label; composition reports the
+// MEET — the weakest finality-bearing constituent's rank, the UNION of
+// consumed assumptions, and the AND of the `pq` bit. Trust composition
+// becomes type-checked: adding a certificate profile without a label is
+// a compile error (the wildcard-free match in [`label_of`]), and a
+// collapse object's effective guarantee is exactly what its weakest
+// finality-bearing part earned — never what a caller hoped, and never
+// weaker than truth either: an evidence-only constituent (a continuity
+// binding, a typed root) contributes its assumptions and its `pq` bit
+// but claims no finality, so it can neither grant a rank nor be blamed
+// for one.
+//
+// Rider (C9, the finality menu): per-effect typed finality classes with
+// the assumption vector recorded on receipts, so applications choose
+// finality explicitly and receipts prove which class authorized each
+// effect (spec §19).
+//
+// The ledger ids mirror whitepaper §5.3 (A1–A10). A10 appears here for
+// completeness of the id space; no shipped profile cites it (the
+// succession extension is design-open — three formulations refuted; see
+// the AFT-CB program record).
+
+use std::collections::BTreeSet;
+
+/// The assumption-ledger ids (whitepaper §5.3, A1–A10).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub enum AssumptionId {
+    /// Cryptographic primitives (collision-resistant hashing, EUF-CMA
+    /// signatures) are unbroken.
+    A1,
+    /// Minimal Honesty Axiom: at least one boundary member is honest.
+    A2,
+    /// Journal-guarded single-final-ack discipline holds per member.
+    A3,
+    /// Retriever reach: published bulletin objects are fetchable by the
+    /// parties the protocol obliges to fetch them.
+    A4,
+    /// Live-tier weight + partial-synchrony bounds over the honest mesh.
+    A5,
+    /// The deployed freshness anchor is live and unequivocating.
+    A6,
+    /// Bond and slashing values are economically binding.
+    A7,
+    /// Custody storage integrity over the retention window.
+    A8,
+    /// Physical-time drift bound for the VDF succession clock.
+    A9,
+    /// Succession-path observation (PROVISIONAL — no shipped profile may
+    /// cite it while §16 is design-open).
+    A10,
+}
+
+/// Strength rank of a finality guarantee, ordered weakest-first so the
+/// MEET is the minimum. A rank names what the constituent's own theorem
+/// earns — never what a stronger sibling earns beside it.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub enum GuaranteeRank {
+    /// Observational finality only: honest-majority-of-observers class
+    /// evidence (observer reports, witness lanes). Gates nothing above
+    /// its own lane.
+    Observational,
+    /// Live-tier BFT finality under the engine's weight + synchrony
+    /// bounds (A5-class).
+    LiveTierBft,
+    /// Sealed all-but-one boundary finality (the UBC ladder: A1+A2+A3).
+    SealedAllButOne,
+    /// Sealed and bound into the deployed freshness anchor (adds A6).
+    SealedAnchored,
+}
+
+/// A certificate profile's assumption label.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssumptionLabel {
+    /// The finality rank this certificate can support on its own, or
+    /// `None` for evidence-only constituents (continuity bindings, typed
+    /// roots): they contribute assumptions and the `pq` bit but claim no
+    /// finality, so they neither grant nor degrade a rank.
+    pub finality_rank: Option<GuaranteeRank>,
+    /// The assumption-ledger entries this certificate consumes.
+    pub assumes: BTreeSet<AssumptionId>,
+    /// True only when EVERY cryptographic primitive in this profile's
+    /// verification chain is post-quantum.
+    pub pq: bool,
+}
+
+/// Every certificate profile that can constitute a collapse object or a
+/// finality-receipt basis. EXHAUSTIVE: [`label_of`] matches without a
+/// wildcard, so adding a profile here without deciding its label is a
+/// compile error — that is the T6 mechanism, not a style preference.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub enum CertificateProfile {
+    /// Live-tier quorum certificate (pairing/BLS-class aggregate).
+    LiveQuorumCert,
+    /// Guardian committee certificate bound to a proposal (ed25519).
+    GuardianCommitteeCert,
+    /// Witness certificate (witness-augmented lanes).
+    WitnessCert,
+    /// Observer sealing countersignature (advisory observation lane).
+    ObserverCert,
+    /// Unanimous Boundary Close (n-of-n, attribution-preserving).
+    UnanimousBoundaryClose,
+    /// A UBC whose seal is additionally bound into the deployed
+    /// freshness anchor. A single profile on purpose: a meet can only
+    /// report the weakest constituent, so an UPGRADE (seal + anchor)
+    /// must arrive as one certificate, never as a composition.
+    AnchoredBoundaryClose,
+    /// The labeled non-succinct reference continuity binding (HashPcdV1).
+    /// Evidence-only: it binds history under A1; it finalizes nothing.
+    HashPcdReference,
+    /// An anchored re-genesis root record. A root, never continuity and
+    /// never finality: the new lineage's finality comes from the new
+    /// lineage's own certificates (spec §14).
+    RegenesisRoot,
+}
+
+impl CertificateProfile {
+    /// Every variant, for census-style iteration. [`label_of`]'s
+    /// wildcard-free match is the completeness gate for labels; the
+    /// `certificate_profile_all_is_exhaustive` test pins this list's
+    /// length so a new variant must be added here too.
+    pub const ALL: [CertificateProfile; 8] = [
+        CertificateProfile::LiveQuorumCert,
+        CertificateProfile::GuardianCommitteeCert,
+        CertificateProfile::WitnessCert,
+        CertificateProfile::ObserverCert,
+        CertificateProfile::UnanimousBoundaryClose,
+        CertificateProfile::AnchoredBoundaryClose,
+        CertificateProfile::HashPcdReference,
+        CertificateProfile::RegenesisRoot,
+    ];
+}
+
+/// The single authority on what each profile's label is.
+pub fn label_of(profile: CertificateProfile) -> AssumptionLabel {
+    use AssumptionId::*;
+    use CertificateProfile::*;
+    use GuaranteeRank::*;
+    match profile {
+        LiveQuorumCert => AssumptionLabel {
+            finality_rank: Some(LiveTierBft),
+            assumes: BTreeSet::from([A1, A5]),
+            // Pairing-based aggregate signatures: not post-quantum.
+            pq: false,
+        },
+        GuardianCommitteeCert => AssumptionLabel {
+            finality_rank: Some(LiveTierBft),
+            assumes: BTreeSet::from([A1, A5]),
+            // ed25519: not post-quantum.
+            pq: false,
+        },
+        WitnessCert => AssumptionLabel {
+            finality_rank: Some(Observational),
+            assumes: BTreeSet::from([A1]),
+            pq: false,
+        },
+        ObserverCert => AssumptionLabel {
+            finality_rank: Some(Observational),
+            assumes: BTreeSet::from([A1, A4]),
+            pq: false,
+        },
+        UnanimousBoundaryClose => AssumptionLabel {
+            finality_rank: Some(SealedAllButOne),
+            assumes: BTreeSet::from([A1, A2, A3]),
+            pq: false,
+        },
+        AnchoredBoundaryClose => AssumptionLabel {
+            finality_rank: Some(SealedAnchored),
+            assumes: BTreeSet::from([A1, A2, A3, A6]),
+            pq: false,
+        },
+        HashPcdReference => AssumptionLabel {
+            // Evidence-only: an honest hash binding under A1 — sound
+            // continuity, no finality claim (the Q6 disposition).
+            finality_rank: None,
+            assumes: BTreeSet::from([A1]),
+            // Hash-only construction: post-quantum.
+            pq: true,
+        },
+        RegenesisRoot => AssumptionLabel {
+            // Evidence-only: a typed root records the anchored basis of
+            // a NEW lineage; it finalizes nothing in any lineage.
+            finality_rank: None,
+            assumes: BTreeSet::from([A1, A2, A3, A6]),
+            pq: false,
+        },
+    }
+}
+
+/// The effective guarantee of a composition: minimum rank over the
+/// finality-bearing constituents, UNION of all consumed assumptions
+/// (consuming more is weaker), AND of `pq` over ALL constituents.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EffectiveGuarantee {
+    /// `None` when no constituent bears finality: an evidence-only
+    /// composition has NO finality rank, and callers must treat that as
+    /// a refusal, never a default.
+    pub rank: Option<GuaranteeRank>,
+    /// Union of every assumption-ledger entry the composition consumes.
+    pub assumes: BTreeSet<AssumptionId>,
+    /// AND of every constituent's `pq` bit.
+    pub pq: bool,
+    /// The profiles that produced this meet, for receipts and forensics.
+    pub constituents: BTreeSet<CertificateProfile>,
+}
+
+/// Computes the meet over a non-empty composition. Returns `None` for an
+/// empty composition: an object with no labeled constituent has no
+/// guarantee at all — not even an evidence-only one.
+pub fn assumption_meet(profiles: &[CertificateProfile]) -> Option<EffectiveGuarantee> {
+    if profiles.is_empty() {
+        return None;
+    }
+    let mut rank: Option<GuaranteeRank> = None;
+    let mut assumes = BTreeSet::new();
+    let mut pq = true;
+    for p in profiles {
+        let l = label_of(*p);
+        if let Some(r) = l.finality_rank {
+            rank = Some(match rank {
+                Some(current) if current <= r => current,
+                _ => r,
+            });
+        }
+        assumes.extend(l.assumes);
+        pq = pq && l.pq;
+    }
+    Some(EffectiveGuarantee {
+        rank,
+        assumes,
+        pq,
+        constituents: profiles.iter().copied().collect(),
+    })
+}
+
+/// The finality menu (spec §19): per-effect typed classes. Applications
+/// choose explicitly; receipts prove which class authorized each effect.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub enum FinalityClass {
+    /// Live-tier BFT finality (seconds-class, cheapest).
+    LiveQc,
+    /// UBC super-finality (seal cadence, bond-backed).
+    Sealed,
+    /// Sealed plus the deployed freshness anchor (dearest).
+    SealedAnchored,
+}
+
+/// The minimum rank each finality class honestly requires.
+pub fn required_rank(class: FinalityClass) -> GuaranteeRank {
+    match class {
+        FinalityClass::LiveQc => GuaranteeRank::LiveTierBft,
+        FinalityClass::Sealed => GuaranteeRank::SealedAllButOne,
+        FinalityClass::SealedAnchored => GuaranteeRank::SealedAnchored,
+    }
+}
+
+/// A finality receipt: the self-contained statement of what was trusted
+/// when an effect was authorized. Constructed only through
+/// [`FinalityReceipt::issue`], which refuses a class the composition's
+/// meet cannot honestly support — there is no downgrade-and-issue path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FinalityReceipt {
+    /// The finality class that authorized the effect.
+    pub class: FinalityClass,
+    /// The full assumption vector of the authorizing composition.
+    pub guarantee: EffectiveGuarantee,
+    /// Declared latency parameter for the class at issue time (ms).
+    pub declared_latency_ms: u64,
+    /// Declared price parameter for the class at issue time (integer
+    /// milliunits of the deployment's billing currency).
+    pub declared_price_milliunits: u64,
+}
+
+impl FinalityReceipt {
+    /// Issues a receipt iff the composition's meet supports the class.
+    pub fn issue(
+        class: FinalityClass,
+        profiles: &[CertificateProfile],
+        declared_latency_ms: u64,
+        declared_price_milliunits: u64,
+    ) -> Result<FinalityReceipt, FinalityRefusal> {
+        let guarantee =
+            assumption_meet(profiles).ok_or(FinalityRefusal::EmptyComposition)?;
+        let achieved = guarantee.rank.ok_or(FinalityRefusal::NoFinalityBearer)?;
+        if achieved < required_rank(class) {
+            return Err(FinalityRefusal::RankBelowClass { class, achieved });
+        }
+        Ok(FinalityReceipt {
+            class,
+            guarantee,
+            declared_latency_ms,
+            declared_price_milliunits,
+        })
+    }
+}
+
+/// Typed refusals for finality issuance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FinalityRefusal {
+    /// No labeled constituent at all: nothing exists to grade.
+    EmptyComposition,
+    /// Every constituent is evidence-only: no finality claim exists.
+    NoFinalityBearer,
+    /// The composition's meet is below the requested class.
+    RankBelowClass {
+        /// The finality class that was requested.
+        class: FinalityClass,
+        /// The rank the composition's meet actually achieved.
+        achieved: GuaranteeRank,
+    },
+}
+
+impl CanonicalCollapseObject {
+    /// The certificate profiles this collapse object's SHAPE claims as
+    /// its finality basis, derived from its populated parts — never from
+    /// a caller's assertion. Advisory observation is NOT basis: a sealed
+    /// slot's finality rests on the UBC alone (the two-tier separation),
+    /// so observer countersignatures never appear here. Verifying that
+    /// the claimed parts are themselves valid remains the collapse
+    /// validators' job — this derivation grades, it does not verify.
+    pub fn constituent_profiles(&self) -> Vec<CertificateProfile> {
+        let mut profiles = vec![CertificateProfile::HashPcdReference];
+        if self.sealing.is_some() {
+            profiles.push(CertificateProfile::UnanimousBoundaryClose);
+        } else {
+            profiles.push(CertificateProfile::GuardianCommitteeCert);
+        }
+        profiles
+    }
+
+    /// The collapse object's effective guarantee: the meet over its
+    /// shape-derived constituents.
+    pub fn effective_guarantee(&self) -> Option<EffectiveGuarantee> {
+        assumption_meet(&self.constituent_profiles())
+    }
+}

--- a/crates/types/src/app/consensus/tests.rs
+++ b/crates/types/src/app/consensus/tests.rs
@@ -6,3 +6,4 @@ include!("tests_parts/recoverable_payload_hashes.rs");
 include!("tests_parts/archived_history.rs");
 include!("tests_parts/payload_reconstruction.rs");
 include!("tests_parts/collapse_continuity.rs");
+include!("tests_parts/assumption_lattice.rs");

--- a/crates/types/src/app/consensus/tests_parts/assumption_lattice.rs
+++ b/crates/types/src/app/consensus/tests_parts/assumption_lattice.rs
@@ -1,0 +1,237 @@
+// AFT-CB R6 gate tests — the assumption lattice's four gates:
+//   G1  the meet reports the weakest finality-bearing constituent;
+//   G2  evidence-only constituents contribute assumptions + pq, never rank;
+//   G3  receipts record the finality class and the full assumption vector;
+//   G4  pq meets correctly: any non-pq constituent ⇒ non-pq object.
+// The fifth gate — adding a CertificateProfile variant without a label is
+// a compile error — is `label_of`'s wildcard-free match itself; the
+// census test below pins `ALL` so the variant list can't silently drift.
+
+use std::collections::BTreeSet;
+
+#[test]
+fn certificate_profile_census_is_exhaustive() {
+    // Every listed profile has a constructible label, and the list has
+    // no duplicates. `label_of`'s wildcard-free match is the compile
+    // gate for NEW variants; this pins the census length so ALL must be
+    // extended in the same change.
+    let unique: BTreeSet<_> = CertificateProfile::ALL.iter().copied().collect();
+    assert_eq!(unique.len(), CertificateProfile::ALL.len());
+    assert_eq!(CertificateProfile::ALL.len(), 8);
+    for p in CertificateProfile::ALL {
+        let _ = label_of(p);
+    }
+}
+
+#[test]
+fn guarantee_ranks_order_weakest_first() {
+    assert!(GuaranteeRank::Observational < GuaranteeRank::LiveTierBft);
+    assert!(GuaranteeRank::LiveTierBft < GuaranteeRank::SealedAllButOne);
+    assert!(GuaranteeRank::SealedAllButOne < GuaranteeRank::SealedAnchored);
+}
+
+#[test]
+fn meet_reports_weakest_finality_bearing_constituent() {
+    // G1: a live QC beside a seal degrades the composition to live-tier.
+    let g = assumption_meet(&[
+        CertificateProfile::UnanimousBoundaryClose,
+        CertificateProfile::GuardianCommitteeCert,
+    ])
+    .expect("non-empty");
+    assert_eq!(g.rank, Some(GuaranteeRank::LiveTierBft));
+
+    // G1 + the observer mutation target: an observer countersignature
+    // listed as basis pins the meet at Observational. Mislabeling the
+    // observer one level strong (LiveTierBft) turns this RED.
+    let g = assumption_meet(&[
+        CertificateProfile::ObserverCert,
+        CertificateProfile::UnanimousBoundaryClose,
+    ])
+    .expect("non-empty");
+    assert_eq!(g.rank, Some(GuaranteeRank::Observational));
+
+    // An observer-only composition can never authorize live-QC finality.
+    let refusal = FinalityReceipt::issue(
+        FinalityClass::LiveQc,
+        &[CertificateProfile::ObserverCert],
+        0,
+        0,
+    )
+    .expect_err("observational basis must refuse LiveQc");
+    assert_eq!(
+        refusal,
+        FinalityRefusal::RankBelowClass {
+            class: FinalityClass::LiveQc,
+            achieved: GuaranteeRank::Observational,
+        }
+    );
+
+    // Assumptions UNION (consuming more is weaker): seal + QC consumes
+    // the union of both ledgers.
+    let g = assumption_meet(&[
+        CertificateProfile::UnanimousBoundaryClose,
+        CertificateProfile::GuardianCommitteeCert,
+    ])
+    .expect("non-empty");
+    assert_eq!(
+        g.assumes,
+        BTreeSet::from([
+            AssumptionId::A1,
+            AssumptionId::A2,
+            AssumptionId::A3,
+            AssumptionId::A5,
+        ])
+    );
+}
+
+#[test]
+fn evidence_only_constituents_never_bear_or_degrade_rank() {
+    // G2a: evidence-only composition has NO rank and refuses issuance.
+    let g = assumption_meet(&[CertificateProfile::HashPcdReference]).expect("non-empty");
+    assert_eq!(g.rank, None);
+    let refusal = FinalityReceipt::issue(
+        FinalityClass::LiveQc,
+        &[CertificateProfile::HashPcdReference],
+        0,
+        0,
+    )
+    .expect_err("evidence-only basis must refuse");
+    assert_eq!(refusal, FinalityRefusal::NoFinalityBearer);
+
+    // G2b: evidence beside a seal does NOT degrade the seal's rank —
+    // but its assumptions still land in the vector.
+    let g = assumption_meet(&[
+        CertificateProfile::HashPcdReference,
+        CertificateProfile::UnanimousBoundaryClose,
+    ])
+    .expect("non-empty");
+    assert_eq!(g.rank, Some(GuaranteeRank::SealedAllButOne));
+    assert!(g.assumes.contains(&AssumptionId::A1));
+
+    // G2c: a typed re-genesis root bears no finality in any lineage.
+    let g = assumption_meet(&[CertificateProfile::RegenesisRoot]).expect("non-empty");
+    assert_eq!(g.rank, None);
+
+    // Empty composition: nothing to grade at all.
+    assert_eq!(assumption_meet(&[]), None);
+    assert_eq!(
+        FinalityReceipt::issue(FinalityClass::LiveQc, &[], 0, 0),
+        Err(FinalityRefusal::EmptyComposition)
+    );
+}
+
+#[test]
+fn receipt_records_finality_class_and_assumption_vector() {
+    // G3: an issued receipt carries the class and the full vector, and
+    // both survive serialization. Stripping the class field from the
+    // receipt turns this RED (and fails to compile).
+    let receipt = FinalityReceipt::issue(
+        FinalityClass::Sealed,
+        &[
+            CertificateProfile::HashPcdReference,
+            CertificateProfile::UnanimousBoundaryClose,
+        ],
+        30_000,
+        250,
+    )
+    .expect("sealed basis supports Sealed");
+    assert_eq!(receipt.class, FinalityClass::Sealed);
+    assert_eq!(receipt.guarantee.rank, Some(GuaranteeRank::SealedAllButOne));
+    assert_eq!(
+        receipt.guarantee.assumes,
+        BTreeSet::from([AssumptionId::A1, AssumptionId::A2, AssumptionId::A3])
+    );
+    assert_eq!(receipt.declared_latency_ms, 30_000);
+    assert_eq!(receipt.declared_price_milliunits, 250);
+
+    let json = serde_json::to_value(&receipt).expect("serializes");
+    assert_eq!(json["class"], serde_json::json!("Sealed"));
+    assert_eq!(
+        json["guarantee"]["assumes"],
+        serde_json::json!(["A1", "A2", "A3"])
+    );
+
+    // The anchored class needs the anchored profile — a bare seal is a
+    // typed refusal, never a silent upgrade.
+    let refusal = FinalityReceipt::issue(
+        FinalityClass::SealedAnchored,
+        &[CertificateProfile::UnanimousBoundaryClose],
+        0,
+        0,
+    )
+    .expect_err("bare seal must refuse SealedAnchored");
+    assert_eq!(
+        refusal,
+        FinalityRefusal::RankBelowClass {
+            class: FinalityClass::SealedAnchored,
+            achieved: GuaranteeRank::SealedAllButOne,
+        }
+    );
+    let receipt = FinalityReceipt::issue(
+        FinalityClass::SealedAnchored,
+        &[CertificateProfile::AnchoredBoundaryClose],
+        0,
+        0,
+    )
+    .expect("anchored close supports SealedAnchored");
+    assert!(receipt.guarantee.assumes.contains(&AssumptionId::A6));
+}
+
+#[test]
+fn pq_meets_correctly() {
+    // G4: any non-pq constituent makes the object non-pq. The
+    // pairing-based live QC is non-pq; marking it pq turns this RED.
+    let g = assumption_meet(&[
+        CertificateProfile::HashPcdReference,
+        CertificateProfile::LiveQuorumCert,
+    ])
+    .expect("non-empty");
+    assert!(!g.pq, "pairing-based constituent must force non-pq");
+    assert!(!label_of(CertificateProfile::LiveQuorumCert).pq);
+
+    // The hash-only binding alone IS pq — the AND has a true case, so
+    // the assertion above can't pass vacuously.
+    let g = assumption_meet(&[CertificateProfile::HashPcdReference]).expect("non-empty");
+    assert!(g.pq);
+
+    // Today every finality-bearing profile is pre-quantum: no
+    // composition with a rank may report pq.
+    for p in CertificateProfile::ALL {
+        let l = label_of(p);
+        if l.finality_rank.is_some() {
+            assert!(!l.pq, "{p:?}: no shipped finality-bearing profile is pq");
+        }
+    }
+}
+
+#[test]
+fn collapse_object_exposes_shape_derived_guarantee() {
+    // Unsealed object: live-tier basis.
+    let unsealed = CanonicalCollapseObject::default();
+    assert!(unsealed.sealing.is_none());
+    let g = unsealed.effective_guarantee().expect("shape has a basis");
+    assert_eq!(g.rank, Some(GuaranteeRank::LiveTierBft));
+    assert!(g
+        .constituents
+        .contains(&CertificateProfile::GuardianCommitteeCert));
+    assert!(g.constituents.contains(&CertificateProfile::HashPcdReference));
+    assert!(!g.pq);
+
+    // Sealed object: the seal alone is the finality basis (two-tier
+    // separation) — the rank is SealedAllButOne, not live-tier, and not
+    // Observational either (advisory observation is never basis).
+    let sealed = CanonicalCollapseObject {
+        sealing: Some(Default::default()),
+        ..Default::default()
+    };
+    let g = sealed.effective_guarantee().expect("shape has a basis");
+    assert_eq!(g.rank, Some(GuaranteeRank::SealedAllButOne));
+    assert!(g
+        .constituents
+        .contains(&CertificateProfile::UnanimousBoundaryClose));
+    assert!(!g.constituents.contains(&CertificateProfile::ObserverCert));
+    assert_eq!(
+        g.assumes,
+        BTreeSet::from([AssumptionId::A1, AssumptionId::A2, AssumptionId::A3])
+    );
+}


### PR DESCRIPTION
## AFT-CB R6 — the assumption lattice (P3 chain start)

T6 lands in types. Every certificate profile carries a machine-readable `AssumptionLabel` — finality rank, A1–A10 ledger citations, pq bit — through a wildcard-free match in `label_of`: **adding a profile without deciding its label is a compile error.** Composition reports the **meet**: minimum rank over finality-bearing constituents, union of consumed assumptions, AND of pq.

### Design decisions
- **Evidence-only constituents** (HashPcd continuity binding, typed re-genesis roots) have `finality_rank: None`: they contribute assumptions + pq but neither grant nor degrade a rank. A sealed object is graded by its seal alone (the two-tier separation); an all-evidence composition is a typed refusal (`NoFinalityBearer`), never a default.
- **`AnchoredBoundaryClose` is a single profile on purpose**: a meet can only report the weakest constituent, so the seal+anchor upgrade must arrive as one certificate, never as a composition.
- **`CanonicalCollapseObject::effective_guarantee`** derives the basis from the object's shape (sealed → UBC; unsealed → guardian cert; hash binding always present as evidence). It grades — validation stays with the collapse validators.
- **Rider C9 (finality menu, spec §19)**: `FinalityClass {LiveQc, Sealed, SealedAnchored}`; `FinalityReceipt::issue` is the only constructor and refuses a class the meet cannot support, recording class + full assumption vector + declared latency/price.
- A10 exists in the id space; no shipped profile may cite it (succession design-open, three formulations refuted).

### Leg gates — all mutation-drilled RED→revert→GREEN
| Gate | Mutation | Result |
|---|---|---|
| Meet reports weakest constituent | observer mislabeled one level strong | RED at the pinning assertion (line 51) |
| Receipt records class + vector | class stripped from serialized form | RED at the JSON assertion |
| pq meets correctly | pairing-based live QC marked pq | RED ("pairing-based constituent must force non-pq") |
| Exhaustive labeling | (compile gate — wildcard-free match) | census test pins 8 profiles |

`cargo test --locked -p ioi-types --lib`: **387/387 green**, mutations reverted (grep-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)