### PR TITLE
feat(mec): C6 — provider-address pin enforcement + real lease-state proof retrieval

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-ontology-admission-census.mjs
@@ -230,7 +230,7 @@ const RECORDED_TEST_WRITES = {
 const PINNED = {
   modules: 88,
   familyMentions: 300,
-  tokenMentions: 107232,
+  tokenMentions: 107252,
   judgedTokenPositions: 282,
   productionWriterCalls: { family: 72, nonFamilyLiteral: 206, runtimeParameter: 290 },
   productionFsCalls: 228,
@@ -251,7 +251,7 @@ const PINNED = {
    * Burning these down, and entailing the resolver so they need not exist, is next-legs XV.
    */
   unadjudicable: {
-    "foreign-qualified": 3500,
+    "foreign-qualified": 3501,
     "opaque-initialiser": 1556,
     "bare-undeclared": 517,
     "ambiguous-module": 0,

--- a/crates/drivers/src/provisioning/akash_console.rs
+++ b/crates/drivers/src/provisioning/akash_console.rs
@@ -261,6 +261,26 @@ pub fn parse_cheapest_bid(resp: &Value) -> Option<AkashBid> {
     best.map(|(_, b)| b)
 }
 
+/// The bid from a SPECIFIC provider address in a `getBids` response, or `None` if
+/// that provider is not among the bidders. C6 provider-pin: when a caller pins a
+/// provider address (the one the wallet challenge hashed), the daemon deploys on
+/// THAT provider or refuses — it never silently falls through to the cheapest.
+/// Selecting by pin proves `selected == pinned` by construction.
+pub fn parse_pinned_bid(resp: &Value, provider: &str) -> Option<AkashBid> {
+    let bids = resp.pointer("/data/data").and_then(Value::as_array)?;
+    for entry in bids {
+        let id = entry.pointer("/bid/id")?;
+        if id.get("provider").and_then(Value::as_str) == Some(provider) {
+            return Some(AkashBid {
+                gseq: id.get("gseq").and_then(Value::as_i64)?,
+                oseq: id.get("oseq").and_then(Value::as_i64)?,
+                provider: provider.to_string(),
+            });
+        }
+    }
+    None
+}
+
 /// The deployment `state` from a `getDeployment` response
 /// (`{"data": {"deployment": {"state": "…"}}}`), e.g. `"active"`/`"closed"`.
 pub fn parse_deployment_state(resp: &Value) -> Option<String> {

--- a/crates/drivers/src/provisioning/akash_console/tests.rs
+++ b/crates/drivers/src/provisioning/akash_console/tests.rs
@@ -141,6 +141,26 @@ fn parse_cheapest_bid_selects_the_lowest_price() {
 }
 
 #[test]
+fn parse_pinned_bid_selects_the_pinned_provider_or_refuses() {
+    // C6 provider-pin: the pinned provider's bid is selected EVEN when it is not
+    // the cheapest (so the daemon deploys where the wallet approved, never on the
+    // cheapest fall-through); a pin that did not bid returns None → the caller refuses.
+    let resp = json!({
+        "data": { "data": [
+            { "bid": { "id": { "gseq": 1, "oseq": 1, "provider": "expensive" }, "price": { "amount": "1000", "denom": "uakt" } } },
+            { "bid": { "id": { "gseq": 1, "oseq": 2, "provider": "cheap"     }, "price": { "amount": "250",  "denom": "uakt" } } },
+            { "bid": { "id": { "gseq": 1, "oseq": 3, "provider": "mid"       }, "price": { "amount": "500",  "denom": "uakt" } } }
+        ]}
+    });
+    // Pinning "mid" selects mid — NOT the cheapest "cheap".
+    let pinned = parse_pinned_bid(&resp, "mid").expect("the pinned provider bid is present");
+    assert_eq!(pinned.provider, "mid");
+    assert_eq!(pinned.oseq, 3);
+    // A provider that did not bid is refused (None), never silently downgraded.
+    assert!(parse_pinned_bid(&resp, "akash1neverbid").is_none());
+}
+
+#[test]
 fn parse_deployment_state_reads_either_envelope() {
     assert_eq!(
         parse_deployment_state(&json!({ "data": { "deployment": { "state": "active" } } }))

--- a/crates/node/src/bin/hypervisor_daemon_routes/provider_routes.rs
+++ b/crates/node/src/bin/hypervisor_daemon_routes/provider_routes.rs
@@ -4840,6 +4840,11 @@ impl AkashProvider {
                 ));
             }
 
+            // C6 provider-pin: the caller may pin the provider address (the one the
+            // wallet challenge hashed into the approval). If set, the daemon deploys
+            // on THAT provider or refuses — it never falls through to the cheapest.
+            let pinned_provider = text(plan, "provider_address").to_string();
+
             // Run the async create→bid→lease→status flow from this sync body,
             // mirroring the live Vast path.
             let live: Value = tokio::task::block_in_place(|| {
@@ -4886,21 +4891,40 @@ impl AkashProvider {
                         "akash_console_create_no_manifest — create response had no data.manifest",
                     )?;
 
-                    // 2. poll bids (up to 10× at 6s), pick the cheapest
+                    // 2. poll bids (up to 10× at 6s). Pinned → select THAT provider's
+                    //    bid (refuse if it never bids); unpinned → the cheapest.
                     let mut selected = None;
                     for _ in 0..10 {
                         let (bc, bl) = send(ac::list_bids(&api_key, &dseq)).await?;
                         if (200..300).contains(&bc) {
-                            if let Some(b) = ac::parse_cheapest_bid(&bl) {
+                            let picked = if pinned_provider.is_empty() {
+                                ac::parse_cheapest_bid(&bl)
+                            } else {
+                                ac::parse_pinned_bid(&bl, &pinned_provider)
+                            };
+                            if let Some(b) = picked {
                                 selected = Some(b);
                                 break;
                             }
                         }
                         tokio::time::sleep(std::time::Duration::from_secs(6)).await;
                     }
-                    let bid = selected.ok_or(
-                        "akash_console_no_bids — no provider bid within the polling window",
-                    )?;
+                    let bid = selected.ok_or_else(|| {
+                        if pinned_provider.is_empty() {
+                            "akash_console_no_bids — no provider bid within the polling window"
+                                .to_string()
+                        } else {
+                            format!("akash_pinned_provider_did_not_bid — the wallet-approved provider '{pinned_provider}' returned no bid within the polling window; the daemon refuses to deploy on a provider that was not approved")
+                        }
+                    })?;
+                    // Prove selected == pinned (the pin selector guarantees it; assert the invariant
+                    // so a future selector change cannot silently deploy on an unapproved provider).
+                    if !pinned_provider.is_empty() && bid.provider != pinned_provider {
+                        return Err(format!(
+                            "akash_pin_mismatch — selected provider '{}' != wallet-approved '{pinned_provider}'",
+                            bid.provider
+                        ));
+                    }
 
                     // 3. create the lease against the selected bid
                     let (lc, ll) = send(ac::create_lease(&api_key, &manifest, &dseq, &bid)).await?;
@@ -5280,13 +5304,69 @@ impl EnvironmentProvider for AkashProvider {
         let dep = self
             .deployment(data_dir, env_ref)
             .ok_or("akash_deployment_absent")?;
-        Ok(json!({
+        let mut out = json!({
             "deployment_ref": dep["deployment_ref"], "lease_ref": dep["lease_ref"],
             "control_plane_log": dep.get("events").cloned().unwrap_or(json!([])),
-            "service_logs": "unavailable_in_simulator — provider-native service logs land with the live lease; workspace exec outputs are receipted in the Work Ledger",
             "execution_mode": dep["execution_mode"],
             "basis": "daemon-recorded control-plane events — provider evidence, not authority",
-        }))
+        });
+        if self.mode() == "live" {
+            // C6 — real proof retrieval. "Proof of execution" is a FETCHED fact — the
+            // lease's on-chain deployment state, read live from the managed Console API
+            // (GET /v1/deployments/{dseq}, spend:false) — not a daemon assertion. The
+            // managed Console API does NOT expose container service logs (those need the
+            // provider's own endpoint), so that is stated honestly, never faked.
+            let dseq = text(&dep, "dseq").to_string();
+            if dseq.is_empty() {
+                return Err(
+                    "akash_live_logs_no_dseq — the live deployment record carries no dseq to read"
+                        .into(),
+                );
+            }
+            let Some(cred) = load_account_credential(data_dir, self.account_id()) else {
+                return Err(
+                    "akash_live_credentials_absent — proof retrieval needs the bound credential"
+                        .into(),
+                );
+            };
+            let api_key = cred["sealed_token"]
+                .as_str()
+                .and_then(open_scm_token)
+                .ok_or(
+                    "akash_live_credential_unresolvable — the sealed Console key did not decrypt",
+                )?;
+            let detail: Value = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    use ioi_drivers::provisioning::akash_console as ac;
+                    let req = ac::get_deployment(&api_key, &dseq);
+                    let (hn, hv) = req.header();
+                    let url = format!("{}{}", ac::AKASH_CONSOLE_BASE_URL, req.path);
+                    let resp = reqwest::Client::new()
+                        .get(&url)
+                        .header(hn, hv)
+                        .timeout(std::time::Duration::from_secs(30))
+                        .send()
+                        .await
+                        .map_err(|e| format!("akash_console_http_failed: {e}"))?;
+                    let code = resp.status().as_u16();
+                    let body: Value = resp.json().await.unwrap_or(Value::Null);
+                    if !(200..300).contains(&code) {
+                        return Err(format!("akash_console_get_deployment_failed: http {code}"));
+                    }
+                    Ok::<Value, String>(body)
+                })
+            })?;
+            let state = ioi_drivers::provisioning::akash_console::parse_deployment_state(&detail);
+            out["lease_state_proof"] = json!({
+                "deployment_state": state,
+                "retrieved_live": true,
+                "source": "managed Console API GET /v1/deployments/{dseq} — the lease's on-chain state, fetched not asserted",
+            });
+            out["service_logs"] = json!("not_exposed_by_managed_console_api — container logs require the provider's own endpoint; the retrievable proof is the live lease state above");
+        } else {
+            out["service_logs"] = json!("unavailable_in_simulator — provider-native service logs land with the live lease; workspace exec outputs are receipted in the Work Ledger");
+        }
+        Ok(out)
     }
     fn events(&self, data_dir: &str, env_ref: &str) -> Result<Value, String> {
         let dep = self


### PR DESCRIPTION
## MEC leg C6 — deploy only where the wallet approved; prove execution by a fetched fact

**Stacked on #349 (C2) → #348 → #347.** Bases retarget to `master` as the stack merges.

Closes the C6-design gaps: the live akash flow selected the **cheapest** bid (never the caller's pinned provider), and `logs()` returned `"unavailable_in_simulator"` even in live mode — so a deploy could neither be constrained to the approved provider nor prove it actually ran.

### C6(a) — provider pin (fully local, unit-tested + mutation-drilled)
- `akash_console::parse_pinned_bid(resp, provider)` selects the bid from a **specific** provider among **all** bids. `parse_cheapest_bid` collapses the list to one winner, so it can't observe whether the pinned provider even bid; the pin selector can.
- `AkashProvider::provision` reads `plan.provider_address` — the provider facet the wallet capability-lease challenge **hashed into the approval**. If pinned: select that provider's bid or **refuse** (`akash_pinned_provider_did_not_bid`) — never fall through to the cheapest — and assert `selected == pinned` (`akash_pin_mismatch`). Unpinned keeps the cheapest.
- Test extends the 3-provider fixture: pinning `"mid"` selects mid (not the cheapest `"cheap"`); a provider that didn't bid → `None` → refuse. **Mutation drill:** bypass the provider match → the pin test goes RED (wrong provider selected); reverted → 12/12.

### C6(b) — real proof retrieval (code + accessor tested; live read exercised at the first live deploy)
- The managed Console API exposes **no** container service logs (those require the provider's own endpoint), so "proof of execution" is the lease's on-chain deployment **state**, *fetched* not asserted.
- `AkashProvider::logs` live branch now does a real `GET /v1/deployments/{dseq}` (`spend:false`), surfaces `parse_deployment_state` as `lease_state_proof.deployment_state` (`retrieved_live: true`), and labels `service_logs` honestly (`not_exposed_by_managed_console_api`). Simulator path unchanged; `parse_deployment_state` already unit-tested.

### Verification
- `ioi-drivers` akash_console suite **12/12** (incl. the new pin test + mutation drill).
- Daemon compiles clean; census re-pin `tokenMentions` 107232→107252, `foreign-qualified` 3500→3501; **25/25**.

**Spends nothing** (`get_deployment` is `spend:false`). This completes the free capstone legs — after this, only **C7 (the single minimal spend)** remains, which is owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)