### PR TITLE
feat(types): measured costs (AFT-CB P4.3)

### DIFF
--- a/crates/types/src/app/consensus/tests.rs
+++ b/crates/types/src/app/consensus/tests.rs
@@ -7,3 +7,4 @@ include!("tests_parts/archived_history.rs");
 include!("tests_parts/payload_reconstruction.rs");
 include!("tests_parts/collapse_continuity.rs");
 include!("tests_parts/assumption_lattice.rs");
+include!("tests_parts/measured_wire_costs.rs");

--- a/crates/types/src/app/consensus/tests_parts/measured_wire_costs.rs
+++ b/crates/types/src/app/consensus/tests_parts/measured_wire_costs.rs
@@ -1,0 +1,52 @@
+// AFT-CB P4.3 — structural wire-cost measurements. These are EXACT
+// (SCALE-encoded byte sizes of the canonical objects) and reproduce with
+// zero variance: the test pins each size, so a wire-format change that
+// moves a cost updates the pinned number here and is visible in review.
+// The memo (specs/p4_measured_costs.md) cites these figures.
+
+#[test]
+fn measured_wire_costs_are_pinned() {
+    use crate::codec;
+
+    // The custody / validate-and-hold binding (T3): the object whose
+    // signature MEANS validate-and-hold. This is the per-slot standing
+    // cost — NOT a per-holder audit record.
+    let availability = BulletinAvailabilityCertificate {
+        height: 1,
+        bulletin_commitment_hash: [0x11; 32],
+        recoverability_root: [0x22; 32],
+    };
+    let availability_bytes = codec::to_bytes_canonical(&availability).unwrap().len();
+
+    // The canonical bulletin close (the sealed-slot commitment).
+    let close = CanonicalBulletinClose {
+        height: 1,
+        cutoff_timestamp_ms: 1_770_000_000,
+        bulletin_commitment_hash: [0x11; 32],
+        bulletin_availability_certificate_hash: [0x22; 32],
+        bulletin_retrievability_profile_hash: [0x33; 32],
+        bulletin_shard_manifest_hash: [0x44; 32],
+        bulletin_custody_receipt_hash: [0x55; 32],
+        entry_count: 128,
+    };
+    let close_bytes = codec::to_bytes_canonical(&close).unwrap().len();
+
+    // The OPTIONAL audit-enforcement record (R2): the additive
+    // per-probe cost. A close verifies with ZERO of these, so this is
+    // the marginal cost of the audit lane, paid only when a probe is
+    // recorded.
+    let audit = AvailabilityAuditRecord {
+        height: 1,
+        auditor_account_id: AccountId([0x01; 32]),
+        holder_account_id: AccountId([0x02; 32]),
+        tx_hash: [0x03; 32],
+        outcome: AvailabilityAuditOutcome::Served,
+        details: String::new(),
+    };
+    let audit_bytes = codec::to_bytes_canonical(&audit).unwrap().len();
+
+    // Pinned exact sizes (bytes). Any wire-format change surfaces here.
+    assert_eq!(availability_bytes, 72, "validate-and-hold binding");
+    assert_eq!(close_bytes, 180, "canonical bulletin close");
+    assert_eq!(audit_bytes, 106, "optional audit record (marginal, zero at rest)");
+}

--- a/internal-docs/architecture/protocols/aft/specs/p4_measured_costs.md
+++ b/internal-docs/architecture/protocols/aft/specs/p4_measured_costs.md
@@ -1,0 +1,80 @@
+# AFT-CB P4.3 — Measured Costs
+
+Gate: every number reproduces within its stated variance on re-run. The
+figures split into three reproduction classes, and each row says which
+class it is — a number without a reproduction path is not in this table.
+
+## Class A — exact, zero variance (structural wire costs)
+
+Pinned by the test `measured_wire_costs_are_pinned`
+(`crates/types/src/app/consensus/tests_parts/measured_wire_costs.rs`):
+these are SCALE-encoded byte sizes of the canonical objects, so they
+reproduce exactly and any wire-format change updates the pinned number in
+review.
+
+| Quantity | Bytes | What it is |
+|---|---|---|
+| Validate-and-hold binding | **72** | `BulletinAvailabilityCertificate` — the per-slot custody standing whose signature MEANS validate-and-hold (T3). Paid once per sealed slot. |
+| Canonical bulletin close | **180** | `CanonicalBulletinClose` — the sealed-slot commitment (height, cutoff, five surface hashes, entry count). |
+| Optional audit record | **106** | `AvailabilityAuditRecord` — the ADDITIVE per-probe audit cost (R2). A close verifies with ZERO of these, so 106 B is the MARGINAL cost of the audit lane, paid only when a probe is recorded; the at-rest audit cost is zero. |
+
+Reproduce: `cargo test --locked -p ioi-types --lib measured_wire_costs_are_pinned`.
+
+Reading: the audit lane's cost is strictly marginal — the zero-audit
+close gate (R2) proves no verification path reads an audit record, so a
+deployment that never probes pays 0 bytes for audit, and each probe it
+DOES record costs 106 B. Validate-and-hold is 72 B per slot regardless
+of ring size, because the binding is over the committed surface, not
+per-holder.
+
+## Class B — measured once, reproduces within CPU variance (proving time)
+
+The P2.5 SP1 continuity proof, measured locally during P2.5 de-risking:
+
+| Quantity | Value | Variance class |
+|---|---|---|
+| CORE continuity proof, one step | **~27 s CPU** | ±CPU scheduling; single-thread bound |
+| 3-step chain (harness `chain` e2e) | **~84 s wall, CPU backend** | ±CPU scheduling |
+
+Reproduce: the P2.5 recipe (`crates/aft-proofs`, sp1up + cargo-prove
+f66b4bf, CPU backend) documented in the program record; the nightly lane
+`aft-proofs-nightly.yml` runs it. These are CPU-backend figures; a GPU
+or the Succinct prover network would change them by an order of
+magnitude and is out of scope for an in-repo measurement.
+
+## Class C — box-variable, deferred to a pinned bench runner (throughput / close latency)
+
+Boundary-close LATENCY and sustained TPS at n ∈ {4, 8} are produced by
+the existing paper-benchmark harness
+(`crates/cli/tests/benchmark_throughput/aft*`, `PaperBenchmarkResult`
+with p50/p95/p99/max commit latency + injection/sustained TPS + churn).
+The harness EXISTS and is the reproduction instrument; committed numbers
+are deliberately NOT pinned in this repo because:
+
+- the figures are runner-dependent (the program's own history notes the
+  verifier is env-flaky on the slow development box), so a number
+  committed from an ad-hoc local run would fail its own
+  reproduce-within-variance gate on a different box;
+- reproducible throughput numbers require a PINNED bench-CI runner — the
+  same discipline the estate already applies to its deterministic gates.
+
+**Honest residual (RES-P4.3-throughput):** the close-latency / TPS table
+at n ∈ {4, 8} lands when a pinned bench runner exists. The instrument is
+built; only the stable execution environment is missing. Reproduce the
+shape today with:
+`cargo test -p ioi-cli --features consensus-aft,vm-wasm,state-jellyfish -- --ignored <aft paper-benchmark scenario>`
+(runner-dependent absolute values; use for relative comparison only until
+the pinned lane lands).
+
+Bandwidth at payload sizes rides the same harness (bytes per committed
+block are derivable from the Class A per-object costs times the block's
+object count) and is deferred with it.
+
+## Summary
+
+Class A (the wire costs — the numbers a protocol reviewer needs to reason
+about custody and audit overhead) are exact and gate-pinned now. Class B
+(proving) reproduces within CPU variance via the nightly lane. Class C
+(throughput/latency) is instrument-ready but honestly deferred to a
+pinned runner rather than committed from a variable box — recording the
+residual instead of a number that could not survive its own gate.


### PR DESCRIPTION
## AFT-CB P4.3 — measured costs

Every number carries its reproduction class; a number without a reproduction path is not in the table.

### Class A — exact, zero variance (gate-pinned now)
`measured_wire_costs_are_pinned` pins SCALE-encoded sizes:
| Quantity | Bytes | Note |
|---|---|---|
| Validate-and-hold binding | 72 | per slot, ring-size independent |
| Canonical bulletin close | 180 | sealed-slot commitment |
| Optional audit record | 106 | **marginal** — zero at rest (close verifies with zero audit records), 106 B per recorded probe |

### Class B — CPU variance (nightly lane)
P2.5 proving: ~27 s/step, ~84 s 3-step chain, CPU backend.

### Class C — box-variable, deferred (RES-P4.3-throughput)
Close latency + TPS at n∈{4,8} come from the existing `benchmark_throughput/aft` harness (`PaperBenchmarkResult`). The instrument exists; committed numbers need a **pinned bench-CI runner** — an ad-hoc local figure would fail its own reproduce-within-variance gate on a different box. Filed with the exact reproduction command.

The wire costs a reviewer needs to reason about custody/audit overhead are exact now; throughput is honestly residual-ed rather than committed from a variable box. Claim-discipline gate green; ioi-types green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)