### PR TITLE
fix(mec): re-pin admission-evidence provenance for the C6 provider_op reshape

### DIFF
--- a/apps/hypervisor/scripts/verify-hypervisor-named-gap-truth.mjs
+++ b/apps/hypervisor/scripts/verify-hypervisor-named-gap-truth.mjs
@@ -147,7 +147,11 @@ const PINNED = {
   // 74 includes this gate's OWN two absence-worded labels. It walks every verifier in the estate and
   // is one of them; excluding itself would be the first exemption, and exemptions are how a closed
   // world stops being one.
-  verifierAbsenceLabels: 75,
+  // 75 -> 77 (2026-08-20): #350's C3 credential-isolation leg added two absence-worded assertions
+  // to verify-hypervisor-byo-provider-plane.mjs ("akash api_key never leaks — absent from every
+  // projection + preflight" and "the sealed_token blob never crosses the API") — both verified
+  // honest (neither resolves a probe URL; the resolving population stays 15).
+  verifierAbsenceLabels: 77,
   verifierAbsenceLabelsResolvingAUrl: 15,
 };
 

--- a/scripts/audit-admission-evidence-provenance.mjs
+++ b/scripts/audit-admission-evidence-provenance.mjs
@@ -267,6 +267,7 @@ const PINNED = [
   {"file": "orchestration_routes.rs", "rule": "F", "key": "auth-header", "count": 1, "disposition": "sanctioned", "justification": "read 2026-08-08: webhook delivery authenticates by a per-automation rotated trigger token (x-ioi-trigger-token / Bearer) compared against the stored secret \u2014 a presented capability, not a principal resolver"},
   {"file": "portal_session_exchange_routes.rs", "rule": "F", "key": "tenant-resolver", "count": 1, "disposition": "sanctioned", "justification": "read 2026-08-08: session-mint seam delegates to the canonical lifecycle_routes resolver to snapshot full membership INTO the session record (the projection later requests narrow FROM); it does not re-derive scope on a later request"},
   {"file": "supervisor_routes.rs", "rule": "F", "key": "auth-header", "count": 1, "disposition": "sanctioned", "justification": "read 2026-08-08: bearer() extracts a capability-lease token adjudicated against the durable authority-grants record (lease_binds_env) \u2014 a presented grant independently verified, not a principal resolver"},
+  {"file": "provider_routes.rs", "rule": "E", "key": "handle_provider_op", "count": 1, "disposition": "sanctioned", "justification": "read 2026-08-19 (post-C6 #351 reshape): the pre-identity reads are the quote/pin GATES reading daemon-owned records (cloud-resource-candidates, provider accounts) to REFUSE under-evidenced ops fail-closed with receipted refusals; identity is resolved by require_write_caller at the C2 intent phase BEFORE any external effect or record write \u2014 gate-reads-then-authenticate-before-effect, not bc73b5b20's authorize-after-admission-read. The same reshape moved this handler OUT of the rule-H no-in-handler-identity baseline (an improvement, re-pinned by removal)."},
 ];
 
 // Rule H baseline: mutating handlers with no in-handler identity/authority
@@ -442,7 +443,6 @@ const H_BASELINE = [
   "provider_routes.rs::handle_provider_account_delete",
   "provider_routes.rs::handle_provider_account_patch",
   "provider_routes.rs::handle_provider_account_preflight",
-  "provider_routes.rs::handle_provider_op",
   "resource_routes.rs::handle_allocate",
   "resource_routes.rs::handle_budget_create",
   "resource_routes.rs::handle_catchup",


### PR DESCRIPTION
check:admission-evidence has been red on master since #351 reshaped provider_routes.rs handle_provider_op. The pre-identity reads there are the quote/pin gates reading daemon-owned records (cloud-resource-candidates, provider accounts) to refuse under-evidenced ops fail-closed with receipted refusals; identity resolves via require_write_caller at the C2 intent phase before any external effect — gate-reads-then-authenticate-before-effect, not the authorize-after-admission-read defect the rule hunts. Pinned sanctioned under rule E; removed from the rule-H no-in-handler-identity baseline (the reshape moved the handler out of that class — an improvement, re-pinned by removal).

Gate local: admission-evidence provenance OK — 87 files, 12 pinned leads, H-census 208/208 baseline.

Unblocks CI for every PR stacked on master since #351 (incl. #354).

🤖 Generated with [Claude Code](https://claude.com/claude-code)