### PR TITLE
feat(consensus): adaptive view-timeout backoff — RES-R10 D1

### DIFF
--- a/crates/consensus/src/aft/guardian_majority/pacemaker.rs
+++ b/crates/consensus/src/aft/guardian_majority/pacemaker.rs
@@ -5,8 +5,24 @@
 //! The Pacemaker decouples the "when" from the "what" of consensus. It tracks
 //! the current view, calculates timeouts based on exponential backoff, and
 //! signals when a view change is required due to lack of progress.
+//!
+//! AFT-CB RES-R10 D1 (adaptive backoff): the timeout for a view now scales
+//! with the number of CONSECUTIVE failed views since the last observed
+//! progress, so a partition that keeps failing views widens the timeout
+//! window geometrically (bounded by a cap) and stops the pathological case
+//! where a fixed timeout shorter than the actual post-GST delay can never
+//! let a view complete. Real progress resets the backoff to the base. This
+//! is assumption-neutral --- it changes only WHEN the pacemaker fires, never
+//! the safety rules --- and it is the buildable half of the R10 fallback
+//! design (the D2--D4 pessimistic path with a common coin remains a named
+//! residual gated on a fresh theorem review).
 
 use std::time::{Duration, Instant};
+
+/// The largest consecutive-failure exponent the backoff applies. Beyond
+/// this the timeout is held flat, so a permanently stalled height cannot
+/// drive the timeout to an unbounded value.
+const MAX_BACKOFF_EXPONENT: u32 = 8;
 
 /// Manages view timers and timeouts.
 #[derive(Debug)]
@@ -19,6 +35,12 @@ pub struct Pacemaker {
     pub base_timeout: Duration,
     /// The multiplier for exponential backoff on timeouts.
     pub backoff_factor: f64,
+    /// Consecutive views entered without an intervening progress
+    /// observation (AFT-CB RES-R10 D1). Zero in steady state; each view
+    /// advance without progress increments it, and any observed progress
+    /// resets it. This is the exponent the backoff raises `backoff_factor`
+    /// to.
+    consecutive_timeouts: u32,
 }
 
 impl Pacemaker {
@@ -29,6 +51,7 @@ impl Pacemaker {
             view_start_time: Instant::now(),
             base_timeout,
             backoff_factor: 1.2, // Conservative exponential backoff
+            consecutive_timeouts: 0,
         }
     }
 
@@ -36,41 +59,75 @@ impl Pacemaker {
     /// Returns true if `now - view_start_time > timeout_for_view`.
     pub fn check_timeout(&self) -> bool {
         let elapsed = self.view_start_time.elapsed();
-        let timeout = self.timeout_for_view(self.current_view);
+        let timeout = self.timeout_for_view();
         elapsed > timeout
     }
 
     /// Advances the pacemaker to a new view, resetting the timer.
     /// If `new_view` is not greater than `current_view`, this is a no-op (idempotency).
+    ///
+    /// A forward advance is a view that failed to commit before it was
+    /// superseded (a timeout certificate formed, or a relayed one was
+    /// adopted), so it counts toward the consecutive-failure backoff until
+    /// real progress resets it (AFT-CB RES-R10 D1).
     pub fn advance_view(&mut self, new_view: u64) {
         if new_view > self.current_view {
+            self.consecutive_timeouts = self.consecutive_timeouts.saturating_add(1);
             self.current_view = new_view;
             self.view_start_time = Instant::now();
         }
     }
 
+    /// Adopts a view learned from a RELAYED timeout certificate (AFT-CB
+    /// RES-R10 D1, the synchronizer edge): a node that did not itself
+    /// witness the quorum forming a TC still enters the new view within one
+    /// message delay of the relayer rather than waiting out its own timer.
+    /// Semantically identical to [`advance_view`] --- the distinct name
+    /// documents the synchronizer intent at the call site in the runtime,
+    /// where the relay broadcast lives.
+    pub fn adopt_relayed_view(&mut self, relayed_view: u64) {
+        self.advance_view(relayed_view);
+    }
+
     /// Records forward progress for the current height. A valid proposal in the
     /// current or a newer view should suppress spurious timeouts while the node
     /// is verifying and voting on that proposal.
+    ///
+    /// Progress resets the consecutive-failure backoff: the timeout window
+    /// returns to the base for the next view (AFT-CB RES-R10 D1).
     pub fn observe_progress(&mut self, view: u64) {
         if view > self.current_view {
             self.current_view = view;
         }
+        self.consecutive_timeouts = 0;
         self.view_start_time = Instant::now();
     }
 
-    /// Calculates the timeout duration for a specific view.
-    /// Formula: `base_timeout * (backoff_factor ^ view_delta)`
-    /// Note: `view_delta` is relative to a successful round, but for simplicity here
-    /// we just scale slightly or keep flat if we assume steady state.
-    /// A robust implementation tracks consecutive failures.
+    /// The consecutive-failure exponent currently applied to the backoff
+    /// (AFT-CB RES-R10 D1). Exposed for observability and tests.
+    pub fn consecutive_timeouts(&self) -> u32 {
+        self.consecutive_timeouts
+    }
+
+    /// Calculates the timeout duration for the current view.
     ///
-    /// For this version, we use a simple linear scaling cap to avoid excessive delays.
-    fn timeout_for_view(&self, _view: u64) -> Duration {
-        // In a real BFT, this scales with the number of *failed* views since the last commit.
-        // Since we don't track `last_commit_view` here yet, we return base_timeout.
-        // Future optimization: pass `last_committed_view` to this function.
-        self.base_timeout
+    /// AFT-CB RES-R10 D1: `base_timeout * backoff_factor^consecutive_timeouts`,
+    /// with the exponent capped at [`MAX_BACKOFF_EXPONENT`] so an
+    /// indefinitely stalled height holds a bounded (not unbounded) timeout.
+    /// With `consecutive_timeouts == 0` this is exactly `base_timeout`, so
+    /// steady-state behavior is unchanged.
+    fn timeout_for_view(&self) -> Duration {
+        let exponent = self.consecutive_timeouts.min(MAX_BACKOFF_EXPONENT);
+        if exponent == 0 {
+            return self.base_timeout;
+        }
+        let scale = self.backoff_factor.powi(exponent as i32);
+        // Guard against a non-finite or non-positive factor collapsing the
+        // timeout; fall back to the base rather than to zero.
+        if !scale.is_finite() || scale <= 0.0 {
+            return self.base_timeout;
+        }
+        self.base_timeout.mul_f64(scale)
     }
 }
 

--- a/crates/consensus/src/aft/guardian_majority/pacemaker/tests.rs
+++ b/crates/consensus/src/aft/guardian_majority/pacemaker/tests.rs
@@ -30,3 +30,109 @@ fn test_advance_view_monotonicity() {
     pm.advance_view(3);
     assert_eq!(pm.current_view, 5);
 }
+
+// AFT-CB RES-R10 D1 — adaptive backoff.
+
+#[test]
+fn steady_state_timeout_equals_base() {
+    let pm = Pacemaker::new(Duration::from_millis(100));
+    assert_eq!(pm.consecutive_timeouts(), 0);
+    assert_eq!(pm.timeout_for_view(), Duration::from_millis(100));
+}
+
+#[test]
+fn consecutive_advances_widen_the_timeout_geometrically() {
+    let mut pm = Pacemaker::new(Duration::from_millis(100));
+    let base = pm.timeout_for_view();
+
+    pm.advance_view(1);
+    assert_eq!(pm.consecutive_timeouts(), 1);
+    let after_one = pm.timeout_for_view();
+    assert!(after_one > base, "one failed view widens the window");
+
+    pm.advance_view(2);
+    let after_two = pm.timeout_for_view();
+    assert!(
+        after_two > after_one,
+        "a second failed view widens it further"
+    );
+
+    // Exactly base * factor^2.
+    let expected = Duration::from_millis(100).mul_f64(1.2_f64.powi(2));
+    assert_eq!(after_two, expected);
+}
+
+#[test]
+fn progress_resets_the_backoff_to_base() {
+    let mut pm = Pacemaker::new(Duration::from_millis(100));
+    pm.advance_view(1);
+    pm.advance_view(2);
+    pm.advance_view(3);
+    assert_eq!(pm.consecutive_timeouts(), 3);
+    assert!(pm.timeout_for_view() > Duration::from_millis(100));
+
+    pm.observe_progress(3);
+    assert_eq!(
+        pm.consecutive_timeouts(),
+        0,
+        "progress clears the failure streak"
+    );
+    assert_eq!(pm.timeout_for_view(), Duration::from_millis(100));
+}
+
+#[test]
+fn backoff_exponent_is_capped() {
+    let mut pm = Pacemaker::new(Duration::from_millis(10));
+    for v in 1..=(MAX_BACKOFF_EXPONENT as u64 + 20) {
+        pm.advance_view(v);
+    }
+    // The applied exponent is capped even though the raw counter is higher.
+    assert!(pm.consecutive_timeouts() > MAX_BACKOFF_EXPONENT);
+    let capped = Duration::from_millis(10).mul_f64(1.2_f64.powi(MAX_BACKOFF_EXPONENT as i32));
+    assert_eq!(
+        pm.timeout_for_view(),
+        capped,
+        "timeout holds flat at the cap"
+    );
+}
+
+#[test]
+fn relayed_view_adoption_advances_and_counts_as_a_failed_view() {
+    let mut pm = Pacemaker::new(Duration::from_millis(100));
+    pm.adopt_relayed_view(4);
+    assert_eq!(
+        pm.current_view, 4,
+        "adopts the relayed view without waiting out the timer"
+    );
+    assert_eq!(
+        pm.consecutive_timeouts(),
+        1,
+        "the superseded views count toward backoff"
+    );
+    // A stale relayed view is ignored (monotonicity preserved).
+    pm.adopt_relayed_view(2);
+    assert_eq!(pm.current_view, 4);
+}
+
+#[test]
+fn adaptive_backoff_lets_a_slow_view_complete_that_a_flat_timeout_would_miss() {
+    // The R10 pathology: a base timeout shorter than the real post-partition
+    // delay means a flat timeout can never let a view finish. With backoff,
+    // after enough failed views the window exceeds the delay.
+    let base = Duration::from_millis(50);
+    let real_delay = Duration::from_millis(200);
+    let mut pm = Pacemaker::new(base);
+    assert!(
+        pm.timeout_for_view() < real_delay,
+        "flat base cannot cover the delay"
+    );
+    let mut advances = 0;
+    while pm.timeout_for_view() <= real_delay && advances < 100 {
+        pm.advance_view(pm.current_view + 1);
+        advances += 1;
+    }
+    assert!(
+        pm.timeout_for_view() > real_delay,
+        "adaptive backoff eventually covers the real delay ({advances} views)"
+    );
+}


### PR DESCRIPTION
## AFT-CB RES-R10 D1 — adaptive view-timeout backoff

The assumption-neutral, locally-testable half of the R10 asynchronous-fallback design (owner-authorized D1). Wires the dormant `backoff_factor` a prior comment flagged as a stub, repairing the concrete pathology the R10 assessment named: **a fixed base timeout shorter than the real post-partition delay can never let a view complete**, so recovery stalls forever.

- `consecutive_timeouts`: incremented on each forward view advance (a view that failed to commit before being superseded), reset on `observe_progress`. `timeout_for_view = base * backoff_factor^consecutive_timeouts`, exponent capped at 8, exactly `base` at zero — steady state unchanged. Changes only *when* the pacemaker fires, never a safety rule.
- `adopt_relayed_view`: the synchronizer edge (TC-relay intent) as a named entry point; a node that didn't witness the quorum still enters the new view on a relayed TC without waiting out its timer. The broadcast that carries the relay is the runtime-integration follow-up.

### Proof
| | |
|---|---|
| Pacemaker suite | 9/9 |
| Consensus `--features aft` | 115/115 |
| Pathology test (adaptive covers a delay flat base cannot) | green |
| Mutation: exponent forced to zero → four adaptive tests RED | drilled |

D2–D4 (the pessimistic path + common coin) remain the named residual, gated on a fresh theorem review per the owner ruling. An in-session VDF/coin review is running to determine whether the clock and the coin are one primitive or two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)