### PR TITLE
feat(formal): T5d resolved — responsive succession impossible, scheduled succession mechanized

### DIFF
--- a/.github/scripts/run_aft_formal_checks.sh
+++ b/.github/scripts/run_aft_formal_checks.sh
@@ -43,6 +43,7 @@ MODELS=(
   "common_boundary/ForensicAccountability.cfg|common_boundary/ForensicAccountability.tla"
   "common_boundary/ForensicAccountabilityAllByz.cfg|common_boundary/ForensicAccountability.tla"
   "common_boundary/SuccessionClock.cfg|common_boundary/SuccessionClock.tla"
+  "common_boundary/SuccessionSchedule.cfg|common_boundary/SuccessionSchedule.tla"
 )
 
 # Every trace-conformance replay (AFT-CB R13 / C4a), as

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/SuccessionSchedule.cfg
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/SuccessionSchedule.cfg
@@ -1,0 +1,20 @@
+\* AFT-CB T5d resolution — TLC exploration of SCHEDULED succession.
+\* Four slots, a fence at slot 2, two candidate values (so a conflict is
+\* expressible), and a clock that runs to 5. The adversary explores every
+\* interleaving of Tick / OrigSeal / StbySeal. Disjoint and NoFork must
+\* hold in every reachable state — proving scheduled succession safe.
+\* Removing the `s <= Fence` conjunct from OrigSeal (the fence) makes
+\* NoFork reachably false, reproducing the impossibility.
+CONSTANTS
+  Slots = {1, 2, 3, 4}
+  Values = {vA, vB}
+  NoVal = NoVal
+  Fence = 2
+  MaxTick = 5
+
+INIT Init
+NEXT Next
+
+INVARIANT TypeOK
+INVARIANT Disjoint
+INVARIANT NoFork

--- a/internal-docs/architecture/protocols/aft/formal/common_boundary/SuccessionSchedule.tla
+++ b/internal-docs/architecture/protocols/aft/formal/common_boundary/SuccessionSchedule.tla
@@ -1,0 +1,139 @@
+---- MODULE SuccessionSchedule ----
+(***************************************************************************)
+(* AFT-CB T5d resolution — SCHEDULED succession is safe; RESPONSIVE       *)
+(* succession is impossible.                                              *)
+(*                                                                         *)
+(* Two independent fresh-context theory reviews (blind to the three       *)
+(* refuted T5d formulations) converged: detection-triggered (responsive)  *)
+(* succession cannot be both safe and live in the async model — a dead    *)
+(* ring is indistinguishable from a partitioned one (CAP + FLP). The ONLY *)
+(* escape is a CLOCK-FENCED LEASE pre-consented at formation: at least    *)
+(* one honest member of the original ring emits no signature for any slot *)
+(* past a fixed public clock deadline T. Because a seal is n-of-n, that   *)
+(* one fenced honest member vetoes EVERY future original seal above the   *)
+(* fence, so the standby can seal strictly above T with provable          *)
+(* slot-range disjointness and never needs to learn the partitioned       *)
+(* ring's hidden prefix.                                                  *)
+(*                                                                         *)
+(* This module mechanizes the SUFFICIENCY construction (the minimal one:  *)
+(* safe in the pure async model given only the fence, no synchrony        *)
+(* bound). The adversary schedules the clock and may create the original  *)
+(* seal at any admissible moment; the fence is the only safety mechanism. *)
+(* TLC checks Disjoint (inductive) and NoFork over the reachable states.  *)
+(*                                                                         *)
+(* THE MUTATION (the impossibility, mechanized): remove the `s <= Fence`  *)
+(* fence from OrigSeal (i.e. let the original seal above the fence, as an  *)
+(* unfenced honest member legally may in the pure model) and TLC          *)
+(* reaches a state with conflicting seals for one slot — NoFork RED. That *)
+(* is Theorem 1 (responsive succession impossible) reproduced in the      *)
+(* model checker; the fence is exactly the load-bearing assumption.       *)
+(*                                                                         *)
+(* Reviews (internal workspace): reviews/t5d-clean-slate-{neutral,        *)
+(* impossibility}.md.  Adjudication: specs/t5d_succession_resolution.md.  *)
+(***************************************************************************)
+EXTENDS Naturals
+
+CONSTANTS
+  Slots,       \* the finite slot space explored (e.g. 1..4)
+  Values,      \* candidate seal values (>= 2 so a conflict is expressible)
+  NoVal,       \* sentinel: "no seal for this slot"; a model value outside Values
+  Fence,       \* T: the public lease deadline; original seals only slots <= T
+  MaxTick      \* clock exploration bound
+
+ASSUME ConstantAssumptions ==
+  /\ NoVal \notin Values
+  /\ Fence \in Slots
+  /\ \E a, b \in Values : a # b      \* a conflict must be expressible
+
+VARIABLES
+  clk,         \* the public VDF tick (monotone; the adversary advances it)
+  origSealed,  \* [Slots -> Values \cup {NoVal}] : the original ring's seals
+  stbySealed   \* [Slots -> Values \cup {NoVal}] : the standby ring's seals
+
+vars == <<clk, origSealed, stbySealed>>
+
+TypeOK ==
+  /\ clk \in 0..MaxTick
+  /\ origSealed \in [Slots -> Values \cup {NoVal}]
+  /\ stbySealed \in [Slots -> Values \cup {NoVal}]
+
+Init ==
+  /\ clk = 0
+  /\ origSealed = [s \in Slots |-> NoVal]
+  /\ stbySealed = [s \in Slots |-> NoVal]
+
+(***************************************************************************)
+(* Tick: the adversary advances the public clock (bounded for TLC). The   *)
+(* clock delivers no messages and compels nothing — it only measures      *)
+(* elapsed time.                                                          *)
+(***************************************************************************)
+Tick ==
+  /\ clk < MaxTick
+  /\ clk' = clk + 1
+  /\ UNCHANGED <<origSealed, stbySealed>>
+
+(***************************************************************************)
+(* OrigSeal: the original ring seals slot s with value v. THE FENCE is    *)
+(* the conjunct `s <= Fence`: the modeled content of the clock-fenced     *)
+(* lease. An unfenced honest original member could sign any slot at any   *)
+(* time (honesty bounds VALUES, never TIMING); the lease strengthens it   *)
+(* so no signature is emitted past the fence, and n-of-n makes that one   *)
+(* member's refusal veto the whole seal. The adversary chooses WHEN this  *)
+(* fires (any clk) and WHICH value — a partitioned-but-alive ring may     *)
+(* seal late, which is exactly why only the slot fence, not a timeout,    *)
+(* can be safe.                                                           *)
+(***************************************************************************)
+OrigSeal(s, v) ==
+  /\ s \in Slots
+  /\ v \in Values
+  /\ origSealed[s] = NoVal
+  /\ s <= Fence                          \* <-- THE FENCE (delete => NoFork RED)
+  /\ origSealed' = [origSealed EXCEPT ![s] = v]
+  /\ UNCHANGED <<clk, stbySealed>>
+
+(***************************************************************************)
+(* StbySeal: the standby ring seals slot s, strictly above the fence and  *)
+(* only after the public clock has passed the fence. It NEVER consults    *)
+(* the original ring's state — it does not need to, because the ranges    *)
+(* are disjoint. The adversary chooses the value.                         *)
+(***************************************************************************)
+StbySeal(s, v) ==
+  /\ s \in Slots
+  /\ v \in Values
+  /\ stbySealed[s] = NoVal
+  /\ s > Fence
+  /\ clk > Fence
+  /\ stbySealed' = [stbySealed EXCEPT ![s] = v]
+  /\ UNCHANGED <<clk, origSealed>>
+
+Next ==
+  \/ Tick
+  \/ \E s \in Slots, v \in Values : OrigSeal(s, v)
+  \/ \E s \in Slots, v \in Values : StbySeal(s, v)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* The safety property: no slot bears conflicting seals from the two      *)
+(* rings.                                                                 *)
+(***************************************************************************)
+NoFork ==
+  \A s \in Slots :
+    (stbySealed[s] # NoVal /\ origSealed[s] # NoVal) => stbySealed[s] = origSealed[s]
+
+(***************************************************************************)
+(* The inductive invariant that implies it — slot-range disjointness. The *)
+(* original never seals above the fence (the lease); the standby never    *)
+(* seals at or below it (its guard). So no slot ever bears two seals, a   *)
+(* fortiori no conflicting pair — NoFork holds vacuously.                 *)
+(***************************************************************************)
+Disjoint ==
+  /\ \A s \in Slots : (origSealed[s] # NoVal) => (s <= Fence)
+  /\ \A s \in Slots : (stbySealed[s] # NoVal) => (s > Fence)
+
+Inv ==
+  /\ TypeOK
+  /\ Disjoint
+  /\ NoFork
+
+====

--- a/internal-docs/architecture/protocols/aft/specs/common_boundary_theorems.md
+++ b/internal-docs/architecture/protocols/aft/specs/common_boundary_theorems.md
@@ -277,16 +277,35 @@ assertion). Pairing: L2 (unanimity forced at f = n−1) and L1.
 
 Assumes: A1, A2, A3, A9, A10.
 
-**STATUS: WITHDRAWN FOR THIS PROGRAM CYCLE — v3 REFUTED AT REVIEW ROUND
-5 (three formulations refuted: rounds 1, 2, 5).** The round-5 review
-proved the SuccessionClock kernel discharges a strictly NARROWED
+**STATUS: RESOLVED (2026-08-18) — RESPONSIVE succession is PROVEN
+IMPOSSIBLE; SCHEDULED succession is SAFE and MECHANIZED.** A clean-slate
+theorem challenge (two procedurally-isolated fresh-context theorists,
+each given only the model and the safety property, blind to v1–v3)
+CONVERGED on the answer the three refuted formulations were circling:
+detection-triggered (responsive) succession cannot be both safe and live
+in the asynchronous model — a dead ring is indistinguishable from a
+partitioned one (CAP + FLP; robust to randomization). The verifiable
+clock cannot help because it certifies elapsed TIME, never the original
+ring's future INACTION. The only escape is a CLOCK-FENCED LEASE
+pre-consented at formation (an honest member emits no signature past a
+public deadline `T`); because seals are n-of-n, one fenced honest member
+vetoes every future original seal, so a SCHEDULED succession (standby
+seals strictly above the fence, slot-disjoint from the original) is safe
+with no cross-ring view. This is machine-checked in
+`SuccessionSchedule.tla` (TLC green; deleting the fence reproduces the
+fork), and the full adjudication is in `p4`-adjacent
+`t5d_succession_resolution.md`. The prior "v4 conditions" question is
+answered: there is no v4 RESPONSIVE design to find. The final flagship
+rung stays unreachable (it was gated on a mechanized *positive*
+pre-consented-succession theorem with R11+R12 landed; the resolution
+sharpens that residual into an impossibility rather than opening the
+rung). Historical record of the refutation rounds follows. The round-5
+review proved the SuccessionClock kernel discharges a strictly NARROWED
 statement (the Byzantine standby has no modeled behavior; obs_commit is
 never adversary-chosen; the theorem's "binding" restriction excludes
 exactly the genuine-but-void rivals that still fork executors — R5-F3),
 and refuted the v3 spec twice independently (R5-F1 obs_commit padding;
-R5-F2 unwired voidness + the expiry/void contradiction). T5d does not
-return this cycle; the final flagship rung stays unreachable; the v4
-conditions are recorded in spec §16's banner and the review file.
+R5-F2 unwired voidness + the expiry/void contradiction).
 Historical record of the first two refutations: The round-1
 formulation was refuted (publication ≠ delivery under asynchrony); its
 round-2 repair was refuted in turn (the succession medium is an unmodeled
@@ -351,12 +370,18 @@ history. Succession under pure asynchrony with no such assumption is
 impossible — a dead ring and a partitioned ring are indistinguishable —
 and the ledger now prices this (A10) instead of the proof smuggling it.
 
-Mechanization: P2.7 (`SuccessionClock.tla`: the reachability theorem over
-BINDING seals, the voidness rules, the no-silence trigger assertion, the
-grace-window and anchoring-deadline mutations). Pairing: L-OPEN (the
-necessity of a scoped observation assumption for any safe succession —
-conjectured forced by the round-1 asynchrony argument; formalization
-open).
+Mechanization: the resolution kernel is `SuccessionSchedule.tla` (TLC:
+scheduled succession safe — `Disjoint` and `NoFork` hold over all
+reachable states; the fence-deleted mutation reaches the fork,
+mechanizing the impossibility). `SuccessionClock.tla` survives as the
+honestly-narrowed P2.7 kernel of the withdrawn responsive draft.
+Pairing: L-OPEN in the flagship sense, but the succession lower-bound
+question is now ANSWERED: safe succession with liveness is impossible in
+the pure async model, forced (by two convergent reductions) to require a
+scoped assumption — the clock-fenced lease (necessary and sufficient for
+the scheduled form), plus a known staleness bound only for gapless
+continuation. Formalization is no longer open; it is
+`t5d_succession_resolution.md` + `SuccessionSchedule.tla`.
 
 ## T6 — Composition (the lattice meet)
 

--- a/internal-docs/architecture/protocols/aft/specs/r11_r12_clock_succession_residuals.md
+++ b/internal-docs/architecture/protocols/aft/specs/r11_r12_clock_succession_residuals.md
@@ -53,20 +53,31 @@ activation only on the objective tick trigger, a fallback grace window
 with published-old-seal preemption, the honest-publication duty enforced
 in the signer, standby diversity against targeted capture.
 
-**Why it is a residual and not a build.** Two independent gates, either
-of which suffices:
+**Why it is a residual and not a build — and, since 2026-08-18, why the
+RESPONSIVE version is not merely open but IMPOSSIBLE.** Two independent
+gates, either of which suffices:
 
-1. **T5d is WITHDRAWN for this cycle.** Three formulations were refuted
-   across five review rounds (publication≠delivery; the bulletin as an
-   unmodeled consensus object; observation-committed adjudication whose
-   refusal rules Byzantine padding satisfies). The operative exits
-   remain §9 handover and §14 labeled re-genesis; §16's banner carries
-   the v4 conditions. Building R12's activation path would put runtime
-   under a safety statement the program itself refuted.
-2. **R11 is a residual.** The "objective tick trigger" IS the VDF
-   clock; without it, activation would fall back to wall-clock or
-   silence-derived triggers — the exact defect classes the program
-   exists to kill.
+1. **T5d is RESOLVED as an impossibility (was: withdrawn).** The
+   clean-slate theorem challenge (`t5d_succession_resolution.md`,
+   mechanized in `SuccessionSchedule.tla`) proved that RESPONSIVE
+   succession — activation triggered by evidence the original ring died,
+   which is exactly what R12's "kill-one-member → T_halt → activate"
+   path is — cannot be safe and live in the async model. So R12's
+   responsive activation path is not awaiting a fourth design; it is
+   provably unbuildable. What IS safe is SCHEDULED succession under a
+   clock-fenced lease pre-consented at formation (the standby seals
+   strictly above a public fence, slot-disjoint from the original). R12
+   is accordingly re-scoped: if it is ever built, it is the SCHEDULED
+   form (a formation-time lease + fence), never the responsive form. The
+   operative exits remain §9 handover and §14 labeled re-genesis — both
+   already scheduled/consented, i.e. exactly the safe shape.
+2. **R11 is a residual.** The clock-fenced lease still needs the
+   objective tick trigger — the VDF clock — for the fence deadline to be
+   publicly verifiable; without R11, activation would fall back to
+   wall-clock or silence-derived triggers, the exact defect classes the
+   program exists to kill. (The clock provides the fence's *time*; per
+   `t5d_succession_resolution.md` it provably cannot provide death
+   *detection*, which is why the lease, not a timeout, is load-bearing.)
 
 **What exists today, honestly labeled.** The pieces of R12 that are
 SAFE without the theorem all landed elsewhere: R9's signer makes the
@@ -77,11 +88,16 @@ R3's resolution log holds post-close evidence without mutation. What
 did NOT land — deliberately — is any path that ACTIVATES a successor
 ring from elapsed time or non-response.
 
-**Closing condition.** T5d v4 survives its own adversarial review
-(the §16 banner's conditions) AND R11 closes; then R12's build follows
-the leg spec's gates (kill-one-member cadence-freeze → T_halt →
-activation with continuity labels; the hidden-seal grace-window drill)
-and mutations.
+**Closing condition (re-scoped after the T5d resolution).** The
+RESPONSIVE R12 is closed as impossible — nothing to build. A SCHEDULED
+R12, if the owner wants it, closes when R11 lands (the clock for the
+fence deadline) and the formation-time lease is wired into the
+membership plane (an honest member's signing is fenced at a public
+deadline, mechanically enforced) — its safety is already mechanized in
+`SuccessionSchedule.tla`, so its build gate is integration, not a new
+theorem. The kill-one-member/T_halt "detect death then activate" gates
+from the original leg spec are RETIRED: they describe the impossible
+responsive form.
 
 ## Claim-surface effects
 

--- a/internal-docs/architecture/protocols/aft/specs/t5d_succession_resolution.md
+++ b/internal-docs/architecture/protocols/aft/specs/t5d_succession_resolution.md
@@ -1,0 +1,130 @@
+# T5d Resolution — Responsive Succession Is Impossible; Scheduled Succession Is Safe
+
+**Status: RESOLVED (2026-08-18) by a clean-slate theorem challenge with a
+mechanized artifact.** This supersedes the T5d "WITHDRAWN — design-open"
+state. The succession question is not open pending a fourth design attempt;
+it is answered: the class of designs that were refuted three times
+(responsive / death-detecting succession) is *provably impossible*, and
+the safe alternative (scheduled succession under a clock-fenced lease) is
+mechanized. This document is the adjudication; the machine-checked artifact
+is `formal/common_boundary/SuccessionSchedule.tla`.
+
+## How this was produced (the discipline, so the result is trustable)
+
+Per the owner ruling on external-capacity substitution: two procedurally
+isolated fresh-context theorists were each given ONLY the model and the
+desired safety property — never the three refuted formulations (v1
+publication≠delivery, v2 bulletin-as-consensus-object, v3
+observation-committed adjudication), so neither could anchor on a known-bad
+design. One was framed neutrally ("solve or prove impossible"), one
+impossibility-first. Their full analyses are internal workspace records
+(`reviews/t5d-clean-slate-{neutral,impossibility}.md`). A reviewer's
+conclusion closes nothing on its own; what closes the gap here is (a) two
+INDEPENDENT rigorous reductions that CONVERGE, and (b) a mechanized TLA+
+kernel whose mutation reproduces the impossibility.
+
+## The convergent result
+
+Both theorists reached the same impossibility by the same reduction
+family, independently:
+
+**Impossibility (unanimous).** *Responsive* succession — succession
+triggered by evidence that the original ring has died (a timeout, a
+silence detector) — cannot be both SAFE (never forks a slot) and LIVE
+(a genuinely dead ring is eventually succeeded) in the asynchronous
+model. Proof: a two-execution indistinguishability argument. A dead
+original ring and an alive-but-partitioned original ring that has already
+sealed a conflicting value present the standby with an IDENTICAL view at
+its decision point; a deterministic mechanism therefore acts identically,
+and in the partitioned world that action is a fork. Randomization does not
+help (the violation is on safety, not termination). This is the
+CAP/partitioned-agreement theorem (Gilbert–Lynch) specialized to a
+write-once (ring, slot)→value register, with FLP supplying the
+async-indistinguishability method.
+
+**Why the clock cannot save it (the pivotal lemma).** The verifiable-delay
+clock certifies elapsed *time*, never the original ring's *inaction*: it
+delivers no messages, holds no secret, and compels no one. Safety requires
+a certificate of the original's *future inaction* on a slot, and silence
+under asynchrony can never provide one — an unsent-looking gap is
+indistinguishable from a sent-but-delayed message. The hardware-advantage
+margin σ is therefore a *liveness/latency* parameter, not a safety one.
+(This is the same structural fact the VDF/coin review found from the other
+direction: a VDF is public and deterministic, so it can be a clock but not
+a secret-holding coin — `r11_vdf_coin_review.md`.)
+
+**The necessary escape (unanimous): a clock-fenced lease, pre-consented at
+formation.** Strengthen the original ring's honesty from value-only to
+value-AND-timing: at least one honest member emits NO signature for any
+slot past a fixed public clock deadline `T`. This is strictly beyond the
+model's honesty (which bounds *which* values a member signs, never *when*
+it stops), and the clock cannot impose it — it must be a pre-commitment.
+Because a seal is n-of-n, that one fenced honest member VETOES every future
+original seal above the fence. This discharges the "no future conflicting
+seal" obligation for free, communication-free, across the two disjoint
+rings.
+
+## The two safe constructions (a tradeoff, not a disagreement)
+
+The theorists gave two constructions that sit at different points on an
+assumption/liveness tradeoff. They do not conflict; the second buys
+gapless continuation at the price of a stronger assumption.
+
+- **Scheduled / slot-disjoint (minimal assumption).** The standby takes a
+  DISJOINT slot range: the original owns slots ≤ T, the standby owns slots
+  > T. Safe with ONLY the fence — no synchrony bound, no cross-ring view —
+  because the two ranges never intersect, so the standby need never learn
+  the partitioned ring's hidden prefix. Cost: slots below the fence are
+  burned, and handover is on a fixed schedule regardless of when the
+  original died. **This is the construction mechanized below.**
+
+- **Continued / gapless (stronger assumption).** To let the standby
+  CONTINUE the same slot sequence with no burned gap, add a known,
+  σ-adjusted staleness bound Δ on original-seal surfacing to the standby
+  (equivalently a class-P perfect stop-detector, or a known synchrony
+  bound). Strictly stronger than eventual synchrony / Ω / ◇S, and — the
+  sharp finding — strictly stronger than what ordinary consensus needs,
+  because succession is reconfiguration to a DISJOINT committee with no
+  quorum intersection to mask an imperfect detector's mistake (one wrong
+  "stopped" verdict is a direct fork).
+
+**Irreducible residue (unanimous).** Responsiveness itself — demoting only
+a genuinely-dead ring while never demoting a healthy one — is
+unconditionally impossible. A healthy-but-partitioned original MUST be
+demoted at the fence. There is no assumption that buys it back.
+
+## The mechanized artifact
+
+`formal/common_boundary/SuccessionSchedule.tla` models the async adversary
+(who schedules the clock and may seal the original at any admissible
+moment), the two disjoint rings, and the fence. TLC checks the
+slot-disjointness invariant and the no-fork safety property over every
+reachable state.
+
+- **Sufficiency, machine-checked:** with the fence, TLC explores the model
+  (Slots = 1..4, Fence = 2, two values, clock to 5) and finds `Disjoint`
+  and `NoFork` hold in all reachable states — scheduled succession is safe.
+- **Impossibility, machine-checked:** delete the fence conjunct from
+  `OrigSeal` (let the original seal above the fence, as an unfenced honest
+  member legally may) and TLC reaches a state where the original and the
+  standby seal the same slot with conflicting values — `NoFork` RED. That
+  is the impossibility theorem reproduced in the model checker; the fence
+  is exactly the load-bearing assumption.
+
+The kernel runs in the `aft_formal_floor` CI job on every build.
+
+## What this changes in the corpus
+
+- **T5d** moves from "WITHDRAWN — design-open" to a resolved pair: the
+  responsive-succession IMPOSSIBILITY (a publishable result) plus the
+  SCHEDULED-succession safety theorem (mechanized). The §16 banner's "v4
+  conditions" are answered: there is no v4 responsive design to find; the
+  safe form is scheduled, and it is here.
+- The operative exits from a dead ring remain, and are now *justified* as
+  the only safe options: the §9 unanimous handover and the §14 labeled
+  re-genesis are scheduled/consented transitions, exactly the fence shape.
+- The T5d pairing row stays L-OPEN in the flagship sense (the succession
+  lower-bound question is now ANSWERED as an impossibility, but the
+  program's final-flagship rung was gated on a mechanized *positive* T5d
+  with R11+R12 landed; that rung stays unreachable — the resolution
+  sharpens the residual rather than opening the rung).


### PR DESCRIPTION
## AFT-CB — T5d resolution

A clean-slate theorem challenge (two procedurally-isolated fresh-context theorists, each given only the model and the safety property, **blind to the three refuted formulations**) converged on the answer those refutations were circling.

### The convergent result
- **Responsive succession is IMPOSSIBLE.** Death-triggered safe-and-live succession cannot exist in the async model — a dead ring is indistinguishable from a partitioned one, so the standby's view is identical in both worlds and a deterministic mechanism forks. CAP (Gilbert–Lynch) + FLP; robust to randomization.
- **The clock can't save it:** it certifies elapsed *time*, never the original's *inaction*. σ is a liveness parameter, not safety.
- **Necessary + sufficient escape:** a **clock-fenced lease** pre-consented at formation (n-of-n makes one fenced honest member veto every future original seal). Two safe constructions on a tradeoff — slot-disjoint (lease only) vs. gapless (adds a staleness bound, *strictly harder than consensus* because disjoint committees lack quorum intersection).
- **Irreducible residue:** responsiveness is unconditionally impossible.

### Mechanized (the checkable close)
`SuccessionSchedule.tla` — TLC green (Disjoint + NoFork over all reachable states = scheduled succession safe). **Mutation: delete the fence → TLC reaches the fork → NoFork RED = the impossibility, mechanized.** Wired into the formal floor (census 35 = 22 executed + 13 manual).

### Corpus
T5d: WITHDRAWN → RESOLVED. RES-R12 re-scoped (responsive R12 impossible; scheduled R12 = integration, not new theory). Adjudication in `t5d_succession_resolution.md`.

This converts the program's deepest scar — cross-partition adjudication as the recurring defect class — into a theorem: the three refutations were circling an impossibility, now proven and mechanized, with the safe alternative machine-checked. All gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)