### PR TITLE
infra(aft): Akash Stage-1 bench kit — Dockerfile + SDL + runner for a NON-GATING RES-P4.3 reference

### DIFF
--- a/internal-docs/architecture/protocols/aft/bench/akash/Dockerfile
+++ b/internal-docs/architecture/protocols/aft/bench/akash/Dockerfile
@@ -1,0 +1,55 @@
+# AFT paper-benchmark runner image (RES-P4.3, Stage 1: Akash console deploy).
+#
+# Builds the ioi workspace at a pinned commit and runs the AFT paper-benchmark
+# matrix. Output is a Markdown table on stdout (retrieve via `akash ... lease-logs`).
+#
+# PROPRIETARY: this image contains the full ioi source at the pinned commit.
+# It MUST be pushed to a PRIVATE registry only, and the Akash SDL must pull it
+# with `credentials` (see deploy.sdl). Never push to a public registry.
+#
+# Reproducibility: pin the toolchain (rust-toolchain.toml → 1.93.1) and the
+# source commit. The host KERNEL is the Akash provider's, not ours — a
+# documented caveat; this run is a NON-GATING reference until a reserved
+# bare-metal / pinned runner exists (see README.md and the RES-P4.3 residual).
+
+FROM rust:1.93.1-bookworm
+
+# Native deps — mirrors the "Install native deps for kernel build" CI step.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config \
+        cmake \
+        libdbus-1-dev \
+        protobuf-compiler \
+        libxcb1-dev \
+        libxdo-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /ioi
+
+# Build context MUST be a clean checkout of the pinned commit:
+#   git -C <repo> archive 98a04f163 | tar -x -C /tmp/ioi-pinned
+#   docker build -f internal-docs/architecture/protocols/aft/bench/akash/Dockerfile -t <registry>/aft-bench:98a04f163 /tmp/ioi-pinned
+COPY . .
+
+# Record the source commit into the image for the manifest (best-effort;
+# overridable via --build-arg so an archive build without .git still stamps it).
+ARG IOI_COMMIT=98a04f163b1b1e5c81d953eeeb71511114acc83e
+ENV IOI_BENCH_COMMIT=${IOI_COMMIT}
+
+# Pre-compile the benchmark test binary (release) at build time so the paid
+# Akash lease pays for EXECUTION, not compilation.
+RUN cargo test --release --no-run \
+        -p ioi-cli \
+        --features consensus-aft,vm-wasm,state-jellyfish \
+        -- test_aft_paper_benchmark_matrix
+
+COPY internal-docs/architecture/protocols/aft/bench/akash/run-bench.sh /usr/local/bin/run-bench.sh
+RUN chmod +x /usr/local/bin/run-bench.sh
+
+# Repetition + warmup knobs (override in the SDL env).
+ENV AFT_BENCH_WARMUPS=1 \
+    AFT_BENCH_REPEATS=5 \
+    IOI_AFT_BENCH_SCENARIO= \
+    IOI_TEST_BUILD_PROFILE=release
+
+ENTRYPOINT ["/usr/local/bin/run-bench.sh"]

--- a/internal-docs/architecture/protocols/aft/bench/akash/README.md
+++ b/internal-docs/architecture/protocols/aft/bench/akash/README.md
@@ -1,0 +1,92 @@
+# AFT paper-benchmark on Akash — RES-P4.3 Stage 1 (console deploy)
+
+Turnkey kit to run the AFT paper-benchmark matrix on a rented Akash lease and
+retrieve a **variance-caveated, NON-GATING** reference table. This does **not**
+close RES-P4.3: its gate is "reproduces within stated variance on re-run,"
+which needs a reserved/pinned runner. A generic Akash lease is a container on a
+heterogeneous third-party provider — another variable box, and a re-run may
+even land on a different host. What this kit buys:
+
+1. a reference number off *our* dev box (which runs CI on every merge and is
+   actively used), on a spec we control; and
+2. the first real Akash workload, de-risking the image + SDL ahead of Stage 2
+   (routing deployments through the hypervisor's own Akash adapter).
+
+## Honest reproducibility rules (for the number to mean anything)
+
+- **Pin one provider.** Select the SAME provider on every re-run and record its
+  provider address. Akash SDL filters by attributes, not provider address, so
+  the pin is enforced by *your* bid selection, not the SDL alone.
+- **Request whole-core dedicated CPU.** Oversubscribed vCPU is the main
+  variance source. Prefer a provider that advertises dedicated CPU.
+- **Warmups + repeats.** `AFT_BENCH_WARMUPS` discarded passes, then
+  `AFT_BENCH_REPEATS` measured passes; report min/median/max and the spread.
+- **Record the manifest.** The runner prints an `===AFT-BENCH ENVIRONMENT
+  MANIFEST===` block (commit, CPU model, cores, mem, kernel, rustc, governor).
+  Keep it with the numbers. The host **kernel is the provider's** — a caveat.
+- Label the result table **RELATIVE-COMPARISON-ONLY / NON-GATING** wherever it
+  is cited, per the RES-P4.3 residual (`../../specs/p4_measured_costs.md`).
+
+## Build (private registry — mandatory)
+
+The image carries proprietary source at the pinned commit. Push to a **private**
+registry only.
+
+```bash
+# From the repo root, build a clean archive of the pinned commit as the context:
+git archive 98a04f163 | tar -x -C /tmp/ioi-pinned
+docker build \
+  -f internal-docs/architecture/protocols/aft/bench/akash/Dockerfile \
+  -t REGISTRY_HOST/ORG/aft-bench:98a04f163 \
+  /tmp/ioi-pinned
+docker push REGISTRY_HOST/ORG/aft-bench:98a04f163
+```
+
+Building the image compiles the workspace once (release). Prefer building in CI
+or on an idle machine, not the shared dev box under load. (A GHCR build job is
+the clean home for this — a Stage 2 follow-up.)
+
+## Deploy (Akash console — your spend)
+
+1. Edit `deploy.sdl`: set `image`, `credentials` (private registry token), CPU
+   units, and the max `amount`.
+2. In console.akash.network → **Deploy image / custom SDL**, paste `deploy.sdl`.
+3. Review bids, **pick your pinned provider**, create the lease, send the
+   manifest. CPU-only; ignore GPU providers.
+
+Cost: single-digit-dollar range for a CPU lease held briefly; the $1 trial
+covers a smoke. **Spend and the wallet are yours — this kit never spends.**
+
+## Retrieve + tear down
+
+```bash
+# Stream the results (Markdown tables between ===AFT-BENCH RUN k/N=== markers):
+akash provider lease-logs --dseq <DSEQ> --provider <PROVIDER> --follow
+
+# When you have all N runs' tables + the manifest, CLOSE THE LEASE:
+akash tx deployment close --dseq <DSEQ> --from <KEY>
+```
+
+The container holds (`sleep infinity`) after the runs so logs stay retrievable;
+it does **not** self-close — closing is manual so you don't lose output and
+don't get billed for an auto-restart re-running the matrix.
+
+## What the runner does
+
+`run-bench.sh` → env manifest → `AFT_BENCH_WARMUPS` discarded warmups →
+`AFT_BENCH_REPEATS` measured passes of
+`cargo test --release -p ioi-cli --features consensus-aft,vm-wasm,state-jellyfish -- --ignored --nocapture test_aft_paper_benchmark_matrix`,
+each wrapped in run markers. Scenarios (via `IOI_AFT_BENCH_SCENARIO`):
+`paper_guardian_majority_4v`, `paper_guardian_majority_7v`,
+`paper_asymptote_4v`, `paper_asymptote_7v` (n ∈ {4, 7}; empty = full matrix).
+Output is a Markdown table per pass — retrieve via lease-logs.
+
+## Stage 2 (separate)
+
+Routing the deployment through the hypervisor's own Akash adapter is a distinct
+cut: [crates/drivers/src/provisioning/akash.rs](../../../../../../crates/drivers/src/provisioning/akash.rs)
+currently STUBS `provision()` (generates SDL, logs it; the sign-tx →
+broadcast → bids → lease → manifest flow is a comment). The merged Akash DePIN
+work is the candidate/quote plane only (source-quoted USD, never authority).
+This bench image is the intended first end-to-end workload once that live-lease
+path is built (needs a funded wallet + owner spend authorization).

--- a/internal-docs/architecture/protocols/aft/bench/akash/deploy.sdl
+++ b/internal-docs/architecture/protocols/aft/bench/akash/deploy.sdl
@@ -1,0 +1,70 @@
+---
+# AFT paper-benchmark on Akash (RES-P4.3, Stage 1: console deploy).
+#
+# Batch job: runs the benchmark matrix, prints Markdown tables to stdout
+# (retrieve via lease-logs), then holds the container so results stay
+# retrievable. CLOSE THE LEASE MANUALLY when you have the logs.
+#
+# REPRODUCIBILITY: Akash schedules onto heterogeneous third-party providers,
+# so a fresh lease can land on a different host. For RES-P4.3 you MUST select
+# the SAME provider on every re-run (record its provider address + the printed
+# environment manifest), request whole-core dedicated CPU, and report the
+# run-to-run variance envelope. The provider host kernel is not ours — a
+# documented caveat. This remains a NON-GATING reference until a reserved
+# bare-metal / pinned runner exists.
+#
+# PRIVATE IMAGE: fill `credentials` with a PRIVATE registry token. The image
+# carries proprietary source — never a public registry.
+
+version: "2.0"
+
+services:
+  aft-bench:
+    # Pin the image by the source commit tag, not `latest`.
+    image: REGISTRY_HOST/ORG/aft-bench:98a04f163
+    credentials:
+      host: REGISTRY_HOST
+      username: REGISTRY_USER
+      password: REGISTRY_TOKEN
+    env:
+      - AFT_BENCH_WARMUPS=1
+      - AFT_BENCH_REPEATS=5
+      # Empty = full matrix. Or pin one scenario:
+      #   paper_guardian_majority_4v | paper_guardian_majority_7v
+      #   paper_asymptote_4v         | paper_asymptote_7v
+      - IOI_AFT_BENCH_SCENARIO=
+    # No `expose`: this is a batch job; results come back over lease-logs.
+
+profiles:
+  compute:
+    aft-bench:
+      resources:
+        cpu:
+          # Whole-core request. Prefer a provider that honors dedicated CPU;
+          # oversubscribed vCPU is the main reproducibility risk.
+          units: 8
+        memory:
+          size: 16Gi
+        storage:
+          size: 20Gi
+  placement:
+    pinned:
+      # Constrain the bid set. For a true pin, narrow these to attributes only
+      # your chosen provider advertises (and/or `signedBy` an audited set),
+      # then still select the SAME provider from the bid list each re-run.
+      attributes:
+        host: akash
+      # signedBy:
+      #   anyOf:
+      #     - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"   # example auditor
+      pricing:
+        aft-bench:
+          denom: uakt
+          # Max price you'll pay (console lets you set this at deploy time).
+          amount: 100000
+
+deployment:
+  aft-bench:
+    pinned:
+      profile: aft-bench
+      count: 1

--- a/internal-docs/architecture/protocols/aft/bench/akash/run-bench.sh
+++ b/internal-docs/architecture/protocols/aft/bench/akash/run-bench.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# AFT paper-benchmark runner entrypoint (RES-P4.3, Stage 1).
+#
+# Prints an environment manifest, runs AFT_BENCH_WARMUPS discarded warmups,
+# then AFT_BENCH_REPEATS measured passes of the AFT paper-benchmark matrix.
+# Each pass is wrapped in ===AFT-BENCH RUN k/N=== markers so the Markdown
+# tables can be split for variance analysis. After the passes it sleeps so the
+# Akash lease stays up for log retrieval — CLOSE THE LEASE MANUALLY when done.
+#
+# Retrieval: the results are on stdout (provider lease-logs). If /output is a
+# mounted volume, each pass is also written there.
+set -uo pipefail
+
+WARMUPS="${AFT_BENCH_WARMUPS:-1}"
+REPEATS="${AFT_BENCH_REPEATS:-5}"
+SCENARIO="${IOI_AFT_BENCH_SCENARIO:-}"   # empty = full matrix (4v+7v, both families)
+OUTDIR="${AFT_BENCH_OUTDIR:-/output}"
+mkdir -p "$OUTDIR" 2>/dev/null || true
+
+bench_cmd() {
+  cargo test --release \
+    -p ioi-cli \
+    --features consensus-aft,vm-wasm,state-jellyfish \
+    -- --ignored --nocapture test_aft_paper_benchmark_matrix
+}
+
+echo "===AFT-BENCH ENVIRONMENT MANIFEST==="
+echo "source_commit: ${IOI_BENCH_COMMIT:-unknown}"
+echo "scenario_filter: ${SCENARIO:-<full-matrix>}"
+echo "warmups: ${WARMUPS}   repeats: ${REPEATS}"
+echo "cpu_model: $(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2 | sed 's/^ //')"
+echo "cpu_cores_online: $(nproc 2>/dev/null)"
+echo "mem_total: $(awk '/MemTotal/{print $2 $3}' /proc/meminfo 2>/dev/null)"
+echo "kernel: $(uname -r 2>/dev/null)   (NOTE: provider host kernel, not ours)"
+echo "rustc: $(rustc --version 2>/dev/null)"
+echo "governor: $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo unknown)"
+echo "===END MANIFEST==="
+
+for w in $(seq 1 "${WARMUPS}"); do
+  echo "===AFT-BENCH WARMUP ${w}/${WARMUPS} (discarded)==="
+  bench_cmd >/dev/null 2>&1 || echo "warmup ${w} exited non-zero (continuing)"
+done
+
+for k in $(seq 1 "${REPEATS}"); do
+  echo "===AFT-BENCH RUN ${k}/${REPEATS} BEGIN==="
+  if [ -w "$OUTDIR" ]; then
+    bench_cmd 2>&1 | tee "${OUTDIR}/run-${k}.md"
+  else
+    bench_cmd 2>&1
+  fi
+  echo "===AFT-BENCH RUN ${k}/${REPEATS} END==="
+done
+
+echo "===AFT-BENCH ALL RUNS COMPLETE — lease idle, CLOSE IT MANUALLY==="
+# Keep the container alive so `lease-logs` and any mounted /output remain
+# retrievable. Akash treats an exited service as crashed and restarts it,
+# which would re-run the whole matrix and bill for it — so we hold here.
+sleep infinity


### PR DESCRIPTION
## What

Turnkey kit under `internal-docs/architecture/protocols/aft/bench/akash/` to run the AFT paper-benchmark matrix on a rented Akash lease and retrieve a **variance-caveated, NON-GATING** reference table. Stage 1 of the owner-approved "both, staged" Akash plan.

**This does not close RES-P4.3.** The residual's gate is "reproduces within stated variance on re-run," which needs a reserved/pinned runner; a generic Akash lease is a container on a heterogeneous third-party provider — another variable box. What it buys: (1) a reference number on a spec we control instead of the shared dev box (which runs CI on every merge and is actively used), and (2) the first real Akash workload, de-risking the image + SDL ahead of Stage 2.

## Files

| File | Role |
|---|---|
| `Dockerfile` | rust 1.93.1, CI native-deps, pinned commit `98a04f163`, pre-compiles the bench binary at build time (paid lease pays for execution, not compilation). **Proprietary — private registry only.** |
| `run-bench.sh` | env manifest → warmups → repeats of the documented `cargo test … test_aft_paper_benchmark_matrix`, run-markered; holds the container so lease-logs stay retrievable |
| `deploy.sdl` | whole-core dedicated CPU, private-image `credentials`, provider-pinning notes; batch job, results via lease-logs |
| `README.md` | honest reproducibility rules, build/deploy/retrieve/teardown, Stage 2 pointer |

## Honest reproducibility framing (in the README + SDL comments)

Pin one provider (Akash filters by attributes, not address — enforce via your bid selection), request whole-core dedicated CPU, warmups + repeats, record the printed manifest (**host kernel is the provider's** — a caveat), and label the table **RELATIVE-COMPARISON-ONLY / NON-GATING** per `../../specs/p4_measured_costs.md`.

## Not in scope (Stage 2)

Routing through the hypervisor's own Akash adapter — [crates/drivers/src/provisioning/akash.rs](crates/drivers/src/provisioning/akash.rs) still stubs `provision()` (SDL generated + logged; sign-tx → bids → lease → manifest is a comment). The merged Akash DePIN work is the candidate/quote plane only. This bench image is the intended first e2e workload once the live-lease path is built (needs a funded wallet + spend authorization).

## Spend

None here — the kit is templates (registry/provider/price are placeholders). Spend and the wallet stay with the owner.

## Validation

`bash -n run-bench.sh` clean; `deploy.sdl` parses as valid SDL v2; scenario names + features verified against the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)