### PR TITLE
feat(zk): proof-system completion — succinct lane real-or-refuse, mock constructor deleted (AFT-CB R4c)

### DIFF
--- a/.github/scripts/check_aft_no_mock_proof.sh
+++ b/.github/scripts/check_aft_no_mock_proof.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# AFT-CB R4c gate: the release tree contains NO mock succinct-proof
+# constructor and NO simulated fallback on the succinct continuity lane.
+#
+#   1. no `fn new_mock` anywhere under the zk driver or its consumers'
+#      release sources (a mock constructor deleted must STAY deleted);
+#   2. no `impl Default for SuccinctDriver` (the Default that routed to
+#      the mock is the same defect under another name);
+#   3. the driver's non-native SuccinctSp1V1 arm is a refusal: the
+#      refusal string is present, and `SimulatedGroth16` does not appear
+#      inside the canonical-collapse continuity impl;
+#   4. the governed pin constant exists and matches vkey.json (the
+#      cfg-audit TEST asserts the same at runtime; this is the static
+#      floor).
+#
+# Mutation-tested per AFT-CB standing rule 3: reintroducing
+# `fn new_mock` (or the Default impl) must turn this gate RED.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DRIVER_SRC="$ROOT/crates/plugins/zk-driver-succinct/src"
+fail=0
+err() { echo "FAIL: $1"; fail=1; }
+
+# 1. No mock constructors in release sources (tests excluded: tests may
+#    construct adversarial fixtures, but a *constructor named mock* is
+#    barred even there — the fixture builder is not a driver constructor).
+hits=$(grep -rn "fn new_mock" \
+  "$DRIVER_SRC" \
+  "$ROOT/crates/plugins/ibc-service/src" \
+  "$ROOT/crates/consensus/src" \
+  "$ROOT/crates/validator/src" \
+  "$ROOT/crates/node/src" 2>/dev/null || true)
+[[ -z "$hits" ]] || err "mock constructor present:
+$hits"
+
+# 2. No Default impl for the driver.
+hits=$(grep -rn "impl Default for SuccinctDriver" "$DRIVER_SRC" 2>/dev/null || true)
+[[ -z "$hits" ]] || err "SuccinctDriver regained a Default impl:
+$hits"
+
+# 3. The non-native continuity arm refuses; no simulated delegation in
+#    the continuity impl. Extract the CanonicalCollapseContinuityVerifier
+#    impl block and inspect it.
+lib="$DRIVER_SRC/lib.rs"
+impl_block=$(awk '/^impl CanonicalCollapseContinuityVerifier for SuccinctDriver/,/^}/' "$lib")
+[[ -n "$impl_block" ]] || err "continuity verifier impl not found in lib.rs"
+grep -q "no simulated fallback" <<<"$impl_block" \
+  || err "continuity impl lost its non-native refusal (AFT-CB R4c string missing)"
+if grep -q "SimulatedGroth16" <<<"$impl_block"; then
+  err "continuity impl delegates to SimulatedGroth16 — the simulated fallback is back"
+fi
+
+# 4. Pin constant present and equal to the governed document.
+pin_const=$(grep -oP 'CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN: &str =\s*\n?\s*"\K0x[0-9a-f]{64}' -z "$DRIVER_SRC/config.rs" | tr -d '\0' || true)
+[[ -n "$pin_const" ]] || err "governed pin constant missing from config.rs"
+pin_doc=$(python3 -c "import json;print(json.load(open('$ROOT/crates/aft-proofs/vkey.json'))['vkey_bytes32'])")
+if [[ -n "$pin_const" && "$pin_const" != "$pin_doc" ]]; then
+  err "pin drift: config.rs=$pin_const vkey.json=$pin_doc"
+fi
+
+if [[ $fail -ne 0 ]]; then
+  echo "check_aft_no_mock_proof: FAILED"
+  exit 1
+fi
+echo "no-mock-proof OK: no mock constructor, no Default driver, non-native lane refuses, pin matches vkey.json ($pin_doc)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,12 @@ jobs:
       - name: Theorem Assumes discipline (common boundary)
         run: bash .github/scripts/check_aft_theorem_assumes.sh
 
+      # R4c's gate: the release tree contains no mock succinct-proof
+      # constructor, the succinct continuity lane has no simulated
+      # fallback, and the driver pin matches the governed vkey.json.
+      - name: No mock proof constructor (succinct lane real-or-refuse)
+        run: bash .github/scripts/check_aft_no_mock_proof.sh
+
       - name: Determine whether formal sources changed
         id: formal_diff
         run: |

--- a/crates/consensus/src/aft/guardian_majority/mod.rs
+++ b/crates/consensus/src/aft/guardian_majority/mod.rs
@@ -276,7 +276,12 @@ struct SharedContinuityVerifier(Arc<dyn CanonicalCollapseContinuityVerifier>);
 
 impl Default for SharedContinuityVerifier {
     fn default() -> Self {
-        Self(Arc::new(SuccinctDriver::default()))
+        // The governed pin, not a mock (AFT-CB R4c): succinct-labeled
+        // proofs verify only through the native SP1 backend against the
+        // pinned vkey, and refuse in builds without that backend.
+        Self(Arc::new(SuccinctDriver::new(
+            zk_driver_succinct::config::SuccinctDriverConfig::pinned(),
+        )))
     }
 }
 

--- a/crates/consensus/src/aft/guardian_majority/tests_parts/base_asymptote.rs
+++ b/crates/consensus/src/aft/guardian_majority/tests_parts/base_asymptote.rs
@@ -1,20 +1,20 @@
 #[test]
-fn verify_canonical_collapse_backend_accepts_and_rejects_simulated_succinct_proofs() {
-    // Backend ROUTING only: the engine routes SuccinctSp1V1 to the zk
-    // driver, whose simulated lane accepts its own private recipe bytes and
-    // rejects mutations. The combined runtime path still rejects every
-    // succinct-labeled object at the types layer (AFT-CB R4c).
+fn verify_canonical_collapse_backend_refuses_succinct_without_native_backend() {
+    // Backend ROUTING: the engine routes SuccinctSp1V1 to the zk driver,
+    // which since AFT-CB R4c has NO simulated lane — a build without the
+    // native SP1 backend refuses even bytes that satisfy the retired
+    // simulated recipe. (This test suite builds the driver non-native.)
     let engine = GuardianMajorityEngine::new(AftSafetyMode::Asymptote);
     let mut collapse = test_canonical_collapse_object(1, None, [0x21u8; 32], [0x22u8; 32]);
     bind_simulated_succinct_continuity(&mut collapse);
 
-    engine
+    let err = engine
         .verify_canonical_collapse_backend(&collapse)
-        .expect("simulated succinct backend proof should verify");
-
-    let mut mutated = collapse.clone();
-    mutated.continuity_recursive_proof.proof_bytes[0] ^= 0xFF;
-    assert!(engine.verify_canonical_collapse_backend(&mutated).is_err());
+        .expect_err("succinct-labeled proof must refuse without the native backend");
+    assert!(
+        err.to_string().contains("native SP1 backend"),
+        "refusal names the missing backend, got: {err}"
+    );
 }
 
 #[test]

--- a/crates/node/src/bin/orchestration.rs
+++ b/crates/node/src/bin/orchestration.rs
@@ -557,7 +557,7 @@ where
                             beacon_vkey_bytes: beacon_bytes,
                             state_inclusion_vkey_hash: zk_cfg.state_inclusion_vkey.clone(),
                             state_inclusion_vkey_bytes: state_bytes,
-                            ..SuccinctDriverConfig::default()
+                            ..SuccinctDriverConfig::pinned()
                         };
                         let eth_verifier =
                             EthereumZkLightClient::new("eth-mainnet".to_string(), driver_config);

--- a/crates/plugins/ibc-service/src/light_clients/ethereum_zk.rs
+++ b/crates/plugins/ibc-service/src/light_clients/ethereum_zk.rs
@@ -25,13 +25,6 @@ impl EthereumZkLightClient {
         }
     }
 
-    /// Create a new client with default (mock) configuration.
-    pub fn new_mock(chain_id: String) -> Self {
-        Self {
-            chain_id,
-            zk_driver: Arc::new(SuccinctDriver::new_mock()),
-        }
-    }
 }
 
 #[async_trait]

--- a/crates/plugins/ibc-service/src/light_clients/ethereum_zk.rs
+++ b/crates/plugins/ibc-service/src/light_clients/ethereum_zk.rs
@@ -24,7 +24,6 @@ impl EthereumZkLightClient {
             zk_driver: Arc::new(SuccinctDriver::new(config)),
         }
     }
-
 }
 
 #[async_trait]

--- a/crates/plugins/zk-driver-succinct/src/config.rs
+++ b/crates/plugins/zk-driver-succinct/src/config.rs
@@ -49,8 +49,8 @@ impl SuccinctDriverConfig {
             beacon_vkey_bytes: Vec::new(),
             state_inclusion_vkey_hash: String::new(),
             state_inclusion_vkey_bytes: Vec::new(),
-            canonical_collapse_continuity_vkey_hash:
-                CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN.to_string(),
+            canonical_collapse_continuity_vkey_hash: CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN
+                .to_string(),
             canonical_collapse_continuity_vkey_bytes: pin_bytes(
                 CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN,
             ),
@@ -78,14 +78,10 @@ mod pin_tests {
     /// governance surface, this constant is the enforcement surface.
     #[test]
     fn config_pin_matches_governed_vkey_document() {
-        let doc_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../aft-proofs/vkey.json"
-        );
+        let doc_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../aft-proofs/vkey.json");
         let doc = std::fs::read_to_string(doc_path)
             .expect("governed pin document crates/aft-proofs/vkey.json exists");
-        let parsed: serde_json::Value =
-            serde_json::from_str(&doc).expect("vkey.json parses");
+        let parsed: serde_json::Value = serde_json::from_str(&doc).expect("vkey.json parses");
         assert_eq!(
             parsed["vkey_bytes32"].as_str().expect("vkey_bytes32 field"),
             CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN,

--- a/crates/plugins/zk-driver-succinct/src/config.rs
+++ b/crates/plugins/zk-driver-succinct/src/config.rs
@@ -1,41 +1,110 @@
 // Path: crates/zk-driver-succinct/src/config.rs
 use serde::{Deserialize, Serialize};
 
+/// The governed verifying-key pin for the aft-continuity guest (AFT-CB
+/// R4c). This value mirrors `crates/aft-proofs/vkey.json` — the governed
+/// pin document — and a test asserts the two never drift. Changing it is
+/// a protocol-parameter change: it lands only through a reviewed PR that
+/// names the guest change forcing it. UNPINNED is a refusal state, never
+/// a fallback.
+pub const CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN: &str =
+    "0x00ccba8a34fdefd3b465c31e26fe7f953da63e4cd371dbdf9179974e47a5cf02";
+
 /// Configuration for the Succinct ZK Driver.
+///
+/// There is deliberately NO `Default` impl (AFT-CB R4c): a default-mock
+/// configuration was the mock constructor's substance, and release code
+/// must choose its trust anchors explicitly. Use [`SuccinctDriverConfig::pinned`]
+/// for the governed AFT-continuity pin, or construct explicitly.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SuccinctDriverConfig {
     /// The expected hash of the Beacon VK (hex string). This serves as the trust anchor.
     pub beacon_vkey_hash: String,
     /// The raw bytes of the Beacon VK, required for actual verification in native mode.
-    /// In mock mode, this can be empty.
+    /// Empty means unprovisioned: native verification refuses.
     pub beacon_vkey_bytes: Vec<u8>,
 
     /// The expected hash of the State Inclusion VK (hex string). This serves as the trust anchor.
     pub state_inclusion_vkey_hash: String,
     /// The raw bytes of the State Inclusion VK, required for actual verification in native mode.
-    /// In mock mode, this can be empty.
+    /// Empty means unprovisioned: native verification refuses.
     pub state_inclusion_vkey_bytes: Vec<u8>,
 
     /// The expected hash of the canonical-collapse continuity VK (hex string).
     pub canonical_collapse_continuity_vkey_hash: String,
-    /// The raw bytes of the canonical-collapse continuity VK, required for native verification.
-    /// In mock mode, this can be empty.
+    /// The 32-byte canonical vkey digest (`vk.bytes32()`) the SP1 backend
+    /// verifies against. Empty means unprovisioned: verification refuses.
     pub canonical_collapse_continuity_vkey_bytes: Vec<u8>,
 }
 
-impl Default for SuccinctDriverConfig {
-    fn default() -> Self {
+impl SuccinctDriverConfig {
+    /// The governed configuration: the AFT canonical-collapse continuity
+    /// lane pinned to [`CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN`]; the IBC
+    /// lanes (beacon, state-inclusion) explicitly UNPROVISIONED — their
+    /// native verification refuses until a deployment provisions real
+    /// vkeys through its own governed configuration.
+    pub fn pinned() -> Self {
         Self {
-            // Placeholders for development (Mock mode defaults)
-            beacon_vkey_hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
-                .to_string(),
+            beacon_vkey_hash: String::new(),
             beacon_vkey_bytes: Vec::new(),
-            state_inclusion_vkey_hash:
-                "0x0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            state_inclusion_vkey_hash: String::new(),
             state_inclusion_vkey_bytes: Vec::new(),
             canonical_collapse_continuity_vkey_hash:
-                "0x0000000000000000000000000000000000000000000000000000000000000000".to_string(),
-            canonical_collapse_continuity_vkey_bytes: Vec::new(),
+                CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN.to_string(),
+            canonical_collapse_continuity_vkey_bytes: pin_bytes(
+                CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN,
+            ),
         }
+    }
+}
+
+/// Decodes a `0x`-prefixed 32-byte pin into its raw bytes. The pin is a
+/// compile-time constant; a malformed pin is a programming error surfaced
+/// at first use, and the empty vector it yields is a refusal state in
+/// every verification path (never a silent accept).
+fn pin_bytes(pin: &str) -> Vec<u8> {
+    match hex::decode(pin.trim_start_matches("0x")) {
+        Ok(bytes) if bytes.len() == 32 => bytes,
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod pin_tests {
+    use super::*;
+
+    /// The config pin and the governed pin document
+    /// (`crates/aft-proofs/vkey.json`) must never drift: vkey.json is the
+    /// governance surface, this constant is the enforcement surface.
+    #[test]
+    fn config_pin_matches_governed_vkey_document() {
+        let doc_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../aft-proofs/vkey.json"
+        );
+        let doc = std::fs::read_to_string(doc_path)
+            .expect("governed pin document crates/aft-proofs/vkey.json exists");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&doc).expect("vkey.json parses");
+        assert_eq!(
+            parsed["vkey_bytes32"].as_str().expect("vkey_bytes32 field"),
+            CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN,
+            "config pin drifted from the governed vkey.json pin"
+        );
+    }
+
+    #[test]
+    fn pinned_config_carries_decoded_pin_bytes() {
+        let cfg = SuccinctDriverConfig::pinned();
+        assert_eq!(cfg.canonical_collapse_continuity_vkey_bytes.len(), 32);
+        assert_eq!(
+            format!(
+                "0x{}",
+                hex::encode(&cfg.canonical_collapse_continuity_vkey_bytes)
+            ),
+            CANONICAL_COLLAPSE_CONTINUITY_VKEY_PIN
+        );
+        assert!(cfg.beacon_vkey_bytes.is_empty(), "IBC lanes unprovisioned");
+        assert!(cfg.state_inclusion_vkey_bytes.is_empty());
     }
 }

--- a/crates/plugins/zk-driver-succinct/src/lib.rs
+++ b/crates/plugins/zk-driver-succinct/src/lib.rs
@@ -111,7 +111,6 @@ impl SuccinctDriver {
             _config: Arc::new(config),
         }
     }
-
 }
 
 impl CanonicalCollapseContinuityVerifier for SuccinctDriver {

--- a/crates/plugins/zk-driver-succinct/src/lib.rs
+++ b/crates/plugins/zk-driver-succinct/src/lib.rs
@@ -23,12 +23,13 @@ use std::sync::Arc; // [FIX] Added async_trait import
 // Re-export canonical types from the shared crate
 pub use zk_types::{BeaconPublicInputs, StateInclusionPublicInputs};
 
-/// Deterministic proof bytes for the SIMULATED (non-native) continuity lane.
+/// Deterministic bytes matching the RETIRED simulated continuity recipe.
 ///
-/// This is the plugin's own simulation rule, private to the simulated driver:
-/// the kernel reference runtime no longer defines or accepts any mock
-/// succinct bytes (AFT-CB P0.3). Real `SuccinctSp1V1` bytes come only from
-/// the SP1 backend behind the `native` feature.
+/// AFT-CB R4c: no verification path accepts these bytes anymore — the
+/// succinct continuity lane verifies only through the native SP1 backend
+/// and REFUSES in builds without it. This function survives solely so
+/// adversarial tests can construct "bytes that would have satisfied the
+/// old mock" and prove every layer now rejects them.
 pub fn simulated_continuity_proof_bytes(
     public_inputs: &CanonicalCollapseContinuityPublicInputs,
 ) -> Result<Vec<u8>, ioi_api::error::CryptoError> {
@@ -101,21 +102,16 @@ pub struct SuccinctDriver {
 }
 
 impl SuccinctDriver {
+    /// The only constructor (AFT-CB R4c): a driver exists only over an
+    /// explicitly chosen configuration. The mock constructor and the
+    /// `Default` impl that routed to it are deleted, not gated — use
+    /// `SuccinctDriverConfig::pinned()` for the governed AFT pin.
     pub fn new(config: SuccinctDriverConfig) -> Self {
         Self {
             _config: Arc::new(config),
         }
     }
 
-    pub fn new_mock() -> Self {
-        Self::new(SuccinctDriverConfig::default())
-    }
-}
-
-impl Default for SuccinctDriver {
-    fn default() -> Self {
-        Self::new_mock()
-    }
 }
 
 impl CanonicalCollapseContinuityVerifier for SuccinctDriver {
@@ -130,11 +126,25 @@ impl CanonicalCollapseContinuityVerifier for SuccinctDriver {
                 "HashPcdV1 continuity proofs are verified by the reference runtime, not the succinct driver".into(),
             )),
             CanonicalCollapseContinuityProofSystem::SuccinctSp1V1 => {
-                let public_inputs_bytes = bincode::serialize(public_inputs)
-                    .map_err(|e| CoreError::Custom(format!("Serialization failed: {}", e)))?;
                 #[cfg(feature = "native")]
                 {
                     use crate::sp1_backend::Sp1ProofSystem;
+                    // The vkey is the governed trust anchor (AFT-CB R4c):
+                    // unpinned/unprovisioned is a refusal state, never a
+                    // fallback to any weaker check.
+                    if self
+                        ._config
+                        .canonical_collapse_continuity_vkey_bytes
+                        .is_empty()
+                    {
+                        return Err(CoreError::Custom(
+                            "SuccinctSp1V1 continuity vkey is unprovisioned; \
+                             verification refuses (AFT-CB R4c)"
+                                .into(),
+                        ));
+                    }
+                    let public_inputs_bytes = bincode::serialize(public_inputs)
+                        .map_err(|e| CoreError::Custom(format!("Serialization failed: {}", e)))?;
                     let valid = Sp1ProofSystem::verify(
                         &self._config.canonical_collapse_continuity_vkey_bytes,
                         &proof.to_vec(),
@@ -151,14 +161,18 @@ impl CanonicalCollapseContinuityVerifier for SuccinctDriver {
 
                 #[cfg(not(feature = "native"))]
                 {
-                    let valid = SimulatedGroth16::verify(&(), &proof.to_vec(), &public_inputs_bytes)
-                        .map_err(|e| CoreError::Crypto(e.to_string()))?;
-                    if !valid {
-                        return Err(CoreError::Custom(
-                            "mock canonical collapse continuity verification failed".into(),
-                        ));
-                    }
-                    Ok(())
+                    // AFT-CB R4c: the succinct path's only backend is the
+                    // real one. A build without the native SP1 backend
+                    // REFUSES succinct-labeled proofs — there is no
+                    // simulated fallback on this lane. (`proof` and
+                    // `public_inputs` are intentionally unread here.)
+                    let _ = proof;
+                    Err(CoreError::Custom(
+                        "SuccinctSp1V1 continuity verification requires the native \
+                         SP1 backend; this build carries none and refuses \
+                         (AFT-CB R4c — no simulated fallback)"
+                            .into(),
+                    ))
                 }
             }
         }

--- a/crates/plugins/zk-driver-succinct/src/tests/continuity.rs
+++ b/crates/plugins/zk-driver-succinct/src/tests/continuity.rs
@@ -1,3 +1,4 @@
+use crate::config::SuccinctDriverConfig;
 use crate::{simulated_continuity_proof_bytes, SuccinctDriver};
 use ioi_api::consensus::CanonicalCollapseContinuityVerifier;
 use ioi_types::app::{
@@ -18,42 +19,56 @@ fn sample_public_inputs() -> CanonicalCollapseContinuityPublicInputs {
     }
 }
 
+/// AFT-CB R4c cfg-audit: a build WITHOUT the native SP1 backend refuses
+/// SuccinctSp1V1 continuity verification outright — even for bytes that
+/// satisfy the retired simulated recipe. There is no simulated fallback
+/// on this lane.
+#[cfg(not(feature = "native"))]
 #[test]
-fn simulated_continuity_verifier_accepts_valid_succinct_proof() {
-    let driver = SuccinctDriver::new_mock();
+fn non_native_build_refuses_succinct_continuity_even_for_old_recipe_bytes() {
+    let driver = SuccinctDriver::new(SuccinctDriverConfig::pinned());
     let inputs = sample_public_inputs();
-    let proof = simulated_continuity_proof_bytes(&inputs).expect("simulated proof");
+    let old_recipe = simulated_continuity_proof_bytes(&inputs).expect("recipe bytes");
 
-    driver
+    let err = driver
         .verify_canonical_collapse_continuity(
             CanonicalCollapseContinuityProofSystem::SuccinctSp1V1,
-            &proof,
+            &old_recipe,
             &inputs,
         )
-        .expect("simulated succinct continuity proof should verify");
-}
-
-#[test]
-fn simulated_continuity_verifier_rejects_mutated_succinct_proof() {
-    let driver = SuccinctDriver::new_mock();
-    let inputs = sample_public_inputs();
-    let mut proof = simulated_continuity_proof_bytes(&inputs).expect("simulated proof");
-    proof[0] ^= 0xFF;
-
-    let result = driver.verify_canonical_collapse_continuity(
-        CanonicalCollapseContinuityProofSystem::SuccinctSp1V1,
-        &proof,
-        &inputs,
-    );
+        .expect_err("non-native build must refuse the succinct lane");
     assert!(
-        result.is_err(),
-        "mutated succinct continuity proof must fail"
+        err.to_string().contains("native SP1 backend"),
+        "refusal must name the missing backend, got: {err}"
     );
 }
 
+/// AFT-CB R4c: a native build with an UNPROVISIONED vkey refuses — the
+/// pin is the trust anchor, and its absence is a refusal state, never a
+/// fallback.
+#[cfg(feature = "native")]
 #[test]
-fn simulated_continuity_verifier_rejects_reference_hash_proof_system() {
-    let driver = SuccinctDriver::new_mock();
+fn native_build_refuses_unprovisioned_continuity_vkey() {
+    let config = SuccinctDriverConfig {
+        canonical_collapse_continuity_vkey_bytes: Vec::new(),
+        ..SuccinctDriverConfig::pinned()
+    };
+    let driver = SuccinctDriver::new(config);
+    let inputs = sample_public_inputs();
+
+    let err = driver
+        .verify_canonical_collapse_continuity(
+            CanonicalCollapseContinuityProofSystem::SuccinctSp1V1,
+            &[0u8; 32],
+            &inputs,
+        )
+        .expect_err("unprovisioned vkey must refuse");
+    assert!(err.to_string().contains("unprovisioned"));
+}
+
+#[test]
+fn continuity_verifier_rejects_reference_hash_proof_system() {
+    let driver = SuccinctDriver::new(SuccinctDriverConfig::pinned());
     let inputs = sample_public_inputs();
 
     let result = driver.verify_canonical_collapse_continuity(

--- a/crates/validator/src/standard/orchestration/aft_collapse.rs
+++ b/crates/validator/src/standard/orchestration/aft_collapse.rs
@@ -368,7 +368,7 @@ fn verify_canonical_collapse_backend(collapse: &CanonicalCollapseObject) -> Resu
                 proof.payload_hash,
                 proof.previous_recursive_proof_hash,
             );
-            SuccinctDriver::default()
+            SuccinctDriver::new(zk_driver_succinct::config::SuccinctDriverConfig::pinned())
                 .verify_canonical_collapse_continuity(
                     proof.proof_system,
                     &proof.proof_bytes,

--- a/crates/validator/src/standard/orchestration/aft_collapse/tests.rs
+++ b/crates/validator/src/standard/orchestration/aft_collapse/tests.rs
@@ -173,11 +173,12 @@ fn align_block_parent_to_previous_result(
 }
 
 #[test]
-fn verify_canonical_collapse_backend_accepts_and_rejects_simulated_succinct_proofs() {
-    // Backend ROUTING only: the validator routes SuccinctSp1V1 to the zk
-    // driver, whose simulated lane accepts its own private recipe bytes and
-    // rejects mutations. The combined persisted path still rejects every
-    // succinct-labeled object at the types layer (AFT-CB R4c).
+fn verify_canonical_collapse_backend_refuses_succinct_without_native_backend() {
+    // Backend ROUTING: the validator routes SuccinctSp1V1 to the zk
+    // driver, which since AFT-CB R4c has NO simulated lane — a build
+    // without the native SP1 backend refuses even bytes that satisfy the
+    // retired simulated recipe. (This test suite builds the driver
+    // non-native.)
     let mut collapse = CanonicalCollapseObject {
         height: 1,
         previous_canonical_collapse_commitment_hash: [0u8; 32],
@@ -195,12 +196,12 @@ fn verify_canonical_collapse_backend_accepts_and_rejects_simulated_succinct_proo
         .expect("bind continuity");
     bind_simulated_succinct_continuity(&mut collapse);
 
-    verify_canonical_collapse_backend(&collapse)
-        .expect("simulated succinct backend proof should verify");
-
-    let mut mutated = collapse.clone();
-    mutated.continuity_recursive_proof.proof_bytes[0] ^= 0xFF;
-    assert!(verify_canonical_collapse_backend(&mutated).is_err());
+    let err = verify_canonical_collapse_backend(&collapse)
+        .expect_err("succinct-labeled proof must refuse without the native backend");
+    assert!(
+        err.to_string().contains("native SP1 backend"),
+        "refusal names the missing backend, got: {err}"
+    );
 }
 
 #[tokio::test]
@@ -573,10 +574,14 @@ async fn require_persisted_aft_canonical_collapse_rejects_succinct_labeled_previ
     let error = require_persisted_aft_canonical_collapse_for_block(&client, &block)
         .await
         .expect_err("succinct-labeled predecessor should fail");
+    let message = error.to_string();
     assert!(
-        error
-            .to_string()
-            .contains("reserved for a real succinct backend"),
+        // Either refusal layer is the honest outcome (AFT-CB R4c): the
+        // types-level reference runtime refuses succinct-labeled proofs
+        // it cannot own, and the driver refuses without the native SP1
+        // backend. Both are refusals, never a weaker mismatch error.
+        message.contains("reserved for a real succinct backend")
+            || message.contains("requires the native SP1 backend"),
         "unexpected error: {error}"
     );
 }

--- a/crates/validator/src/standard/workload/setup.rs
+++ b/crates/validator/src/standard/workload/setup.rs
@@ -567,7 +567,7 @@ where
                         beacon_vkey_bytes: beacon_bytes,
                         state_inclusion_vkey_hash: zk_cfg.state_inclusion_vkey.clone(),
                         state_inclusion_vkey_bytes: state_bytes,
-                        ..SuccinctDriverConfig::default()
+                        ..SuccinctDriverConfig::pinned()
                     };
                     let eth_verifier =
                         EthereumZkLightClient::new("eth-mainnet".to_string(), driver_config);


### PR DESCRIPTION
## AFT-CB R4c — proof-system completion (kills Q4)

Completes P0.3's types-level fence at the driver layer: **what a `SuccinctSp1V1` proof hits by default is now the real backend or a typed refusal — never a simulation.** `HashPcdV1` remains the reference runtime's only produced system (R6 lattice label: evidence-only), and the types-level succinct refusal stays.

### The deletions (not gatings)
- `SuccinctDriver::new_mock()` and `impl Default for SuccinctDriver` — gone.
- `SuccinctDriverConfig::Default` (zero-hash placeholders — the mock's substance) — gone; replaced by `pinned()`.
- The non-native `SuccinctSp1V1` arm's `SimulatedGroth16` delegation — the last mock verification path — replaced by a typed refusal naming the missing backend. The native arm refuses an unprovisioned vkey.
- `EthereumZkLightClient::new_mock` — gone (no callers).

### The pin
`pinned()` carries the governed pin `0x00ccba8a…cf02` decoded to verification-ready bytes (the SP1 backend's vk input IS the bytes32 digest); IBC lanes explicitly unprovisioned. A test binds the constant to `crates/aft-proofs/vkey.json`: governance surface and enforcement surface cannot drift.

### Gate + drill
`check_aft_no_mock_proof.sh` — no `fn new_mock` across five crates, no Default driver impl, refusal-not-simulation inside the continuity impl, pin equality with vkey.json — wired into CI. **Mutation drilled**: reintroduced `fn new_mock` → gate RED at file:line → reverted → green.

### Proof
| Surface | Result |
|---|---|
| zk-driver-succinct (incl. cfg-audit refusal test + 2 pin tests) | 4/4 |
| ioi-consensus `--features aft` | 96/96 |
| ioi-validator aft_collapse | 11/11 |
| ioi-node orchestration / ibc-service | compile clean |
| e2e real proofs | P2.5 chain harness (3-step CORE + tamper drills), local + nightly lane |

🤖 Generated with [Claude Code](https://claude.com/claude-code)