### PR TITLE
docs(aft): owner-action packets P4.5a-d (AFT-CB P4.5)

### DIFF
--- a/internal-docs/architecture/protocols/aft/packets/P4.5a-external-audit.md
+++ b/internal-docs/architecture/protocols/aft/packets/P4.5a-external-audit.md
@@ -1,0 +1,51 @@
+# P4.5a — External Security Audit Engagement (owner-action packet)
+
+**Status: FILED, NOT EXECUTED.** This packet defines an owner-only action
+(spend + outward engagement). The loop cannot commission or pay for an
+external audit; this records the scope, acceptance criteria, and why it
+is owner-only, ready for the owner to act on.
+
+## Why owner-only
+
+Engaging an external auditor is a spend decision and an outward
+disclosure of the protocol surface to a third party. Both are outside
+loop authority (rule: escalate for spend and outward/irreversible).
+
+## Scope (what the auditor examines)
+
+The mechanized and load-bearing surfaces the program produced:
+
+1. **R3 — immutable closes** (`crates/services/src/guardian_registry/`):
+   the abort-supersedes-only-pre-seal rule and the append-only resolution
+   log. Audit target: can any path mutate a sealed close, or activate an
+   abort against one, outside the resolution log?
+2. **R5 — ring membership plane**
+   (`crates/types/src/app/ring_membership.rs` + the guardian_registry
+   wiring + the membership simulator): the assurance-preserving handover
+   as the only strong-ring transition, the D_act queue, custody-gated
+   bond release. Audit target: is any silence-derived or sub-unanimous
+   transition constructible? Does any live-tier ejection reach the strong
+   ring?
+3. **P2.5 — the SP1 proof system** (`crates/aft-proofs/`): the in-guest
+   ed25519 n-of-n continuity circuit, the governed vkey pin, the proof
+   tampering drills. Audit target: soundness of the guest program and
+   the pin-governance path (R4c flips the default to this backend).
+
+## Acceptance criteria
+
+- A written report enumerating findings by severity against the three
+  surfaces, with each finding reproducible against the named artifacts.
+- Zero unresolved CRITICAL findings on the R3/R5 safety surfaces, or a
+  documented disposition (fix + re-audit, or accepted-with-rationale)
+  for each.
+- The auditor's methodology stated (which properties were checked,
+  which were out of scope) so the audit's own coverage is legible.
+
+## Inputs the owner provides to the auditor
+
+- This repository at the program's close-out commit.
+- The theorem corpus (`specs/common_boundary*.md`), the formal artifacts
+  (`formal/common_boundary/`), and the claim adjudication
+  (`specs/p4_claim_adjudication.md`) as the specification surface.
+- The named residuals (RES-R10/R11/R12/P4.3-throughput, T5d withdrawal)
+  so the auditor does not re-derive known-open gaps as findings.

--- a/internal-docs/architecture/protocols/aft/packets/P4.5b-twin-implementation.md
+++ b/internal-docs/architecture/protocols/aft/packets/P4.5b-twin-implementation.md
@@ -1,0 +1,58 @@
+# P4.5b — Independent Twin Implementation (owner-action packet)
+
+**Status: FILED, NOT EXECUTED.** An independent second implementation of
+the UBC verifier, built from the spec by a separate party, is the
+strongest evidence that the specification — not one codebase's quirks —
+is what carries the safety property. This packet exports the conformance
+surface; commissioning the twin is owner-only (outward engagement +
+spend).
+
+## Why owner-only
+
+A twin implementation is built by an independent party under a separate
+engagement — an outward, funded action outside loop authority.
+
+## What the twin implements
+
+The Unanimous Boundary Close VERIFIER: given a certificate (the n
+individually-verifiable final-ack shares over the domain-separated
+tuple) and the closed boundary, decide accept/reject. This is the
+smallest surface whose correctness carries T1 (uniqueness) and T7
+(forensic attribution), and it is the surface a second implementation
+can most cleanly re-derive from the spec.
+
+## Conformance vectors (exported from P2.1 / P2.5)
+
+The twin must agree with the reference on a vector set the owner exports
+at close-out:
+
+1. **P2.1 boundary-ring vectors**: from the trace-conformance lane
+   (R13, `boundary_ring_reference.trace.jsonl`) — each applied step and
+   the accept/reject at each, so the twin's state machine is checked
+   against the same behavior the TLA model replays.
+2. **P2.5 continuity vectors**: the 3-step chain proof from
+   `crates/aft-proofs/harness` — public inputs, proof bytes, and the
+   pinned vkey, so the twin's succinct-verify path agrees byte-for-byte
+   on accept, and the tampering drills agree on reject.
+3. **R9 attribution vectors**: staged double-seal share sets from the
+   seal signer, so the twin's forensic extractor names the same
+   double-signers.
+
+## Acceptance criteria
+
+- The twin accepts every reference-accept vector and rejects every
+  reference-reject vector, with zero disagreements on the exported set.
+- Any disagreement is adjudicated against the SPEC (not "whichever code
+  is the reference"): a disagreement is a spec-ambiguity finding, and
+  the resolution amends the spec so both implementations converge.
+- The twin is written by a party with no access to the reference
+  implementation's source during construction (spec-only), so agreement
+  is evidence about the spec.
+
+## Relationship to R14
+
+R14 (verified verifier) is the in-repo cousin of this packet — a
+verifier refinement-proven from the spec. R14 is a named residual; the
+twin is its outward complement. Neither gates the flagship rungs, but
+P4.5a's audit packet states R14's status and this packet states the
+twin's.

--- a/internal-docs/architecture/protocols/aft/packets/P4.5c-adversarial-testnet.md
+++ b/internal-docs/architecture/protocols/aft/packets/P4.5c-adversarial-testnet.md
@@ -1,0 +1,49 @@
+# P4.5c — Public Adversarial Testnet (owner-action packet)
+
+**Status: FILED, NOT EXECUTED.** A public testnet where third parties are
+invited to break the protocol turns the in-repo drill campaigns (P4.1)
+into live acceptance criteria. Standing up and funding a public testnet
+is owner-only (spend + outward + operational).
+
+## Why owner-only
+
+A public testnet is deployed infrastructure with an operational cost and
+an outward invitation to adversaries — spend + outward, outside loop
+authority.
+
+## The drill list as acceptance criteria
+
+The P4.1 adversarial campaigns (`crates/consensus/src/aft/
+adversarial_campaigns.rs`) become the testnet's acceptance battery. Each
+campaign is a challenge a participant may attempt; the testnet PASSES the
+battery when none succeeds beyond its named assumption:
+
+| Challenge | Success for the attacker means | The assumption that must hold |
+|---|---|---|
+| Partition | a seal forms on a minority split | A2 (n-of-n over the live ring) |
+| Eclipse | a censored tx is absent yet the block verifies | A4 (reach) is the only exclusion |
+| Custody-deletion | sealed bytes unservable with one honest holder | A2 + validate-and-hold (T3) |
+| n−1-Byzantine ring | two conflicting seals for one slot | A2 (one honest journal) |
+| Long-range bootstrap | a newcomer with a live anchor accepts forged history | A6 anchor liveness |
+| Proof-of-silence | a strong-ring transition from non-response | R5 type enforcement |
+| Post-compromise | pre-unbond history forged after key compromise | A8 + key evolution (R9) |
+
+## Acceptance criteria
+
+- The testnet runs the full P4.1 battery as live challenges for a stated
+  window with a stated bounty.
+- No challenge succeeds WITHIN its named assumption. A success is either
+  (a) an assumption violation the participant engineered (documented,
+  not a protocol break), or (b) a genuine finding that reopens the
+  corresponding leg.
+- The RES-R10 asynchronous-liveness gap is EXCLUDED from the battery
+  (it is a known residual; the testnet does not test what the program
+  already records open), and this exclusion is published so participants
+  are not misled about coverage.
+
+## Relationship to the economics memo
+
+The MHA-purchase-price and griefing-cost figures (P4.2) set the bounty
+floor: a bounty below the cheapest attack's cost invites no serious
+attempt, and one above the all-seat-capture floor risks funding the
+attack it tests. The owner sizes the bounty against P4.2's numbers.

--- a/internal-docs/architecture/protocols/aft/packets/P4.5d-peer-review.md
+++ b/internal-docs/architecture/protocols/aft/packets/P4.5d-peer-review.md
@@ -1,0 +1,57 @@
+# P4.5d — Peer-Review Submission (owner-action packet)
+
+**Status: FILED, NOT EXECUTED.** Submitting the work to peer review is the
+outward validation of the theorem corpus by the research community.
+Preparing and submitting a manuscript is owner-only (outward + the
+manuscript is a public act binding the project's name).
+
+## Why owner-only
+
+Submission publishes the work under the project's name to an external
+venue — an outward, reputationally-binding act outside loop authority.
+
+## The manuscript
+
+The P4.4 yellow-paper v2 is the manuscript spine. Its content surface,
+already produced by the program:
+
+- **Theorems** T1–T3 / T4a–b / T5a–c′ / T6 / T7 / T8 / T9, with the
+  assumption ledger (A1–A10) as the citation surface and the
+  paper-proofs in `specs/common_boundary_theorems.md`.
+- **Mechanized evidence**: the P2 formal artifacts
+  (`formal/common_boundary/`, TLAPS + TLC), cited as the theorems'
+  machine-checked successors.
+- **Lower-bound pairing table**: each positive theorem paired with its
+  necessity bound (L1/L2/L9/L-E/L-H/L-LR/L-M), with the three L-OPEN rows
+  honestly marked.
+- **Measured costs**: the P4.3 appendix (exact wire costs; proving time;
+  the throughput residual).
+- **The claim**: the §9 upgraded claim as the paper's thesis, with the
+  flagship rungs explicitly NOT claimed and the reasons enumerated
+  (`p4_claim_adjudication.md`).
+
+## Acceptance criteria
+
+- The manuscript states the model delta (the assumed common publication
+  boundary) as a first-class assumption in the abstract, not a footnote —
+  the whole result is conditional on it, and a reviewer must see that
+  immediately.
+- Every theorem cites its mechanization artifact and its lower-bound
+  pairing; no positive claim appears without its necessity companion.
+- The claim ladder is presented as the paper's honesty contract: the
+  printable §9 claim as the thesis, the two flagship rungs as
+  explicitly-future work with their exact open gates. A reviewer should
+  be unable to find an overclaim, because the corpus's own gates forbid
+  one.
+- The named residuals (RES-R10/R11/R12, T5d withdrawal, the throughput
+  residual) appear in the paper's limitations section verbatim from the
+  program record — the review sees the same open list the program kept.
+
+## Why this is the last packet
+
+Peer review is downstream of the other three: an audit (P4.5a) hardens
+the implementation the paper describes, a twin (P4.5b) evidences the
+spec's independence, and a testnet (P4.5c) supplies empirical adversarial
+data a strong submission cites. The owner may sequence them so the
+manuscript carries that evidence, or submit the theory paper first and
+fold the empirical packets into a revision.


### PR DESCRIPTION
Four owner-only action packets under `packets/`, each naming scope, acceptance criteria, and why owner-only (spend/outward/operational): **P4.5a** external audit (R3/R5/P2.5 surfaces), **P4.5b** twin implementation (UBC verifier from spec, conformance vectors from P2.1/P2.5/R9), **P4.5c** adversarial testnet (P4.1 drills as acceptance battery, RES-R10 excluded, bounty sized against P4.2), **P4.5d** peer review (P4.4 as manuscript, model delta first-class, claim ladder as honesty contract). Filed not executed — the loop cannot commission spend or outward engagements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)