### PR TITLE
feat(mec): C4 — a live akash provider spend requires a daemon-authored, wallet-admitted operation proposal (the not-curl boundary)

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -230,7 +230,7 @@ const RECORDED_TEST_WRITES = {
 const PINNED = {
   modules: 88,
   familyMentions: 300,
-  tokenMentions: 106985,
+  tokenMentions: 107048,
   judgedTokenPositions: 282,
   productionWriterCalls: { family: 72, nonFamilyLiteral: 206, runtimeParameter: 290 },
   productionFsCalls: 228,
@@ -251,7 +251,7 @@ const PINNED = {
    * Burning these down, and entailing the resolver so they need not exist, is next-legs XV.
    */
   unadjudicable: {
-    "foreign-qualified": 3497,
+    "foreign-qualified": 3498,
     "opaque-initialiser": 1556,
     "bare-undeclared": 517,
     "ambiguous-module": 0,

--- a/crates/node/src/bin/hypervisor_daemon_routes/provider_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/provider_routes.rs
@@ -21,6 +21,8 @@ use axum::Json;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
+use ioi_services::agentic::runtime::kernel::runtime_hypervisor_approved_operation_admission::RuntimeHypervisorApprovedOperationAdmissionCore;
+
 use super::lifecycle_routes::{
     authorize_capability_lease, open_scm_token, seal_scm_token, CapabilityLeaseRequest,
 };
@@ -6109,6 +6111,24 @@ pub(crate) async fn handle_providers_list(State(st): State<Arc<DaemonState>>) ->
 /// Body: `{ provider_id, op, environment_ref?, plan?, command?, material_ref?, grant_ref? }`.
 /// op ∈ preflight | create | start | workrun | stop | snapshot | restore | inject_outage |
 /// recover | delete | observe. Records an admitted-operation record + a provider receipt.
+/// C4 — models propose, Hypervisor executes. A LIVE provider spend op must
+/// carry a daemon-authored `operation_proposal` (a provider_operation_proposal)
+/// that the admission kernel validates — wallet approval + lease + required
+/// scopes + a daemon-authored proposal source (403 on fixtures / unverified
+/// projections) — before the daemon executes it. This is the not-curl
+/// authority boundary: a live provider op with no admitted proposal is refused,
+/// and the sealed credential never crosses on an unauthored request. Returns
+/// the admission record (execution plan) on success, or (status, code).
+fn admit_live_provider_operation(body: &Value, now: &str) -> Result<Value, (u16, String)> {
+    let proposal = body
+        .get("operation_proposal")
+        .cloned()
+        .unwrap_or(Value::Null);
+    RuntimeHypervisorApprovedOperationAdmissionCore
+        .admit(&proposal, now)
+        .map_err(|e| (e.status, e.code))
+}
+
 pub(crate) async fn handle_provider_op(
     State(st): State<Arc<DaemonState>>,
     Json(body): Json<Value>,
@@ -6558,6 +6578,28 @@ pub(crate) async fn handle_provider_op(
             .get("material_ref")
             .and_then(|v| v.as_str())
             .unwrap_or("");
+        // C4 — models propose, Hypervisor executes: a LIVE akash spend op must
+        // present an admitted, daemon-authored operation proposal (wallet
+        // approval + lease + scopes). No admitted proposal → refuse before the
+        // credential crosses; a human curl with no proposal cannot spend.
+        if matches!(op, "create" | "redeploy") && kind == "akash" && vast_mode(&account) == "live" {
+            if let Err((status, code)) = admit_live_provider_operation(&body, &iso_now()) {
+                let receipt = provider_receipt_ext(
+                    data_dir,
+                    &kind,
+                    &env_ref,
+                    op,
+                    "proposal_not_admitted",
+                    &json!({ "account_ref": account_ref, "admission_code": code }),
+                );
+                return (
+                    StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_REQUEST),
+                    Json(json!({ "ok": false, "op": op, "provider": kind,
+                        "reason": "provider_operation_proposal_not_admitted",
+                        "admission_code": code, "receipt_ref": receipt })),
+                );
+            }
+        }
         let result = match op {
             "preflight" => Ok(provider.preflight(&plan)),
             "create" => provider.create(data_dir, &env_ref, &plan),
@@ -6956,6 +6998,49 @@ pub(crate) async fn handle_provider_operations(State(st): State<Arc<DaemonState>
 #[cfg(test)]
 mod containment_tests {
     use super::*;
+
+    // ---- MEC C4: the models-propose gate on the live provider spend path ----
+    fn admitted_provider_op_body() -> Value {
+        json!({ "operation_proposal": {
+            "operation_family": "provider",
+            "proposal_schema_version": "ioi.hypervisor.provider_operation_proposal.v1",
+            "proposal_source": "daemon-provider-operation-proposal",
+            "proposal_ref": "proposal:provider/1",
+            "project_ref": "project:ioi",
+            "operation_kind": "create",
+            "wallet_approval_ref": "approval://wallet/provider/1",
+            "wallet_lease_ref": "lease:wallet/provider/1",
+            "required_scope_refs": ["scope:provider.create"],
+            "agentgres_operation_refs": ["agentgres://operation/provider/1"],
+            "receipt_refs": ["receipt://provider/1"],
+            "state_root_ref": "agentgres://state-root/provider/1",
+            "candidate_ref": "provider-candidate:akash/1",
+            "direct_provider_ref": "provider-account://pacc_1",
+            "environment_ref": "environment:1",
+            "target_ref": "akash-deployment://1"
+        }})
+    }
+
+    #[test]
+    fn a_live_provider_op_with_an_admitted_proposal_passes() {
+        assert!(admit_live_provider_operation(&admitted_provider_op_body(), "now").is_ok());
+    }
+
+    #[test]
+    fn a_live_provider_op_with_no_proposal_is_refused() {
+        // A curl with no operation_proposal cannot spend. (Mutation drill: make
+        // admit_live_provider_operation always return Ok → this goes RED.)
+        let (status, _code) = admit_live_provider_operation(&json!({}), "now").unwrap_err();
+        assert_eq!(status, 400);
+    }
+
+    #[test]
+    fn a_live_provider_op_without_wallet_approval_is_refused_403() {
+        let mut body = admitted_provider_op_body();
+        body["operation_proposal"]["wallet_approval_ref"] = json!("approval://other/1");
+        let (status, _code) = admit_live_provider_operation(&body, "now").unwrap_err();
+        assert_eq!(status, 403);
+    }
 
     // ---- CARVE-OUT: provider deletion stays callable and reports exactly ----
 


### PR DESCRIPTION
## MEC leg C4 — models propose, the Hypervisor executes

The five-gap owner review of the credential-custody baseline named **gap #1: the initiating actor of the proven live provider call was `curl`, not a model.** C4 closes it at the one chokepoint where a live spend is dispatched.

### What
`handle_provider_op`, for `op ∈ {create, redeploy} ∧ kind == akash ∧ live`, now routes the request body's `operation_proposal` through the existing admission kernel — `RuntimeHypervisorApprovedOperationAdmissionCore.admit()`, the same models-propose primitive `package_registry_routes.rs` already uses for candidate/release/installation.

`admit()` requires a daemon-authored `provider_operation_proposal.v1`:
- a wallet **approval** ref (`approval://wallet/`, else 403)
- a wallet **lease** ref (`lease:`, else 403)
- required scopes
- a proposal **source** matched to the provider family (403 on fixtures / unverified local projections — literally the not-curl edge)

No admitted proposal → **refuse before the sealed credential is opened**, with a `proposal_not_admitted` receipt carrying the admission code.

### Where it sits
`authorize_capability_lease` (authority) → **C4 `admit()` (authorship)** → create dispatch. Authority and authorship are both required, in that order.

Scoped to **live akash create/redeploy only** — every simulator flow and every non-spend op (preflight/observe/delete/…) is untouched, so the existing containment tests are unaffected.

### Tests (`containment_tests`)
- an admitted proposal passes
- a body with **no** `operation_proposal` is refused **400** (the curl case)
- a proposal whose `wallet_approval_ref` lacks the `approval://wallet/` prefix is refused **403**

**Mutation drill:** force `admit_live_provider_operation` to always return `Ok` → both refuse tests go RED (1 passed, 2 failed); reverted → 3/3 green.

### Governed census re-pin
The C4 additions move the admission-census token pins (`tokenMentions` 106985→107048, `foreign-qualified` 3497→3498, from the gate's `StatusCode::from_u16`/`BAD_REQUEST`). Both re-derived; **25/25 PASS** — the gate working as designed (it moves when the daemon's literals move).

### Spend safety
This leg spends nothing. It makes a future live spend *harder* to reach, not easier: it adds a required authorship gate in front of the existing authority gate. Building the spend-capable daemon binary and running any real spend (C7/U1) remain explicit owner-authorized steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)