### PR TITLE
chore(ci): job timeouts + apt retry robustness (end the mirror-hang class)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,30 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Cancel superseded runs of the same ref (e.g. a PR force-push) so stale runs
+# don't pile up. Runners are GitHub-hosted (isolated VMs), so this is queue
+# hygiene, not cross-run contention control.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_test:
     name: Build and Test
     runs-on: ubuntu-latest
+    # Hard ceiling so a hung step (e.g. a flaky Ubuntu mirror) fails fast and a
+    # rerun lands on a fresh VM, instead of hanging toward the 6h default.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
 
       - name: Install native deps for kernel build
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          # Bounded retries + connection timeout: a stuck mirror used to hang
+          # this step for hours; now it retries transient failures and fails
+          # fast rather than blocking indefinitely.
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y \
             pkg-config \
             cmake \
             libdbus-1-dev \
@@ -153,6 +166,7 @@ jobs:
   product_surfaces:
     name: Product builds and browser smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: build_and_test
     steps:
       - uses: actions/checkout@v4
@@ -305,6 +319,7 @@ jobs:
   aft_formal_floor:
     name: AFT Formal Floor
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Correcting the diagnosis

I twice attributed the recurring multi-hour "Install native deps" hang (it got #337, then the 06:55 master runs today) to dpkg-lock contention on a self-hosted runner. **That was wrong** — CI runs on GitHub-hosted `ubuntu-latest` (isolated, ephemeral VMs), so there is no shared apt lock across runs. The logs show the real cause: `Ign: azure.archive.ubuntu.com …` — a **flaky Ubuntu mirror**, with **no job timeout**, so a stuck `apt-get` ran toward GitHub's 6h default.

## Fix

| Change | Effect |
|---|---|
| `timeout-minutes` on all 3 jobs (build_and_test **90**, product_surfaces **45**, aft_formal_floor **30**) | a hung step fails fast; a rerun lands on a fresh VM instead of blocking for hours |
| `apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30` on the native-deps step | transient mirror failures retry / fail fast instead of hanging |
| `concurrency` group (`cancel-in-progress: true`) | supersede stale runs on force-push (queue hygiene) |

## Merge note

Touches `.github/workflows/ci.yml`, so it needs an **owner workflow-scoped merge** — this token lacks `workflow` scope (same constraint as R4c #318). No code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)