### PR TITLE
feat(consensus): ring membership simulator — the five R5 sim gates (AFT-CB R5 stage 2)

### DIFF
--- a/crates/consensus/src/aft/mod.rs
+++ b/crates/consensus/src/aft/mod.rs
@@ -1,6 +1,7 @@
 pub mod boundary_ring_trace;
 pub mod experimental;
 pub mod guardian_majority;
+pub mod ring_membership_sim;
 
 use crate::{ConsensusDecision, ConsensusEngine, PenaltyEngine, PenaltyMechanism};
 use async_trait::async_trait;

--- a/crates/consensus/src/aft/ring_membership_sim.rs
+++ b/crates/consensus/src/aft/ring_membership_sim.rs
@@ -1,0 +1,229 @@
+//! AFT-CB R5 stage 2 — the boundary-ring MEMBERSHIP simulator (n ≤ 8).
+//!
+//! Extends the estate's abstract-simulation idiom (state machines over
+//! counts and records, not network executions) with a multi-member ring
+//! driving the REAL stage-1 membership types: journal-guarded single
+//! final-ack per member, n-of-n seal assembly over the LIVE ring
+//! configuration, assurance-preserving handover as the only strong-ring
+//! transition, typed re-genesis lineage severing, custody-gated bond
+//! release, beacon sortition, and watchtower records that gate nothing.
+//!
+//! The five R5 sim gates live in this module's tests:
+//! (a) one withholder freezes seal cadence while the live tier produces;
+//! (b) three-Byzantine-of-four equivocation yields ZERO conflicting
+//!     seals (uniqueness DERIVED from the honest journal, not enforced
+//!     by the seal map);
+//! (c) succession without reconstruction refuses bond release;
+//! (d) handover end-to-end + lineage queries: handover preserves
+//!     lineage, a re-genesis root severs it — never continuity;
+//! (e) seat assignment reproduces deterministically from the beacon,
+//!     and a seal verifies identically with and without watchtower
+//!     countersignatures.
+
+use ioi_types::app::{
+    build_assurance_preserving_handover, AccountId, AssurancePreservingHandover,
+    BoundaryRingConfig, HandoverAcceptance, HandoverApproval, RingConfigClose,
+    WatchtowerCountersignRecord,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// One simulated ring member: honesty flag and the A3 journal.
+#[derive(Debug, Clone)]
+pub struct SimMember {
+    /// Whether the member follows the honest single-final-ack rule.
+    pub honest: bool,
+    /// The journal: slot → the ONE root this member final-acked.
+    pub journal: BTreeMap<u64, [u8; 32]>,
+    /// Whether the member is currently withholding acks entirely.
+    pub withholding: bool,
+}
+
+/// The membership simulator state.
+#[derive(Debug, Clone)]
+pub struct BoundaryRingMembershipSim {
+    /// The live ring configuration (seals need ITS n-of-n).
+    pub config: BoundaryRingConfig,
+    /// Closed predecessor configurations, by version.
+    pub closed_configs: BTreeMap<u64, BoundaryRingConfig>,
+    /// Member state, keyed by account.
+    pub members: BTreeMap<AccountId, SimMember>,
+    /// Final-ack shares in existence: (member, slot, root).
+    pub acks: BTreeSet<(AccountId, u64, [u8; 32])>,
+    /// Assembled seals: slot → every root sealed for it. Uniqueness is
+    /// ASSERTED by the gates, never enforced here — the map can hold a
+    /// conflict if the discipline fails, which is exactly what the
+    /// drills probe.
+    pub seals: BTreeMap<u64, BTreeSet<[u8; 32]>>,
+    /// The live tier's block height — advances independently of seals.
+    pub live_tier_height: u64,
+    /// Re-genesis roots declared during the run (event ordinals).
+    pub regenesis_events: Vec<u64>,
+    /// Watchtower countersignatures received (from ANYONE); nothing in
+    /// this simulator reads them back.
+    pub watchtower_records: Vec<WatchtowerCountersignRecord>,
+    /// Monotone protocol-event counter.
+    pub event_counter: u64,
+}
+
+impl BoundaryRingMembershipSim {
+    /// Builds a simulator over a fresh configuration; `honest` flags
+    /// align with `config.members` order.
+    pub fn new(config: BoundaryRingConfig, honest: &[bool]) -> Result<Self, String> {
+        if config.members.len() != honest.len() {
+            return Err("honesty flags must cover every member".into());
+        }
+        if config.members.len() > 8 {
+            return Err("the membership simulator models rings up to n = 8".into());
+        }
+        let members = config
+            .members
+            .iter()
+            .zip(honest)
+            .map(|(account, flag)| {
+                (
+                    *account,
+                    SimMember {
+                        honest: *flag,
+                        journal: BTreeMap::new(),
+                        withholding: false,
+                    },
+                )
+            })
+            .collect();
+        Ok(Self {
+            config,
+            closed_configs: BTreeMap::new(),
+            members,
+            acks: BTreeSet::new(),
+            seals: BTreeMap::new(),
+            live_tier_height: 0,
+            regenesis_events: Vec::new(),
+            watchtower_records: Vec::new(),
+            event_counter: 0,
+        })
+    }
+
+    /// The live tier produces a block: ALWAYS possible — no seal rule
+    /// appears in this path (two-tier separation).
+    pub fn live_tier_produce(&mut self) -> u64 {
+        self.live_tier_height += 1;
+        self.event_counter += 1;
+        self.live_tier_height
+    }
+
+    /// An honest member final-acks (slot, root) under the A3 journal
+    /// guard: one root per slot, forever.
+    pub fn honest_final_ack(
+        &mut self,
+        account: &AccountId,
+        slot: u64,
+        root: [u8; 32],
+    ) -> Result<(), String> {
+        let member = self
+            .members
+            .get_mut(account)
+            .ok_or_else(|| "unknown member".to_string())?;
+        if !member.honest {
+            return Err("byzantine members do not use the honest ack path".into());
+        }
+        if member.withholding {
+            return Err("member is withholding".into());
+        }
+        if let Some(journaled) = member.journal.get(&slot) {
+            if *journaled != root {
+                return Err("journal occupied: single final-ack discipline refuses".into());
+            }
+            return Ok(());
+        }
+        member.journal.insert(slot, root);
+        self.acks.insert((*account, slot, root));
+        self.event_counter += 1;
+        Ok(())
+    }
+
+    /// A Byzantine member emits ANY share, any number of times — no
+    /// journal binds it.
+    pub fn byzantine_emit(
+        &mut self,
+        account: &AccountId,
+        slot: u64,
+        root: [u8; 32],
+    ) -> Result<(), String> {
+        let member = self
+            .members
+            .get(account)
+            .ok_or_else(|| "unknown member".to_string())?;
+        if member.honest {
+            return Err("honest members cannot take the byzantine path".into());
+        }
+        self.acks.insert((*account, slot, root));
+        self.event_counter += 1;
+        Ok(())
+    }
+
+    /// Attempts to assemble a seal for (slot, root): n-of-n over the
+    /// LIVE configuration — every current member's share must exist.
+    pub fn try_seal(&mut self, slot: u64, root: [u8; 32]) -> Result<bool, String> {
+        for account in &self.config.members {
+            if !self.acks.contains(&(*account, slot, root)) {
+                return Ok(false);
+            }
+        }
+        self.seals.entry(slot).or_default().insert(root);
+        self.event_counter += 1;
+        Ok(true)
+    }
+
+    /// True iff any slot carries two different sealed roots — the
+    /// disaster the uniqueness gates assert never happens.
+    pub fn has_conflicting_seals(&self) -> bool {
+        self.seals.values().any(|roots| roots.len() > 1)
+    }
+
+    /// Executes the assurance-preserving handover: the ONLY transition
+    /// that replaces the strong ring. On success the old configuration
+    /// closes and the new one becomes live (new members default honest
+    /// and un-journaled).
+    pub fn handover(
+        &mut self,
+        new_config: BoundaryRingConfig,
+        approvals: &[HandoverApproval],
+        acceptances: &[HandoverAcceptance],
+    ) -> Result<AssurancePreservingHandover, String> {
+        let handover =
+            build_assurance_preserving_handover(&self.config, &new_config, approvals, acceptances)?;
+        self.event_counter += 1;
+        let mut closed = self.config.clone();
+        closed.closed_by = Some(RingConfigClose {
+            successor_version: new_config.version,
+            closed_at_event: self.event_counter,
+        });
+        self.closed_configs.insert(closed.version, closed);
+        for account in &new_config.members {
+            self.members.entry(*account).or_insert(SimMember {
+                honest: true,
+                journal: BTreeMap::new(),
+                withholding: false,
+            });
+        }
+        self.config = new_config;
+        Ok(handover)
+    }
+
+    /// Declares a re-genesis root at the current event ordinal.
+    pub fn declare_regenesis(&mut self) -> u64 {
+        self.event_counter += 1;
+        self.regenesis_events.push(self.event_counter);
+        self.event_counter
+    }
+
+    /// Records a watchtower countersignature — from ANYONE. Nothing in
+    /// this simulator ever reads these back: they gate nothing.
+    pub fn record_watchtower(&mut self, record: WatchtowerCountersignRecord) {
+        self.watchtower_records.push(record);
+    }
+}
+
+#[cfg(test)]
+#[path = "ring_membership_sim/tests.rs"]
+mod tests;

--- a/crates/consensus/src/aft/ring_membership_sim/tests.rs
+++ b/crates/consensus/src/aft/ring_membership_sim/tests.rs
@@ -1,0 +1,227 @@
+use super::*;
+use ioi_types::app::{
+    assign_seats, authorize_bond_release, lineage_relation, AnchoredRegenesisRoot,
+    ConstituencyFloor, CustodyHandoverReceipt, LineageRelation, RingMemberRegistration,
+};
+
+fn account(byte: u8) -> AccountId {
+    AccountId([byte; 32])
+}
+
+fn config(version: u64, member_bytes: &[u8]) -> BoundaryRingConfig {
+    BoundaryRingConfig {
+        version,
+        members: member_bytes.iter().map(|b| account(*b)).collect(),
+        member_bonds: Default::default(),
+        activated_at_event: 0,
+        closed_by: None,
+    }
+}
+
+fn approval(member: u8, old: u64, new: u64) -> HandoverApproval {
+    HandoverApproval {
+        member: account(member),
+        old_version: old,
+        new_version: new,
+        signature_bytes: vec![member],
+    }
+}
+
+fn acceptance(member: u8, new: u64) -> HandoverAcceptance {
+    HandoverAcceptance {
+        member: account(member),
+        new_version: new,
+        signature_bytes: vec![member],
+    }
+}
+
+/// Gate (a): one withholder freezes seal cadence; the live tier keeps
+/// producing blocks (two-tier separation).
+#[test]
+fn one_withholder_freezes_seals_while_live_tier_produces() {
+    let mut sim =
+        BoundaryRingMembershipSim::new(config(1, &[1, 2, 3, 4]), &[true, true, true, true])
+            .expect("sim");
+    sim.members.get_mut(&account(4)).unwrap().withholding = true;
+
+    let root = [0xAA; 32];
+    for member in [1u8, 2, 3] {
+        sim.honest_final_ack(&account(member), 1, root)
+            .expect("ack");
+    }
+    assert!(sim.honest_final_ack(&account(4), 1, root).is_err());
+    assert!(
+        !sim.try_seal(1, root).expect("try"),
+        "n-of-n unmet: no seal"
+    );
+
+    for _ in 0..10 {
+        sim.live_tier_produce();
+    }
+    assert_eq!(sim.live_tier_height, 10, "live tier progressed regardless");
+    assert!(sim.seals.is_empty(), "seal cadence frozen the whole time");
+}
+
+/// Gate (b): n = 4 with THREE Byzantine equivocators and one honest
+/// journal-guarded member — zero conflicting seals, ever. Uniqueness is
+/// DERIVED (the honest share can exist for only one root), not enforced
+/// by the seal map, which would happily hold a conflict.
+#[test]
+fn three_byzantine_of_four_never_assemble_conflicting_seals() {
+    let mut sim =
+        BoundaryRingMembershipSim::new(config(1, &[1, 2, 3, 4]), &[true, false, false, false])
+            .expect("sim");
+    let (r_x, r_y) = ([0xAA; 32], [0xBB; 32]);
+
+    // Every Byzantine member equivocates on BOTH roots.
+    for member in [2u8, 3, 4] {
+        sim.byzantine_emit(&account(member), 1, r_x).expect("emit");
+        sim.byzantine_emit(&account(member), 1, r_y).expect("emit");
+    }
+    // The honest member journals exactly one.
+    sim.honest_final_ack(&account(1), 1, r_x).expect("ack");
+    assert!(
+        sim.honest_final_ack(&account(1), 1, r_y).is_err(),
+        "journal refuses the second root"
+    );
+
+    assert!(
+        sim.try_seal(1, r_x).expect("try"),
+        "the journaled root seals"
+    );
+    assert!(!sim.try_seal(1, r_y).expect("try"), "the other cannot");
+    assert!(!sim.has_conflicting_seals(), "zero conflicting seals");
+}
+
+/// Gate (c): succession without reconstruction refuses bond release;
+/// with the successor's acknowledgement it releases.
+#[test]
+fn succession_without_reconstruction_refuses_bond_release() {
+    let member = account(3);
+    let unreconstructed = CustodyHandoverReceipt {
+        member,
+        config_version: 1,
+        reconstructed_surface_root: [0u8; 32],
+        successor_acknowledgement_bytes: Vec::new(),
+    };
+    assert!(authorize_bond_release(&member, 1, &unreconstructed).is_err());
+
+    let reconstructed = CustodyHandoverReceipt {
+        member,
+        config_version: 1,
+        reconstructed_surface_root: [0x77; 32],
+        successor_acknowledgement_bytes: vec![1],
+    };
+    authorize_bond_release(&member, 1, &reconstructed).expect("release");
+}
+
+/// Gate (d): the handover ceremony end-to-end — old-ring unanimity plus
+/// new-ring acceptance activates the successor; seals resume under it;
+/// a handover PRESERVES lineage while a re-genesis root SEVERS it, and
+/// a severed crossing can never read as continuity.
+#[test]
+fn handover_end_to_end_and_regenesis_severs_lineage() {
+    let mut sim =
+        BoundaryRingMembershipSim::new(config(1, &[1, 2, 3, 4]), &[true; 4]).expect("sim");
+    let before_event = sim.event_counter;
+
+    let new_config = config(2, &[2, 3, 4, 5]);
+    let approvals: Vec<_> = [1u8, 2, 3, 4].iter().map(|m| approval(*m, 1, 2)).collect();
+    let acceptances: Vec<_> = [2u8, 3, 4, 5].iter().map(|m| acceptance(*m, 2)).collect();
+    sim.handover(new_config, &approvals, &acceptances)
+        .expect("ceremony completes");
+    assert_eq!(sim.config.version, 2);
+    assert!(sim.closed_configs.get(&1).unwrap().closed_by.is_some());
+
+    // Seals resume under the NEW ring's n-of-n (member 5 now required).
+    let root = [0xCC; 32];
+    for member in [2u8, 3, 4, 5] {
+        sim.honest_final_ack(&account(member), 2, root)
+            .expect("ack");
+    }
+    assert!(
+        sim.try_seal(2, root).expect("try"),
+        "cadence resumed under v2"
+    );
+
+    // The handover preserved lineage: no root lies across the ceremony.
+    let roots: Vec<AnchoredRegenesisRoot> = sim
+        .regenesis_events
+        .iter()
+        .map(|event| AnchoredRegenesisRoot {
+            lineage_id: [1u8; 32],
+            anchor_reference: [2u8; 32],
+            genesis_state_root: [3u8; 32],
+            declared_at_event: *event,
+        })
+        .collect();
+    assert_eq!(
+        lineage_relation(&roots, before_event, sim.event_counter),
+        LineageRelation::SameLineage,
+        "handover is continuity"
+    );
+
+    // A re-genesis root severs: the crossing MUST read NewLineage.
+    let pre_regenesis = sim.event_counter;
+    sim.declare_regenesis();
+    let roots: Vec<AnchoredRegenesisRoot> = sim
+        .regenesis_events
+        .iter()
+        .map(|event| AnchoredRegenesisRoot {
+            lineage_id: [1u8; 32],
+            anchor_reference: [2u8; 32],
+            genesis_state_root: [3u8; 32],
+            declared_at_event: *event,
+        })
+        .collect();
+    assert_eq!(
+        lineage_relation(&roots, pre_regenesis, sim.event_counter + 1),
+        LineageRelation::NewLineage,
+        "a re-genesis crossing is NEVER continuity"
+    );
+}
+
+/// Gate (e): seat assignment reproduces deterministically from the
+/// beacon and honors floors; a watchtower countersignature is recorded
+/// but the seal outcome is IDENTICAL without it.
+#[test]
+fn sortition_reproduces_and_watchtowers_gate_nothing() {
+    let candidates: Vec<RingMemberRegistration> = (1u8..=8)
+        .map(|b| RingMemberRegistration {
+            account_id: account(b),
+            bond_amount: 1_000,
+            constituency_id: u32::from(b % 2),
+            registered_at_event: 0,
+        })
+        .collect();
+    let floors = vec![ConstituencyFloor {
+        constituency_id: 1,
+        min_seats: 2,
+    }];
+    let beacon = [0x55; 32];
+    let seats_a = assign_seats(&beacon, &candidates, &floors, 4).expect("assign");
+    let seats_b = assign_seats(&beacon, &candidates, &floors, 4).expect("assign");
+    assert_eq!(seats_a, seats_b, "deterministic from the beacon");
+
+    // Two identical runs, one with a watchtower record: same seals.
+    let run = |with_watchtower: bool| -> BTreeMap<u64, BTreeSet<[u8; 32]>> {
+        let mut sim =
+            BoundaryRingMembershipSim::new(config(1, &[1, 2, 3]), &[true; 3]).expect("sim");
+        if with_watchtower {
+            sim.record_watchtower(WatchtowerCountersignRecord {
+                height: 1,
+                watcher_account_id: account(99),
+                seal_hash: [0xEE; 32],
+                signature_bytes: vec![9, 9],
+            });
+        }
+        let root = [0xDD; 32];
+        for member in [1u8, 2, 3] {
+            sim.honest_final_ack(&account(member), 1, root)
+                .expect("ack");
+        }
+        sim.try_seal(1, root).expect("try");
+        sim.seals
+    };
+    assert_eq!(run(false), run(true), "the watchtower record gates NOTHING");
+}


### PR DESCRIPTION
## AFT-CB R5 stage 2 — the membership simulator

The boundary-ring membership simulator in the estate's abstract-simulation idiom, driving the REAL stage-1 types. **Uniqueness is derived, never enforced**: the seal map will happily hold a conflict — exactly what the drills probe — and the honest journal is the only thing standing between three Byzantine equivocators and a double seal.

### The five gates (green)
| Gate | Pinned |
|---|---|
| (a) One withholder freezes cadence; live tier produces 10 blocks regardless | two-tier separation |
| (b) 3-Byzantine-of-4 equivocation → journaled root seals, other cannot, zero conflicts | uniqueness derived from the journal |
| (c) Succession without reconstruction → bond release refused | custody gating |
| (d) Handover e2e (unanimity + acceptance, seals resume under v2) — handover preserves lineage, re-genesis severs it | never continuity |
| (e) Sortition deterministic + floors; seals byte-identical with/without watchtower records | riders C5/C6 |

### Mutations — both RED → revert → GREEN (count-based, per the drill scar)
`try_seal` tolerating one missing share → gate (b) RED · `declare_regenesis` dropping the record → gate (d) RED.

Stage 3 (guardian_registry service wiring) follows as the final R5 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)