### PR TITLE
feat(mec): C3 — akash credential isolation demonstrated (egress route audit; no leak)

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-byo-provider-plane.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-byo-provider-plane.mjs
@@ -43,7 +43,7 @@ async function preClean() {
   // and the verifier's external_spend budget record (the no-budget check needs its absence).
   const accounts = (await jd("GET", "/v1/hypervisor/provider-accounts")).j.accounts || [];
   for (const a of accounts) {
-    if (/^(BYO node|BYO unverified|AWS) /.test(a.display_name || "")) {
+    if (/^(BYO node|BYO unverified|AWS|AKASH) /.test(a.display_name || "")) {
       await jd("DELETE", `/v1/hypervisor/provider-accounts/${a.account_id}`);
     }
   }
@@ -253,6 +253,42 @@ async function run() {
   ok("provider secrets never leak — absent from every projection, sealed (not plaintext) at rest",
     leaks.length === 0 && !awsCredDisk.includes(SECRET) && awsCredDisk.includes("sealed_secret_access_key"),
     leaks.length ? `leaked: ${leaks.join(",")}` : "");
+
+  // ── 16b. C3 credential isolation — the bearer/api_key provisioning kinds ──
+  // §16 proves it for the AWS SECRET; this proves the SAME boundary for the akash Console
+  // x-api-key (cred_kind "bearer", sealed as sealed_token) — the credential the capstone's
+  // own live deploy will carry. The unsealed key must reach ONLY the outbound provider
+  // request, never a projection, the preflight evidence, or a durable byte; and the sealed
+  // blob itself must never cross the API (no route returns the vault record wholesale).
+  const AKASH_SECRET = `SUPERSECRET-AKASH-APIKEY-${tag}`;
+  const akash = (await jd("POST", "/v1/hypervisor/provider-accounts", { kind: "akash", display_name: `AKASH ${tag}` })).j.account || {};
+  await jd("POST", `/v1/hypervisor/provider-accounts/${akash.account_id}/credential`, { api_key: AKASH_SECRET });
+  const akashPf = await jd("POST", `/v1/hypervisor/provider-accounts/${akash.account_id}/preflight`);
+  const akashSurfaces = {
+    accounts: (await jd("GET", "/v1/hypervisor/provider-accounts")).j,
+    account_get: (await jd("GET", `/v1/hypervisor/provider-accounts/${akash.account_id}`)).j,
+    operations: (await jd("GET", "/v1/hypervisor/provider-operations")).j,
+    receipts: (await jd("GET", "/v1/hypervisor/provider-receipts")).j,
+    materials: (await jd("GET", "/v1/hypervisor/provider-materials")).j,
+    leases: (await jd("GET", "/v1/hypervisor/capability-leases")).j,
+    preflight: akashPf.j,
+  };
+  const akashLeaks = Object.entries(akashSurfaces)
+    .filter(([, j]) => JSON.stringify(j).includes(AKASH_SECRET)).map(([n]) => n);
+  const akashCredDisk = readFileSync(path.join(DATA, "provider-credentials", `pcred_${akash.account_id}.json`), "utf8");
+  ok("C3: akash api_key never leaks — absent from every projection + preflight, sealed_token (not plaintext) at rest",
+    akashLeaks.length === 0 && !akashCredDisk.includes(AKASH_SECRET) && akashCredDisk.includes("sealed_token"),
+    akashLeaks.length ? `leaked: ${akashLeaks.join(",")}` : "");
+  // The sealed (encrypted) blob is vault-only: no projection returns the credential record wholesale.
+  const sealedOnSurface = Object.entries(akashSurfaces)
+    .filter(([, j]) => JSON.stringify(j).includes("sealed_token")).map(([n]) => n);
+  ok("C3: the sealed_token blob never crosses the API — no route returns the vault record wholesale",
+    sealedOnSurface.length === 0,
+    sealedOnSurface.length ? `sealed on: ${sealedOnSurface.join(",")}` : "");
+  // Preflight exposes the fingerprint + probe, never the key: credential isolation, demonstrated.
+  ok("C3: akash preflight evidence exposes fingerprint + probe, never the api_key",
+    /^sha256:/.test(akashPf.j.account?.preflight?.evidence?.fingerprint || "")
+    && !JSON.stringify(akashPf.j).includes(AKASH_SECRET));
 
   // ── 17. No fee/markup objects anywhere on the plane (routing-fee covenant: this cut takes NO fee) ──
   const feeAudit = JSON.stringify(surfaces).toLowerCase();


### PR DESCRIPTION
## MEC leg C3 — credential isolation, demonstrated

Closes baseline **gap #5**: *"credential isolation from a model is architecturally plausible, **not demonstrated** — no route audit exists."* This is that route audit + the empirical demonstration for the **akash Console `x-api-key`** — the credential the capstone's own live deploy carries.

### Route audit verdict — **no plaintext-egress leak**
Every unseal of a provider credential reaches exactly one destination: an outbound HTTP header (`x-api-key` for akash; `Authorization: Bearer` for vast/runpod/lambda) or a transient `0600` SSH key file unlinked by `KeyGuard::drop`. No unsealed plaintext reaches a response, a log, a persisted record, a journal/receipt, a model surface, or an error message.

| Unseal site | file:line | plaintext | ONLY destination |
|---|---|---|---|
| akash live create/lease | `provider_routes.rs:4785,4819` | `api_key` | `req.header()` → reqwest `.header()` |
| akash live verify | `provider_routes.rs:5960,5994` | `api_key` | `verify_key` → `.header()` |
| vast/runpod/lambda REST | `provider_routes.rs:1306,1467,1597,1735,2247` | `bearer` | `.bearer_auth()` only |
| ssh key materialize ×4 | `provider_routes.rs:744,1192,1766,2277` | `key` | `0600` file, unlinked on drop |

- **No logging exists**: `grep eprintln|println|tracing|{:?}` over `provider_routes.rs` + `akash_console.rs` → **zero matches**.
- What is stored/returned is only the `sha256:` fingerprint; the `sealed_token` blob never leaves the vault record.
- Existing redaction: `akash_console.rs` `Debug` masks the `api_key`; `provider_transport` hashes upstream error bodies so a hostile endpoint can't reflect a `Bearer` header into the durable stream.

### Demonstration (`§16b`)
`verify-hypervisor-byo-provider-plane.mjs` §16 already proves this for the AWS `SECRET`; **§16b extends the identical scan to the akash `api_key`**: absent from every projection + the preflight evidence, the `sealed_token` blob returned by no route, the on-disk record holds `sealed_token` not plaintext, preflight exposes only the `sha256:` fingerprint.

**Locally verified** against a running daemon (isolated probe): `LEAKS []`, `SEALED_TOKEN on surface []`, disk has no plaintext + has `sealed_token`, preflight fingerprint `sha256:…` — **VERDICT PASS**.

### Honest scope
- `byo-provider-plane` is a **manual done-bar** verifier (not in the CI floor), so §16b demonstrates but does not continuously gate. A CI-gated Rust regression test in the daemon suite is the **C3.1** follow-up.
- Named soft-spot (not a leak): `KeyGuard` unlinks the transient ssh key file but does not `zeroize` the in-memory buffer — a `zeroize` pass is a candidate hardening.

Spends nothing. Independent of the C4/C5b/C2 stack (verifier-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)