### PR TITLE
docs(aft): claim adjudication + flagship-gating enforcement (AFT-CB P4.4)

### DIFF
--- a/.github/scripts/check_aft_claim_discipline.sh
+++ b/.github/scripts/check_aft_claim_discipline.sh
@@ -79,4 +79,34 @@ if [ "${violations}" -ne 0 ]; then
   exit 1
 fi
 
-echo "PASS: no unqualified 99% tolerance spellings in the AFT specs/formal corpus."
+# AFT-CB P4.4 flagship-gating: neither flagship rung may appear in the
+# corpus as a BARE assertion. The distinctive rung phrase "frontier-
+# complete" may appear ONLY on a line that also carries a blocked/gated
+# marker (BLOCKED, "does not print", "gated on", "unreachable", "cannot
+# print", "REMAINING EDITORIAL", or the adjudication's quoting context).
+# Both flagship rungs are blocked this cycle (RES-R10, T5d withdrawn,
+# RES-R11/R12, three L-OPEN rows); a bare assertion of frontier-
+# completeness is therefore a false claim and fails the gate. This gate
+# is mutation-tested (AFT-CB standing rule 3): a bare "frontier-complete
+# consensus architecture" line must turn it RED.
+FLAGSHIP_PATTERN='frontier-complete'
+FLAGSHIP_ALLOW='BLOCKED|does not print|cannot print|gated on|unreachable|REMAINING EDITORIAL|only where.*marked|no flagship rung|flagship rung is absent|flagship strings|frontier-completeness flagship|the .{0,3}frontier-complete.{0,3} strings'
+flagship_violations=0
+while IFS= read -r hit; do
+  file="${hit%%:*}"
+  rest="${hit#*:}"
+  line_no="${rest%%:*}"
+  line="${rest#*:}"
+  if printf '%s' "${line}" | grep -qE "${FLAGSHIP_ALLOW}"; then
+    continue
+  fi
+  echo "FLAGSHIP-GATING VIOLATION (bare flagship assertion): ${file}:${line_no}:${line}" >&2
+  flagship_violations=$((flagship_violations + 1))
+done < <(grep -rnE --include='*.tex' --include='*.md' "${FLAGSHIP_PATTERN}" "${SPECS_DIR}" "${FORMAL_DIR}" || true)
+
+if [ "${flagship_violations}" -ne 0 ]; then
+  echo "FAIL: ${flagship_violations} bare flagship assertion(s) — a flagship rung printed without its blocked/gated marker while its condition set is open (see p4_claim_adjudication.md)." >&2
+  exit 1
+fi
+
+echo "PASS: no unqualified 99% tolerance spellings, and no bare flagship assertions, in the AFT specs/formal corpus."

--- a/internal-docs/architecture/protocols/aft/specs/common_boundary_theorems.md
+++ b/internal-docs/architecture/protocols/aft/specs/common_boundary_theorems.md
@@ -705,6 +705,4 @@ this table has zero `L-OPEN` rows (P4.4 gate).
 | T8 selection supply | — | **L-OPEN** (cheapest-capture supply bound: P4.2 analysis) |
 | T9 maximal accountable safety | L9 (ratio 1.0 is the cap) | cited |
 
-Three `L-OPEN` rows stand. Per the claim ladder, the frontier-completeness
-flagship does not print while any row is open; the interim conditional
-claim (whitepaper §5.3) does not require this table to be closed.
+Three `L-OPEN` rows stand. Per the claim ladder, the frontier-completeness flagship does not print while any row is open (see `p4_claim_adjudication.md`); the interim conditional claim (whitepaper §5.3) does not require this table to be closed.

--- a/internal-docs/architecture/protocols/aft/specs/p4_claim_adjudication.md
+++ b/internal-docs/architecture/protocols/aft/specs/p4_claim_adjudication.md
@@ -1,0 +1,89 @@
+# AFT-CB P4.4 — Claim Adjudication
+
+This document adjudicates exactly which claim the program may print, and
+enumerates the precise gates blocking each flagship rung. It is the
+authority the machine gate enforces: `check_aft_claim_discipline.sh`
+asserts that no flagship rung appears in the corpus as a bare assertion —
+the "frontier-complete" strings may appear ONLY where they are marked
+BLOCKED with their open gates named (as they are here).
+
+The full `yellow_paper.tex` rewrite around the T1–T3/T4a–b/T5a–c′/T6/T7/T8
+theorem surface is REMAINING EDITORIAL WORK; it may adopt the printable
+claim below verbatim and MUST NOT print either flagship rung while this
+adjudication records them blocked. The adjudication — not the LaTeX
+prose — is what determines what can be claimed.
+
+## The printable claim (program doc §9, upgraded)
+
+> **Deterministic all-but-one safety for certified boundaries; live
+> consensus under separately bounded adversarial weight and eventual
+> synchrony.**
+
+**PRINTABLE.** Every leg this claim depends on is closed:
+
+- *Deterministic all-but-one safety for certified boundaries* is T1,
+  paper-proved and MECHANIZED at P2.1 (`BoundaryRing.tla` + TLAPS
+  inductive invariant; TLC at the MHA corner). It is unconditional under
+  A2 and bond-independent — the economics memo (P4.2) prices how open
+  selection SUPPLIES A2 but the safety statement does not rest on that
+  supply.
+- *Live consensus under separately bounded adversarial weight and
+  eventual synchrony* is T4a, and the claim STATES its two conditions
+  (bounded weight; eventual synchrony = A5). Because the claim scopes
+  itself to eventual synchrony, R10's asynchronous-fallback residual
+  (RES-R10) does NOT undercut it — the claim never asserted asynchronous
+  liveness. This is the exact line the intermediate flagship crosses and
+  this claim does not.
+
+No rounded-percentage tolerance figure appears; the claim-discipline
+gate (P0.2) enforces that.
+
+## Intermediate flagship — BLOCKED
+
+> "AFT is a frontier-complete consensus architecture…" (program doc §0b) — BLOCKED, does not print; open gates below.
+
+This rung is **BLOCKED**. Its condition set (spec: the §9 claim's
+conditions PLUS the four below) is not satisfied:
+
+| Condition | State | Gate |
+|---|---|---|
+| R10 asynchronous fallback DEMONSTRATED (not residual) | **OPEN** | RES-R10 is filed as a residual + design; the fallback is not built (FLP forecloses it without a common coin — engine-structure change). |
+| T7 proven against the wire format | CLOSED | P2.6 (`ForensicAccountability.tla`, 146/146) proves T7 against the P2.6 seal-share wire format; R9 lands the attribution-preserving signer. |
+| T8 published in probabilistic form | CLOSED | P4.2 publishes T8 in correlated-failure probabilistic form, with the no-deterministic-conversion rule. |
+| Pairing table has ZERO `L-OPEN` rows | **OPEN** | Three `L-OPEN` rows stand: T4a (RES-R10), T5d (withdrawn), T8 (supply lower bound is an analysis, not a proven bound). |
+
+Two independent gates (R10 fallback + the L-OPEN rows) block this rung.
+It cannot print this cycle.
+
+## Final flagship — BLOCKED
+
+> "frontier-complete, fully accountable… succession pre-consented at formation and clocked by verifiable elapsed time… verifier held to its proofs by continuous conformance" (program doc §0c) — BLOCKED, does not print; open gates below.
+
+This rung is **BLOCKED**. Beyond the intermediate rung's open gates, its
+additional conditions are not satisfied:
+
+| Condition | State | Gate |
+|---|---|---|
+| T5d mechanized (P2.7) | **OPEN** | T5d is WITHDRAWN for this cycle — three formulations refuted across five review rounds; §16's banner carries the v4 conditions. |
+| R11 + R12 landed | **OPEN** | RES-R11 (VDF vetting, rule-12 owner action) and RES-R12 (depends on T5d + R11) are filed as residuals. |
+| T9/L9 paired in the table | CLOSED | The pairing table pairs T9 (maximal accountable safety) with L9 (attribution cap, ratio 1.0). |
+| R13 trace-conformance lane green | CLOSED | R13 merged; the lane runs in `aft_formal_floor` on every build. |
+
+The "clocked by verifiable elapsed time" and "succession pre-consented at
+formation" phrases require exactly the two residual planes (R11, R12);
+"held to its proofs by continuous conformance" is R13-green (satisfied)
+but the rung needs its full set. It cannot print this cycle.
+
+## Adjudication summary
+
+- **Prints now:** the §9 upgraded claim (deterministic all-but-one
+  safety + synchrony-conditional live consensus).
+- **Blocked, this cycle:** both flagship rungs, by residuals the program
+  deliberately did not paper over (RES-R10, T5d withdrawal, RES-R11/R12,
+  three L-OPEN rows).
+- **Enforcement:** the flagship strings appear in this corpus only where
+  marked BLOCKED; the claim-discipline gate fails on any bare flagship
+  assertion.
+- **Remaining editorial:** the `yellow_paper.tex` v2 prose rewrite may
+  adopt the printable claim and the pairing/measured-cost surfaces, and
+  is bound by this adjudication.


### PR DESCRIPTION
## AFT-CB P4.4 — claim adjudication + flagship-gating

The load-bearing part of P4.4: `specs/p4_claim_adjudication.md` determines what the program may print and enumerates the exact gates blocking each flagship, plus the machine enforcement the P4.4 gate requires. The full `yellow_paper.tex` prose rewrite (2844 lines) is recorded as remaining editorial work, bound by this adjudication.

### Adjudication
- **PRINTABLE** — the §9 upgraded claim: *deterministic all-but-one safety for certified boundaries; live consensus under separately bounded adversarial weight and eventual synchrony.* T1 is mechanized (P2.1); the live-consensus clause states its synchrony condition (A5), so RES-R10 does not undercut it — the claim never asserted asynchronous liveness. That is the exact line the flagships cross and this claim does not.
- **Intermediate flagship — BLOCKED**: two independent open gates (R10 fallback not demonstrated; three L-OPEN pairing rows). T7-vs-wire, T8-probabilistic CLOSED.
- **Final flagship — BLOCKED**: T5d withdrawn, RES-R11/R12 open. T9/L9 paired, R13 green CLOSED.

### Enforcement
The P4.4 gate — "a checker asserts each flagship rung is absent unless its condition set is closed" — is met by extending `check_aft_claim_discipline.sh` (the existing CI script, **not** a workflow edit, so this PR stays mergeable): the "frontier-complete" rung phrase may appear only on a line carrying a blocked/gated marker. **Mutation drilled**: a bare flagship line → gate RED → reverted → green. The extension also caught+fixed one pre-existing wrapped gating sentence.

All AFT claim gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)