### PR TITLE
feat(drivers): Akash Console (managed) API client — transport-free request specs + response accessors (no spend)

### DIFF
--- a/crates/drivers/src/provisioning/akash_console.rs
+++ b/crates/drivers/src/provisioning/akash_console.rs
@@ -1,0 +1,272 @@
+//! Akash **Console (managed) API** — request specifications and response
+//! accessors for the managed-wallet REST surface.
+//!
+//! This is the managed path: authenticate with an `x-api-key` and let the
+//! Console back-end custody the wallet/escrow. There is no chain transaction,
+//! no AKT, and no key-signing here — only REST. It is the surface behind the
+//! `$100 credit` API keys created at `console.akash.network`.
+//!
+//! **Transport-free by design.** Each builder returns a [`ConsoleRequest`]
+//! describing exactly what to send (method, path incl. query, the `x-api-key`
+//! header, optional JSON body). The daemon executes it with `reqwest` ONLY
+//! behind its `mode==live` + wallet-lease gate; the spend-capable operations
+//! (`create_deployment`, `create_lease`, `deposit_deployment`, and the
+//! resource-changing `update_deployment`) are **never executed from this
+//! crate**. Keeping the contract pure makes the request shapes unit-testable
+//! without a network and keeps every real spend on the gated side.
+//!
+//! Contract source: `akash-network/console` — `console-api-types`
+//! (OpenAPI-generated `operations.gen.ts`) and the
+//! `managed-api-deployment-flow` end-to-end test. Auth note from the same
+//! source: `x-api-key` and `Authorization` are **mutually exclusive**, so we
+//! send `x-api-key` only.
+
+use serde_json::{json, Value};
+
+/// Base URL for the managed Console API.
+pub const AKASH_CONSOLE_BASE_URL: &str = "https://console-api.akash.network";
+/// The (only) auth header. Never send `Authorization` alongside it.
+pub const API_KEY_HEADER: &str = "x-api-key";
+
+/// HTTP method for a [`ConsoleRequest`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ConsoleMethod {
+    Get,
+    Post,
+    Put,
+    Delete,
+}
+
+impl ConsoleMethod {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConsoleMethod::Get => "GET",
+            ConsoleMethod::Post => "POST",
+            ConsoleMethod::Put => "PUT",
+            ConsoleMethod::Delete => "DELETE",
+        }
+    }
+}
+
+/// A fully-specified Console API request. `api_key` is carried for the header
+/// only and is deliberately excluded from `Debug` so the secret cannot leak
+/// into a log line.
+#[derive(Clone)]
+pub struct ConsoleRequest {
+    pub method: ConsoleMethod,
+    /// Path including any query string, e.g. `"/v1/bids?dseq=123"`. Join to
+    /// [`AKASH_CONSOLE_BASE_URL`] (or an override base) to form the full URL.
+    pub path: String,
+    /// JSON body for POST/PUT operations; `None` for GET/DELETE.
+    pub body: Option<Value>,
+    /// Whether this request moves money / provisions resources. The daemon
+    /// MUST require a redeemed wallet lease (and, for the first live run, an
+    /// explicit human confirm) before executing a spend request.
+    pub spend: bool,
+    api_key: String,
+}
+
+impl std::fmt::Debug for ConsoleRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConsoleRequest")
+            .field("method", &self.method)
+            .field("path", &self.path)
+            .field("body", &self.body)
+            .field("spend", &self.spend)
+            .field("api_key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl ConsoleRequest {
+    fn get(api_key: &str, path: impl Into<String>) -> Self {
+        Self {
+            method: ConsoleMethod::Get,
+            path: path.into(),
+            body: None,
+            spend: false,
+            api_key: api_key.to_string(),
+        }
+    }
+
+    /// The auth header pair to attach to the outgoing request.
+    pub fn header(&self) -> (&'static str, &str) {
+        (API_KEY_HEADER, &self.api_key)
+    }
+
+    /// True iff this request provisions resources or moves credits.
+    pub fn is_spend(&self) -> bool {
+        self.spend
+    }
+}
+
+/// A selected bid, extracted from `GET /v1/bids?dseq=…`. The provider-native
+/// ids (`gseq`/`oseq`/`provider`) are evidence used to create the lease.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AkashBid {
+    pub gseq: i64,
+    pub oseq: i64,
+    pub provider: String,
+}
+
+// ----- read-only operations (never spend) -----
+
+/// Read-only credential probe. A `200` proves the sealed key authenticates,
+/// which is how an akash account transitions to `status == "verified"` WITHOUT
+/// any spend. `GET /v1/wallet-settings`.
+pub fn verify_key(api_key: &str) -> ConsoleRequest {
+    ConsoleRequest::get(api_key, "/v1/wallet-settings")
+}
+
+/// List existing deployments (read-only). `GET /v1/deployments?skip=&limit=`.
+pub fn list_deployments(api_key: &str, skip: u32, limit: u32) -> ConsoleRequest {
+    ConsoleRequest::get(
+        api_key,
+        format!("/v1/deployments?skip={skip}&limit={limit}"),
+    )
+}
+
+/// List bids for a deployment (read-only). Poll until `data.data[0]` exists.
+/// `GET /v1/bids?dseq=…`.
+pub fn list_bids(api_key: &str, dseq: &str) -> ConsoleRequest {
+    ConsoleRequest::get(api_key, format!("/v1/bids?dseq={dseq}"))
+}
+
+/// Get one deployment incl. leases + escrow (read-only). Used to poll status
+/// and read lease endpoints. `GET /v1/deployments/{dseq}`.
+pub fn get_deployment(api_key: &str, dseq: &str) -> ConsoleRequest {
+    ConsoleRequest::get(api_key, format!("/v1/deployments/{dseq}"))
+}
+
+// ----- state-changing operations -----
+
+/// Close a deployment. `DELETE /v1/deployments/{dseq}`. Not a *spend* (it stops
+/// spend), but it IS a lifecycle mutation the daemon receipts.
+pub fn close_deployment(api_key: &str, dseq: &str) -> ConsoleRequest {
+    ConsoleRequest {
+        method: ConsoleMethod::Delete,
+        path: format!("/v1/deployments/{dseq}"),
+        body: None,
+        spend: false,
+        api_key: api_key.to_string(),
+    }
+}
+
+// ----- SPEND operations (daemon must gate on a redeemed wallet lease) -----
+
+/// Create a deployment from an SDL yaml string, funded with `deposit` credits
+/// (dollars on the managed wallet). SPEND. `POST /v1/deployments` with body
+/// `{"data": {"sdl": "<yaml>", "deposit": <n>}}`.
+pub fn create_deployment(api_key: &str, sdl_yaml: &str, deposit: f64) -> ConsoleRequest {
+    ConsoleRequest {
+        method: ConsoleMethod::Post,
+        path: "/v1/deployments".to_string(),
+        body: Some(json!({ "data": { "sdl": sdl_yaml, "deposit": deposit } })),
+        spend: true,
+        api_key: api_key.to_string(),
+    }
+}
+
+/// Create a lease against a selected bid, sending the encoded manifest returned
+/// by `create_deployment`. SPEND (starts the accruing lease). `POST /v1/leases`
+/// with body `{"manifest": "<enc>", "leases": [{dseq, gseq, oseq, provider}]}`.
+pub fn create_lease(api_key: &str, manifest: &str, dseq: &str, bid: &AkashBid) -> ConsoleRequest {
+    ConsoleRequest {
+        method: ConsoleMethod::Post,
+        path: "/v1/leases".to_string(),
+        body: Some(json!({
+            "manifest": manifest,
+            "leases": [{
+                "dseq": dseq,
+                "gseq": bid.gseq,
+                "oseq": bid.oseq,
+                "provider": bid.provider,
+            }],
+        })),
+        spend: true,
+        api_key: api_key.to_string(),
+    }
+}
+
+/// Add credits to an existing deployment's escrow. SPEND.
+/// `POST /v1/deposit-deployment` with body `{"data": {"dseq", "deposit"}}`.
+pub fn deposit_deployment(api_key: &str, dseq: &str, deposit: f64) -> ConsoleRequest {
+    ConsoleRequest {
+        method: ConsoleMethod::Post,
+        path: "/v1/deposit-deployment".to_string(),
+        body: Some(json!({ "data": { "dseq": dseq, "deposit": deposit } })),
+        spend: true,
+        api_key: api_key.to_string(),
+    }
+}
+
+// ----- response accessors (pure; over the documented shapes) -----
+
+/// The `dseq` from a `createDeployment` response: `{"data": {"dseq": "…"}}`.
+pub fn parse_created_dseq(resp: &Value) -> Option<String> {
+    resp.pointer("/data/dseq")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// The encoded manifest from a `createDeployment` response, needed by
+/// `create_lease`: `{"data": {"manifest": "…"}}`.
+pub fn parse_created_manifest(resp: &Value) -> Option<String> {
+    resp.pointer("/data/manifest")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// The first bid from a `listBids` response, shape `{"data": {"data": [ {"bid":
+/// {"id": {"gseq", "oseq", "provider"}}} ]}}`. Returns `None` while no provider
+/// has bid yet (keep polling).
+pub fn parse_first_bid(resp: &Value) -> Option<AkashBid> {
+    let bid = resp.pointer("/data/data/0/bid/id")?;
+    Some(AkashBid {
+        gseq: bid.get("gseq").and_then(Value::as_i64)?,
+        oseq: bid.get("oseq").and_then(Value::as_i64)?,
+        provider: bid.get("provider").and_then(Value::as_str)?.to_string(),
+    })
+}
+
+/// The lowest-priced bid across a `listBids` response, so selection can respect
+/// a price cap. Falls back to the first bid's ordering when prices are absent.
+pub fn parse_cheapest_bid(resp: &Value) -> Option<AkashBid> {
+    let bids = resp.pointer("/data/data").and_then(Value::as_array)?;
+    let mut best: Option<(f64, AkashBid)> = None;
+    for entry in bids {
+        let id = entry.pointer("/bid/id")?;
+        let bid = AkashBid {
+            gseq: id.get("gseq").and_then(Value::as_i64)?,
+            oseq: id.get("oseq").and_then(Value::as_i64)?,
+            provider: id.get("provider").and_then(Value::as_str)?.to_string(),
+        };
+        // price.amount is a decimal string in the smallest denom; missing → max.
+        let price = entry
+            .pointer("/bid/price/amount")
+            .and_then(|v| {
+                v.as_str()
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .or_else(|| v.as_f64())
+            })
+            .unwrap_or(f64::MAX);
+        match &best {
+            Some((p, _)) if *p <= price => {}
+            _ => best = Some((price, bid)),
+        }
+    }
+    best.map(|(_, b)| b)
+}
+
+/// The deployment `state` from a `getDeployment` response
+/// (`{"data": {"deployment": {"state": "…"}}}`), e.g. `"active"`/`"closed"`.
+pub fn parse_deployment_state(resp: &Value) -> Option<String> {
+    resp.pointer("/data/deployment/state")
+        .or_else(|| resp.pointer("/deployment/state"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+#[path = "akash_console/tests.rs"]
+mod tests;

--- a/crates/drivers/src/provisioning/akash_console/tests.rs
+++ b/crates/drivers/src/provisioning/akash_console/tests.rs
@@ -1,0 +1,154 @@
+use super::*;
+use serde_json::json;
+
+const KEY: &str = "ak-secret-do-not-log";
+
+// ----- request construction is exact (method, path, header, body, spend flag) -----
+
+#[test]
+fn verify_key_is_a_read_only_wallet_settings_get() {
+    let r = verify_key(KEY);
+    assert_eq!(r.method, ConsoleMethod::Get);
+    assert_eq!(r.path, "/v1/wallet-settings");
+    assert!(r.body.is_none());
+    assert!(!r.is_spend(), "a credential probe must never be a spend");
+    assert_eq!(r.header(), (API_KEY_HEADER, KEY));
+    assert_eq!(API_KEY_HEADER, "x-api-key");
+}
+
+#[test]
+fn list_bids_carries_the_dseq_query() {
+    let r = list_bids(KEY, "123456");
+    assert_eq!(r.method, ConsoleMethod::Get);
+    assert_eq!(r.path, "/v1/bids?dseq=123456");
+    assert!(!r.is_spend());
+}
+
+#[test]
+fn get_and_close_deployment_hit_the_dseq_path() {
+    let g = get_deployment(KEY, "42");
+    assert_eq!(g.method, ConsoleMethod::Get);
+    assert_eq!(g.path, "/v1/deployments/42");
+    assert!(!g.is_spend());
+
+    let c = close_deployment(KEY, "42");
+    assert_eq!(c.method, ConsoleMethod::Delete);
+    assert_eq!(c.path, "/v1/deployments/42");
+    // Closing stops spend; it is not itself a spend.
+    assert!(!c.is_spend());
+}
+
+#[test]
+fn create_deployment_wraps_sdl_and_deposit_and_is_a_spend() {
+    let r = create_deployment(KEY, "version: \"2.0\"\n", 5.0);
+    assert_eq!(r.method, ConsoleMethod::Post);
+    assert_eq!(r.path, "/v1/deployments");
+    assert_eq!(
+        r.body.as_ref().unwrap(),
+        &json!({ "data": { "sdl": "version: \"2.0\"\n", "deposit": 5.0 } })
+    );
+    assert!(
+        r.is_spend(),
+        "creating a funded deployment MUST classify as spend"
+    );
+}
+
+#[test]
+fn create_lease_targets_the_selected_bid_and_is_a_spend() {
+    let bid = AkashBid {
+        gseq: 1,
+        oseq: 2,
+        provider: "akash1prov".into(),
+    };
+    let r = create_lease(KEY, "ENCODED_MANIFEST", "789", &bid);
+    assert_eq!(r.method, ConsoleMethod::Post);
+    assert_eq!(r.path, "/v1/leases");
+    assert_eq!(
+        r.body.as_ref().unwrap(),
+        &json!({
+            "manifest": "ENCODED_MANIFEST",
+            "leases": [{ "dseq": "789", "gseq": 1, "oseq": 2, "provider": "akash1prov" }]
+        })
+    );
+    assert!(r.is_spend(), "opening a lease starts accruing spend");
+}
+
+#[test]
+fn deposit_is_a_spend_with_the_documented_body() {
+    let r = deposit_deployment(KEY, "789", 0.5);
+    assert_eq!(r.method, ConsoleMethod::Post);
+    assert_eq!(r.path, "/v1/deposit-deployment");
+    assert_eq!(
+        r.body.as_ref().unwrap(),
+        &json!({ "data": { "dseq": "789", "deposit": 0.5 } })
+    );
+    assert!(r.is_spend());
+}
+
+// ----- the secret never leaks through Debug -----
+
+#[test]
+fn debug_redacts_the_api_key() {
+    let r = create_deployment(KEY, "sdl", 5.0);
+    let dbg = format!("{r:?}");
+    assert!(
+        !dbg.contains(KEY),
+        "Debug must not print the api key: {dbg}"
+    );
+    assert!(dbg.contains("<redacted>"));
+}
+
+// ----- response accessors over the documented shapes -----
+
+#[test]
+fn parse_created_deployment_reads_dseq_and_manifest() {
+    let resp = json!({ "data": { "dseq": "555", "manifest": "ENC" } });
+    assert_eq!(parse_created_dseq(&resp).as_deref(), Some("555"));
+    assert_eq!(parse_created_manifest(&resp).as_deref(), Some("ENC"));
+    // A missing field yields None, never a panic or a fabricated value.
+    assert_eq!(parse_created_dseq(&json!({ "data": {} })), None);
+}
+
+#[test]
+fn parse_first_bid_reads_the_provider_native_ids() {
+    let resp = json!({
+        "data": { "data": [
+            { "bid": { "id": { "gseq": 1, "oseq": 3, "provider": "akash1abc" } } }
+        ]}
+    });
+    assert_eq!(
+        parse_first_bid(&resp),
+        Some(AkashBid {
+            gseq: 1,
+            oseq: 3,
+            provider: "akash1abc".into()
+        })
+    );
+    // No bids yet → None (keep polling), not an error.
+    assert_eq!(parse_first_bid(&json!({ "data": { "data": [] } })), None);
+}
+
+#[test]
+fn parse_cheapest_bid_selects_the_lowest_price() {
+    let resp = json!({
+        "data": { "data": [
+            { "bid": { "id": { "gseq": 1, "oseq": 1, "provider": "expensive" }, "price": { "amount": "1000", "denom": "uakt" } } },
+            { "bid": { "id": { "gseq": 1, "oseq": 2, "provider": "cheap"     }, "price": { "amount": "250",  "denom": "uakt" } } },
+            { "bid": { "id": { "gseq": 1, "oseq": 3, "provider": "mid"       }, "price": { "amount": "500",  "denom": "uakt" } } }
+        ]}
+    });
+    assert_eq!(parse_cheapest_bid(&resp).unwrap().provider, "cheap");
+}
+
+#[test]
+fn parse_deployment_state_reads_either_envelope() {
+    assert_eq!(
+        parse_deployment_state(&json!({ "data": { "deployment": { "state": "active" } } }))
+            .as_deref(),
+        Some("active")
+    );
+    assert_eq!(
+        parse_deployment_state(&json!({ "deployment": { "state": "closed" } })).as_deref(),
+        Some("closed")
+    );
+}

--- a/crates/drivers/src/provisioning/mod.rs
+++ b/crates/drivers/src/provisioning/mod.rs
@@ -1,6 +1,7 @@
 // Path: crates/drivers/src/provisioning/mod.rs
 
 pub mod akash;
+pub mod akash_console;
 pub mod aws;
 
 // Abstract interface for any cloud provider (Web2 or Web3).


### PR DESCRIPTION
## What

The $100 Akash key is a **managed Console API key** — `x-api-key` REST against `https://console-api.akash.network`, custodial wallet, credit funding, **no chain tx / no AKT / no key-signing**. This adds the one net-new piece the hypervisor's Akash live path was missing: a faithful client for that API.

**Transport-free by design.** Each builder returns a `ConsoleRequest` describing exactly what to send (method, path incl. query, `x-api-key` header, optional JSON body). The daemon executes it with `reqwest` **only** behind its `mode==live` + wallet-lease gate; the spend-capable ops never execute from this crate. That keeps request shapes unit-testable with zero network and keeps every real spend on the gated side.

## Operations

Contract reverse-engineered from `akash-network/console` — `console-api-types` (OpenAPI) + the `managed-api-deployment-flow` e2e test.

| Fn | Method + path | Spend? |
|---|---|---|
| `verify_key` | `GET /v1/wallet-settings` | no — read-only probe → `status=verified` |
| `list_deployments` | `GET /v1/deployments?skip&limit` | no |
| `list_bids` | `GET /v1/bids?dseq` | no (poll) |
| `get_deployment` | `GET /v1/deployments/{dseq}` | no (status) |
| `close_deployment` | `DELETE /v1/deployments/{dseq}` | no (stops spend) |
| `create_deployment` | `POST /v1/deployments` `{data:{sdl,deposit}}` | **SPEND** |
| `create_lease` | `POST /v1/leases` | **SPEND** |
| `deposit_deployment` | `POST /v1/deposit-deployment` | **SPEND** |

Plus pure response accessors (`dseq`, `manifest`, first/cheapest bid, state) and an `is_spend()` classification the daemon gate keys on.

## Safety properties

- **No spend, no network, no new deps** (serde_json only) — this is transport-only.
- `api_key` is excluded from `Debug` so the secret can't leak to a log (test enforces it).
- `x-api-key` and `Authorization` are mutually exclusive per the source → we send `x-api-key` only.
- 11 unit tests lock every request shape, the response parsers, the spend classification, and the redaction.

## Where it fits (no second spine)

This is the transport for the **existing** Guardian pipeline: seal the key via `POST /v1/hypervisor/provider-accounts/:id/credential` (dcrypt into `provider-credentials`) → `authorize_capability_lease` (wallet-gated) → the live `AkashProvider` branch in `provider_routes.rs` (currently stubbed at `akash_live_deployment_tx_not_implemented`) resolves the sealed key and calls these ops → `provider_receipt_ext`. **M2** wires that live branch behind `mode==live` + the wallet lease + a per-deploy deposit cap + a first-spend human confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)